### PR TITLE
Permit panels to be 100% width

### DIFF
--- a/src/resources/filters/layout/latex.lua
+++ b/src/resources/filters/layout/latex.lua
@@ -316,7 +316,7 @@ function latexCell(cell, endOfRow, endOfTable)
     tappend(content, cell.content)
   end
   
-  latexAppend(suffix, "\n\\end{minipage}")
+  latexAppend(suffix, "\\end{minipage}%")
   
   if isSubRef then
     latexAppend(suffix, "\n}")

--- a/src/resources/filters/layout/layout.lua
+++ b/src/resources/filters/layout/layout.lua
@@ -248,7 +248,7 @@ function layoutCells(divEl, cells)
       -- percentage based layouts need to be scaled down so they don't overflow the page 
       local percentWidth = widthToPercent(attribute(cell, "width", nil))
       if percentWidth then
-        percentWidth = round(percentWidth * 0.96,1)
+        percentWidth = round(percentWidth,1)
         cell.attr.attributes["width"] = tostring(percentWidth) .. "%"
       end
       

--- a/src/resources/filters/layout/meta.lua
+++ b/src/resources/filters/layout/meta.lua
@@ -30,7 +30,6 @@ function metaInject()
   }
   .quarto-layout-cell {
     position: relative;
-    padding-right: 15px;
   }
   .quarto-layout-cell:last-child {
     padding-right: 0;


### PR DESCRIPTION
- We were previously constraining widths to 96%.
- For html remove panel right padding.
- For latex, remove extraneous whitespace when we terminate minipages

### Example
![Screen Shot 2021-02-25 at 5 05 50 PM](https://user-images.githubusercontent.com/261654/109225917-f8026c80-778b-11eb-8de8-47fd11dfe3d8.png)

### Renders As
| html | latex |
|---|---|
| ![Screen Shot 2021-02-25 at 5 06 10 PM](https://user-images.githubusercontent.com/261654/109226138-46177000-778c-11eb-800e-9170c40a61b9.png)  | ![Screen Shot 2021-02-25 at 5 05 53 PM](https://user-images.githubusercontent.com/261654/109226147-49126080-778c-11eb-8a0a-ae4e604603e8.png)  |

