### PR TITLE
Set different default configuration for revealjs

### DIFF
--- a/src/format/formats-shared.ts
+++ b/src/format/formats-shared.ts
@@ -184,9 +184,7 @@ function defaultFormat(): Format {
       [kLinkExternalIcon]: false,
       [kLinkExternalNewwindow]: false,
     },
-    pandoc: {
-      from: "markdown",
-    },
+    pandoc: {},
     metadata: {},
   };
 }

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -14,7 +14,7 @@ import {
   Metadata,
   PandocFlags,
 } from "../../config/types.ts";
-import { kTheme } from "../../config/constants.ts";
+import { kFrom, kTheme } from "../../config/constants.ts";
 import { mergeConfigs } from "../../core/config.ts";
 import { createHtmlPresentationFormat } from "../formats-shared.ts";
 
@@ -99,6 +99,7 @@ export function revealjsFormat() {
 
         if (format.metadata[kTheme] === kThemeQuarto) {
           format.metadata[kTheme] = "white";
+          format.pandoc[kFrom] = "markdown-auto_identifiers";
 
           extras.metadata = revealMetadataFilter({
             controlsTutorial: false,
@@ -108,9 +109,6 @@ export function revealjsFormat() {
             transition: "none",
             backgroundTransition: "none",
           });
-          extras.pandoc = {
-            from: "markdown-auto_identifiers",
-          };
         }
 
         extras.html = {

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -105,7 +105,7 @@ export function revealjsFormat() {
     createHtmlPresentationFormat(9, 5),
     {
       metadata: revealMetadataFilter({
-        [kHashType]: "id",
+        [kHashType]: "number",
       }),
       metadataFilter: revealMetadataFilter,
       formatExtras: (_input: string, _flags: PandocFlags, format: Format) => {
@@ -119,7 +119,7 @@ export function revealjsFormat() {
             throw new Error("from can't be changed in reveal format.");
           }
 
-          extras.pandoc = format.metadata[kHashType] === "id"
+          extras.pandoc = format.metadata[kHashType] === "number"
             ? {
               from: "markdown-auto_identifiers",
             }

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -21,6 +21,18 @@ export function revealjsFormat() {
     {
       metadata: {
         theme: "white",
+        controlsTutorial: false,
+        hash: true,
+        hashOneBasedIndex: true,
+        center: false,
+        transition: 'none',
+        backgroundTransition: 'none',
+        width: 1600,
+        height: 900,
+        margin: 0.1,
+      },
+      pandoc: {
+        from: 'markdown-auto_identifiers',
       },
       formatExtras: (_input: string, _flags: PandocFlags, _format: Format) => {
         return {

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -73,6 +73,8 @@ const kRevealOptions = [
   "mathjax",
 ];
 
+const kHashType = "hash-type";
+
 const kRevealKebabOptions = kRevealOptions.reduce(
   (options: string[], option: string) => {
     const kebab = camelToKebab(option);
@@ -88,10 +90,13 @@ export function revealjsFormat() {
   return mergeConfigs(
     createHtmlPresentationFormat(9, 5),
     {
+      metadata: revealMetadataFilter({
+        [kHashType]: "id",
+      }),
       metadataFilter: revealMetadataFilter,
       formatExtras: (_input: string, _flags: PandocFlags, format: Format) => {
         const extras: FormatExtras = {};
-
+        // Only tweak when Quarto theme is used (no reveal theme)
         if (format.metadata[kTheme] === undefined) {
           extras.metadata = revealMetadataFilter({
             theme: "white",
@@ -103,9 +108,13 @@ export function revealjsFormat() {
             backgroundTransition: "none",
           });
 
-          extras.pandoc = {
-            from: "markdown-auto_identifiers",
-          };
+          extras.pandoc = format.metadata[kHashType] === "id"
+            ? {
+              from: "markdown-auto_identifiers",
+            }
+            : {
+              from: "markdown",
+            };
         }
 
         extras.html = {

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -73,6 +73,20 @@ const kRevealOptions = [
   "mathjax",
 ];
 
+const kRevealThemes = [
+  "black",
+  "white",
+  "league",
+  "beige",
+  "sky",
+  "night",
+  "serif",
+  "simple",
+  "solarized",
+  "blood",
+  "moon",
+];
+
 const kHashType = "hash-type";
 
 const kRevealKebabOptions = kRevealOptions.reduce(
@@ -96,8 +110,11 @@ export function revealjsFormat() {
       metadataFilter: revealMetadataFilter,
       formatExtras: (_input: string, _flags: PandocFlags, format: Format) => {
         const extras: FormatExtras = {};
-        // Only tweak when Quarto theme is used (no reveal theme)
-        if (format.metadata[kTheme] === undefined) {
+        // Only tweak when no reveal built-in theme is used
+        if (
+          format.metadata[kTheme] ||
+          !kRevealThemes.includes(format.metadata[kTheme] as string)
+        ) {
           if (format.pandoc[kFrom] != undefined) {
             throw new Error("from can't be changed in reveal format.");
           }

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -18,6 +18,7 @@ import {
 import { kFrom, kTheme } from "../../config/constants.ts";
 import { mergeConfigs } from "../../core/config.ts";
 import { createHtmlPresentationFormat } from "../formats-shared.ts";
+import { pandocFormatWith } from "../../core/pandoc/pandoc-formats.ts";
 
 const kRevealOptions = [
   "controls",
@@ -113,18 +114,18 @@ export function revealjsFormat() {
           format.metadata[kTheme] === undefined ||
           !kRevealThemes.includes(format.metadata[kTheme] as string)
         ) {
-          if (format.pandoc[kFrom] != undefined) {
-            throw new Error("from can't be changed in reveal format.");
-          }
-
-          extras.pandoc = format.metadata[kHashType] === undefined ||
-              format.metadata[kHashType] === "number"
-            ? {
-              from: "markdown-auto_identifiers",
-            }
-            : {
-              from: "markdown",
+          if (
+            format.metadata[kHashType] === undefined ||
+            format.metadata[kHashType] === "number"
+          ) {
+            extras.pandoc = {
+              from: pandocFormatWith(
+                format.pandoc[kFrom] || "markdown",
+                "",
+                "-auto_identifiers",
+              ),
             };
+          }
 
           extras.metadata = revealMetadataFilter({
             theme: "white",

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -105,9 +105,6 @@ export function revealjsFormat() {
   return mergeConfigs(
     createHtmlPresentationFormat(9, 5),
     {
-      metadata: revealMetadataFilter({
-        [kHashType]: "number",
-      }),
       metadataFilter: revealMetadataFilter,
       formatExtras: (_input: string, _flags: PandocFlags, format: Format) => {
         const extras: FormatExtras = {};
@@ -120,7 +117,8 @@ export function revealjsFormat() {
             throw new Error("from can't be changed in reveal format.");
           }
 
-          extras.pandoc = format.metadata[kHashType] === "number"
+          extras.pandoc = format.metadata[kHashType] === undefined ||
+              format.metadata[kHashType] === "number"
             ? {
               from: "markdown-auto_identifiers",
             }

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -113,7 +113,7 @@ export function revealjsFormat() {
         const extras: FormatExtras = {};
         // Only tweak when no reveal built-in theme is used
         if (
-          format.metadata[kTheme] ||
+          format.metadata[kTheme] === undefined ||
           !kRevealThemes.includes(format.metadata[kTheme] as string)
         ) {
           if (format.pandoc[kFrom] != undefined) {

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -14,7 +14,7 @@ import {
   Metadata,
   PandocFlags,
 } from "../../config/types.ts";
-import { kFrom, kTheme } from "../../config/constants.ts";
+import { kTheme } from "../../config/constants.ts";
 import { mergeConfigs } from "../../core/config.ts";
 import { createHtmlPresentationFormat } from "../formats-shared.ts";
 
@@ -84,24 +84,17 @@ const kRevealKebabOptions = kRevealOptions.reduce(
   [],
 );
 
-const kThemeQuarto = "quarto";
-
 export function revealjsFormat() {
   return mergeConfigs(
     createHtmlPresentationFormat(9, 5),
     {
-      metadata: {
-        theme: kThemeQuarto,
-      },
       metadataFilter: revealMetadataFilter,
       formatExtras: (_input: string, _flags: PandocFlags, format: Format) => {
         const extras: FormatExtras = {};
 
-        if (format.metadata[kTheme] === kThemeQuarto) {
-          format.metadata[kTheme] = "white";
-          format.pandoc[kFrom] = `${format.pandoc[kFrom]}-auto_identifiers`;
-
+        if (format.metadata[kTheme] === undefined) {
           extras.metadata = revealMetadataFilter({
+            theme: "white",
             controlsTutorial: false,
             hash: true,
             hashOneBasedIndex: true,
@@ -109,6 +102,10 @@ export function revealjsFormat() {
             transition: "none",
             backgroundTransition: "none",
           });
+
+          extras.pandoc = {
+            from: "markdown-auto_identifiers",
+          };
         }
 
         extras.html = {

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -99,7 +99,7 @@ export function revealjsFormat() {
 
         if (format.metadata[kTheme] === kThemeQuarto) {
           format.metadata[kTheme] = "white";
-          format.pandoc[kFrom] = "markdown-auto_identifiers";
+          format.pandoc[kFrom] = `${format.pandoc[kFrom]}-auto_identifiers`;
 
           extras.metadata = revealMetadataFilter({
             controlsTutorial: false,

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -14,7 +14,7 @@ import {
   Metadata,
   PandocFlags,
 } from "../../config/types.ts";
-import { kTheme } from "../../config/constants.ts";
+import { kFrom, kTheme } from "../../config/constants.ts";
 import { mergeConfigs } from "../../core/config.ts";
 import { createHtmlPresentationFormat } from "../formats-shared.ts";
 
@@ -98,15 +98,9 @@ export function revealjsFormat() {
         const extras: FormatExtras = {};
         // Only tweak when Quarto theme is used (no reveal theme)
         if (format.metadata[kTheme] === undefined) {
-          extras.metadata = revealMetadataFilter({
-            theme: "white",
-            controlsTutorial: false,
-            hash: true,
-            hashOneBasedIndex: true,
-            center: false,
-            transition: "none",
-            backgroundTransition: "none",
-          });
+          if (format.pandoc[kFrom] != undefined) {
+            throw new Error("from can't be changed in reveal format.");
+          }
 
           extras.pandoc = format.metadata[kHashType] === "id"
             ? {
@@ -115,6 +109,16 @@ export function revealjsFormat() {
             : {
               from: "markdown",
             };
+
+          extras.metadata = revealMetadataFilter({
+            theme: "white",
+            center: false,
+            controlsTutorial: false,
+            hash: true,
+            hashOneBasedIndex: true,
+            transition: "none",
+            backgroundTransition: "none",
+          });
         }
 
         extras.html = {

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -94,9 +94,6 @@ export function revealjsFormat() {
         center: false,
         transition: "none",
         backgroundTransition: "none",
-        width: 1600,
-        height: 900,
-        margin: 0.1,
       }),
       pandoc: {
         from: "markdown-auto_identifiers",

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -9,10 +9,12 @@ import { Document, Element } from "deno_dom/deno-dom-wasm-noinit.ts";
 
 import {
   Format,
+  FormatExtras,
   kHtmlPostprocessors,
   Metadata,
   PandocFlags,
 } from "../../config/types.ts";
+import { kTheme } from "../../config/constants.ts";
 import { mergeConfigs } from "../../core/config.ts";
 import { createHtmlPresentationFormat } from "../formats-shared.ts";
 
@@ -82,29 +84,40 @@ const kRevealKebabOptions = kRevealOptions.reduce(
   [],
 );
 
+const kThemeQuarto = "quarto";
+
 export function revealjsFormat() {
   return mergeConfigs(
     createHtmlPresentationFormat(9, 5),
     {
-      metadata: revealMetadataFilter({
-        theme: "white",
-        controlsTutorial: false,
-        hash: true,
-        hashOneBasedIndex: true,
-        center: false,
-        transition: "none",
-        backgroundTransition: "none",
-      }),
-      pandoc: {
-        from: "markdown-auto_identifiers",
+      metadata: {
+        theme: kThemeQuarto,
       },
       metadataFilter: revealMetadataFilter,
-      formatExtras: (_input: string, _flags: PandocFlags, _format: Format) => {
-        return {
-          html: {
-            [kHtmlPostprocessors]: [revealHtmlPostprocessor()],
-          },
+      formatExtras: (_input: string, _flags: PandocFlags, format: Format) => {
+        const extras: FormatExtras = {};
+
+        if (format.metadata[kTheme] === kThemeQuarto) {
+          format.metadata[kTheme] = "white";
+
+          extras.metadata = revealMetadataFilter({
+            controlsTutorial: false,
+            hash: true,
+            hashOneBasedIndex: true,
+            center: false,
+            transition: "none",
+            backgroundTransition: "none",
+          });
+          extras.pandoc = {
+            from: "markdown-auto_identifiers",
+          };
+        }
+
+        extras.html = {
+          [kHtmlPostprocessors]: [revealHtmlPostprocessor()],
         };
+
+        return extras;
       },
     },
   );


### PR DESCRIPTION
This PR is a first try at modifying Quarto code base. 

This will set different default in Quarto slide format than the ones from reveal.js. Pandoc is using default from reveal directly

What we modify 

* No boucing of controls
* Having a numbered hash in the URL (and not auto identifier)
* No transitions by default
* ~Defaulting to 16/9 size~