### PR TITLE
reveal: Default to slide level 2 and allow vertical navigation only when navigationMode is changed

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -72,6 +72,7 @@ import {
   kSelfContained,
   kSelfContainedMath,
   kShiftHeadingLevelBy,
+  kSlideLevel,
   kTableOfContents,
   kTemplate,
   kTitlePrefix,
@@ -300,6 +301,7 @@ export interface FormatPandoc {
   [kTopLevelDivision]?: string;
   [kShiftHeadingLevelBy]?: number;
   [kTitlePrefix]?: string;
+  [kSlideLevel]?: number;
 }
 
 export interface PandocFlags {

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -188,8 +188,9 @@ export function revealjsFormat() {
         if (format.metadata[kRevealJsConfig] !== "default") {
           // detect whether we are using vertical slides
           const navigationMode = format.metadata["navigationMode"];
+          const slideLevel = format.pandoc[kSlideLevel];
           const verticalSlides = navigationMode === "default" ||
-            navigationMode === "grid";
+            navigationMode === "grid" || slideLevel === 2;
 
           // if the user set slideNumber to true then provide
           // linear slides (if they havne't specified vertical slides)
@@ -205,7 +206,7 @@ export function revealjsFormat() {
               height: 700,
               margin: 0.1,
               center: false,
-              navigationMode: "linear",
+              navigationMode: verticalSlides ? "default" : "linear",
               controls: verticalSlides,
               controlsTutorial: false,
               hash: true,
@@ -270,7 +271,7 @@ function revealMetadataFilter(metadata: Metadata) {
 
 function revealHtmlPostprocessor(format: Format) {
   return (doc: Document): Promise<string[]> => {
-    // find reveal initializatio and perform fixups
+    // find reveal initialization and perform fixups
     const scripts = doc.querySelectorAll("script");
     for (const script of scripts) {
       const scriptEl = script as Element;

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -289,8 +289,7 @@ function revealHtmlPostprocessor(format: Format) {
 
     // remove all attributes from slide headings (pandoc has already moved
     // them to the enclosing section)
-    const slideLevel = parseInt(format.metadata[kSlideLevel] as string, 10) ||
-      2;
+    const slideLevel = format.pandoc[kSlideLevel] || 2;
     const slideHeadingTags = Array.from(Array(slideLevel)).map((_e, i) =>
       "H" + (i + 1)
     );

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -116,6 +116,7 @@ export function revealjsFormat() {
           url:
             "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_HTML-full",
         },
+        [kSlideLevel]: 2,
       },
       metadataFilter: revealMetadataFilter,
       formatPreviewFile: revealMuliplexPreviewFile,
@@ -188,9 +189,8 @@ export function revealjsFormat() {
         if (format.metadata[kRevealJsConfig] !== "default") {
           // detect whether we are using vertical slides
           const navigationMode = format.metadata["navigationMode"];
-          const slideLevel = format.pandoc[kSlideLevel];
           const verticalSlides = navigationMode === "default" ||
-            navigationMode === "grid" || slideLevel === 2;
+            navigationMode === "grid";
 
           // if the user set slideNumber to true then provide
           // linear slides (if they havne't specified vertical slides)
@@ -206,7 +206,7 @@ export function revealjsFormat() {
               height: 700,
               margin: 0.1,
               center: false,
-              navigationMode: verticalSlides ? "default" : "linear",
+              navigationMode: "linear",
               controls: verticalSlides,
               controlsTutorial: false,
               hash: true,


### PR DESCRIPTION
Following discussion, this PR has changed purposed.  A very small PR after all

This sets slide-level to be 2 by default, meaning with this example
````
---
title: demo reveal
output: revealjs
---

# Section Header

## Header on vertical slide

Content on verticle slide

# Section header 

With content 

## Another slide 

will be vertical in reveal. 
````

We would have 
1. A title slide
2. A section title slide
3. A slide with content
4. A section title slide with content
5. A slide with content

Activating overview would show the vertical slides but `navigationMode: linear` would prevent a vertical navigation. 

To activate verticals controls, one would have to do `navigationMode: default`. This would not change the content, but add the controls and right arrow would only show section titles.

Is this a good new default ? Only usage could tell us. While documenting the feature we could change our decision. 

From my tests, other useful value for revealjs are: 

* `slide-level: 0` : only `---` would create slides
* `slide-level: 1`: Slide would be created only with header 1 
* `slide-level` > 2 : would be a very bad idea with revealJS as it would create normal slide for the slide level only. This would only be useful when a upper level is never used. e.g `slide-level: 3` when only `##` for section and `###` for slides is used. Not sure it should happen. 