### PR TITLE
Add process to update reveal.js in `update-html-dependencies`

### DIFF
--- a/configuration
+++ b/configuration
@@ -25,6 +25,7 @@ export POPPER_JS=2.9.1
 export CLIPBOARD_JS=2.0.8
 export TIPPY_JS=6.3.0
 export PDF_JS=2.8.335
+export REVEAL_JS=4.1.2
 
 # javascript search dependencies
 export AUTOCOMPLETE_JS=1.4.0

--- a/configuration
+++ b/configuration
@@ -25,7 +25,7 @@ export POPPER_JS=2.9.1
 export CLIPBOARD_JS=2.0.8
 export TIPPY_JS=6.3.0
 export PDF_JS=2.8.335
-export REVEAL_JS=4.1.2
+export REVEAL_JS=05e57dea66529a1b472f743f8ac520fb8bed0ba2
 
 # javascript search dependencies
 export AUTOCOMPLETE_JS=1.4.0

--- a/configuration
+++ b/configuration
@@ -25,7 +25,7 @@ export POPPER_JS=2.9.1
 export CLIPBOARD_JS=2.0.8
 export TIPPY_JS=6.3.0
 export PDF_JS=2.8.335
-export REVEAL_JS=05e57dea66529a1b472f743f8ac520fb8bed0ba2
+export REVEAL_JS=92a0d472372fbbc7a2b11ab9375cd87519d379e7
 
 # javascript search dependencies
 export AUTOCOMPLETE_JS=1.4.0

--- a/package/src/common/update-html-dependencies.ts
+++ b/package/src/common/update-html-dependencies.ts
@@ -94,7 +94,6 @@ export async function updateHtmlDepedencies(config: Configuration) {
         clipboardJs,
       );
     },
-    "v",
   );
   cleanSourceMap(clipboardJs);
 
@@ -139,7 +138,6 @@ export async function updateHtmlDepedencies(config: Configuration) {
         fuseJs,
       );
     },
-    "v",
   );
   cleanSourceMap(fuseJs);
 
@@ -184,6 +182,7 @@ export async function updateHtmlDepedencies(config: Configuration) {
         join(revealJs, "plugin"),
       );
     },
+    "commit",
   );
 
   // Autocomplete
@@ -538,15 +537,19 @@ async function updateGithubSourceCodeDependency(
   versionEnvVar: string,
   working: string,
   onDownload: (dir: string, version: string) => void,
-  tagPrefix?: string,
+  type = "tag", // set to commit to download repo from commit working dir
 ) {
   info(`Updating ${name}...`);
   const version = Deno.env.get(versionEnvVar);
   if (version) {
-    const tag = tagPrefix ? tagPrefix.concat(version) : version;
     const fileName = `${name}.zip`;
-    const distUrl = `https://github.com/${repo}/archive/refs/tags/${tag}.zip`;
+    const distUrl = join(
+      `https://github.com/${repo}/archive`,
+      type === "tag" ? `refs/tags/v${version}.zip` : `${version}.zip`,
+    );
+    info(`Url: ${distUrl}`);
     const zipFile = join(working, fileName);
+    info(`ZIP: ${zipFile}`);
 
     // Download and unzip the release
     info(`Downloading ${distUrl}`);

--- a/package/src/common/update-html-dependencies.ts
+++ b/package/src/common/update-html-dependencies.ts
@@ -182,7 +182,7 @@ export async function updateHtmlDepedencies(config: Configuration) {
         join(revealJs, "plugin"),
       );
     },
-    "commit",
+    true,
   );
 
   // Autocomplete
@@ -537,7 +537,7 @@ async function updateGithubSourceCodeDependency(
   versionEnvVar: string,
   working: string,
   onDownload: (dir: string, version: string) => void,
-  type = "tag", // set to commit to download repo from commit working dir
+  commit = false, // set to true when commit is used instead of a tag
 ) {
   info(`Updating ${name}...`);
   const version = Deno.env.get(versionEnvVar);
@@ -545,7 +545,7 @@ async function updateGithubSourceCodeDependency(
     const fileName = `${name}.zip`;
     const distUrl = join(
       `https://github.com/${repo}/archive`,
-      type === "tag" ? `refs/tags/v${version}.zip` : `${version}.zip`,
+      commit ? `${version}.zip` : `refs/tags/v${version}.zip`,
     );
     const zipFile = join(working, fileName);
 

--- a/package/src/common/update-html-dependencies.ts
+++ b/package/src/common/update-html-dependencies.ts
@@ -262,7 +262,11 @@ export async function updateHtmlDepedencies(config: Configuration) {
   //
 
   // Clean up the temp dir
-  Deno.removeSync(workingDir, { recursive: true });
+  try {
+    Deno.removeSync(workingDir, { recursive: true });
+  } catch (_err) {
+    info(`Folder not deleted - Remove manually: ${workingDir}`);
+  }
   info(
     "\n** Done- please commit any files that have been updated. **\n",
   );

--- a/package/src/common/update-html-dependencies.ts
+++ b/package/src/common/update-html-dependencies.ts
@@ -547,9 +547,7 @@ async function updateGithubSourceCodeDependency(
       `https://github.com/${repo}/archive`,
       type === "tag" ? `refs/tags/v${version}.zip` : `${version}.zip`,
     );
-    info(`Url: ${distUrl}`);
     const zipFile = join(working, fileName);
-    info(`ZIP: ${zipFile}`);
 
     // Download and unzip the release
     info(`Downloading ${distUrl}`);

--- a/package/src/common/update-html-dependencies.ts
+++ b/package/src/common/update-html-dependencies.ts
@@ -135,6 +135,30 @@ export async function updateHtmlDepedencies(config: Configuration) {
   );
   cleanSourceMap(fuseJs);
 
+  // reveal.js
+  const revealJs = join(
+    config.directoryInfo.src,
+    "resources",
+    "format",
+    "revealjs",
+    "reveal",
+  );
+
+  await updateGithubSourceCodeDependency(
+    "reveal.js",
+    "hakimel/reveal.js",
+    "REVEAL_JS",
+    workingDir,
+    (dir: string, version: string) => {
+      // Copy the js file
+      ensureDirSync(dirname(fuseJs));
+      Deno.copyFileSync(
+        join(dir, `Fuse-${version}`, "dist", "fuse.min.js"),
+        fuseJs,
+      );
+    },
+  );
+
   // Autocomplete
   const autocompleteJs = join(
     config.directoryInfo.src,
@@ -207,6 +231,8 @@ export async function updateHtmlDepedencies(config: Configuration) {
 
   // Update Pandoc themes
   await updatePandocHighlighting(config);
+
+  //
 
   // Clean up the temp dir
   Deno.removeSync(workingDir, { recursive: true });

--- a/package/src/common/update-html-dependencies.ts
+++ b/package/src/common/update-html-dependencies.ts
@@ -12,7 +12,7 @@ import {
   moveSync,
 } from "fs/mod.ts";
 import { info } from "log/mod.ts";
-import { dirname, join } from "path/mod.ts";
+import { dirname, extname, join } from "path/mod.ts";
 import { lines } from "../../../src/core/text.ts";
 import { runCmd } from "../util/cmd.ts";
 import { Repo, withRepo } from "../util/git.ts";
@@ -160,9 +160,9 @@ export async function updateHtmlDepedencies(config: Configuration) {
     (dir: string, version: string) => {
       // Copy the desired resource files
       if (existsSync(revealJs)) {
-        Deno.removeSync(dirname(revealJs), { recursive: true });
+        Deno.removeSync(revealJs, { recursive: true });
       }
-      ensureDirSync(dirname(revealJs));
+      ensureDirSync(revealJs);
       copySync(join(dir, `reveal.js-${version}`, "css"), join(revealJs, "css"));
       copySync(
         join(dir, `reveal.js-${version}`, "dist"),
@@ -172,6 +172,16 @@ export async function updateHtmlDepedencies(config: Configuration) {
         join(dir, `reveal.js-${version}`, "plugin"),
         join(revealJs, "plugin"),
       );
+      // remove unneeded CSS files
+      for (
+        const fileEntry of Deno.readDirSync(
+          join(dir, `reveal.js-${version}`, "dist"),
+        )
+      ) {
+        if (fileEntry.isFile && extname(fileEntry.name) === "css") {
+          Deno.removeSync(fileEntry.name);
+        }
+      }
     },
   );
 

--- a/package/src/common/update-html-dependencies.ts
+++ b/package/src/common/update-html-dependencies.ts
@@ -159,26 +159,26 @@ export async function updateHtmlDepedencies(config: Configuration) {
     workingDir,
     (dir: string, version: string) => {
       // Copy the desired resource files
+      info("Copying reveal.js resources' directory");
       if (existsSync(revealJs)) {
         Deno.removeSync(revealJs, { recursive: true });
       }
       ensureDirSync(revealJs);
 
+      info("Copying css/");
       copySync(join(dir, `reveal.js-${version}`, "css"), join(revealJs, "css"));
-
+      info("Copying dist/");
       const dist = join(revealJs, "dist");
       copySync(join(dir, `reveal.js-${version}`, "dist"), dist);
       // remove unneeded CSS files
       const theme = join(dist, "theme");
       for (const fileEntry of Deno.readDirSync(theme)) {
-        info(`Looking at ${fileEntry.name}`);
-        info(`extensions is ${extname(fileEntry.name)}`);
         if (fileEntry.isFile && extname(fileEntry.name) === ".css") {
-          info(`remove ${join(theme, fileEntry.name)}`);
+          info(`-> Removing unneeded ${fileEntry.name}.`);
           Deno.removeSync(join(theme, fileEntry.name));
         }
       }
-
+      info("Copying plugin/");
       copySync(
         join(dir, `reveal.js-${version}`, "plugin"),
         join(revealJs, "plugin"),

--- a/package/src/common/update-html-dependencies.ts
+++ b/package/src/common/update-html-dependencies.ts
@@ -163,25 +163,26 @@ export async function updateHtmlDepedencies(config: Configuration) {
         Deno.removeSync(revealJs, { recursive: true });
       }
       ensureDirSync(revealJs);
+
       copySync(join(dir, `reveal.js-${version}`, "css"), join(revealJs, "css"));
-      copySync(
-        join(dir, `reveal.js-${version}`, "dist"),
-        join(revealJs, "dist"),
-      );
+
+      const dist = join(revealJs, "dist");
+      copySync(join(dir, `reveal.js-${version}`, "dist"), dist);
+      // remove unneeded CSS files
+      const theme = join(dist, "theme");
+      for (const fileEntry of Deno.readDirSync(theme)) {
+        info(`Looking at ${fileEntry.name}`);
+        info(`extensions is ${extname(fileEntry.name)}`);
+        if (fileEntry.isFile && extname(fileEntry.name) === ".css") {
+          info(`remove ${join(theme, fileEntry.name)}`);
+          Deno.removeSync(join(theme, fileEntry.name));
+        }
+      }
+
       copySync(
         join(dir, `reveal.js-${version}`, "plugin"),
         join(revealJs, "plugin"),
       );
-      // remove unneeded CSS files
-      for (
-        const fileEntry of Deno.readDirSync(
-          join(dir, `reveal.js-${version}`, "dist"),
-        )
-      ) {
-        if (fileEntry.isFile && extname(fileEntry.name) === "css") {
-          Deno.removeSync(fileEntry.name);
-        }
-      }
     },
   );
 

--- a/package/src/util/git.ts
+++ b/package/src/util/git.ts
@@ -25,7 +25,11 @@ export async function withRepo(
     },
   };
   await fn(repo);
-  Deno.removeSync(repoPath, { recursive: true });
+  try {
+    Deno.removeSync(repoPath, { recursive: true });
+  } catch (_err) {
+    info(`Folder not deleted by deno: ${repoPath}`);
+  }
 }
 
 async function checkout(dir: string, commit: string) {


### PR DESCRIPTION
At first I did it to update on a github release tag but it seems a commit is better.
Other example on commit is for Bootstrap  and it is using `git`. I think we can do without GIT and did it accordingly for reveal.js. 

this is also in light of an issue discussed with @dragonstyle where on Windows `Deno.removeSync` does not manage to clean a folder cloned using Git. (because of Git access right on filesytem were read only files are created). 
This lead to adding Try Catch so the the scripts runs on Windows without terminating early due to error.

Regarding the reveal.js update: 

* We get `css/`, `dist/` and `plugin/`
* We remove unwanted `.css` in the `dist/theme/` folder

I choose to update the existing `updateGithubSourceCodeDependency()` function to support a commit in addition of a release tag. I used a new optional `commit` argument set to `false` by default. Another idea was do detect if the env var was a git commit or a version number using for example `.` detection as commit won't have any dots usually. It could be on the number of character too. Anyway, tell me if this is a better idea.

If the process seems valid, I could also change the way we get the bootstrap deps to use the same zip download. This would avoid using Git and would avoid the "Permission Denied" issue on Windows. 

