### PR TITLE
Changing meta tags from name to property for OpenGraph

### DIFF
--- a/src/project/types/website/website-meta.ts
+++ b/src/project/types/website/website-meta.ts
@@ -349,7 +349,11 @@ function imageSize(path: string) {
 function writeMeta(name: string, content: string, doc: Document) {
   // Meta tag
   const m = doc.createElement("META");
-  m.setAttribute("name", name);
+  if (name.startsWith("og:")){
+    m.setAttribute("property", name);
+  } else {
+    m.setAttribute("name", name);
+  }
   m.setAttribute("content", content);
 
   // New Line


### PR DESCRIPTION
Facebook preview require "og:" meta tags to be property instead of name. 

This change allows the rendered site to have a proper preview in Facebook. I've validated the preview with [open graph debugger](https://developers.facebook.com/tools/debug/)

Ref:
- [open graph protocol](https://ogp.me/)