### PR TITLE
Fix typo in "Footnotes" French translation

### DIFF
--- a/src/resources/language/_language-fr.yml
+++ b/src/resources/language/_language-fr.yml
@@ -1,7 +1,7 @@
 toc-title-document: "Table des matières"
 toc-title-website: "Sur cette page"
 
-section-title-footnotes: "Note de bas de page"
+section-title-footnotes: "Notes de bas de page"
 
 callout-tip-caption: "Astuce"
 callout-note-caption: "Note"


### PR DESCRIPTION
This fixes a small typo: missing plural in the French translation of "Footnotes".