### PR TITLE
Fix revealJS template patching

### DIFF
--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -247,7 +247,7 @@ function revealRequireJsPatch(template: string) {
     "<script>window.backupDefine = window.define; window.define = undefined;</script>\n  $1",
   );
   template = template.replace(
-    /(<script src="\$revealjs-url\$\/plugin\/math\/math.js"><\/script>\n\$endif\$)/,
+    /(<script src="\$revealjs-url\$\/plugin\/math\/math.js"><\/script>(?:\r?\n|\r)\$endif\$)/,
     "$1\n  <script>window.define = window.backupDefine; window.backupDefine = undefined;</script>\n",
   );
   return template;


### PR DESCRIPTION
Regex needs to match newline on Windows too. Currently the patch does not correctly apply. 

```
<script>window.backupDefine = window.define; window.define = undefined;</script>
```
is added but

```
<script>window.define = window.backupDefine; window.backupDefine = undefined;</script>
```

is not. 
Not sure what this patching do (replacing temporarily `window.define`) but if that is to keep, we should fix this.

At least on Windows where `\r\n` will be the end of line. 

From some search I understand `\r` could be used on old Mac. 

So end of line can be \r\n, \n or \r.

Maybe using `\s*` is enough  here too instead. 
> Matches a single white space character, including space, tab, form feed, line feed, and other Unicode spaces. Equivalent to [ \f\n\r\t\v\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]. For example, /\s\w*/ matches " bar" in "foo bar". 

Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes