### PR TITLE
use native knitr yaml chunk option handling

### DIFF
--- a/tests/renv.lock
+++ b/tests/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.1.0",
+    "Version": "4.0.3",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -60,10 +60,15 @@
     },
     "knitr": {
       "Package": "knitr",
-      "Version": "1.33",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "0bc1b5da1b0eb07cd4b727e95e9ff0b8"
+      "Version": "1.34.2",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteRepo": "knitr",
+      "RemoteUsername": "yihui",
+      "RemoteRef": "HEAD",
+      "RemoteSha": "c9b7e3acae3248e5a48beddd49e98d37d1cf1517",
+      "Hash": "827d1b5bcdcecc344cd48d8b05faa562"
     },
     "magrittr": {
       "Package": "magrittr",
@@ -71,20 +76,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "41287f1ac7d28a92f0a286ed507928d3"
-    },
-    "markdown": {
-      "Package": "markdown",
-      "Version": "1.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "61e4a10781dd00d7d81dd06ca9b94e95"
-    },
-    "mime": {
-      "Package": "mime",
-      "Version": "0.11",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "8974a907200fc9948d636fe7d85ca9fb"
     },
     "renv": {
       "Package": "renv",
@@ -109,10 +100,10 @@
     },
     "stringi": {
       "Package": "stringi",
-      "Version": "1.6.2",
+      "Version": "1.7.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "9df5e6f9a7fa11b84adf0429961de66a"
+      "Hash": "ebaccb577da50829a3bb1b8296f318a5"
     },
     "stringr": {
       "Package": "stringr",
@@ -130,10 +121,10 @@
     },
     "xfun": {
       "Package": "xfun",
-      "Version": "0.24",
+      "Version": "0.26",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "88cdb9779a657ad80ad942245fffba31"
+      "Hash": "a270216f7ffda25e53298293046d1d05"
     },
     "yaml": {
       "Package": "yaml",

--- a/tests/smoke/render/render-r.test.ts
+++ b/tests/smoke/render/render-r.test.ts
@@ -9,7 +9,7 @@ import { docs } from "../../utils.ts";
 import { fileExists } from "../../verify.ts";
 import { testRender } from "./render.ts";
 
-const plotPath = "docs/test_files/figure-html/unnamed-chunk-2-1.png";
+const plotPath = "docs/test_files/figure-html/unnamed-chunk-1-1.png";
 
 testRender(docs("test.Rmd"), "html", false, [
   fileExists(plotPath),


### PR DESCRIPTION
Use the native knitr handling for knitr >= 1.34.2 (the current dev version but not yet the CRAN version). 

@yihui The `original.params.src` as originally forwarded to Quarto included the engine. I noted that what you are currently forwarding does not include the engine so I added this workaround to make the tests pass:

https://github.com/quarto-dev/quarto-cli/compare/feature/knitr-native-yaml-options?expand=1#diff-8db8cafc98f0d728b640552494dd7aac586b9c8ba6f132707c4265276c79ed01R334-R343

If you are okay w/ changing knitr to pass the full original source including the engine then I can remove this bit.
