### PR TITLE
Fix title bottom margin

### DIFF
--- a/src/resources/formats/html/_quarto-rules.scss
+++ b/src/resources/formats/html/_quarto-rules.scss
@@ -128,7 +128,7 @@ h6:hover > .anchorjs-link,
 }
 
 #title-block-header {
-  margin-block-end: 0;
+  margin-block-end: 1rem;
   position: relative;
 }
 


### PR DESCRIPTION
The title bottom margin was recently changed to 0, see here: https://github.com/quarto-dev/quarto-cli/commit/c81327c75bda7957fca878332b773c9356e97dff#diff-b827c75feeeba3628c10453b35b4435c8bf561716345572064cd5c245a06034aR131

Maybe this has been done by mistake? It seems weird to have no spacing between the author and the first heading... Compare the new behavior (left) and the old one with spacing (right):

<img src="https://user-images.githubusercontent.com/2412819/141305113-b4c737ac-4724-4984-8fd6-8a8ea7804dc7.png" width="300"/>

It looks particularly strange when there is text before the first heading:

<img src="https://user-images.githubusercontent.com/2412819/141305281-b1154d1c-8ca4-45d3-8788-42b3d7de8a2f.png" width="300"/>

This PR reverts the margin change. Feel free to close it if the change was intended.