### PR TITLE
Allow calling quarto with no arguments in wrapper script

### DIFF
--- a/package/scripts/common/quarto
+++ b/package/scripts/common/quarto
@@ -30,7 +30,7 @@ if [ -f "$DEV_PATH" ]; then
   export QUARTO_SHARE_PATH="`cd "$SCRIPT_PATH/../../../src/resources/";pwd`"
   export QUARTO_DEBUG=true
 
-  if [ $1 == "--version" ]; then
+  if [ "$1" == "--version" ]; then
     echo "99.9.9"
     exit 0
   fi
@@ -42,14 +42,14 @@ else
   export QUARTO_BIN_PATH=$SCRIPT_PATH
   export QUARTO_SHARE_PATH="`cd "$SCRIPT_PATH/../share";pwd`"
 
-  if [ $1 == "--version" ]; then
+  if [ "$1" == "--version" ]; then
     echo `cat "$QUARTO_SHARE_PATH/version"`
     exit 0
   fi
 
 fi
 
-if [ $1 == "--paths" ]; then
+if [ "$1" == "--paths" ]; then
   echo "$QUARTO_BIN_PATH"
   echo "$QUARTO_SHARE_PATH"
   exit 0


### PR DESCRIPTION
I noticed locally on a mac that running

    $ /usr/local/bin/quarto  # note, no arguments

resulted in

    /usr/local/bin/quarto: line 33: [: ==: unary operator expected
    /usr/local/bin/quarto: line 52: [: ==: unary operator expected

so I added double quotes.