### PR TITLE
Basic Dark Mode Support

### DIFF
--- a/package/src/common/cyclic-dependencies.ts
+++ b/package/src/common/cyclic-dependencies.ts
@@ -10,7 +10,7 @@ import { Command } from "cliffy/command/mod.ts";
 
 import { runCmd } from "../util/cmd.ts";
 import { Configuration, readConfiguration } from "./config.ts";
-import { info } from "log/mod.ts";
+import { error, info } from "log/mod.ts";
 import { progressBar } from "../../../src/core/console.ts";
 
 export function cycleDependenciesCommand() {
@@ -225,8 +225,8 @@ function findCyclicDependencies(
     prog.update(count, status);
     try {
       walkImports(path, modules);
-    } catch {
-      // console.log(`${stack[0]} cycle`);
+    } catch (er) {
+      error(er);
     } finally {
       stack.splice(0, stack.length);
     }

--- a/src/command/render/pandoc-html.ts
+++ b/src/command/render/pandoc-html.ts
@@ -175,7 +175,11 @@ export async function resolveSassBundles(
 
   if (hasDarkStyles) {
     // Provide dark variables for this
-    extras = await resolveQuartoSyntaxHighlighting(extras, pandoc, "dark");
+    extras = await resolveQuartoSyntaxHighlighting(
+      extras,
+      pandoc,
+      "dark",
+    );
   }
 
   // We'll take care of text highlighting for HTML
@@ -439,16 +443,29 @@ const kAbbrevs: Record<string, string> = {
   "Normal": "",
 };
 
-// The media attribute for a style tag
+// Attributes for the style tag
+// Note that we default disable the dark mode and rely on JS to enable it
 function attribForThemeStyle(
   style: "dark" | "light" | "default",
 ): Record<string, string> {
-  if (style === "dark") {
-    return { media: "(prefers-color-scheme: dark)" };
-  } else if (style === "light") {
-    return { media: "(prefers-color-scheme: light)" };
-  } else {
-    return {};
+  const colorModeAttrs = (mode: string, disabled: boolean) => {
+    const attr: Record<string, string> = {
+      class: `quarto-color-scheme ${mode}`,
+    };
+    if (disabled) {
+      attr.disabled = "true";
+    }
+    return attr;
+  };
+
+  switch (style) {
+    case "dark":
+      return colorModeAttrs("dark", true);
+    case "light":
+      return colorModeAttrs("light", false);
+    case "default":
+    default:
+      return {};
   }
 }
 

--- a/src/command/render/pandoc-html.ts
+++ b/src/command/render/pandoc-html.ts
@@ -1,0 +1,475 @@
+/*
+* pandoc-html.ts
+*
+* Copyright (C) 2020 by RStudio, PBC
+*
+*/
+
+import { join } from "path/mod.ts";
+import { ld } from "lodash/mod.ts";
+import { existsSync } from "fs/mod.ts";
+
+import { kHighlightStyle } from "../../config/constants.ts";
+import {
+  FormatExtras,
+  FormatPandoc,
+  kDependencies,
+  kQuartoCssVariables,
+  kTextHighlightingMode,
+  SassBundle,
+} from "../../config/types.ts";
+import { ProjectContext } from "../../project/types.ts";
+import { kDefaultHighlightStyle } from "./types.ts";
+
+import { sessionTempFile } from "../../core/temp.ts";
+import { cssImports, cssResources } from "../../core/css.ts";
+import { textHighlightThemePath } from "../../core/resources.ts";
+
+import { kQuartoHtmlDependency } from "../../format/html/format-html.ts";
+
+import { compileSass } from "./sass.ts";
+
+// The output target for a sass bundle
+// (controls the overall style tag that is emitted)
+interface SassTarget {
+  name: string;
+  bundles: SassBundle[];
+  attribs: Record<string, string>;
+}
+
+export async function resolveSassBundles(
+  extras: FormatExtras,
+  pandoc: FormatPandoc,
+  formatBundles?: SassBundle[],
+  projectBundles?: SassBundle[],
+  project?: ProjectContext,
+) {
+  extras = ld.cloneDeep(extras);
+
+  const mergedBundles: Record<string, SassBundle[]> = {};
+
+  // groups the bundles by dependency name
+  const group = (
+    bundles: SassBundle[],
+    groupedBundles: Record<string, SassBundle[]>,
+  ) => {
+    bundles.forEach((bundle) => {
+      if (!groupedBundles[bundle.dependency]) {
+        groupedBundles[bundle.dependency] = [];
+      }
+      groupedBundles[bundle.dependency].push(bundle);
+    });
+  };
+
+  // group project provided bundles
+  if (projectBundles) {
+    group(projectBundles, mergedBundles);
+  }
+
+  // group format provided bundles
+  if (formatBundles) {
+    group(formatBundles, mergedBundles);
+  }
+
+  // Go through and compile the cssPath for each dependency
+  let hasDarkStyles = false;
+  for (const dependency of Object.keys(mergedBundles)) {
+    // compile the cssPath
+    const bundles = mergedBundles[dependency];
+
+    // See if any bundles are providing dark specific css
+    const hasDark = bundles.some((bundle) => bundle.dark !== undefined);
+
+    const targets: SassTarget[] = [{
+      name: `${dependency}.min.css`,
+      bundles,
+      attribs: {},
+    }];
+    if (hasDark) {
+      // Note that the other bundle provides light
+      targets[0].attribs = {
+        ...targets[0].attribs,
+        ...attribForThemeStyle("light"),
+      };
+
+      // Provide a dark bundle for this
+      const darkBundles = bundles.map((bundle) => {
+        bundle = ld.cloneDeep(bundle);
+        bundle.user = bundle.dark?.user || bundle.user;
+        bundle.quarto = bundle.dark?.quarto || bundle.quarto;
+        bundle.framework = bundle.dark?.framework || bundle.framework;
+        return bundle;
+      });
+      targets.push({
+        name: `${dependency}-dark.min.css`,
+        bundles: darkBundles,
+        attribs: attribForThemeStyle("dark"),
+      });
+
+      hasDarkStyles = true;
+    }
+
+    for (const target of targets) {
+      let cssPath = await compileSass(target.bundles);
+
+      // look for a sentinel 'dark' value, extract variables
+      cssPath = processCssIntoExtras(cssPath, extras);
+
+      // Find any imported stylesheets or url references
+      // (These could come from user scss that is merged into our theme, for example)
+      const css = Deno.readTextFileSync(cssPath);
+      const toDependencies = (paths: string[]) => {
+        return paths.map((path) => {
+          return {
+            name: path,
+            path: project ? join(project.dir, path) : path,
+            attribs: target.attribs,
+          };
+        });
+      };
+      const resources = toDependencies(cssResources(css));
+      const imports = toDependencies(cssImports(css));
+
+      // Push the compiled Css onto the dependency
+      const extraDeps = extras.html?.[kDependencies];
+
+      if (extraDeps) {
+        const existingDependency = extraDeps.find((extraDep) =>
+          extraDep.name === dependency
+        );
+
+        if (existingDependency) {
+          if (!existingDependency.stylesheets) {
+            existingDependency.stylesheets = [];
+          }
+          existingDependency.stylesheets.push({
+            name: target.name,
+            path: cssPath,
+            attribs: target.attribs,
+          });
+
+          // Add any css references
+          existingDependency.stylesheets.push(...imports);
+          existingDependency.resources?.push(...resources);
+        } else {
+          extraDeps.push({
+            name: dependency,
+            stylesheets: [{
+              name: target.name,
+              path: cssPath,
+              attribs: target.attribs,
+            }, ...imports],
+            resources,
+          });
+        }
+      }
+    }
+  }
+
+  // Resolve generated quarto css variables
+  extras = await resolveQuartoSyntaxHighlighting(
+    extras,
+    pandoc,
+    hasDarkStyles ? "light" : "default",
+  );
+
+  if (hasDarkStyles) {
+    // Provide dark variables for this
+    extras = await resolveQuartoSyntaxHighlighting(extras, pandoc, "dark");
+  }
+
+  // We'll take care of text highlighting for HTML
+  setTextHighlightStyle("none", extras);
+
+  return extras;
+}
+
+// Generates syntax highlighting Css and Css variables
+async function resolveQuartoSyntaxHighlighting(
+  extras: FormatExtras,
+  pandoc: FormatPandoc,
+  style: "dark" | "light" | "default",
+) {
+  extras = ld.cloneDeep(extras);
+
+  // If we're using default highlighting, use theme darkness to select highlight style
+  const mediaAttr = attribForThemeStyle(style);
+  if (style === "default") {
+    if (extras.html?.[kTextHighlightingMode] === "dark") {
+      style = "dark";
+    }
+  }
+
+  // Generate and inject the text highlighting css
+  const cssFileName = `quarto-syntax-highlighting${
+    style === "dark" ? "-dark" : ""
+  }.css`;
+
+  // Read the highlight style (theme name)
+  const theme = pandoc[kHighlightStyle] || kDefaultHighlightStyle;
+  if (theme) {
+    const themeRaw = readTheme(theme, style);
+    if (themeRaw) {
+      const themeJson = JSON.parse(themeRaw);
+
+      // Other variables that need to be injected (if any)
+      const extraVariables = extras.html?.[kQuartoCssVariables] || [];
+
+      // The text highlighting CSS variables
+      const highlightCss = generateThemeCssVars(themeJson);
+      if (highlightCss) {
+        const rules = [
+          highlightCss,
+          "",
+          "/* other quarto variables */",
+          ...extraVariables,
+        ];
+
+        // The text highlighting CSS rules
+        const textHighlightCssRules = generateThemeCssClasses(themeJson);
+        if (textHighlightCssRules) {
+          rules.push(...textHighlightCssRules);
+        }
+
+        // Compile the scss
+        const highlightCssPath = await compileSass([{
+          dependency: cssFileName,
+          key: cssFileName,
+          quarto: {
+            defaults: "",
+            functions: "",
+            mixins: "",
+            rules: rules.join("\n"),
+          },
+        }], false);
+
+        // Find the quarto-html dependency and inject this stylesheet
+        const extraDeps = extras.html?.[kDependencies];
+        if (extraDeps) {
+          const existingDependency = extraDeps.find((extraDep) =>
+            extraDep.name === kQuartoHtmlDependency
+          );
+          if (existingDependency) {
+            existingDependency.stylesheets = existingDependency.stylesheets ||
+              [];
+
+            existingDependency.stylesheets.push({
+              name: cssFileName,
+              path: highlightCssPath,
+              attribs: mediaAttr,
+            });
+          }
+        }
+      }
+    }
+  }
+  return extras;
+}
+
+// Generates CSS variables based upon the syntax highlighting rules in a theme file
+function generateThemeCssVars(
+  themeJson: Record<string, unknown>,
+) {
+  const textStyles = themeJson["text-styles"] as Record<
+    string,
+    Record<string, unknown>
+  >;
+  if (textStyles) {
+    const lines: string[] = [];
+    lines.push("/* quarto syntax highlight colors */");
+    lines.push(":root {");
+    Object.keys(textStyles).forEach((styleName) => {
+      const abbr = kAbbrevs[styleName];
+      if (abbr) {
+        const textValues = textStyles[styleName];
+        Object.keys(textValues).forEach((textAttr) => {
+          switch (textAttr) {
+            case "text-color":
+              lines.push(
+                `  --quarto-hl-${abbr}-color: ${textValues[textAttr] ||
+                  "inherit"};`,
+              );
+              break;
+          }
+        });
+      }
+    });
+    lines.push("}");
+    return lines.join("\n");
+  }
+  return undefined;
+}
+
+// Generates CSS rules based upon the syntax highlighting rules in a theme file
+function generateThemeCssClasses(
+  themeJson: Record<string, unknown>,
+) {
+  const textStyles = themeJson["text-styles"] as Record<
+    string,
+    Record<string, unknown>
+  >;
+  if (textStyles) {
+    const lines: string[] = [];
+
+    Object.keys(textStyles).forEach((styleName) => {
+      const abbr = kAbbrevs[styleName];
+      if (abbr !== undefined) {
+        const textValues = textStyles[styleName];
+        const cssValues = generateCssKeyValues(textValues);
+
+        if (abbr !== "") {
+          lines.push(`\ncode span.${abbr} {`);
+          lines.push(...cssValues);
+          lines.push("}\n");
+        } else {
+          ["code span", "div.sourceCode"].forEach((selector) => {
+            lines.push(`\n${selector} {`);
+            lines.push(...cssValues);
+            lines.push("}\n");
+          });
+        }
+      }
+    });
+    return lines;
+  }
+  return undefined;
+}
+
+// Processes CSS into format extras (scanning for variables and removing them)
+function processCssIntoExtras(cssPath: string, extras: FormatExtras) {
+  extras.html = extras.html || {};
+  const css = Deno.readTextFileSync(cssPath);
+
+  // Extract dark sentinel value
+  if (!extras.html[kTextHighlightingMode] && css.match(/\/\*! dark \*\//g)) {
+    setTextHighlightStyle("dark", extras);
+  }
+
+  // Extract variables
+  const matches = css.matchAll(kVariablesRegex);
+  if (matches) {
+    extras.html[kQuartoCssVariables] = extras.html[kQuartoCssVariables] || [];
+    let dirty = false;
+    for (const match of matches) {
+      const variables = match[1];
+      extras.html[kQuartoCssVariables]?.push(variables);
+      dirty = true;
+    }
+
+    if (dirty) {
+      const cleanedCss = css.replaceAll(kVariablesRegex, "");
+      const newCssPath = sessionTempFile({ suffix: ".css" });
+      Deno.writeTextFileSync(newCssPath, cleanedCss);
+      return newCssPath;
+    }
+  }
+  return cssPath;
+}
+const kVariablesRegex =
+  /\/\*\! quarto-variables-start \*\/([\S\s]*)\/\*\! quarto-variables-end \*\//g;
+
+// Generates key values for CSS text highlighing variables
+function generateCssKeyValues(textValues: Record<string, unknown>) {
+  const lines: string[] = [];
+  Object.keys(textValues).forEach((textAttr) => {
+    switch (textAttr) {
+      case "text-color":
+        lines.push(
+          `color: ${textValues[textAttr]};`,
+        );
+        break;
+      case "background":
+        lines.push(
+          `background-color: ${textValues[textAttr]};`,
+        );
+        break;
+
+      case "bold":
+        if (textValues[textAttr]) {
+          lines.push("font-weight: bold;");
+        }
+        break;
+      case "italic":
+        if (textValues[textAttr]) {
+          lines.push("font-style: italic;");
+        }
+        break;
+      case "underline":
+        if (textValues[textAttr]) {
+          lines.push("text-decoration: underline;");
+        }
+        break;
+    }
+  });
+  return lines;
+}
+
+// From  https://github.com/jgm/skylighting/blob/a1d02a0db6260c73aaf04aae2e6e18b569caacdc/skylighting-core/src/Skylighting/Format/HTML.hs#L117-L147
+const kAbbrevs: Record<string, string> = {
+  "Keyword": "kw",
+  "DataType": "dt",
+  "DecVal": "dv",
+  "BaseN": "bn",
+  "Float": "fl",
+  "Char": "ch",
+  "String": "st",
+  "Comment": "co",
+  "Other": "ot",
+  "Alert": "al",
+  "Function": "fu",
+  "RegionMarker": "re",
+  "Error": "er",
+  "Constant": "cn",
+  "SpecialChar": "sc",
+  "VerbatimString": "vs",
+  "SpecialString": "ss",
+  "Import": "im",
+  "Documentation": "do",
+  "Annotation": "an",
+  "CommentVar": "cv",
+  "Variable": "va",
+  "ControlFlow": "cf",
+  "Operator": "op",
+  "BuiltIn": "bu",
+  "Extension": "ex",
+  "Preprocessor": "pp",
+  "Attribute": "at",
+  "Information": "in",
+  "Warning": "wa",
+  "Normal": "",
+};
+
+// The media attribute for a style tag
+function attribForThemeStyle(
+  style: "dark" | "light" | "default",
+): Record<string, string> {
+  if (style === "dark") {
+    return { media: "(prefers-color-scheme: dark)" };
+  } else if (style === "light") {
+    return { media: "(prefers-color-scheme: light)" };
+  } else {
+    return {};
+  }
+}
+
+// Note the text highlight style in extras
+export function setTextHighlightStyle(
+  style: "light" | "dark" | "none",
+  extras: FormatExtras,
+) {
+  extras.html = extras.html || {};
+  extras.html[kTextHighlightingMode] = style;
+}
+
+// Reads the contents of a theme file, falling back if the style specific version isn't available
+export function readTheme(theme: string, style: "light" | "dark" | "default") {
+  const themeFile = textHighlightThemePath(
+    theme,
+    style === "default" ? undefined : style,
+  );
+  if (themeFile && existsSync(themeFile)) {
+    return Deno.readTextFileSync(themeFile);
+  } else {
+    return undefined;
+  }
+}

--- a/src/command/render/render.ts
+++ b/src/command/render/render.ts
@@ -861,7 +861,7 @@ async function resolveFormats(
 
     // resolve theme (project-level bootstrap theme always wins)
     if (project && formatHasBootstrap(projFormat)) {
-      if (formatHasBootstrap(inputFormat)) {
+      if (projFormat.metadata[kTheme] && formatHasBootstrap(inputFormat)) {
         delete inputFormat.metadata[kTheme];
       } else {
         delete projFormat.metadata[kTheme];

--- a/src/command/render/types.ts
+++ b/src/command/render/types.ts
@@ -17,6 +17,7 @@ import { Metadata } from "../../config/types.ts";
 import { ProjectContext } from "../../project/types.ts";
 
 export const kMarkdownBlockSeparator = "\n\n<!-- -->\n\n";
+export const kDefaultHighlightStyle = "arrow";
 
 // options for render
 export interface RenderOptions {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -164,7 +164,7 @@ export interface FormatExtras {
     [kSassBundles]?: SassBundle[];
     [kBodyEnvelope]?: BodyEnvelope;
     [kHtmlPostprocessors]?: Array<(doc: Document) => Promise<string[]>>;
-    [kTextHighlightingMode]?: "dark" | "light" | undefined;
+    [kTextHighlightingMode]?: "light" | "dark" | "none" | undefined;
     [kQuartoCssVariables]?: string[];
   };
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -139,6 +139,12 @@ export interface SassBundle {
   quarto?: SassLayer;
   framework?: SassLayer;
   loadPath?: string;
+  dark?: {
+    user?: SassLayer;
+    quarto?: SassLayer;
+    framework?: SassLayer;
+  };
+  attribs?: Record<string, string>;
 }
 
 export interface FormatExtras {

--- a/src/core/resources.ts
+++ b/src/core/resources.ts
@@ -5,7 +5,7 @@
 *
 */
 
-import { walkSync } from "fs/mod.ts";
+import { existsSync, walkSync } from "fs/mod.ts";
 import { join } from "path/mod.ts";
 import { quartoConfig } from "./quarto.ts";
 
@@ -55,4 +55,23 @@ export function rBinaryPath(binary: string): string {
 
 export function projectTypeResourcePath(projectType: string) {
   return resourcePath(join("projects", projectType));
+}
+
+const kDarkSuffix = "dark";
+const kLightSuffix = "light";
+
+export function textHighlightThemePath(
+  theme: string,
+  style?: "dark" | "light",
+) {
+  // First try the style specific version of the theme, otherwise
+  // fall back to the plain name
+  const names = [
+    `${theme}-${style === "dark" ? kDarkSuffix : kLightSuffix}`,
+    theme,
+  ];
+  const themePath = names.map((name) => {
+    return resourcePath(join("pandoc", "highlight-styles", `${name}.theme`));
+  }).find((path) => existsSync(path));
+  return themePath;
 }

--- a/src/format/html/format-html-bootstrap.ts
+++ b/src/format/html/format-html-bootstrap.ts
@@ -25,6 +25,7 @@ import {
   kDependencies,
   kHtmlPostprocessors,
   kSassBundles,
+  Metadata,
 } from "../../config/types.ts";
 import { isHtmlOutput } from "../../config/format.ts";
 import { PandocFlags } from "../../config/types.ts";
@@ -51,6 +52,34 @@ export function formatHasBootstrap(format: Format) {
   } else {
     return false;
   }
+}
+
+// Returns a boolean indicating whether dark mode is requested
+// (true or false) or undefined if the dark mode support isn't present
+// Key order determines whether dark mode is true or false
+export function formatDarkMode(format: Format): boolean | undefined {
+  const isBootstrap = formatHasBootstrap(format);
+  if (isBootstrap) {
+    return darkModeDefault(format.metadata);
+  }
+  return undefined;
+}
+
+function darkModeDefault(metadata?: Metadata): boolean | undefined {
+  if (metadata !== undefined) {
+    const theme = metadata[kTheme];
+    if (theme && typeof (theme) === "object") {
+      const keys = Object.keys(theme);
+      if (keys.includes("dark")) {
+        if (keys[0] === "dark") {
+          return true;
+        } else {
+          return false;
+        }
+      }
+    }
+  }
+  return undefined;
 }
 
 export function formatPageLayout(format: Format) {

--- a/src/format/html/format-html-bootstrap.ts
+++ b/src/format/html/format-html-bootstrap.ts
@@ -136,7 +136,7 @@ export function boostrapExtras(
       : undefined,
 
     html: {
-      [kSassBundles]: [resolveBootstrapScss(input, format.metadata)],
+      [kSassBundles]: resolveBootstrapScss(input, format.metadata),
       [kDependencies]: [bootstrapFormatDependency()],
       [kBodyEnvelope]: bodyEnvelope,
       [kHtmlPostprocessors]: [

--- a/src/format/html/format-html-scss.ts
+++ b/src/format/html/format-html-scss.ts
@@ -119,7 +119,7 @@ export function resolveBootstrapScss(
   // light
   sassBundles.push(
     layerQuartoScss(
-      "theme-light",
+      "quarto-theme",
       kBootstrapDependencyName,
       themeSassLayers.light,
       metadata,

--- a/src/format/html/format-html-scss.ts
+++ b/src/format/html/format-html-scss.ts
@@ -53,7 +53,7 @@ function layerQuartoScss(
   dependency: string,
   sassLayer: SassLayer,
   metadata: Metadata,
-  dark?: SassLayer,
+  darkLayer?: SassLayer,
 ): SassBundle {
   const bootstrapDistDir = formatResourcePath(
     "html",
@@ -93,9 +93,11 @@ function layerQuartoScss(
       rules: Deno.readTextFileSync(boostrapRules),
     },
     loadPath: dirname(boostrapRules),
-    dark: {
-      user: dark,
-    },
+    dark: darkLayer
+      ? {
+        user: darkLayer,
+      }
+      : undefined,
   };
 }
 

--- a/src/format/html/format-html.ts
+++ b/src/format/html/format-html.ts
@@ -233,10 +233,7 @@ function htmlFormatExtras(format: Format): FormatExtras {
     options.hoverFootnotes = format.metadata[kHoverFootnotes] || false;
   }
   options.codeTools = formatHasCodeTools(format);
-  const darkMode = formatDarkMode(format);
-  if (darkMode !== undefined) {
-    options.darkMode = darkMode;
-  }
+  options.darkMode = formatDarkMode(format);
 
   // quarto.js helpers
   scripts.push({

--- a/src/format/html/format-html.ts
+++ b/src/format/html/format-html.ts
@@ -40,7 +40,11 @@ import { formatHasCodeTools } from "../../command/render/codetools.ts";
 
 import { createHtmlFormat } from "./../formats-shared.ts";
 
-import { boostrapExtras, formatHasBootstrap } from "./format-html-bootstrap.ts";
+import {
+  boostrapExtras,
+  formatDarkMode,
+  formatHasBootstrap,
+} from "./format-html-bootstrap.ts";
 
 import {
   kAnchorSections,
@@ -229,6 +233,10 @@ function htmlFormatExtras(format: Format): FormatExtras {
     options.hoverFootnotes = format.metadata[kHoverFootnotes] || false;
   }
   options.codeTools = formatHasCodeTools(format);
+  const darkMode = formatDarkMode(format);
+  if (darkMode !== undefined) {
+    options.darkMode = darkMode;
+  }
 
   // quarto.js helpers
   scripts.push({

--- a/src/project/project-config.ts
+++ b/src/project/project-config.ts
@@ -39,6 +39,7 @@ export interface Navbar {
   collapse?: boolean;
   pinned?: boolean;
   [kCollapseBelow]?: LayoutBreak;
+  darkToggle?: boolean;
 }
 
 export interface NavbarItem {

--- a/src/project/types/website/website-navigation.ts
+++ b/src/project/types/website/website-navigation.ts
@@ -38,6 +38,7 @@ import {
 
 import { kBootstrapDependencyName } from "../../../format/html/format-html-shared.ts";
 import {
+  formatDarkMode,
   formatPageLayout,
 } from "../../../format/html/format-html-bootstrap.ts";
 
@@ -186,6 +187,12 @@ export function websiteNavigationExtras(
   // forward the footer
   if (navigation.footer) {
     nav.footer = navigation.footer;
+  }
+
+  // determine whether to show the dark toggle
+  const darkMode = formatDarkMode(format);
+  if (darkMode !== undefined && nav.navbar) {
+    (nav.navbar as Record<string, unknown>).darkToggle = true;
   }
 
   const projTemplate = (template: string) =>

--- a/src/project/types/website/website-navigation.ts
+++ b/src/project/types/website/website-navigation.ts
@@ -193,6 +193,8 @@ export function websiteNavigationExtras(
   const darkMode = formatDarkMode(format);
   if (darkMode !== undefined && nav.navbar) {
     (nav.navbar as Record<string, unknown>).darkToggle = true;
+  } else if (darkMode !== undefined && nav.sidebar) {
+    (nav.sidebar as Record<string, unknown>).darkToggle = true;
   }
 
   const projTemplate = (template: string) =>

--- a/src/resources/formats/html/_quarto-functions.scss
+++ b/src/resources/formats/html/_quarto-functions.scss
@@ -1,12 +1,22 @@
-
-@function colorToRGB ($color) {
-  @return "rgb(" + red($color) + ", " + green($color) + ", " + blue($color)+ ")";
+@function colorToRGB($color) {
+  @return "rgb(" + red($color) + ", " + green($color) + ", " + blue($color) +
+    ")";
 }
 
-@function str-replace($string, $search, $replace: '') {
+@function colorToRGBA($color) {
+  @return "rgba(" + red($color) + ", " + green($color) + ", " + blue($color) +
+    ", " + alpha($color) + ")";
+}
+
+@function str-replace($string, $search, $replace: "") {
   $index: str-index($string, $search);
   @if $index {
-    @return str-slice($string, 1, $index - 1) + $replace + str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
+    @return str-slice($string, 1, $index - 1) + $replace +
+      str-replace(
+        str-slice($string, $index + str-length($search)),
+        $search,
+        $replace
+      );
   }
   @return $string;
 }

--- a/src/resources/formats/html/_quarto-rules.scss
+++ b/src/resources/formats/html/_quarto-rules.scss
@@ -1,3 +1,11 @@
+// floating
+
+.top-right {
+  position: absolute;
+  top: 1em;
+  right: 1em;
+}
+
 // hidden
 
 .hidden {

--- a/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
@@ -625,6 +625,51 @@ $callouts: (
   }
 }
 
+// dark mode
+.navbar #quarto-color-scheme-toggle {
+  @include media-breakpoint-up(lg) {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+  @include media-breakpoint-down(med) {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+#quarto-color-scheme-toggle .bi::before {
+  display: inline-block;
+  height: 1rem;
+  width: 1rem;
+  content: "";
+  background-repeat: no-repeat;
+  background-size: 1rem 1rem;
+}
+
+.navbar-dark #quarto-color-scheme-toggle:not(.dark) .bi::before {
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#{colorToRGBA($navbar-dark-color)}" class="bi bi-toggle-off" viewBox="0 0 16 16"><path d="M11 4a4 4 0 0 1 0 8H8a4.992 4.992 0 0 0 2-4 4.992 4.992 0 0 0-2-4h3zm-6 8a4 4 0 1 1 0-8 4 4 0 0 1 0 8zM0 8a5 5 0 0 0 5 5h6a5 5 0 0 0 0-10H5a5 5 0 0 0-5 5z"/></svg>');
+}
+
+.navbar-dark #quarto-color-scheme-toggle.dark .bi::before {
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#{colorToRGBA($navbar-dark-color)}" class="bi bi-toggle-on" viewBox="0 0 16 16"><path d="M5 3a5 5 0 0 0 0 10h6a5 5 0 0 0 0-10H5zm6 9a4 4 0 1 1 0-8 4 4 0 0 1 0 8z"/></svg>');
+}
+
+.navbar-light #quarto-color-scheme-toggle:not(.dark) .bi::before {
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#{colorToRGBA($navbar-light-color)}" class="bi bi-toggle-off" viewBox="0 0 16 16"><path d="M11 4a4 4 0 0 1 0 8H8a4.992 4.992 0 0 0 2-4 4.992 4.992 0 0 0-2-4h3zm-6 8a4 4 0 1 1 0-8 4 4 0 0 1 0 8zM0 8a5 5 0 0 0 5 5h6a5 5 0 0 0 0-10H5a5 5 0 0 0-5 5z"/></svg>');
+}
+
+.navbar-light #quarto-color-scheme-toggle.dark .bi::before {
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#{colorToRGBA($navbar-light-color)}" class="bi bi-toggle-on" viewBox="0 0 16 16"><path d="M5 3a5 5 0 0 0 0 10h6a5 5 0 0 0 0-10H5zm6 9a4 4 0 1 1 0-8 4 4 0 0 1 0 8z"/></svg>');
+}
+
+.sidebar-navigation #quarto-color-scheme-toggle:not(.dark) .bi::before {
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-toggle-off" viewBox="0 0 16 16"><path d="M11 4a4 4 0 0 1 0 8H8a4.992 4.992 0 0 0 2-4 4.992 4.992 0 0 0-2-4h3zm-6 8a4 4 0 1 1 0-8 4 4 0 0 1 0 8zM0 8a5 5 0 0 0 5 5h6a5 5 0 0 0 0-10H5a5 5 0 0 0-5 5z"/></svg>');
+}
+
+.sidebar-navigation #quarto-color-scheme-toggle.dark .bi::before {
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-toggle-on" viewBox="0 0 16 16"><path d="M5 3a5 5 0 0 0 0 10h6a5 5 0 0 0 0-10H5zm6 9a4 4 0 1 1 0-8 4 4 0 0 1 0 8z"/></svg>');
+}
+
 // This is a sentinel value that renderers can use to determine
 // whether the theme is dark or light
 @if (color.blackness($body-bg) > $code-theme-dark-threshhold) {

--- a/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
@@ -646,6 +646,16 @@ $callouts: (
   background-size: 1rem 1rem;
 }
 
+.sidebar-navigation #quarto-color-scheme-toggle .bi::before {
+  padding-top: 0.1rem;
+  margin-bottom: -0.1rem;
+}
+
+.navbar #quarto-color-scheme-toggle .bi::before {
+  padding-top: 0.2rem;
+  margin-bottom: -0.2rem;
+}
+
 .navbar-dark #quarto-color-scheme-toggle:not(.dark) .bi::before {
   background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#{colorToRGBA($navbar-dark-color)}" class="bi bi-toggle-off" viewBox="0 0 16 16"><path d="M11 4a4 4 0 0 1 0 8H8a4.992 4.992 0 0 0 2-4 4.992 4.992 0 0 0-2-4h3zm-6 8a4 4 0 1 1 0-8 4 4 0 0 1 0 8zM0 8a5 5 0 0 0 5 5h6a5 5 0 0 0 0-10H5a5 5 0 0 0-5 5z"/></svg>');
 }
@@ -663,11 +673,11 @@ $callouts: (
 }
 
 .sidebar-navigation #quarto-color-scheme-toggle:not(.dark) .bi::before {
-  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-toggle-off" viewBox="0 0 16 16"><path d="M11 4a4 4 0 0 1 0 8H8a4.992 4.992 0 0 0 2-4 4.992 4.992 0 0 0-2-4h3zm-6 8a4 4 0 1 1 0-8 4 4 0 0 1 0 8zM0 8a5 5 0 0 0 5 5h6a5 5 0 0 0 0-10H5a5 5 0 0 0-5 5z"/></svg>');
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#{colorToRGBA(theme-dim($body-color, 10%))}" class="bi bi-toggle-off" viewBox="0 0 16 16"><path d="M11 4a4 4 0 0 1 0 8H8a4.992 4.992 0 0 0 2-4 4.992 4.992 0 0 0-2-4h3zm-6 8a4 4 0 1 1 0-8 4 4 0 0 1 0 8zM0 8a5 5 0 0 0 5 5h6a5 5 0 0 0 0-10H5a5 5 0 0 0-5 5z"/></svg>');
 }
 
 .sidebar-navigation #quarto-color-scheme-toggle.dark .bi::before {
-  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-toggle-on" viewBox="0 0 16 16"><path d="M5 3a5 5 0 0 0 0 10h6a5 5 0 0 0 0-10H5zm6 9a4 4 0 1 1 0-8 4 4 0 0 1 0 8z"/></svg>');
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#{colorToRGBA(theme-dim($body-color, 10%))}" class="bi bi-toggle-on" viewBox="0 0 16 16"><path d="M5 3a5 5 0 0 0 0 10h6a5 5 0 0 0 0-10H5zm6 9a4 4 0 1 1 0-8 4 4 0 0 1 0 8z"/></svg>');
 }
 
 // This is a sentinel value that renderers can use to determine

--- a/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
@@ -680,6 +680,14 @@ $callouts: (
   background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#{colorToRGBA(theme-dim($body-color, 10%))}" class="bi bi-toggle-on" viewBox="0 0 16 16"><path d="M5 3a5 5 0 0 0 0 10h6a5 5 0 0 0 0-10H5zm6 9a4 4 0 1 1 0-8 4 4 0 0 1 0 8z"/></svg>');
 }
 
+#quarto-color-scheme-toggle:not(.dark).top-right .bi::before {
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#{colorToRGBA(theme-dim($body-color, 35%))}" class="bi bi-toggle-off" viewBox="0 0 16 16"><path d="M11 4a4 4 0 0 1 0 8H8a4.992 4.992 0 0 0 2-4 4.992 4.992 0 0 0-2-4h3zm-6 8a4 4 0 1 1 0-8 4 4 0 0 1 0 8zM0 8a5 5 0 0 0 5 5h6a5 5 0 0 0 0-10H5a5 5 0 0 0-5 5z"/></svg>');
+}
+
+#quarto-color-scheme-toggle.dark.top-right .bi::before {
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#{colorToRGBA(theme-dim($body-color, 20%))}" class="bi bi-toggle-on" viewBox="0 0 16 16"><path d="M5 3a5 5 0 0 0 0 10h6a5 5 0 0 0 0-10H5zm6 9a4 4 0 1 1 0-8 4 4 0 0 1 0 8z"/></svg>');
+}
+
 // This is a sentinel value that renderers can use to determine
 // whether the theme is dark or light
 @if (color.blackness($body-bg) > $code-theme-dark-threshhold) {

--- a/src/resources/formats/html/templates/quarto-html.ejs.js
+++ b/src/resources/formats/html/templates/quarto-html.ejs.js
@@ -2,6 +2,71 @@
 
 window.document.addEventListener("DOMContentLoaded", function (event) {
 
+  <% if (darkMode !== undefined) { %> 
+
+  const disableEls = (els) => {
+    for (let i=0; i < els.length; i++) {
+      const el = els[i];
+      el.disabled = true;
+    }
+  }
+
+  const enableEls = (els) => {
+    for (let i=0; i < els.length; i++) {
+      const el = els[i];
+      el.removeAttribute("disabled");
+    }
+  }
+
+  const toggleColorMode = (dark) => {
+    const toggle = window.document.getElementById('quarto-color-scheme-toggle');
+    const lightEls = window.document.querySelectorAll('link.quarto-color-scheme.light');
+    const darkEls = window.document.querySelectorAll('link.quarto-color-scheme.dark');
+    if (dark) {
+      enableEls(darkEls);
+      disableEls(lightEls);
+      toggle.classList.remove("light");
+      toggle.classList.add("dark");     
+    } else {
+      enableEls(lightEls);
+      disableEls(darkEls);
+      toggle.classList.remove("dark");
+      toggle.classList.add("light");
+    }
+  }
+
+  const hasDarkSentinel = () => {
+    let darkSentinel = window.localStorage.getItem("quarto-color-scheme");
+    if (darkSentinel !== null) {
+      return darkSentinel === "dark";
+    } else {
+      return <%= darkMode %>;
+    }
+  }
+
+  const setDarkSentinel = (toDark) => {
+    if (toDark) {
+      window.localStorage.setItem("quarto-color-scheme", "dark");
+    } else { 
+      window.localStorage.setItem("quarto-color-scheme", "light");
+    }
+  }
+
+  // Switch to dark mode if need be
+  if (hasDarkSentinel()) {
+    toggleColorMode(true);
+  } 
+   
+  // Dark / light mode switch
+  window.quartoToggleColorScheme = () => {
+    // Read the current dark / light value 
+    let toDark = !hasDarkSentinel();
+    toggleColorMode(toDark);
+    setDarkSentinel(toDark);
+  };
+
+  <% } %>
+
   <% if (anchors) { %>
 
   const icon = "<%= anchors === true ? '' : anchors %>";

--- a/src/resources/formats/html/templates/quarto-html.ejs.js
+++ b/src/resources/formats/html/templates/quarto-html.ejs.js
@@ -18,20 +18,42 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
     }
   }
 
+  const manageTransitions = (selector, allowTransitions) => {
+    const els = window.document.querySelectorAll(selector);
+    for (let i=0; i < els.length; i++) {
+      const el = els[i];
+      if (allowTransitions) {
+        console.log("remove");
+        console.log(el);
+        el.classList.remove('notransition');
+      } else {
+                console.log("add");
+        console.log(el);
+
+        el.classList.add('notransition');
+      }
+    }
+  }
+
   const toggleColorMode = (dark) => {
     const toggle = window.document.getElementById('quarto-color-scheme-toggle');
-    const lightEls = window.document.querySelectorAll('link.quarto-color-scheme.light');
-    const darkEls = window.document.querySelectorAll('link.quarto-color-scheme.dark');
-    if (dark) {
-      enableEls(darkEls);
-      disableEls(lightEls);
-      toggle.classList.remove("light");
-      toggle.classList.add("dark");     
-    } else {
-      enableEls(lightEls);
-      disableEls(darkEls);
-      toggle.classList.remove("dark");
-      toggle.classList.add("light");
+    if (toggle) {
+      const lightEls = window.document.querySelectorAll('link.quarto-color-scheme.light');
+      const darkEls = window.document.querySelectorAll('link.quarto-color-scheme.dark');
+
+      manageTransitions('div.sidebar-toc .nav-link', false);
+      if (dark) {
+        enableEls(darkEls);
+        disableEls(lightEls);
+        toggle.classList.remove("light");
+        toggle.classList.add("dark");     
+      } else {
+        enableEls(lightEls);
+        disableEls(darkEls);
+        toggle.classList.remove("dark");
+        toggle.classList.add("light");
+      }
+      manageTransitions('.quarto-toc-sidebar .nav-link', true);
     }
   }
 

--- a/src/resources/formats/html/templates/quarto-html.ejs.js
+++ b/src/resources/formats/html/templates/quarto-html.ejs.js
@@ -52,8 +52,12 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
     }
   }
 
-  const hasDarkSentinel = () => {
-    let darkSentinel = window.localStorage.getItem("quarto-color-scheme");
+  const isFileUrl = () => { 
+    return window.location.protocol === 'file:';
+  }
+
+  const hasDarkSentinel = () => {  
+    let darkSentinel = getDarkSentinel();
     if (darkSentinel !== null) {
       return darkSentinel === "dark";
     } else {
@@ -62,18 +66,23 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
   }
 
   const setDarkSentinel = (toDark) => {
-    if (toDark) {
-      window.localStorage.setItem("quarto-color-scheme", "dark");
-    } else { 
-      window.localStorage.setItem("quarto-color-scheme", "light");
+    const value = toDark ? "dark" : "light";
+    if (!isFileUrl()) {
+      window.localStorage.setItem("quarto-color-scheme", value);
+    } else {
+      localDarkSentinel = value;
     }
   }
 
-  // Switch to dark mode if need be
-  if (hasDarkSentinel()) {
-    toggleColorMode(true);
-  } 
-   
+  const getDarkSentinel = () => {
+    if (!isFileUrl()) {
+      return window.localStorage.getItem("quarto-color-scheme");
+    } else {
+      return localDarkSentinel;
+    }
+  }
+  let localDarkSentinel = null;
+  
   // Dark / light mode switch
   window.quartoToggleColorScheme = () => {
     // Read the current dark / light value 
@@ -81,6 +90,27 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
     toggleColorMode(toDark);
     setDarkSentinel(toDark);
   };
+
+  // Ensure there is a toggle, if there isn't float one in the top right
+  if (window.document.getElementById('quarto-color-scheme-toggle') === null) {
+    const a = window.document.createElement('a');
+    a.id = "quarto-color-scheme-toggle";
+    a.classList.add('top-right');
+    a.href = "";
+    a.onclick = function() { window.quartoToggleColorScheme(); return false; };
+
+    const i = window.document.createElement("i");
+    i.classList.add('bi');
+    a.appendChild(i);
+
+    window.document.body.appendChild(a);
+  }
+
+  // Switch to dark mode if need be
+  if (hasDarkSentinel()) {
+    toggleColorMode(true);
+  } 
+  
 
   <% } %>
 

--- a/src/resources/formats/html/templates/quarto-html.ejs.js
+++ b/src/resources/formats/html/templates/quarto-html.ejs.js
@@ -23,13 +23,8 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
     for (let i=0; i < els.length; i++) {
       const el = els[i];
       if (allowTransitions) {
-        console.log("remove");
-        console.log(el);
         el.classList.remove('notransition');
       } else {
-                console.log("add");
-        console.log(el);
-
         el.classList.add('notransition');
       }
     }

--- a/src/resources/pandoc/highlight-styles/arrow-light.theme
+++ b/src/resources/pandoc/highlight-styles/arrow-light.theme
@@ -4,6 +4,9 @@
     "line-number-color": "#aaaaaa",
     "line-number-background-color": null,
     "text-styles": {
+        "Normal": {
+            "text-color": "#007BA5"
+        },
         "Other": {
             "text-color": "#007BA5",
             "background-color": null,

--- a/src/resources/projects/website/templates/nav-before-body.ejs
+++ b/src/resources/projects/website/templates/nav-before-body.ejs
@@ -22,6 +22,9 @@
       <% partial('navcollapse.ejs') %>
         <% partial('navitems.ejs', { align: 'start', items: nav.navbar.left}) %>
         <% partial('navitems.ejs', { align: 'end', items: nav.navbar.right }) %>
+        <% if (nav.navbar.darkToggle) { %>
+          <% partial('navdarktoggle.ejs', { classes: 'nav-link' }) %>
+        <% } %>    
         <% if (nav.navbar.search) { %>
           <% partial('navsearch.ejs', { search: nav.navbar.search }) %>
         <% } %>
@@ -29,11 +32,17 @@
     <% } else { %>
       <% partial('navitems.ejs', { align: 'start', items: nav.navbar.left}) %>
       <% partial('navitems.ejs', { align: 'end', items: nav.navbar.right }) %>
+      <% if (nav.navbar.darkToggle) { %>
+        <% partial('navdarktoggle.ejs', { classes: 'nav-link' }) %>
+      <% } %>    
       <% if (nav.navbar.search) { %>
         <% partial('navsearch.ejs', { search: nav.navbar.search }) %>
       <% } %>
     <% } %> 
   <% } else { %>
+    <% if (nav.navbar.darkToggle) { %>
+      <% partial('navdarktoggle.ejs', { classes: 'nav-link' }) %>
+    <% } %>    
     <% if (nav.navbar.search) { %>
       <% partial('navsearch.ejs', { search: nav.navbar.search }) %>
     <% } %>

--- a/src/resources/projects/website/templates/nav-before-body.ejs
+++ b/src/resources/projects/website/templates/nav-before-body.ejs
@@ -23,7 +23,9 @@
         <% partial('navitems.ejs', { align: 'start', items: nav.navbar.left}) %>
         <% partial('navitems.ejs', { align: 'end', items: nav.navbar.right }) %>
         <% if (nav.navbar.darkToggle) { %>
-          <% partial('navdarktoggle.ejs', { classes: 'nav-link' }) %>
+          <div>
+            <% partial('navdarktoggle.ejs', { classes: 'nav-link' }) %>
+          </div>
         <% } %>    
         <% if (nav.navbar.search) { %>
           <% partial('navsearch.ejs', { search: nav.navbar.search }) %>
@@ -33,7 +35,9 @@
       <% partial('navitems.ejs', { align: 'start', items: nav.navbar.left}) %>
       <% partial('navitems.ejs', { align: 'end', items: nav.navbar.right }) %>
       <% if (nav.navbar.darkToggle) { %>
+        <div>
         <% partial('navdarktoggle.ejs', { classes: 'nav-link' }) %>
+        </div>
       <% } %>    
       <% if (nav.navbar.search) { %>
         <% partial('navsearch.ejs', { search: nav.navbar.search }) %>
@@ -41,7 +45,9 @@
     <% } %> 
   <% } else { %>
     <% if (nav.navbar.darkToggle) { %>
-      <% partial('navdarktoggle.ejs', { classes: 'nav-link' }) %>
+      <div>
+        <% partial('navdarktoggle.ejs', { classes: 'nav-link' }) %>
+      </div>
     <% } %>    
     <% if (nav.navbar.search) { %>
       <% partial('navsearch.ejs', { search: nav.navbar.search }) %>

--- a/src/resources/projects/website/templates/navdarktoggle.ejs
+++ b/src/resources/projects/website/templates/navdarktoggle.ejs
@@ -1,3 +1,1 @@
-<div class="pt-2">
-  <a href="" class="<%= classes %>" id="quarto-color-scheme-toggle" onclick="window.quartoToggleColorScheme(); return false;"><i class="bi"></i></a>
-</div>
+<a href="" class="<%= classes %>" id="quarto-color-scheme-toggle" onclick="window.quartoToggleColorScheme(); return false;"><i class="bi"></i></a>

--- a/src/resources/projects/website/templates/navdarktoggle.ejs
+++ b/src/resources/projects/website/templates/navdarktoggle.ejs
@@ -1,0 +1,3 @@
+<div class="pt-2">
+  <a href="" class="<%= classes %>" id="quarto-color-scheme-toggle" onclick="window.quartoToggleColorScheme(); return false;"><i class="bi"></i></a>
+</div>

--- a/src/resources/projects/website/templates/sidebar.ejs
+++ b/src/resources/projects/website/templates/sidebar.ejs
@@ -19,8 +19,8 @@ if (sidebar.align === "center") {
     <% if (sidebar.logo) { %>
     <img src="<%- sidebar.logo %>" alt="" class="sidebar-logo py-0 d-lg-inline d-none"/>
      <% if (sidebar.tools && !sidebar.title) { %>
-      <% partial('sidebartools.ejs', { tools: sidebar.tools, className: 'sidebar-tools-main' })%>
-     <% } %>
+      <% partial('sidebartools.ejs', { tools: sidebar.tools, className: 'sidebar-tools-main', darkToggle: sidebar.darkToggle })%>
+     <% } %> 
     <% } %>
     
     <% if (sidebar.title) { %>
@@ -29,8 +29,8 @@ if (sidebar.align === "center") {
       <%- sidebar.title %>
       </a>
       <% if (sidebar.tools) { %>
-        <% partial('sidebartools.ejs', { tools: sidebar.tools, className: 'sidebar-tools-main' })%>
-      <% } %>
+        <% partial('sidebartools.ejs', { tools: sidebar.tools, className: 'sidebar-tools-main', darkToggle: sidebar.darkToggle })%>
+      <% } %>  
     </div>
 
     <% } %>
@@ -42,7 +42,7 @@ if (sidebar.align === "center") {
       <% partial('navsearch.ejs', { search: sidebar.search }) %>
       </div>
       <% if (sidebar.tools) { %>
-        <% partial('sidebartools.ejs', { tools: sidebar.tools, className: 'sidebar-tools-collapse' })%>
+        <% partial('sidebartools.ejs', { tools: sidebar.tools, className: 'sidebar-tools-collapse', darkToggle: sidebar.darkToggle })%>
       <% } %>
     </div>
   <% } %>

--- a/src/resources/projects/website/templates/sidebartools.ejs
+++ b/src/resources/projects/website/templates/sidebartools.ejs
@@ -25,4 +25,7 @@
     <a href="<%- tool.href %>" title="<%- tool.text %>" class="sidebar-tool px-1"><i class="bi bi-<%- tool.icon %>"></i></a>
   <% } %>
 <% }) %>
+<% if (darkToggle) { %>
+  <% partial('navdarktoggle.ejs', { classes: '' }) %>
+<% } %>    
 </div>


### PR DESCRIPTION
Implements support for basic dark mode. Dark mode correctly selects the theme and text highlighting style for css based upon the system expressed dark or light mode setting. Follow on commits / PRs will implement a user controllable switch.

Usage:

```
theme: yeti
```

or

```
theme:
  light: cosmo
  dark: darkly
```

or 

```
theme:
  light: 
    - cosmo
    - theme-custom.scss
  dark: 
    - darkly
    - theme-custom.scss
```


Sample examples of the toggle that appears:

### Navbar

| ![Screen Shot 2021-07-07 at 8 28 02 PM](https://user-images.githubusercontent.com/261654/124844355-0fcfd580-df62-11eb-83ab-4b59ad3ba5d3.png)  |  ![Screen Shot 2021-07-07 at 8 28 07 PM](https://user-images.githubusercontent.com/261654/124844358-11999900-df62-11eb-906c-2ea15a56e250.png)  |
|---|---|

### Sidebar

| ![Screen Shot 2021-07-07 at 8 27 23 PM](https://user-images.githubusercontent.com/261654/124844368-165e4d00-df62-11eb-8217-7c46248142ff.png)  |  ![Screen Shot 2021-07-07 at 8 28 16 PM](https://user-images.githubusercontent.com/261654/124844370-178f7a00-df62-11eb-85f2-c6cd4c681fd6.png)  |
|---|---|





### Document
(The document toggle appears when the website or author doesn't provide a toggle)

| ![Screen Shot 2021-07-07 at 8 31 03 PM](https://user-images.githubusercontent.com/261654/124844464-545b7100-df62-11eb-976c-00a66e6d3f15.png)  |  ![Screen Shot 2021-07-07 at 8 31 10 PM](https://user-images.githubusercontent.com/261654/124844466-56bdcb00-df62-11eb-8b74-cd272763ed5f.png) |
|---|---|







