### PR TITLE
fix ojs line annotations bug

### DIFF
--- a/src/command/render/render.ts
+++ b/src/command/render/render.ts
@@ -22,8 +22,6 @@ import { Document, DOMParser } from "deno_dom/deno-dom-wasm.ts";
 
 import { info } from "log/mod.ts";
 
-import { shortUuid } from "../../core/uuid.ts";
-
 import { mergeConfigs } from "../../core/config.ts";
 import { resourcePath } from "../../core/resources.ts";
 import { createSessionTempDir } from "../../core/temp.ts";
@@ -183,7 +181,7 @@ export async function renderFiles(
 
         // patch source file
         const { ojsBlockLineNumbers } = annotateOjsLineNumbers(context);
-        
+
         // execute
         const baseExecuteResult = await renderExecute(
           context,
@@ -195,7 +193,7 @@ export async function renderFiles(
         const { executeResult, resourceFiles } = await ojsExecuteResult(
           context,
           baseExecuteResult,
-          ojsBlockLineNumbers
+          ojsBlockLineNumbers,
         );
 
         // callback

--- a/src/command/render/render.ts
+++ b/src/command/render/render.ts
@@ -182,16 +182,7 @@ export async function renderFiles(
         );
 
         // patch source file
-        const { patchedSource } = annotateOjsLineNumbers(context);
-        const oldTarget = context.target;
-        if (patchedSource) {
-          const newTarget = {
-            ...context.target,
-            source: patchedSource,
-            input: patchedSource
-          };
-          context.target = newTarget;
-        }
+        const { ojsBlockLineNumbers } = annotateOjsLineNumbers(context);
         
         // execute
         const baseExecuteResult = await renderExecute(
@@ -204,13 +195,8 @@ export async function renderFiles(
         const { executeResult, resourceFiles } = await ojsExecuteResult(
           context,
           baseExecuteResult,
+          ojsBlockLineNumbers
         );
-
-        // restore context, remove patched source
-        context.target = oldTarget;
-        if (patchedSource) {
-          removeIfExists(patchedSource);
-        }
 
         // callback
         await pandocRenderer.onRender(format, {

--- a/src/execute/ojs/annotate-source.ts
+++ b/src/execute/ojs/annotate-source.ts
@@ -5,38 +5,24 @@
 *
 */
 
-import {
-  inputFilesDir
-} from "../../core/render.ts";
+import { RenderContext } from "../../command/render/types.ts";
 
-import {
-  RenderContext
-} from "../../command/render/types.ts";
+import { lines } from "../../core/text.ts";
 
-import {
-  lines
-} from "../../core/text.ts";
-
-import {
-  isJupyterNotebook
-} from "../../core/jupyter/jupyter.ts";
+import { isJupyterNotebook } from "../../core/jupyter/jupyter.ts";
 
 interface OJSLineNumbersAnnotation {
-  ojsBlockLineNumbers: number[],
-};
+  ojsBlockLineNumbers: number[];
+}
 
 import { dirname, extname } from "path/mod.ts";
 
 export function annotateOjsLineNumbers(
-  context: RenderContext
-): OJSLineNumbersAnnotation
-{
-  const ext = extname(context.target.input);
+  context: RenderContext,
+): OJSLineNumbersAnnotation {
   const canPatch = !isJupyterNotebook(context.target.input);
 
   if (canPatch) {
-    const dir = dirname(context.target.input);
-    
     const source = lines(Deno.readTextFileSync(context.target.input));
 
     const ojsBlockLineNumbers: number[] = [];
@@ -47,8 +33,8 @@ export function annotateOjsLineNumbers(
     // https://github.com/yihui/knitr/blob/3237add034368a3018ff26fa9f4d0ca89a4afd78/R/pattern.R#L32
     const chunkBegin = /^[\t ]*```+\s*\{(ojs( *[ ,].*)?)\}\s*$/;
 
-    source.forEach(line => {
-      if (line === "```{ojs}") {
+    source.forEach((line) => {
+      if (line.match(chunkBegin)) {
         waitingForOjs = true;
       } else if (waitingForOjs && !line.startsWith("//|")) {
         waitingForOjs = false;
@@ -57,13 +43,12 @@ export function annotateOjsLineNumbers(
       lineNumber++;
     });
 
-
     return {
-      ojsBlockLineNumbers
+      ojsBlockLineNumbers,
     };
   } else {
     return {
-      ojsBlockLineNumbers: []
+      ojsBlockLineNumbers: [],
     };
   }
 }

--- a/src/execute/ojs/annotate-source.ts
+++ b/src/execute/ojs/annotate-source.ts
@@ -31,18 +31,18 @@ export function annotateOjsLineNumbers(
   context: RenderContext
 ): OJSLineNumbersAnnotation
 {
-  const ext = extname(context.target.source);
-  const canPatch = !isJupyterNotebook(context.target.source);
+  const ext = extname(context.target.input);
+  const canPatch = !isJupyterNotebook(context.target.input);
 
   if (canPatch) {
-    const dir = dirname(context.target.source);
+    const dir = dirname(context.target.input);
     
     const patchedFileName = Deno.makeTempFileSync({
       dir,
       suffix: ext
     });
     
-    const source = lines(Deno.readTextFileSync(context.target.source));
+    const source = lines(Deno.readTextFileSync(context.target.input));
 
     const output: string[] = [];
     let waitingForOjs = false;

--- a/src/execute/ojs/annotate-source.ts
+++ b/src/execute/ojs/annotate-source.ts
@@ -1,0 +1,67 @@
+/*
+* annotate-source.ts
+*
+* Copyright (C) 2021 by RStudio, PBC
+*
+*/
+
+import {
+  inputFilesDir
+} from "../../core/render.ts";
+
+import {
+  RenderContext
+} from "../../command/render/types.ts";
+
+import {
+  lines
+} from "../../core/text.ts";
+
+interface OJSLineNumbersAnnotation {
+  patchedSource?: string
+};
+
+import { dirname } from "path/mod.ts";
+
+export function annotateOjsLineNumbers(
+  context: RenderContext
+): OJSLineNumbersAnnotation
+{
+  // FIXME Check for ipynb later
+  const canPatch = true;
+
+  if (canPatch) {
+    const dir = dirname(context.target.source);
+    
+    // FIXME use correct extension, we might be ".rmd" or ".md"
+    const patchedFileName = Deno.makeTempFileSync({
+      dir,
+      suffix: ".qmd"
+    });
+    
+    const source = lines(Deno.readTextFileSync(context.target.source));
+
+    const output: string[] = [];
+    let waitingForOjs = false;
+    let lineNumber = 0;
+    source.forEach(line => {
+      // FIXME use a better regexp
+      if (line === "```{ojs}") {
+        waitingForOjs = true;
+      } else if (waitingForOjs && !line.startsWith("//|")) {
+        output.push(`//| internal-chunk-line-number: ${lineNumber}`);
+        waitingForOjs = false;
+      }
+      lineNumber++;
+      output.push(line);
+    });
+
+    Deno.writeTextFileSync(patchedFileName, output.join("\n"));
+
+    return {
+      patchedSource: patchedFileName,
+    };
+  } else {
+    return {};
+  }
+}

--- a/src/execute/ojs/compile.ts
+++ b/src/execute/ojs/compile.ts
@@ -231,6 +231,7 @@ export async function ojsCompile(
       interface ParsedCellInfo {
         info: SourceInfo[];
       }
+      const cellStartingLoc = Number(cell.options!["internal-chunk-line-number"] as string);
 
       const handleError = (err: any, cellSrc: string) => {
         const div = pandocBlock(":::::")({
@@ -240,12 +241,12 @@ export async function ojsCompile(
           / *\(\d+:\d+\)$/,
           "",
         );
-        ojsParseError(err, cellSrc, cell.startingLoc);
+        ojsParseError(err, cellSrc, cellStartingLoc);
 
         const preDiv = pandocBlock("````")({
           classes: ["numberLines", "java"],
           attrs: [
-            `startFrom="${cell.startingLoc}"`,
+            `startFrom="${cellStartingLoc}"`,
             `syntax-error-position="${err.pos}"`,
             `source-offset="9"`,
           ],
@@ -262,7 +263,7 @@ export async function ojsCompile(
         calloutDiv.push(
           pandocRawStr(
             `#### OJS Syntax Error (line ${err.loc.line +
-              cell.startingLoc}, column ${err.loc.column})`,
+              cellStartingLoc}, column ${err.loc.column})`,
           ),
         );
         calloutDiv.push(pandocRawStr(`${fullMsg}`));
@@ -397,6 +398,7 @@ export async function ojsCompile(
         "plot.hidden",
         "output.hidden",
         "echo.hidden",
+        "internal-chunk-line-number",
       ]);
 
       for (const [key, value] of Object.entries(cell.options || {})) {
@@ -518,7 +520,7 @@ export async function ojsCompile(
             const linesSkipped =
               cellSrcStr.substring(0, innerInfo[0].start).split("\n").length;
 
-            ourAttrs.push(`startFrom="${cell.startingLoc + linesSkipped}"`);
+            ourAttrs.push(`startFrom="${cellStartingLoc + linesSkipped}"`);
             ourAttrs.push(`source-offset="-${innerInfo[0].start}"`);
             const srcDiv = pandocCode({
               attrs: ourAttrs,
@@ -576,7 +578,7 @@ export async function ojsCompile(
           // compute offset from cell start to div start
           const linesSkipped =
             cellSrcStr.substring(0, innerInfo[0].start).split("\n").length;
-          ourAttrs.push(`startFrom="${cell.startingLoc + linesSkipped}"`);
+          ourAttrs.push(`startFrom="${cellStartingLoc + linesSkipped}"`);
           ourAttrs.push(`source-offset="-${innerInfo[0].start}"`);
           const srcDiv = pandocCode({
             attrs: ourAttrs,

--- a/src/execute/ojs/compile.ts
+++ b/src/execute/ojs/compile.ts
@@ -233,10 +233,12 @@ export async function ojsCompile(
       interface ParsedCellInfo {
         info: SourceInfo[];
       }
-      
+
       const cellStartingLoc = ojsBlockLineNumbers[ojsBlockIndex++] || 0;
       if (cellStartingLoc === 0) {
-        warnOnce("OJS block count mismatch. Line number reporting is likely to be wrong");
+        warnOnce(
+          "OJS block count mismatch. Line number reporting is likely to be wrong",
+        );
       }
 
       const handleError = (err: any, cellSrc: string) => {
@@ -403,7 +405,7 @@ export async function ojsCompile(
         "source.hidden",
         "plot.hidden",
         "output.hidden",
-        "echo.hidden"
+        "echo.hidden",
       ]);
 
       for (const [key, value] of Object.entries(cell.options || {})) {
@@ -466,7 +468,7 @@ export async function ojsCompile(
       // the only effect of echoVal in OJS blocks
       // is to hide the div. We need source always to pinpoint
       // errors in source in case of runtime errors.
-      // 
+      //
       // FIXME This is
       // potentially wrong in the presence of !includeVal
       if (!echoVal) {
@@ -506,7 +508,9 @@ export async function ojsCompile(
 
       const makeSubFigures = (specs: SubfigureSpec[]) => {
         let subfigIx = 1;
-        let cellInfo = ([] as SourceInfo[]).concat(...(parsedCells.map(n => n.info)));
+        let cellInfo = ([] as SourceInfo[]).concat(
+          ...(parsedCells.map((n) => n.info)),
+        );
         for (const spec of specs) {
           const outputDiv = pandocDiv({
             classes: outputCellClasses,
@@ -517,7 +521,7 @@ export async function ojsCompile(
           const innerInfo = parsedCells[subfigIx - 1].info;
           const ojsDiv = pandocDiv({
             id: `${ojsId}-${subfigIx}`,
-            attrs: [`nodetype="${cellInfo[subfigIx-1].cellType}"`]
+            attrs: [`nodetype="${cellInfo[subfigIx - 1].cellType}"`],
           });
           if (innerInfo.length > 0 && srcConfig !== undefined) {
             const ourAttrs = srcConfig.attrs.slice();
@@ -811,7 +815,7 @@ export async function ojsCompile(
 export async function ojsExecuteResult(
   context: RenderContext,
   executeResult: ExecuteResult,
-  ojsBlockLineNumbers: number[]
+  ojsBlockLineNumbers: number[],
 ) {
   executeResult = ld.cloneDeep(executeResult);
 
@@ -822,7 +826,7 @@ export async function ojsExecuteResult(
     markdown: executeResult.markdown,
     libDir: context.libDir,
     project: context.project,
-    ojsBlockLineNumbers
+    ojsBlockLineNumbers,
   });
 
   // merge in results


### PR DESCRIPTION
This passes tests and fixes the issues with tracking line numbers across the different markdown we produce inside quarto