### PR TITLE
[reveal] reduce font-size for figcaption

### DIFF
--- a/src/resources/formats/revealjs/styles.html
+++ b/src/resources/formats/revealjs/styles.html
@@ -67,4 +67,8 @@
   .reveal .tippy-content>*:last-child {
     margin-bottom: 0.2em;
   }
+
+  .reveal .slide figure > figcaption {
+    font-size: 0.5em
+  }
 </style>


### PR DESCRIPTION
Following https://github.com/quarto-dev/quarto-cli/pull/218,  suggestion is to reduce font-size on fig caption for revealjs slides