### PR TITLE
Remove parenthesis for revealjs slideNumber option

### DIFF
--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -46,7 +46,7 @@ function revealHtmlPostprocessor() {
         // quote slideNumber
         scriptEl.innerText = scriptEl.innerText.replace(
           /slideNumber: (h[\.\/]v|c(?:\/t)?)/,
-          "slideNumber: '($1)'",
+          "slideNumber: '$1'",
         );
       }
     }


### PR DESCRIPTION
slideNumber in revealjs can be boolean or string. 

Quarto, like rmarkdown, does a special handling of this option. However, there should not be some parenthesis I think (https://revealjs.com/slide-numbers/) 

This fix #62

Tested with `configure-windows.cmd` then rendering an example 
````markdown
---
title: test
format: 
  revealjs:
    slideNumber: 'c/t'
---

## slide 1

## Slide 2
````