### PR TITLE
Add a knitr option hook to set default comment when collapse = TRUE

### DIFF
--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -85,6 +85,18 @@ knitr_hooks <- function(format, resourceDir) {
     options
   }
 
+  opts_hooks[["collapse"]] <- function(options) {
+    if (isTRUE(options[["collapse"]])) {
+      comment <- options[["comment"]]
+      if (is.null(comment) || nzchar(comment) || is.na(comment)) {
+        options[["comment"]] <- "##"
+      }
+    }
+   
+    # return options
+    options
+  }
+
   # opts hooks for implementing keep-hidden
   register_hidden_hook <- function(option, hidden = option) {
     opts_hooks[[option]] <<- function(options) {

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -88,7 +88,7 @@ knitr_hooks <- function(format, resourceDir) {
   opts_hooks[["collapse"]] <- function(options) {
     if (isTRUE(options[["collapse"]])) {
       comment <- options[["comment"]]
-      if (is.null(comment) || nzchar(comment) || is.na(comment)) {
+      if (is.null(comment) || !nzchar(comment) || is.na(comment)) {
         options[["comment"]] <- "##"
       }
     }


### PR DESCRIPTION
This will close #140 


````markdown
---
title: "Title"
format: 
  html: default
---

```{r, collapse = TRUE}
1 + 1
```
```` 

![image](https://user-images.githubusercontent.com/6791940/138119125-c4079f03-5a48-4c7b-9b51-a863359bcd48.png)

````markdown
---
title: "Title"
format: 
  html: default
---

```{r}
1 + 1
```
````
![image](https://user-images.githubusercontent.com/6791940/138119204-a59727b6-71e8-4304-95b6-1c44b0525190.png)
