### PR TITLE
deno: write to stdin in 4k chunks

### DIFF
--- a/src/core/pdfjs.ts
+++ b/src/core/pdfjs.ts
@@ -62,7 +62,7 @@ export function pdfJsFileHandler(
         );
       // always hide the sidebar in the viewer pane
       const referrer = req.headers.get("Referer");
-      const isViewer = referrer && referrer.includes("viewer_pane=1");
+      const isViewer = referrer && referrer.includes("capabilities=");
       if (isViewer) {
         viewerJs = viewerJs.replace(
           "sidebarView: sidebarView",

--- a/src/resources/formats/html/templates/quarto-html.ejs
+++ b/src/resources/formats/html/templates/quarto-html.ejs
@@ -169,7 +169,8 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
     const sourceUrl = viewSource.getAttribute("data-quarto-source-url");
     viewSource.addEventListener("click", function(e) {
       if (sourceUrl) {
-        if (/\bviewer_pane=1\b/.test(window.location)) {
+        // rstudio viewer pane
+        if (/\bcapabilities=\b/.test(window.location)) {
           window.open(sourceUrl);
         } else {
           window.location.href = sourceUrl;


### PR DESCRIPTION
@cscheid This resolves the issue you observed with writing large files/buffers to stdin. Could you do a review? (I find that i/o loops are very commonly the source of unexpected bugs so would love the sanity check).

I rendered `quarto-web` with both the 4k window size in the code now but also w/ a much smaller window (3 bytes) to make sure we are windowing correctly and getting the end boundary right.