### PR TITLE
fix linux install after previous sudo install

### DIFF
--- a/package/src/common/configure.ts
+++ b/package/src/common/configure.ts
@@ -60,10 +60,14 @@ export async function configure(
     for (let i = 0; i < symlinkPaths.length; i++) {
       const symlinkPath = symlinkPaths[i];
       info(`> Trying ${symlinkPath}`);
-      if (existsSync(symlinkPath)) {
-        Deno.removeSync(symlinkPath);
+      try {
+        if (existsSync(symlinkPath)) {
+          Deno.removeSync(symlinkPath);
+        }
+      } catch (error) {
+        info(error);
+        info("\n> Failed to remove existing symlink.\n> Did you previously install with sudo? Run 'which quarto' to test which version will be used.");
       }
-
       try {
         // for the last path, try even creating a directory as a last ditch effort
         if (i === symlinkPaths.length - 1) {


### PR DESCRIPTION
When running the `./configure-linux.sh` command with sudo powers, quarto gets installed to `/usr/local/bin/quarto`. If you then later on attempt to install without `sudo`, quarto fails to delete the old symlink and doesn't attempt to install to  `~/bin/` as it would normally do because the attempt of symlink removal was outside of the `try` block. This PR adds another `try` block with a helpful error message.