### PR TITLE
Add patch for leaflet due to reveal scaling feature

### DIFF
--- a/src/resources/formats/revealjs/plugins/support/support.js
+++ b/src/resources/formats/revealjs/plugins/support/support.js
@@ -106,7 +106,7 @@ window.QuartoSupport = function () {
         unScale2(deck.getSlidesElement(), deck.getScale());
 
         // And unscale each time presentation is resized
-        Reveal.on("resize", function (ev) {
+        deck.on("resize", function (ev) {
           unScale2(deck.getSlidesElement(), ev.scale);
         });
       });

--- a/src/resources/formats/revealjs/plugins/support/support.js
+++ b/src/resources/formats/revealjs/plugins/support/support.js
@@ -99,9 +99,13 @@ window.QuartoSupport = function () {
           this.invalidateSize();
         }
 
+        // bind the leaflet Map object to unscale
         const unScale2 = unScale.bind(this);
 
-        // We run the unscaling each time the presentation is resize
+        // Unscale at initialization
+        unScale2(deck.getSlidesElement(), deck.getScale());
+
+        // And unscale each time presentation is resized
         Reveal.on("resize", function (ev) {
           unScale2(deck.getSlidesElement(), ev.scale);
         });

--- a/src/resources/formats/revealjs/plugins/support/support.js
+++ b/src/resources/formats/revealjs/plugins/support/support.js
@@ -73,6 +73,32 @@ window.QuartoSupport = function () {
     }
   }
 
+  // Patch leaflet for compatibility with revealjs
+  function patchLeaflet(deck) {
+    // check if leaflet is used
+    if (window.L) {
+      L.Map.addInitHook(function () {
+        const slides = deck.getSlidesElement();
+        const scale = deck.getScale();
+
+        const container = this.getContainer();
+
+        // Cancel revealjs scaling on map container by doing the opposite of what it sets
+        // zoom will be used for scale > 1
+        // transform will be used for scale < 1
+        if (slides.style.zoom) {
+          container.style.zoom = 1 / scale;
+        } else if (slides.style.transform) {
+          // reveal.js use transform: scale(..)
+          container.style.transform = "scale(" + 1 / scale + ")";
+        }
+
+        // Update the map on container size changed
+        this.invalidateSize();
+      });
+    }
+  }
+
   return {
     id: "quarto-support",
     init: function (deck) {
@@ -80,6 +106,7 @@ window.QuartoSupport = function () {
       addLogoImage(deck);
       addFooterText(deck);
       addChalkboardButtons(deck);
+      patchLeaflet(deck);
     },
   };
 };


### PR DESCRIPTION
This PR add a path for leaflet when used in revealjs. 

Reveal with use scaling feature and this mess up the pointer on the map with tooltip
![lealfet-tooltip-nok](https://user-images.githubusercontent.com/6791940/142435474-5b16bad9-ee05-4bd1-8cfc-2c406b6c38ed.gif)

With this plugin, it will "cancel" the zooming for the leaflet container so that the pointer x / y coordinates are correct to place the tooltip. 

![lealfet-tooltip-ok](https://user-images.githubusercontent.com/6791940/142436708-923cb66c-1995-4970-8098-d3cfa515f170.gif)

However it still need to be tweaked so that it is recalculated each time the slide scale changes using 
````
Reveal.on( 'resize', event => {
  // event.scale, event.oldScale, event.size
} );
````

Hence the draft PR for now
