### PR TITLE
Get images, alignement and caption before removing any element

### DIFF
--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -601,23 +601,16 @@ function applyStretch(doc: Document, autoStretch: boolean) {
         hasStretchClass(imageEl) &&
         imageEl.parentNode?.nodeName !== "SECTION"
       ) {
+        // Remove element then maybe remove its parents if empty
         const removeEmpty = function (el: Element) {
           const parentEl = el.parentElement;
-          // Remove element then maybe remove its parents
           parentEl?.removeChild(el);
           if (parentEl?.innerText.trim() === "") removeEmpty(parentEl);
         };
 
-        // Remove image from its parent
-        removeEmpty(imageEl);
-        // insert at first level after the element
-        slideEl.insertBefore(
-          image,
-          nodeEl.nextElementSibling,
-        );
-
         // Figure environment ? Get caption and alignment
         const quartoFig = slideEl.querySelector("div.quarto-figure");
+        const caption = doc.createElement("p");
         if (quartoFig) {
           // Get alignment
           const align = quartoFig.className.match(
@@ -627,18 +620,28 @@ function applyStretch(doc: Document, autoStretch: boolean) {
           // Get Caption
           const figCaption = nodeEl.querySelector("figcaption");
           if (figCaption) {
-            const caption = doc.createElement("p");
             caption.classList.add("caption");
             caption.innerHTML = figCaption.innerHTML;
-            slideEl.insertBefore(
-              caption,
-              imageEl.nextElementSibling,
-            );
-            figCaption.remove();
           }
-          // Remove the container
-          removeEmpty(quartoFig);
         }
+
+        // Remove image from its parent
+        removeEmpty(imageEl);
+        // insert at first level after the element
+        slideEl.insertBefore(
+          image,
+          nodeEl.nextElementSibling,
+        );
+
+        // If there was a caption processed add it after
+        if (caption.classList.contains("caption")) {
+          slideEl.insertBefore(
+            caption,
+            imageEl.nextElementSibling,
+          );
+        }
+        // Remove container if still there
+        if (quartoFig) removeEmpty(quartoFig);
       }
     }
   }


### PR DESCRIPTION
This follows #231 and #224. 

There was a mix in the process for images with no caption - the quarto figure container was removed before the alignement value was picked up and put on the moved `<img>`

It could be the source of the report in https://github.com/quarto-dev/quarto-cli/pull/231#issuecomment-998496713 by @JulianTao

This PR changes the order. 

One the image and its main container is found, we
1. Check if there is a figure environment and if so, 
2. Get the alignement value to put on the `<img>`
3. Get a caption if any

Then
4. we remove the image from its node and delete its empty parent if any
5. We move it to the first level
6. we add the `<p>` caption just below
7. we remove the whole figure container if still one 

It seems better ordered this way.