### PR TITLE
Follow-up PR on auto-stretch feature for reveal presentation

### DIFF
--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -550,6 +550,10 @@ function applyStretch(doc: Document, autoStretch: boolean) {
   const allSlides = doc.querySelectorAll("section");
   for (const slide of allSlides) {
     const slideEl = slide as Element;
+
+    // opt-out mechanism per slide
+    if (slideEl.classList.contains("nostretch")) continue;
+
     const images = slideEl.querySelectorAll("img");
     // only target slides with one image
     if (images.length === 1) {

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -583,7 +583,13 @@ function applyStretch(doc: Document, autoStretch: boolean) {
         return imageEl.classList.contains("stretch") ||
           imageEl.classList.contains("r-stretch");
       };
-      if (autoStretch === true && !hasStretchClass(imageEl)) {
+      if (
+        autoStretch === true &&
+        !hasStretchClass(imageEl) &&
+        // if height is already set, we do nothing
+        !imageEl.getAttribute("style")?.match("height:") &&
+        !imageEl.hasAttribute("height")
+      ) {
         imageEl.classList.add("r-stretch");
       }
       // If <img class="stetch"> is not a direct child of <section>, move it


### PR DESCRIPTION
This follows https://github.com/quarto-dev/quarto-cli/pull/224 by adding the following: 

- [x] Ignore images in block like layout
- [x] Ignore inline image (i.e image in `<p>` inline with other text in the paragraph)
- [x] Add a opt-out mechanism at the slide level using `.nostretch` class
- [x] Don't "auto-stretch" image with a height already define (in `style` or as its own attribute)

To do that, I change `forEach` by classic for loop so that we can exist early. Finding the upper level node is now done earlier too. 

<details>
<summary>test qmd file</summary>

````markdown
---
title: "test stretched"
format: 
  revealjs: 
    auto-stretch: true
execute:
  keep-md: true
---

## Insert an image

Without stretch feature

![revealjs logo](https://revealjs.com/images/logo/reveal-black-text.svg)

## Insert an image with code content below

Without stretch feature

![revealjs logo](https://revealjs.com/images/logo/reveal-black-text.svg)

```{r, echo = TRUE}
1 + 1 
```

## Insert an image with no caption

Without stretch feature

![](https://revealjs.com/images/logo/reveal-black-text.svg)

## Insert an image with height defined

Without stretch feature

![](https://revealjs.com/images/logo/reveal-black-text.svg){height=50%}

## Insert an image with right alignment

Without stretch feature

![](https://revealjs.com/images/logo/reveal-black-text.svg){fig-align='right'}

## Insert an image with caption text

![Elephant](https://raw.githubusercontent.com/quarto-dev/quarto-web/main/docs/authoring/elephant.png)

## Column layout

:::: {.columns}

::: {.column width="40%"}
On the right a nice elephant
:::

::: {.column width="60%"}
![Elephant](https://raw.githubusercontent.com/quarto-dev/quarto-web/main/docs/authoring/elephant.png)
:::

::::

## Insert an image with alt text

![](https://raw.githubusercontent.com/quarto-dev/quarto-web/main/docs/authoring/elephant.png){fig-alt="A drawing of an elephant."}

## Insert an image with alt text, caption and title

![Elephant](https://raw.githubusercontent.com/quarto-dev/quarto-web/main/docs/authoring/elephant.png "Title: An elephant"){fig-alt="A drawing of an elephant."}

## Insert an image specifying `.strech` explicitly (no caption)

With adding stretch feature

![](https://revealjs.com/images/logo/reveal-black-text.svg){.stretch}

## Insert an image specifying `.strech` explicitly (with caption)

Using the `.strech` class

![revealjs logo](https://revealjs.com/images/logo/reveal-black-text.svg){.stretch}

## No strech when more than one image

![revealjs logo](https://revealjs.com/images/logo/reveal-black-text.svg)

And another

![revealjs logo](https://revealjs.com/images/logo/reveal-black-text.svg)

## No stretch when `.nostretch` is used at slide level {.nostretch}

![revealjs logo](https://revealjs.com/images/logo/reveal-black-text.svg)

## Using knitr to create a plot

```{r, echo = TRUE, fig.cap = "Knitr figure"}
plot(cars)
```

## Using knitr to create a plot without echo

```{r, echo = FALSE, fig.cap = "Knitr figure"}
plot(cars)
```

## Using knitr to create a plot without other text

```{r, echo = FALSE, fig.cap = "Knitr figure"}
plot(cars)
```

On this plot, we have interesting informations.

## Using knitr to specify alignement

```{r, echo = FALSE, fig.cap = "Knitr figure", fig.align='right'}
plot(cars)
```

## Using knitr to specify height

```{r, echo = FALSE, fig.cap = "Knitr figure", out.height="120px"}
plot(cars)
```

## Using knitr to specify height in %

```{r, echo = FALSE, fig.cap = "Knitr figure", out.height="50%"}
plot(cars)
```

## Inline images

And how does it works with inline images like ![](https://revealjs.com/images/logo/reveal-black-text.svg)

## Slide with python code

```{python}
#| fig-cap: "Polar axis plot"
#| fig-alt: "A line plot on a polar axis"

import numpy as np
import matplotlib.pyplot as plt

r = np.arange(0, 2, 0.01)
theta = 2 * np.pi * r
fig, ax = plt.subplots(subplot_kw={'projection': 'polar'})
ax.plot(theta, r)
ax.set_rticks([0.5, 1, 1.5, 2])
ax.grid(True)
plt.show()
```

## Is a widget breaking the feature ? 

```{r}
library(plotly)
fig = list(
  data = list(
    list(
      x = c(1, 2, 3),
      y = c(1, 3, 2),
      type = 'bar'
    )
  ),
  layout = list(
    title = 'A Figure Specified By R List',
    plot_bgcolor='#e5ecf6', 
         xaxis = list( 
           zerolinecolor = '#ffff', 
           zerolinewidth = 2, 
           gridcolor = 'ffff'), 
         yaxis = list( 
           zerolinecolor = '#ffff', 
           zerolinewidth = 2, 
           gridcolor = 'ffff')
  )
)
# To display the figure defined by this list, use the plotly_build function
plotly_build(fig)
```

## Using block layout

::: {layout-ncol=2}

- Item A
- Item B
- Item C

![](https://revealjs.com/images/logo/reveal-black-text.svg)
:::

## Using figure table layout

```{r}
#| layout-ncol: 2

library(knitr)
kable(head(cars), caption = "Cars")
plot(cars)
```
````

</details>