### PR TITLE
fix configuration for symlink bin directories

### DIFF
--- a/package/src/common/configure.ts
+++ b/package/src/common/configure.ts
@@ -4,7 +4,7 @@
 * Copyright (C) 2020 by RStudio, PBC
 *
 */
-import { dirname, join } from "path/mod.ts";
+import { dirname, join, SEP } from "path/mod.ts";
 import { ensureDirSync, existsSync } from "fs/mod.ts";
 import { info, warning } from "log/mod.ts";
 
@@ -71,7 +71,8 @@ export async function configure(
       try {
         // for the last path, try even creating a directory as a last ditch effort
         if (i === symlinkPaths.length - 1) {
-          ensureDirSync(dirname(symlinkPath));
+          // append path separator to resolve the dir name (in case it's a symlink)
+          ensureDirSync(dirname(symlinkPath) + SEP);
         }
         Deno.symlinkSync(
           join(config.directoryInfo.bin, "quarto"),


### PR DESCRIPTION
Calling `ensureDirSync` on `"/home/user/bin"` for example will fail if `bin` is a symlink to a directory (because it's a file). Calling it on `"/home/user/bin/"` (by appending a path separator) will force resolving the link so bin is seen as a directory (if the link target is a directory). This mechanism is described at https://man7.org/linux/man-pages/man7/path_resolution.7.html 

This fixes the build on my computer where `~/bin` is a symlink.