### PR TITLE
Add new ignored chunk options for knitr

### DIFF
--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -261,7 +261,9 @@ knitr_hooks <- function(format, resourceDir) {
                      "output", "include.hidden", "source.hidden", "plot.hidden", "output.hidden")
     other_opts <- c("eval", "out.width", "yaml.code", "code", "params.src", "original.params.src", 
                     "fenced.echo", "chunk.echo",
-                    "out.width.px", "out.height.px", "indent")
+                    "out.width.px", "out.height.px", "indent", "class.source", 
+                    "class.output", "class.message", "class.warning", "class.error", "attr.source", 
+                    "attr.output", "attr.message", "attr.warning", "attr.error")
     known_opts <- c(knitr_default_opts, quarto_opts, other_opts)
     unknown_opts <- setdiff(names(options), known_opts)
     unknown_opts <- Filter(Negate(is.null), unknown_opts)


### PR DESCRIPTION
This PR adds new knitr chunk option `class.*` and `attr.*` that can be used on chunk so that **knitr** will add class or attributes on the source or resulting part. 

Currently, it was not working as expected because those options were not ignored.  So there were added on the `::: {.cell` div header.

This is useful for using special option for highlight.js for example in reveal format

````markdown
```{r}
#| eval: FALSE
#| attr.source : 'data-line-numbers="1|2-3|4-6"'
ggplot(penguins, aes(x = island, fill = species)) +
  geom_bar(alpha = 0.8) +
  scale_fill_manual(values = c("darkorange","purple","cyan4"),
                    guide = FALSE) +
  theme_minimal() +
  facet_wrap(~species, ncol = 1) +
  coord_flip()
```
````

This PR only add those options in the ignored set
