### PR TITLE
patch revealjs template to allow disableLayout variable

### DIFF
--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -155,7 +155,17 @@ export function revealjsFormat() {
             metadataOverride: {} as Metadata,
             [kIncludeInHeader]: [formatResourcePath("revealjs", "styles.html")],
             html: {
-              [kTemplatePatches]: [revealRequireJsPatch],
+              [kTemplatePatches]: [
+                revealRequireJsPatch,
+                /* TODO: Remove when the fix is available in Pandoc https://github.com/jgm/pandoc/pull/7670 */
+                (template: string) => {
+                  template = template.replace(
+                    /(disableLayout: )false/,
+                    "$1$disableLayout$",
+                  );
+                  return template;
+                },
+              ],
               [kHtmlPostprocessors]: [
                 revealHtmlPostprocessor(format),
               ],


### PR DESCRIPTION
During my test of widgets, I wanted to see the impact of the reveal layout feature. Using `disableLayout` was not effective because Pandoc's template hard code to false. 

I think this is an issue in Pandoc so I proposed a patched there (https://github.com/jgm/pandoc/pull/7670). 

For it to work on our side now, I added a patch. 

I used anonymous function as it is supposed to be temporary, but if it is better to use a named function for clarity, I'll change. 

Happy to not merge also to wait on Pandoc - the code is working so I can use this branch to test if needed.