### PR TITLE
figcaption styling in slides 

### DIFF
--- a/src/resources/formats/html/_quarto-rules.scss
+++ b/src/resources/formats/html/_quarto-rules.scss
@@ -80,14 +80,23 @@
   width: 100%;
   margin-bottom: 0;
 }
-.quarto-figure-left > figure > p {
-  text-align: left;
+.quarto-figure-left > figure {
+  > p,
+  > figcaption {
+    text-align: left;
+  }
 }
-.quarto-figure-center > figure > p {
-  text-align: center;
+.quarto-figure-center > figure {
+  > p,
+  > figcaption {
+    text-align: center;
+  }
 }
-.quarto-figure-right > figure > p {
-  text-align: right;
+.quarto-figure-right > figure {
+  > p,
+  > figcaption {
+    text-align: right;
+  }
 }
 figure > p:empty {
   display: none;


### PR DESCRIPTION
Currently in Quarto presentation we got this 
* One image 
```markdown
## Insert an image

Without stretch feature

![revealjs logo](https://revealjs.com/images/logo/reveal-black-text.svg)
```

![image](https://user-images.githubusercontent.com/6791940/145864709-e6203980-80d0-49eb-8539-fd4ac260982b.png)

* 2 images
```markdown
## No strech when more than one image

![revealjs logo](https://revealjs.com/images/logo/reveal-black-text.svg)

And another 

![revealjs logo](https://revealjs.com/images/logo/reveal-black-text.svg)
```

![image](https://user-images.githubusercontent.com/6791940/145867941-d1f956a3-0de8-4cc3-a1e1-15b2f2d283ef.png)



It seems it would be better to align the `figcaption` where there is one with the image

This PR does that. 

I would also style the caption differently (maybe smaller font size ?) - would that be something to add ? 


Obviously, when I get the `.stretch` working, we either remove the caption or keep it, and I still think it should be centered. 

After this PR. 
![image](https://user-images.githubusercontent.com/6791940/145872424-6b5d5df6-3493-4c2c-8ae9-684ecaa51fdb.png)

![image](https://user-images.githubusercontent.com/6791940/145872482-94462548-97d5-47e5-b463-cdb57242c15d.png)


 