### PR TITLE
[reveal] Remove leaflet patch from support plugin

### DIFF
--- a/src/resources/formats/revealjs/plugins/support/support.js
+++ b/src/resources/formats/revealjs/plugins/support/support.js
@@ -197,45 +197,6 @@ window.QuartoSupport = function () {
     }
   }
 
-  // Patch leaflet for compatibility with revealjs
-  function patchLeaflet(deck) {
-    // check if leaflet is used
-    if (window.L) {
-      L.Map.addInitHook(function () {
-        function unScale(slides, scale) {
-          const container = this.getContainer();
-
-          // Cancel revealjs scaling on map container by doing the opposite of what it sets
-          // * zoom will be used for scale > 1
-          // * transform will be used for scale < 1
-          // As we change on every resize, we remove other value if it was previously set
-          if (slides.style.zoom) {
-            if (slides.style.transform) slides.style.transform = null;
-            container.style.zoom = 1 / scale;
-          } else if (slides.style.transform) {
-            // reveal.js use transform: scale(..)
-            if (slides.style.zoom) slides.style.zoom = null;
-            container.style.transform = "scale(" + 1 / scale + ")";
-          }
-
-          // Checks if the map container size changed and updates the map
-          this.invalidateSize();
-        }
-
-        // bind the leaflet Map object to unscale
-        const unScale2 = unScale.bind(this);
-
-        // Unscale at initialization
-        unScale2(deck.getSlidesElement(), deck.getScale());
-
-        // And unscale each time presentation is resized
-        deck.on("resize", function (ev) {
-          unScale2(deck.getSlidesElement(), ev.scale);
-        });
-      });
-    }
-  }
-
   function handleTabbyClicks() {
     const tabs = document.querySelectorAll(".panel-tabset-tabby > li > a");
     for (let i = 0; i < tabs.length; i++) {
@@ -273,7 +234,6 @@ window.QuartoSupport = function () {
       addLogoImage(deck);
       addFooter(deck);
       addChalkboardButtons(deck);
-      patchLeaflet(deck);
       handleTabbyClicks();
     },
   };


### PR DESCRIPTION
We decided to revert changes from #189 

The issue with leaflet being impacted by the scaling should be dealt upstream as it has been done in plotly and other JS lib. 

It is then known that we have a limitation with leaflet in reveal.js regarding any behavior backed by coord X / Y (like the tooltip position). This is due to scaling. It will be the case with other htmlwidgets anyway and it is not a good idea to patch them all probably. 

This PR and the previous one are enough to document this limitation.