### PR TITLE
use dash (-) rather than dot (.) to delimit fig/layout/code chunk options

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -26,7 +26,6 @@ export const kOutput = "output";
 export const kWarning = "warning";
 export const kError = "error";
 export const kInclude = "include";
-export const kFold = "fold";
 
 export const kResources = "resources";
 
@@ -302,30 +301,28 @@ export const kRawMimeType = "raw_mimetype";
 
 export const kCellId = "id";
 export const kCellLabel = "label";
-export const kCellFigCap = "fig.cap";
-export const kCellFigSubCap = "fig.subcap";
-export const kCellFigScap = "fig.scap";
-export const kCellFigLink = "fig.link";
-export const kCellFigAlign = "fig.align";
-export const kCellFigEnv = "fig.env";
-export const kCellFigPos = "fig.pos";
-export const kCellFigAlt = "fig.alt";
-export const kCellLstLabel = "lst.label";
-export const kCellLstCap = "lst.cap";
+export const kCellFigCap = "fig-cap";
+export const kCellFigSubCap = "fig-subcap";
+export const kCellFigScap = "fig-scap";
+export const kCellFigLink = "fig-link";
+export const kCellFigAlign = "fig-align";
+export const kCellFigEnv = "fig-env";
+export const kCellFigPos = "fig-pos";
+export const kCellFigAlt = "fig-alt";
+export const kCellLstLabel = "lst-label";
+export const kCellLstCap = "lst-cap";
 export const kCellClasses = "classes";
 export const kCellPanel = "panel";
-export const kCellOutWidth = "out.width";
-export const kCellOutHeight = "out.height";
-export const kCellFold = "fold";
-export const kCellSummary = "summary";
-export const kCellMdIndent = "md_indent";
+export const kCellOutWidth = "out-width";
+export const kCellOutHeight = "out-height";
+export const kCellMdIndent = "md-indent";
 
 export const kCellColab = "colab";
 export const kCellColabType = "colab_type";
 export const kCellColbOutputId = "outputId";
 
-export const kLayoutAlign = "layout.align";
-export const kLayoutVAlign = "layout.valign";
-export const kLayoutNcol = "layout.ncol";
-export const kLayoutNrow = "layout.nrow";
+export const kLayoutAlign = "layout-align";
+export const kLayoutVAlign = "layout-valign";
+export const kLayoutNcol = "layout-ncol";
+export const kLayoutNrow = "layout-nrow";
 export const kLayout = "layout";

--- a/src/core/jupyter/jupyter.ts
+++ b/src/core/jupyter/jupyter.ts
@@ -84,7 +84,6 @@ import {
   kCellFigPos,
   kCellFigScap,
   kCellFigSubCap,
-  kCellFold,
   kCellFormat,
   kCellId,
   kCellLabel,
@@ -96,8 +95,9 @@ import {
   kCellOutHeight,
   kCellOutWidth,
   kCellPanel,
-  kCellSummary,
   kCellTags,
+  kCodeFold,
+  kCodeSummary,
   kEcho,
   kError,
   kEval,
@@ -193,8 +193,8 @@ export interface JupyterCellOptions extends JupyterOutputFigureOptions {
   [kCellLstCap]?: string;
   [kCellClasses]?: string;
   [kCellPanel]?: string;
-  [kCellFold]?: string;
-  [kCellSummary]?: string;
+  [kCodeFold]?: string;
+  [kCodeSummary]?: string;
   [kCellMdIndent]?: string;
   [kEval]?: true | false | null;
   [kEcho]?: boolean;
@@ -224,8 +224,6 @@ export const kJupyterCellInternalOptionKeys = [
   kCellLabel,
   kCellClasses,
   kCellPanel,
-  kCellFold,
-  kCellSummary,
   kCellFigCap,
   kCellFigSubCap,
   kCellFigScap,
@@ -239,6 +237,8 @@ export const kJupyterCellInternalOptionKeys = [
   kCellOutWidth,
   kCellOutHeight,
   kCellMdIndent,
+  kCodeFold,
+  kCodeSummary,
 ];
 
 export const kJupyterCellOptionKeys = kJupyterCellInternalOptionKeys.concat([
@@ -970,11 +970,11 @@ function mdFromCodeCell(
     if (typeof cell.options[kCellLstCap] === "string") {
       md.push(` caption=\"${cell.options[kCellLstCap]}\"`);
     }
-    if (typeof cell.options[kCellFold] !== "undefined") {
-      md.push(` fold=\"${cell.options[kCellFold]}\"`);
+    if (typeof cell.options[kCodeFold] !== "undefined") {
+      md.push(` code-fold=\"${cell.options[kCodeFold]}\"`);
     }
-    if (typeof cell.options[kCellSummary] !== "undefined") {
-      md.push(` summary=\"${cell.options[kCellSummary]}\"`);
+    if (typeof cell.options[kCodeSummary] !== "undefined") {
+      md.push(` code-summary=\"${cell.options[kCodeSummary]}\"`);
     }
     md.push("}\n");
     md.push(...mdTrimEmptyLines(cell.source), "\n");
@@ -1031,12 +1031,12 @@ function mdFromCodeCell(
       const figureOptions: JupyterOutputFigureOptions = {};
       const broadcastFigureOption = (
         name:
-          | "fig.align"
-          | "fig.link"
-          | "fig.env"
-          | "fig.pos"
-          | "fig.scap"
-          | "fig.alt",
+          | "fig-align"
+          | "fig-link"
+          | "fig-env"
+          | "fig-pos"
+          | "fig-scap"
+          | "fig-alt",
       ) => {
         const value = cell.options[name];
         if (value) {

--- a/src/execute/ojs/compile.ts
+++ b/src/execute/ojs/compile.ts
@@ -13,6 +13,16 @@ import { parseModule } from "observablehq/parser";
 import { Format, kDependencies } from "../../config/types.ts";
 import { ExecuteResult, PandocIncludes } from "../../execute/types.ts";
 import {
+  kCellClasses,
+  kCellFigAlign,
+  kCellFigAlt,
+  kCellFigEnv,
+  kCellFigLink,
+  kCellFigPos,
+  kCellFigScap,
+  kCellLabel,
+  kCellPanel,
+  kCodeSummary,
   kIncludeAfterBody,
   kIncludeInHeader,
   kSelfContained,
@@ -42,7 +52,6 @@ import {
   kEcho,
   kError,
   kEval,
-  kFold,
   kInclude,
   kKeepHidden,
   kLayoutNcol,
@@ -207,7 +216,7 @@ export async function ojsCompile(
       };
       const hasFigureSubCaptions = () => {
         // FIXME figure out runtime type validation. This should check
-        // if fig.subcap is an array of strings.
+        // if fig-subcap is an array of strings.
         //
         // WAITING for YAML schemas + validation
         return cell.options?.[kCellFigSubCap];
@@ -285,29 +294,28 @@ export async function ojsCompile(
       };
 
       const keysToSkip = new Set([
-        "echo",
-        "label",
-        "fig.cap",
-        "fig.subcap",
-        "fig.scap",
-        "fig.link",
-        "fig.align",
-        "fig.env",
-        "fig.pos",
-        "fig.num",
-        "fig.alt", // FIXME see if it's possible to do this right wrt accessibility
-        "output",
+        kEcho,
+        kCellLabel,
+        kCellFigCap,
+        kCellFigSubCap,
+        kCellFigScap,
+        kCellFigLink,
+        kCellFigAlign,
+        kCellFigEnv,
+        kCellFigPos,
+        kCellFigAlt, // FIXME see if it's possible to do this right wrt accessibility
+        kOutput,
+        kCellLstCap,
+        kCellLstLabel,
+        kCodeFold,
+        kCodeSummary,
+        kCellClasses,
+        kCellPanel,
         "include.hidden",
         "source.hidden",
         "plot.hidden",
         "output.hidden",
         "echo.hidden",
-        "lst.cap",
-        "lst.label",
-        "fold",
-        "summary",
-        "classes",
-        "panel",
       ]);
 
       for (const [key, value] of Object.entries(cell.options || {})) {
@@ -379,9 +387,9 @@ export async function ojsCompile(
         // for "not set", so we interpret "none" as undefined
         if (
           asUndefined(options.format.render?.[kCodeFold], "none") ??
-            cell.options?.[kFold]
+            cell.options?.[kCodeFold]
         ) {
-          attrs.push('fold="true"');
+          attrs.push(`${kCodeFold}="true"`);
         }
 
         const innerDiv = pandocCode({ classes, attrs });

--- a/src/project/types/project-default.ts
+++ b/src/project/types/project-default.ts
@@ -63,8 +63,8 @@ See @fig-polar for an example of rendering plots as figures:
 
 \`\`\`{python}
 #| label: fig-polar
-#| fig.cap: "A line plot on a polar axis"
-#| fold: true
+#| fig-cap: "A line plot on a polar axis"
+#| code-fold: true
 
 import numpy as np
 import matplotlib.pyplot as plt

--- a/src/resources/filters/common/figures.lua
+++ b/src/resources/filters/common/figures.lua
@@ -2,12 +2,12 @@
 -- Copyright (C) 2020 by RStudio, PBC
 
 -- constants for figure attributes
-kFigAlign = "fig.align"
-kFigEnv = "fig.env"
-kFigAlt = "fig.alt"
-kFigPos = "fig.pos"
-kFigCap = "fig.cap"
-kFigScap = "fig.scap"
+kFigAlign = "fig-align"
+kFigEnv = "fig-env"
+kFigAlt = "fig-alt"
+kFigPos = "fig-pos"
+kFigCap = "fig-cap"
+kFigScap = "fig-scap"
 kResizeWidth = "resize.width"
 kResizeHeight = "resize.height"
 
@@ -18,7 +18,7 @@ end
 
 function figAlignAttribute(el)
   local default = pandoc.utils.stringify(
-    param("fig-align", pandoc.Str("default"))
+    param(kFigAlign, pandoc.Str("default"))
   )
   local align = attribute(el, kFigAlign, default)
   if align == "default" then

--- a/src/resources/filters/common/layout.lua
+++ b/src/resources/filters/common/layout.lua
@@ -1,10 +1,10 @@
 -- layout.lua
 -- Copyright (C) 2020 by RStudio, PBC
 
-kLayoutAlign = "layout.align"
-kLayoutVAlign = "layout.valign"
-kLayoutNcol = "layout.ncol"
-kLayoutNrow = "layout.nrow"
+kLayoutAlign = "layout-align"
+kLayoutVAlign = "layout-valign"
+kLayoutNcol = "layout-ncol"
+kLayoutNrow = "layout-nrow"
 kLayout = "layout"
 
 

--- a/src/resources/filters/crossref/listings.lua
+++ b/src/resources/filters/crossref/listings.lua
@@ -2,7 +2,7 @@
 -- Copyright (C) 2020 by RStudio, PBC
 
 -- constants for list attributes
-kLstCap = "lst.cap"
+kLstCap = "lst-cap"
 
 -- process all listings
 function listings()

--- a/src/resources/filters/layout/figures.lua
+++ b/src/resources/filters/layout/figures.lua
@@ -1,7 +1,7 @@
 -- figures.lua
 -- Copyright (C) 2020 by RStudio, PBC
 
--- extended figure features including fig.align, fig.env, etc.
+-- extended figure features including fig-align, fig-env, etc.
 function extendedFigures() 
   return {
     

--- a/src/resources/filters/quarto-post/foldcode.lua
+++ b/src/resources/filters/quarto-post/foldcode.lua
@@ -9,8 +9,8 @@ function foldCode()
           local fold = foldAttribute(block)
           local summary = summaryAttribute(block)
           if fold ~= nil or summary ~= nil then
-            block.attr.attributes["fold"] = nil
-            block.attr.attributes["summary"] = nil
+            block.attr.attributes["code-fold"] = nil
+            block.attr.attributes["code-summary"] = nil
             if fold ~= "none" then 
               local blocks = pandoc.List:new()
               postState.codeFoldingCss = true
@@ -44,7 +44,7 @@ function foldAttribute(el)
   else
     default = "none"
   end
-  local fold = attribute(el, "fold", default)
+  local fold = attribute(el, "code-fold", default)
   if fold == true or fold == "true" or fold == "1" then
     return "hide"
   elseif fold == nil or fold == false or fold == "false" or fold == "0" then
@@ -61,7 +61,7 @@ function summaryAttribute(el)
   else
     default = "Code"
   end
-  return attribute(el, "summary", default)
+  return attribute(el, "code-summary", default)
 end
 
 

--- a/src/resources/filters/quarto-pre/figures.lua
+++ b/src/resources/filters/quarto-pre/figures.lua
@@ -8,7 +8,7 @@ function figures()
    
     Div = function(el)
       
-      -- propagate fig.cap on figure div to figure caption 
+      -- propagate fig-cap on figure div to figure caption 
       if hasFigureRef(el) then
         local figCap = attribute(el, kFigCap, nil)
         if figCap ~= nil then
@@ -38,14 +38,14 @@ function figures()
       
     end,
 
-    -- propagate fig.alt
+    -- propagate fig-alt
     Image = function(image)
       if isHtmlOutput() then
-        -- read the fig.alt text and set the image alt
+        -- read the fig-alt text and set the image alt
         local altText = attribute(image, kFigAlt, nil);
         if altText ~= nil then
           image.attr.attributes["alt"] = altText
-          image.attr.attributes["fig.alt"] = nil
+          image.attr.attributes[kFigAlt] = nil
           return image
         end
       else 

--- a/src/resources/formats/html/_quarto-rules.scss
+++ b/src/resources/formats/html/_quarto-rules.scss
@@ -169,7 +169,7 @@ details[show] {
   margin-bottom: 0;
 }
 
-.cell > details > summary {
+details > summary {
   color: $text-muted;
 }
 

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -112,7 +112,7 @@ knitr_hooks <- function(format, resourceDir) {
     # read some options
     label <- output_label(options)
     fig.cap <- options[["fig.cap"]]
-    tbl.cap <- options[["tbl.cap"]]
+    tbl.cap <- options[["tbl-cap"]]
     cell.cap <- NULL
     fig.subcap = options[["fig.subcap"]]
     
@@ -173,25 +173,25 @@ knitr_hooks <- function(format, resourceDir) {
       }
       options[["layout"]] <- fig.layout
       
-    # populate layout.ncol from fig.ncol
+    # populate layout-ncol from fig.ncol
     } else if (!is.null(fig.ncol)) {
-      options[["layout.ncol"]] = fig.ncol
+      options[["layout-ncol"]] = fig.ncol
     }
     
-    # alias fig.align to layout.align
+    # alias fig.align to layout-align
     fig.align = options[["fig.align"]]
     if (!is.null(fig.align) && !identical(fig.align, "default")) {
-      options["layout.align"] = fig.align
+      options["layout-align"] = fig.align
     }
 
-    # alias fig.valign to layout.valign
+    # alias fig.valign to layout-valign
     fig.valign = options[["fig.valign"]]
     if (!is.null(fig.valign) && !identical(fig.valign, "default")) {
-      options["layout.valign"] = fig.valign
+      options["layout-valign"] = fig.valign
     }
 
     # forward selected attributes
-    forward <- c("layout", "layout.nrow", "layout.ncol", "layout.align")
+    forward <- c("layout", "layout-nrow", "layout-ncol", "layout-align")
     forwardAttr <- character()
     for (attr in forward) {
       value = options[[attr]]
@@ -210,9 +210,9 @@ knitr_hooks <- function(format, resourceDir) {
     # forward any other unknown attributes
     knitr_default_opts <- names(knitr::opts_chunk$get())
     quarto_opts <- c("label","fig.cap","fig.subcap","fig.scap","fig.link", "fig.alt",
-                     "fig.align","fig.env","fig.pos","fig.num", "lst.cap", 
-                     "lst.label", "layout.align", "layout.valign", "classes", "panel", "fold", "summary",
-                     "layout", "layout.nrow", "layout.ncol", "layout.align",
+                     "fig.align","fig.env","fig.pos","fig.num", "lst-cap", 
+                     "lst-label", "classes", "panel", "code-fold", "code-summary",
+                     "layout", "layout-nrow", "layout-ncol", "layout-align", "layout-valign", 
                      "output", "include.hidden", "source.hidden", "plot.hidden", "output.hidden")
     other_opts <- c("eval", "out.width", "code", "params.src", 
                     "out.width.px", "out.height.px", "indent")
@@ -260,20 +260,20 @@ knitr_hooks <- function(format, resourceDir) {
       class <- paste(class, "hidden")
     }
     if (!identical(format$metadata[["crossref"]], FALSE)) {
-      id <- options[["lst.label"]]
-      if (!is.null(options[["lst.cap"]])) {
-        attr <- paste(attr, paste0('caption="', options[["lst.cap"]], '"'))
+      id <- options[["lst-label"]]
+      if (!is.null(options[["lst-cap"]])) {
+        attr <- paste(attr, paste0('caption="', options[["lst-cap"]], '"'))
       }
     } else {
       id = NULL
     }
-    fold <- options[["fold"]]
+    fold <- options[["code-fold"]]
     if (!is.null(fold)) {
-      attr <- paste(attr, paste0('fold="', tolower(as.character(fold)), '"'))
+      attr <- paste(attr, paste0('code-fold="', tolower(as.character(fold)), '"'))
     }
-    fold <- options[["summary"]]
+    fold <- options[["code-summary"]]
     if (!is.null(fold)) {
-      attr <- paste(attr, paste0('summary="', as.character(fold), '"'))
+      attr <- paste(attr, paste0('code-summary="', as.character(fold), '"'))
     }
     attrs <- block_attr(
       id = id,
@@ -339,23 +339,23 @@ knitr_plot_hook <- function(htmlOutput) {
     keyvalue <- c()
     fig.align <- options[['fig.align']]
     if (!identical(fig.align, "default")) {
-      keyvalue <- c(keyvalue, sprintf("fig.align='%s'", fig.align))
+      keyvalue <- c(keyvalue, sprintf("fig-align='%s'", fig.align))
     }
     fig.env <- options[['fig.env']]
     if (!identical(fig.env, "figure")) {
-      keyvalue <- c(keyvalue, sprintf("fig.env='%s'", fig.env))
+      keyvalue <- c(keyvalue, sprintf("fig-env='%s'", fig.env))
     }
     fig.pos <- options[['fig.pos']]
     if (nzchar(fig.pos)) {
-      keyvalue <- c(keyvalue, sprintf("fig.pos='%s'", fig.pos))
+      keyvalue <- c(keyvalue, sprintf("fig-pos='%s'", fig.pos))
     }
     fig.alt <- options[["fig.alt"]]
     if (!is.null(fig.alt) && nzchar(fig.alt)) {
-       keyvalue <- c(keyvalue, sprintf("fig.alt='%s'", fig.alt))
+       keyvalue <- c(keyvalue, sprintf("fig-alt='%s'", fig.alt))
     }
     fig.scap <- options[['fig.scap']]
     if (!is.null(fig.scap)) {
-      keyvalue <- c(keyvalue, sprintf("fig.scap='%s'", fig.scap))
+      keyvalue <- c(keyvalue, sprintf("fig-scap='%s'", fig.scap))
     }
     resize.width <- options[['resize.width']]
     if (!is.null(resize.width)) {
@@ -455,7 +455,12 @@ knitr_options_hook <- function(options) {
   # partition yaml options
   results <- partition_yaml_options(options$engine, options$code)
   if (!is.null(results$yaml)) {
+    # convert any option with fig- into fig. and out- to out.
+    names(results$yaml) <- sub("^fig-", "fig.", names(results$yaml))
+    names(results$yaml) <- sub("^out-", "out.", names(results$yaml))
+    # merge with other options
     options <- knitr:::merge_list(options, results$yaml)
+    # set code
     options$code <- results$code
   } 
   

--- a/tests/docs/consistency-checks/observable-ref.qmd
+++ b/tests/docs/consistency-checks/observable-ref.qmd
@@ -33,52 +33,52 @@ name
 name
 ```
 
-### `fig.cap`
+### `fig-cap`
 
 ```{ojs}
 //| label: fig-caption-test
-//| fig.cap: A caption for the figure
+//| fig-cap: A caption for the figure
 name
 ```
 
 **(Styling Bug?) Centering of images appears inconsistent depending on whether they have captions?**
 
-### `fig.subcap`
+### `fig-subcap`
 
 ```{ojs}
 //| label: fig-subcap-test
-//| fig.cap: Big caption
-//| fig.subcap: 
+//| fig-cap: Big caption
+//| fig-subcap: 
 //|   - Caption 1
 //|   - Caption 2
 name + " 1"
 name + " 2"
 ```
 
-**(Python Bug?) Sub-captions don't show up unless `fig.cap` is also there:**
+**(Python Bug?) Sub-captions don't show up unless `fig-cap` is also there:**
 
 ```{ojs}
-//| fig.subcap: 
+//| fig-subcap: 
 //|   - Caption 1
 //|   - Caption 2
 name + " 1"
 name + " 2"
 ```
 
-### `fold` and `summary`
+### `code-fold` and `code-summary`
 
 **(Inconsistency?) The R engine sets fold and summary for both the outer and inner div; The Python engine only forwards it to the inner div.**
 
 Fold:
 
 ```{ojs}
-//| fold: true
+//| code-fold: true
 name
 ```
 
 Summary:
 
 ```{ojs}
-//| summary: "some text"
+//| code-summary: "some text"
 name
 ```

--- a/tests/docs/consistency-checks/python-ref.qmd
+++ b/tests/docs/consistency-checks/python-ref.qmd
@@ -32,11 +32,11 @@ plt.plot([1,2,3,4])
 plt.show()
 ```
 
-### `fig.cap`
+### `fig-cap`
 
 ```{python}
 #| label: fig-caption-test
-#| fig.cap: A caption for the figure
+#| fig-cap: A caption for the figure
 
 plt.plot([1,2,3,4])
 plt.show()
@@ -44,12 +44,12 @@ plt.show()
 
 **(Styling Bug?) Centering of images appears inconsistent depending on whether they have captions?**
 
-### `fig.subcap`
+### `fig-subcap`
 
 ```{python}
 #| label: fig-big-caption-test
-#| fig.cap: Big caption
-#| fig.subcap: 
+#| fig-cap: Big caption
+#| fig-subcap: 
 #|   - Caption 1
 #|   - Caption 2
 plt.plot([4,3,2,1])
@@ -62,7 +62,7 @@ plt.show()
 
 ```{python}
 #| label: fig-no-big-caption-test
-#| fig.subcap: 
+#| fig-subcap: 
 #|   - Caption 1
 #|   - Caption 2
 plt.plot([4,3,2,1])
@@ -71,14 +71,14 @@ plt.plot([1,2,3,4])
 plt.show()
 ```
 
-### `fold` and `summary`
+### `code-fold` and `code-summary`
 
-**(Inconsistency?) The R engine sets fold and summary for both the outer and inner div; The Python engine only forwards it to the inner div.**
+**(Inconsistency?) The R engine sets code-fold and code-summary for both the outer and inner div; The Python engine only forwards it to the inner div.**
 
 Fold:
 
 ```{python}
-#| fold: true
+#| code-fold: true
 plt.plot([1,2,3,4])
 plt.show()
 ```
@@ -86,7 +86,7 @@ plt.show()
 Summary:
 
 ```{python}
-#| summary: "Some text"
+#| code-summary: "Some text"
 plt.plot([1,2,3,4])
 plt.show()
 ```

--- a/tests/docs/consistency-checks/r-ref.qmd
+++ b/tests/docs/consistency-checks/r-ref.qmd
@@ -29,52 +29,52 @@ plot(1:10)
 plot(1:10)
 ```
 
-### `fig.cap`
+### `fig-cap`
 
 ```{r}
-#| fig.cap: A caption for the figure
+#| fig-cap: A caption for the figure
 
 plot(1:10)
 ```
 
 **(Styling Bug?) Centering of images appears inconsistent depending on whether they have captions?**
 
-### `fig.subcap`
+### `fig-subcap`
 
 ```{r}
 #| label: fig-big-caption-test
-#| fig.cap: Big caption
-#| fig.subcap: 
+#| fig-cap: Big caption
+#| fig-subcap: 
 #|   - Caption 1
 #|   - Caption 2
 plot(1:10)
 plot(10:1)
 ```
 
-**(Python Bug?) Sub-captions don't show up unless `fig.cap` is also there:**
+**(Python Bug?) Sub-captions don't show up unless `fig-cap` is also there:**
 
 ```{r}
-#| fig.subcap: 
+#| fig-subcap: 
 #|   - Caption 1
 #|   - Caption 2
 plot(1:10)
 plot(10:1)
 ```
 
-### `fold` and `summary`
+### `code-fold` and `code-summary`
 
 **(Inconsistency?) The R engine sets fold and summary for both the outer and inner div; The Python engine only forwards it to the inner div.**
 
 Fold:
 
 ```{r}
-#| fold: true
+#| code-fold: true
 plot(1:10)
 ```
 
 Summary:
 
 ```{r}
-#| summary: "some text"
+#| code-summary: "some text"
 plot(1:10)
 ```

--- a/tests/docs/crossrefs/knitr-tables.qmd
+++ b/tests/docs/crossrefs/knitr-tables.qmd
@@ -4,8 +4,8 @@ title: Knitr Table Test
 
 ```{r}
 #| label: tbl-tables
-#| tbl.cap: "Tables"
-#| layout.ncol: 2
+#| tbl-cap: "Tables"
+#| layout-ncol: 2
 
 library(knitr)
 kable(head(cars), caption = "Cars {#tbl-cars}")

--- a/tests/docs/crossrefs/knitr.qmd
+++ b/tests/docs/crossrefs/knitr.qmd
@@ -6,7 +6,7 @@ title: Knitr Crossref Test
 
 ```{r}
 #| label: fig-plot
-#| fig.cap: "Plot"
+#| fig-cap: "Plot"
 
 plot(cars)
 ```

--- a/tests/docs/crossrefs/listings.qmd
+++ b/tests/docs/crossrefs/listings.qmd
@@ -2,7 +2,7 @@
 title: Listings Test
 ---
 
-```{#lst-customers .sql lst.cap="Customers Query"}
+```{#lst-customers .sql lst-cap="Customers Query"}
 SELECT * FROM Customers
 ```
 

--- a/tests/docs/crossrefs/python-subfig.qmd
+++ b/tests/docs/crossrefs/python-subfig.qmd
@@ -6,11 +6,11 @@ title: Python Subfig Test
 
 ```{python}
 #| label: fig-plots
-#| fig.cap: "Plots" 
-#| fig.subcap:
+#| fig-cap: "Plots" 
+#| fig-subcap:
 #|   - "Plot 1"
 #|   - "Plot 2" 
-#| layout.ncol: 2
+#| layout-ncol: 2
 
 import matplotlib.pyplot as plt
 plt.plot([1,23,2,4])

--- a/tests/docs/crossrefs/python.qmd
+++ b/tests/docs/crossrefs/python.qmd
@@ -6,7 +6,7 @@ title: Python Crossref Test
 
 ```{python}
 #| label: fig-plot
-#| fig.cap: "Plot"
+#| fig-cap: "Plot"
 
 import matplotlib.pyplot as plt
 plt.plot([1,23,2,4])

--- a/tests/docs/crossrefs/simple.qmd
+++ b/tests/docs/crossrefs/simple.qmd
@@ -10,7 +10,7 @@ See @fig-elephant for an illustration
 
 ## Simple Sub Figure
 
-::: {#fig-elephants layout.ncol=2}
+::: {#fig-elephants layout-ncol=2}
 
 ![Surus](img/surus.jpg){#fig-surus}
 

--- a/tests/docs/crossrefs/tables.qmd
+++ b/tests/docs/crossrefs/tables.qmd
@@ -16,7 +16,7 @@ See @tbl-letters.
 
 ## Sub tables
 
-::: {#tbl-panel layout.ncol=2}
+::: {#tbl-panel layout-ncol=2}
 | Col1 | Col2 | Col3 |
 |------|------|------|
 | A    | B    | C    |


### PR DESCRIPTION
All of the Pandoc and Quarto document level YAML options use the pandoc convention of separating multiple words with dashes (e.g. `section-numbers`, `highlight-style`, `toc-float`, etc.). In spite of this, we initially adopted the convention of using dot (.) as the separator for some chunk options (e.g. `fig.cap`, `layout.ncol`). 

This was based on Knitr conventions, which were in turn a consequence of the fact that R symbols can't have an embedded dash unless they are quoted with backticks (e.g. `` `toc-float` = TRUE``), and Knitr chunk options are parsed as R code.

However, this creates some unfortunate inconsistency as users now need to remember when dash is used and when dot is used, and to avoid this confusion in some cases we dropped the prefix from the chunk option. For example, the global YAML options `code-fold` and `code-summary` were mapped to chunk options `fold` and `summary`(the alternative being changing the global YAML options to `fold` and `summary` which is insufficient scoping/namespacing, or changing both global and chunk options to `code.fold` / `code.summary` (which is completely inconsistent with the dash convention used by other options).

Now that Quarto chunk options are specified in YAML format, we have the opportunity to make this completely consistent (use the dash format everywhere). The only major downside of this is that Knitr users migrating to Quarto might still want to use the dot syntax. To mitigate this we do two things:

1) Continue allowing Knitr chunk options to be specified on the top line in R format (using dot notation)
2) Automatically map any `fig.` options provided in YAML to `fig-` (so for Knitr users either syntax is supported).

We will exclusively document the dash syntax, and the dot syntax will be there only as a fallback for Knitr users accustomed to using dot.

This change affects the following chunk options:


| Original      | Revised       |
|---------------|---------------|
| fig.cap       | fig-cap       |
| fig.subcap    | fig-subcap    |
| fig.scap      | fig-scap      |
| fig.link      | fig-link      |
| fig.align     | fig-align     |
| fig.env       | fig-env       |
| fig.pos       | fig-pos       |
| fig.alt       | fig-alt       |
| fold          | code-fold     |
| summary       | code-summary  |
| layout.nrow   | layout-nrow   |
| layout.ncol   | layout-ncol   |
| layout.align  | layout-align  |
| layout.valign | layout-valign |
| lst.label     | lst-label     |
| lst.cap       | lst-cap       |
| out.width     | out-width     |
| out.height    | out-height    |



