### PR TITLE
Try to fix the problem with the argument --lite

### DIFF
--- a/package/src/common/compile-quarto-latexmk.ts
+++ b/package/src/common/compile-quarto-latexmk.ts
@@ -131,7 +131,7 @@ export async function compileQuartoLatexmk(
       await compile(
         entryPointPath(config),
         output,
-        [...kFlags, "--lite"],
+        [...kFlags],
         config,
       );
       info(output + "\n");


### PR DESCRIPTION
I'm running into this error when building quarto-latexmk on macOS:

```
Compiling for x86_64-apple-darwin:
error: Found argument '--lite' which wasn't expected, or isn't valid in this context
USAGE:
    deno compile <SCRIPT_ARG>... --allow-env=<allow-env> --allow-net=<allow-net> --allow-read=<allow-read> --allow-run=<allow-run> --allow-write=<allow-write> --import-map <FILE> --output <output> --unstable
For more information try --help
error: Uncaught (in promise) Error: Failure to compile /Users/appveyor/projects/tinytex/quarto-cli/src/command/render/latexmk/quarto-latexmk.ts
    throw Error(`Failure to compile ${input}`);
          ^
    at compile (file:///Users/appveyor/projects/tinytex/quarto-cli/package/src/util/deno.ts:65:11)
    at async compileQuartoLatexmk (file:///Users/appveyor/projects/tinytex/quarto-cli/package/src/common/compile-quarto-latexmk.ts:131:7)
```

I'm not sure what the right fix would be. This is just a blind attempt. Please feel free to close.

Same problem when

```
Compiling for x86_64-unknown-linux-gnu:
...
```

or

```
Compiling for x86_64-pc-windows-msvc:
```

This problem started to occur on July 9. I just noticed it today.