### PR TITLE
[linux] use ~/.local/bin instead of ~/bin/quarto

### DIFF
--- a/package/src/common/configure.ts
+++ b/package/src/common/configure.ts
@@ -53,7 +53,7 @@ export async function configure(
   }
 
   // Set up a symlink (if appropriate)
-  const symlinkPaths = ["/usr/local/bin/quarto", expandPath("~/bin/quarto")];
+  const symlinkPaths = ["/usr/local/bin/quarto", expandPath("~/.local/bin/quarto")];
 
   if (Deno.build.os !== "windows") {
     info("Creating Quarto Symlink");


### PR DESCRIPTION
It seems to be more appropriate for any distro that uses systemd or wants to maintain
compatibility with systemd.

References: https://unix.stackexchange.com/a/392710