### PR TITLE
rename create-project --type site to --type website

### DIFF
--- a/src/command/create-project/cmd.ts
+++ b/src/command/create-project/cmd.ts
@@ -12,10 +12,12 @@ import { Command, EnumType } from "cliffy/command/mod.ts";
 import { executionEngine, executionEngines } from "../../execute/engine.ts";
 
 import { projectCreate } from "../../project/project-create.ts";
-import { projectTypes } from "../../project/types/project-types.ts";
+import { projectTypes, projectTypeAliases } from "../../project/types/project-types.ts";
 import { kMarkdownEngine } from "../../execute/types.ts";
 
 const kProjectTypes = projectTypes();
+const kProjectTypeAliases = projectTypeAliases();
+const kProjectTypesAndAliases = [...kProjectTypes, ...kProjectTypeAliases];
 const kExecutionEngines = executionEngines().reverse();
 
 const editorType = new EnumType(["visual", "source"]);
@@ -34,11 +36,11 @@ export const createProjectCommand = new Command()
     `Project type (${kProjectTypes.join(", ")})`,
     {
       value: (value: string): string => {
-        if (kProjectTypes.indexOf(value || "default") === -1) {
+        if (kProjectTypesAndAliases.indexOf(value || "default") === -1) {
           throw new Error(
             `Project type must be one of ${
               kProjectTypes.join(", ")
-            }, but got "${value}".`,
+            } or site (deprecated), but got "${value}".`,
           );
         }
         return value;
@@ -87,7 +89,7 @@ export const createProjectCommand = new Command()
   )
   .example(
     "Create a website project",
-    "quarto create-project mysite --type site",
+    "quarto create-project mysite --type website",
   )
   .example(
     "Create a book project",
@@ -95,11 +97,11 @@ export const createProjectCommand = new Command()
   )
   .example(
     "Create a website project with jupyter",
-    "quarto create-project mysite --type site --engine jupyter",
+    "quarto create-project mysite --type website --engine jupyter",
   )
   .example(
     "Create a website project with jupyter + kernel",
-    "quarto create-project mysite --type site --engine jupyter:python3",
+    "quarto create-project mysite --type website --engine jupyter:python3",
   )
   .example(
     "Create a book project with knitr",

--- a/src/project/project-context.ts
+++ b/src/project/project-context.ts
@@ -203,7 +203,7 @@ export function projectContextForDirectory(
 export function projectIsWebsite(context?: ProjectContext): boolean {
   if (context) {
     const projType = projectType(context.config?.project?.[kProjectType]);
-    return projType.type === "site" || projType.inheritsType === "site";
+    return projType.type === "website" || projType.inheritsType === "website";
   } else {
     return false;
   }

--- a/src/project/types/project-types.ts
+++ b/src/project/types/project-types.ts
@@ -22,8 +22,12 @@ export function projectTypes(): string[] {
   return kTypes().map((type) => type.type);
 }
 
+export function projectTypeAliases(): string[] {
+  return kTypes().flatMap((type) => type.typeAliases || []);
+}
+
 export function projectType(type = "default"): ProjectType {
-  const projectType = kTypes().find((pt) => pt.type === type);
+  const projectType = kTypes().find((pt) => pt.type === type || pt.typeAliases?.includes(type));
   if (projectType) {
     return projectType;
   } else {

--- a/src/project/types/types.ts
+++ b/src/project/types/types.ts
@@ -13,6 +13,7 @@ import { ProjectConfig, ProjectContext } from "../types.ts";
 
 export interface ProjectType {
   type: string;
+  typeAliases?: string[];  // only for backcompat, site -> website
   inheritsType?: string;
   create: (title: string) => ProjectCreate;
   config?: (

--- a/src/project/types/website/website.ts
+++ b/src/project/types/website/website.ts
@@ -60,7 +60,8 @@ import { htmlResourceResolverPostprocessor } from "./website-resources.ts";
 import { defaultProjectType } from "../project-default.ts";
 
 export const websiteProjectType: ProjectType = {
-  type: "site",
+  type: "website",
+  typeAliases: ["site"],
   create: (title: string): ProjectCreate => {
     const resourceDir = resourcePath(join("projects", "website"));
 

--- a/src/resources/projects/website/templates/_quarto.ejs.yml
+++ b/src/resources/projects/website/templates/_quarto.ejs.yml
@@ -1,5 +1,5 @@
 project:
-  type: site
+  type: website
 
 site:
   title: "<%= title %>"

--- a/tests/docs/project/site/_quarto.yml
+++ b/tests/docs/project/site/_quarto.yml
@@ -1,5 +1,5 @@
 project:
-  type: site
+  type: website
 
 site:
   title: "site"

--- a/tests/smoke/project/project-website.test.ts
+++ b/tests/smoke/project/project-website.test.ts
@@ -26,7 +26,7 @@ import {
 // A website project
 testQuartoCmd(
   "create-project",
-  [kProjectWorkingDir, "--type", "site"],
+  [kProjectWorkingDir, "--type", "website"],
   [
     fileExists(kQuartoProjectFile),
     fileExists(join(kProjectWorkingDir, "index.qmd")),
@@ -39,7 +39,7 @@ testQuartoCmd(
           metadata["project"] !== undefined && metadata["site"] !== undefined
         ) {
           const type = (metadata["project"] as Metadata)["type"];
-          return type === "site";
+          return type === "website";
         } else {
           return false;
         }

--- a/tests/unit/yaml.test.ts
+++ b/tests/unit/yaml.test.ts
@@ -23,7 +23,7 @@ unitTest("yaml", () => {
 
   // Tests of the result
   assert(
-    (yaml.project as Metadata).type === "site",
+    (yaml.project as Metadata).type === "website",
     "Project type not read properly",
   );
   assert(

--- a/tests/unit/yaml.test.ts
+++ b/tests/unit/yaml.test.ts
@@ -11,7 +11,7 @@ import { readYamlFromString } from "../../src/core/yaml.ts";
 
 const yamlStr = `
 project:
-  type: site
+  type: website
 other:
   array:
     - foo


### PR DESCRIPTION
Resolves #92 deprecating 'site' in favor of website, but both still work.

Changed error message:

    $ quarto create-project mysite4 --type asdf
    ERROR: Error: Project type must be one of default, website, book or site (deprecated) but got "asdf".
        ...

Is this the level of deprecation you were thinking of @jjallaire?

There are a couple instances of the string "site" that I didn't change but wasn't sure about.

I haven't run any automated tests so I'll look for CI results.