### PR TITLE
Pandoc 2.5 issue in Lua Filter - remove attributes only if it exists

### DIFF
--- a/src/resources/filters/quarto-post/latexdiv.lua
+++ b/src/resources/filters/quarto-post/latexdiv.lua
@@ -17,8 +17,8 @@ function latexDiv()
       
       -- if the output format is not latex, remove the attr and return
       if not isLatexOutput() then
-        divEl.attributes['latex'] = nil
-        divEl.attributes['data-latex'] = nil
+        if divEl.attributes['latex'] then divEl.attributes['latex']  = nil end
+        if divEl.attributes['data-latex'] then divEl.attributes['data-latex'] = nil end
         return divEl
       end
       


### PR DESCRIPTION
This comes from a fix I needed to make in **rmarkdown** `latex-divs.lua`: https://github.com/rstudio/rmarkdown/pull/2123

It seems there was an issue in Pandoc 2.5 but not in 2.7.3 or 2.0.0.1 (I did not try other versions between that it is only the ones that we test). Issue is a Pandoc error on Lua filter: 
https://github.com/rstudio/rmarkdown/runs/2474772129#step:14:487

The error is 
```
Error running filter C:\Users\chris\Documents\DEV_R\rmarkdown\inst\rmarkdown\lua\latex-div.lua:
C stack overflow
stack traceback:
	[C]: in function 'table.remove'
	[string "--[[..."]:829: in function <[string "--[[..."]:826>
	[C]: in function 'table.remove'
	[string "--[[..."]:829: in function <[string "--[[..."]:826>
	[C]: in function 'table.remove'
	[string "--[[..."]:829: in function <[string "--[[..."]:826>
	[C]: in function 'table.remove'
	[string "--[[..."]:829: in function <[string "--[[..."]:826>
	[C]: in function 'table.remove'
	[string "--[[..."]:829: in function <[string "--[[..."]:826>
	...
	[C]: in function 'table.remove'
	[string "--[[..."]:829: in function <[string "--[[..."]:826>
	[C]: in function 'table.remove'
	[string "--[[..."]:829: in function <[string "--[[..."]:826>
	[C]: in function 'table.remove'
	[string "--[[..."]:829: in function <[string "--[[..."]:826>
	[C]: in function 'table.remove'
	[string "--[[..."]:829: in function <[string "--[[..."]:826>
	[C]: in function 'table.remove'
	[string "--[[..."]:829: in metamethod '__newindex'
	[string "C:\Users\chris\Documents\DEV_R\rmarkdown\inst..."]:36: in function 'Div'
Error: pandoc document conversion failed with error 83
```

This PR ports the fix I have made in **rmarkdown**. 

@dragonstyle I let you test and modified if needed. 

I did not look if you have a helper function already for doing this. easy to add one 
```lua
function table_remove(e, name)
   if e[name] then [name] = nil end
end
```

Also as discussed, I don't know if fixing something for Pandoc 2.5 is something you want to do for Quarto as it bundles Pandoc. 

I let you decided. You are aware of it now. 😉 


