### PR TITLE
Feed Support for Listings

### DIFF
--- a/src/command/render/codetools.ts
+++ b/src/command/render/codetools.ts
@@ -7,7 +7,11 @@
 
 import { Document, Element } from "../../core/deno-dom.ts";
 
-import { kMarkdownBlockSeparator } from "./types.ts";
+import {
+  HtmlPostProcessResult,
+  kHtmlEmptyPostProcessResult,
+  kMarkdownBlockSeparator,
+} from "./types.ts";
 import { Format } from "../../config/types.ts";
 import {
   kCodeTools,
@@ -87,7 +91,7 @@ export function keepSourceBlock(format: Format, source: string) {
 }
 
 export function codeToolsPostprocessor(format: Format) {
-  return (doc: Document): Promise<string[]> => {
+  return (doc: Document): Promise<HtmlPostProcessResult> => {
     if (format.render[kKeepSource]) {
       // fixup the lines in embedded source
       const lines = doc.querySelectorAll(
@@ -255,7 +259,7 @@ export function codeToolsPostprocessor(format: Format) {
       }
     }
 
-    return Promise.resolve([]);
+    return Promise.resolve(kHtmlEmptyPostProcessResult);
   };
 }
 

--- a/src/command/render/layout.ts
+++ b/src/command/render/layout.ts
@@ -11,6 +11,7 @@ import { kPageWidth } from "../../config/constants.ts";
 import { Format } from "../../config/types.ts";
 import { Metadata } from "../../config/types.ts";
 import { resourcePath } from "../../core/resources.ts";
+import { HtmlPostProcessResult, kHtmlEmptyPostProcessResult } from "./types.ts";
 
 export function layoutFilter() {
   return resourcePath("filters/layout/layout.lua");
@@ -25,7 +26,9 @@ export function layoutFilterParams(format: Format) {
   return params;
 }
 
-export function selectInputPostprocessor(doc: Document): Promise<string[]> {
+export function selectInputPostprocessor(
+  doc: Document,
+): Promise<HtmlPostProcessResult> {
   // look for cell-output-display (these will have overflow-x set on them which we
   // will want to disable if there are seledct inputs inside)
   const outputs = doc.querySelectorAll(".cell-output-display");
@@ -36,5 +39,5 @@ export function selectInputPostprocessor(doc: Document): Promise<string[]> {
       output.classList.add("no-overflow-x");
     }
   }
-  return Promise.resolve([]);
+  return Promise.resolve(kHtmlEmptyPostProcessResult);
 }

--- a/src/command/render/pandoc-html.ts
+++ b/src/command/render/pandoc-html.ts
@@ -409,7 +409,7 @@ const kVariablesRegex =
   /\/\*\! quarto-variables-start \*\/([\S\s]*)\/\*\! quarto-variables-end \*\//g;
 
 // Generates key values for CSS text highlighing variables
-function generateCssKeyValues(textValues: Record<string, unknown>) {
+export function generateCssKeyValues(textValues: Record<string, unknown>) {
   const lines: string[] = [];
   Object.keys(textValues).forEach((textAttr) => {
     switch (textAttr) {
@@ -442,6 +442,34 @@ function generateCssKeyValues(textValues: Record<string, unknown>) {
     }
   });
   return lines;
+}
+
+export function defaultSyntaxHighlightingClassMap() {
+  const classToStyleMapping: Record<string, string[]> = {};
+
+  // Read the highlight style (theme name)
+  const theme = kDefaultHighlightStyle;
+  const themeRaw = readTheme(theme, "default");
+  if (themeRaw) {
+    const themeJson = JSON.parse(themeRaw);
+
+    // Generates CSS rules based upon the syntax highlighting rules in a theme file
+    const textStyles = themeJson["text-styles"] as Record<
+      string,
+      Record<string, unknown>
+    >;
+    if (textStyles) {
+      Object.keys(textStyles).forEach((styleName) => {
+        const abbr = kAbbrevs[styleName];
+        if (abbr !== undefined) {
+          const textValues = textStyles[styleName];
+          const cssValues = generateCssKeyValues(textValues);
+          classToStyleMapping[abbr] = cssValues;
+        }
+      });
+    }
+  }
+  return classToStyleMapping;
 }
 
 // From  https://github.com/jgm/skylighting/blob/a1d02a0db6260c73aaf04aae2e6e18b569caacdc/skylighting-core/src/Skylighting/Format/HTML.hs#L117-L147

--- a/src/command/render/pandoc.ts
+++ b/src/command/render/pandoc.ts
@@ -109,6 +109,7 @@ import { TempContext } from "../../core/temp.ts";
 import { discoverResourceRefs } from "../../core/html.ts";
 
 import {
+  HtmlPostProcessResult,
   kDefaultHighlightStyle,
   PandocOptions,
   RunPandocResult,
@@ -220,7 +221,7 @@ export async function runPandoc(
   // see if there are extras
   const postprocessors: Array<(output: string) => Promise<void>> = [];
   const htmlPostprocessors: Array<
-    (doc: Document) => Promise<string[]>
+    (doc: Document) => Promise<HtmlPostProcessResult>
   > = [];
   const htmlFinalizers: Array<(doc: Document) => Promise<void>> = [];
   const htmlRenderAfterBody: string[] = [];

--- a/src/command/render/project.ts
+++ b/src/command/render/project.ts
@@ -107,6 +107,16 @@ export async function renderProject(
   // default for files if not specified
   files = files || context.files.input;
 
+  // See if the project type needs to add additional render files
+  // We don't add supplemental files when this is a dev server reload
+  // to improve render performance
+  if (projType.supplementRender && !options.devServerReload) {
+    const additionalFiles = projType.supplementRender(files);
+    if (additionalFiles) {
+      files.push(...additionalFiles);
+    }
+  }
+
   // projResults to return
   const projResults: RenderResult = {
     baseDir: projDir,

--- a/src/command/render/render.ts
+++ b/src/command/render/render.ts
@@ -76,7 +76,7 @@ import { defaultWriterFormat } from "../../format/formats.ts";
 
 import { formatHasBootstrap } from "../../format/html/format-html-bootstrap.ts";
 
-import { PandocOptions, RenderFlags } from "./types.ts";
+import { HtmlPostProcessResult, PandocOptions, RenderFlags } from "./types.ts";
 import { runPandoc } from "./pandoc.ts";
 import { removePandocToArg, resolveParams } from "./flags.ts";
 import { renderCleanup } from "./cleanup.ts";
@@ -614,7 +614,7 @@ export async function renderPandoc(
     ? pandocResult.htmlFinalizers || []
     : [];
 
-  const resourceRefs = await runHtmlPostprocessors(
+  const htmlPostProcessResult = await runHtmlPostprocessors(
     pandocOptions,
     htmlPostProcessors,
     htmlFinalizers,
@@ -668,6 +668,13 @@ export async function renderPandoc(
       }
     }
   }
+  if (
+    htmlPostProcessResult.supporting &&
+    htmlPostProcessResult.supporting.length > 0
+  ) {
+    supporting = supporting || [];
+    supporting.push(...htmlPostProcessResult.supporting);
+  }
 
   renderCleanup(
     context.target.input,
@@ -708,7 +715,7 @@ export async function renderPandoc(
     file: projectPath(finalOutput),
     resourceFiles: {
       globs: pandocResult.resources,
-      files: resourceFiles.concat(resourceRefs),
+      files: resourceFiles.concat(htmlPostProcessResult.resources),
     },
     selfContained: selfContained,
   };
@@ -959,11 +966,14 @@ export function filesDirLibDir(input: string) {
 async function runHtmlPostprocessors(
   options: PandocOptions,
   htmlPostprocessors: Array<
-    (doc: Document) => Promise<string[]>
+    (doc: Document) => Promise<HtmlPostProcessResult>
   >,
   htmlFinalizers: Array<(doc: Document) => Promise<void>>,
-): Promise<string[]> {
-  const resourceRefs: string[] = [];
+): Promise<HtmlPostProcessResult> {
+  const postProcessResult: HtmlPostProcessResult = {
+    resources: [],
+    supporting: [],
+  };
   if (htmlPostprocessors.length > 0 || htmlFinalizers.length > 0) {
     const outputFile = isAbsolute(options.output)
       ? options.output
@@ -973,7 +983,10 @@ async function runHtmlPostprocessors(
     const doc = new DOMParser().parseFromString(htmlInput, "text/html")!;
     for (let i = 0; i < htmlPostprocessors.length; i++) {
       const postprocessor = htmlPostprocessors[i];
-      resourceRefs.push(...(await postprocessor(doc)));
+      const result = await postprocessor(doc);
+
+      postProcessResult.resources.push(...result.resources);
+      postProcessResult.supporting.push(...result.supporting);
     }
 
     // After the post processing is complete, allow any finalizers
@@ -987,7 +1000,7 @@ async function runHtmlPostprocessors(
       doc.documentElement?.outerHTML!;
     Deno.writeTextFileSync(outputFile, htmlOutput);
   }
-  return resourceRefs;
+  return postProcessResult;
 }
 
 async function resolveFormats(

--- a/src/command/render/render.ts
+++ b/src/command/render/render.ts
@@ -735,14 +735,18 @@ export function renderResultFinalOutput(
   relativeToInputDir?: string,
 ) {
   // final output defaults to the first output of the first result
-  let result = renderResults.files[0];
+  // that isn't a supplemental render file (a file that wasn't explicitly
+  // rendered but that was a side effect of rendering some other file)
+  let result = renderResults.files.find((file) => {
+    return !file.supplemental;
+  });
   if (!result) {
     return undefined;
   }
 
   // see if we can find an index.html instead
   for (const fileResult of renderResults.files) {
-    if (fileResult.file === "index.html") {
+    if (fileResult.file === "index.html" && !fileResult.supplemental) {
       result = fileResult;
       break;
     }

--- a/src/command/render/types.ts
+++ b/src/command/render/types.ts
@@ -44,10 +44,22 @@ export interface RunPandocResult {
   resources: string[];
   postprocessors?: Array<(output: string) => Promise<void>>;
   htmlPostprocessors: Array<
-    (doc: Document) => Promise<string[]>
+    (doc: Document) => Promise<HtmlPostProcessResult>
   >;
   htmlFinalizers?: Array<(doc: Document) => Promise<void>>;
 }
+
+export interface HtmlPostProcessResult {
+  // Relative paths to resources
+  resources: string[];
+  // Supporting files should be absolute paths to the files or directories
+  supporting: string[];
+}
+
+export const kHtmlEmptyPostProcessResult = {
+  resources: [],
+  supporting: [],
+};
 
 export interface RenderResourceFiles {
   globs: string[];

--- a/src/command/render/types.ts
+++ b/src/command/render/types.ts
@@ -80,6 +80,7 @@ export interface RenderResultFile {
   file: string;
   supporting?: string[];
   resourceFiles: string[];
+  supplemental?: boolean;
 }
 
 export interface RenderedFile {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -158,6 +158,7 @@ import {
 } from "./constants.ts";
 
 import { TempContext } from "../core/temp.ts";
+import { HtmlPostProcessResult } from "../command/render/types.ts";
 
 export const kDependencies = "dependencies";
 export const kSassBundles = "sass-bundles";
@@ -243,7 +244,7 @@ export interface FormatExtras {
     [kBodyEnvelope]?: BodyEnvelope;
     [kTemplatePatches]?: Array<(template: string) => string>;
     [kHtmlPostprocessors]?: Array<
-      (doc: Document) => Promise<string[]>
+      (doc: Document) => Promise<HtmlPostProcessResult>
     >;
     [kHtmlFinalizers]?: Array<
       (doc: Document) => Promise<void>

--- a/src/core/html.ts
+++ b/src/core/html.ts
@@ -12,6 +12,7 @@ import { Document, Element } from "./deno-dom.ts";
 import { pandocAutoIdentifier } from "./pandoc/pandoc-id.ts";
 import { isFileRef } from "./http.ts";
 import { cssFileRefs } from "./css.ts";
+import { HtmlPostProcessResult } from "../command/render/types.ts";
 
 export function asHtmlId(text: string) {
   return pandocAutoIdentifier(text, false);
@@ -55,7 +56,9 @@ export const kHtmlResourceTags: Record<string, string[]> = {
   "section": ["data-background-image", "data-background-video"],
 };
 
-export function discoverResourceRefs(doc: Document): Promise<string[]> {
+export function discoverResourceRefs(
+  doc: Document,
+): Promise<HtmlPostProcessResult> {
   // first handle tags
   const refs: string[] = [];
   Object.keys(kHtmlResourceTags).forEach((tag) => {
@@ -71,7 +74,7 @@ export function discoverResourceRefs(doc: Document): Promise<string[]> {
       refs.push(...cssFileRefs(style.innerHTML));
     }
   }
-  return Promise.resolve(refs);
+  return Promise.resolve({ resources: refs, supporting: [] });
 }
 
 export function processFileResourceRefs(

--- a/src/core/image.ts
+++ b/src/core/image.ts
@@ -1,0 +1,47 @@
+/*
+* image.ts
+*
+* Copyright (C) 2020 by RStudio, PBC
+*
+*/
+
+import { existsSync } from "fs/exists.ts";
+import { extname } from "path/mod.ts";
+import PngImage from "./png.ts";
+
+export function imageSize(path: string) {
+  if (path !== undefined) {
+    if (path.endsWith(".png")) {
+      if (existsSync(path)) {
+        const imageData = Deno.readFileSync(path);
+        const png = new PngImage(imageData);
+        return {
+          height: png.height,
+          width: png.width,
+        };
+      }
+    }
+  }
+}
+
+export function imageContentType(path: string) {
+  const ext = extname(path);
+  console.log(ext);
+  return kimageTypes[ext];
+}
+
+// From
+// https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types
+const kimageTypes: Record<string, string> = {
+  ".apng": "image/apng",
+  ".avif": "image/avif",
+  ".gif": "image/gif",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".jfif": "image/jpeg",
+  ".pjpeg": "image/jpeg",
+  ".pjp": "image/jpeg",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".webp": "image/webp",
+};

--- a/src/core/image.ts
+++ b/src/core/image.ts
@@ -26,7 +26,6 @@ export function imageSize(path: string) {
 
 export function imageContentType(path: string) {
   const ext = extname(path);
-  console.log(ext);
   return kimageTypes[ext];
 }
 

--- a/src/format/html/format-html-bootstrap.ts
+++ b/src/format/html/format-html-bootstrap.ts
@@ -44,6 +44,10 @@ import {
   kPageLayoutFull,
   setMainColumn,
 } from "./format-html-shared.ts";
+import {
+  HtmlPostProcessResult,
+  kHtmlEmptyPostProcessResult,
+} from "../../command/render/types.ts";
 
 export function formatHasBootstrap(format: Format) {
   if (format && isHtmlOutput(format.pandoc, true)) {
@@ -195,7 +199,7 @@ const getColumnLayoutElements = (doc: Document) => {
 };
 
 function bootstrapHtmlPostprocessor(flags: PandocFlags, format: Format) {
-  return (doc: Document): Promise<string[]> => {
+  return (doc: Document): Promise<HtmlPostProcessResult> => {
     // use display-7 style for title
     const title = doc.querySelector("header > .title");
     if (title) {
@@ -335,7 +339,7 @@ function bootstrapHtmlPostprocessor(flags: PandocFlags, format: Format) {
     }
 
     // no resource refs
-    return Promise.resolve([]);
+    return Promise.resolve(kHtmlEmptyPostProcessResult);
   };
 }
 

--- a/src/format/html/format-html.ts
+++ b/src/format/html/format-html.ts
@@ -72,6 +72,10 @@ import {
   kSiteUrl,
   kWebsite,
 } from "../../project/types/website/website-config.ts";
+import {
+  HtmlPostProcessResult,
+  kHtmlEmptyPostProcessResult,
+} from "../../command/render/types.ts";
 
 export function htmlFormat(
   figwidth: number,
@@ -461,7 +465,7 @@ function htmlFormatPostprocessor(
     ? format.metadata[kAnchorSections] !== false
     : format.metadata[kAnchorSections] || false;
 
-  return (doc: Document): Promise<string[]> => {
+  return (doc: Document): Promise<HtmlPostProcessResult> => {
     // process all of the code blocks
     const codeBlocks = doc.querySelectorAll("pre.sourceCode");
     for (let i = 0; i < codeBlocks.length; i++) {
@@ -539,7 +543,7 @@ function htmlFormatPostprocessor(
     }
 
     // no resource refs
-    return Promise.resolve([]);
+    return Promise.resolve(kHtmlEmptyPostProcessResult);
   };
 }
 

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -42,6 +42,10 @@ import {
   insertFootnotesTitle,
   removeFootnoteBacklinks,
 } from "../html/format-html-shared.ts";
+import {
+  HtmlPostProcessResult,
+  kHtmlEmptyPostProcessResult,
+} from "../../command/render/types.ts";
 
 const kRevealOptions = [
   "controls",
@@ -426,7 +430,7 @@ function revealMarkdownAfterBody(format: Format) {
 }
 
 function revealHtmlPostprocessor(format: Format) {
-  return (doc: Document): Promise<string[]> => {
+  return (doc: Document): Promise<HtmlPostProcessResult> => {
     // if we are using 'number' as our hash type then remove the
     // title slide id
     if (format.metadata[kHashType] === "number") {
@@ -556,7 +560,7 @@ function revealHtmlPostprocessor(format: Format) {
     // apply stretch to images as required
     applyStretch(doc, format.metadata[kAutoStretch] as boolean);
 
-    return Promise.resolve([]);
+    return Promise.resolve(kHtmlEmptyPostProcessResult);
   };
 }
 

--- a/src/project/serve/serve.ts
+++ b/src/project/serve/serve.ts
@@ -496,7 +496,7 @@ async function serveFiles(
             inputFile,
             project,
           );
-          files.push(...await resolver(doc));
+          files.push(...(await resolver(doc)).resources);
         }
 
         // partition markdown and read globs

--- a/src/project/types/book/book.ts
+++ b/src/project/types/book/book.ts
@@ -34,7 +34,11 @@ import {
 } from "../../../config/constants.ts";
 import { disabledTableOfContents } from "../../../config/toc.ts";
 
-import { PandocOptions } from "../../../command/render/types.ts";
+import {
+  HtmlPostProcessResult,
+  kHtmlEmptyPostProcessResult,
+  PandocOptions,
+} from "../../../command/render/types.ts";
 
 import { ProjectCreate, ProjectType } from "../types.ts";
 import { ProjectContext } from "../../types.ts";
@@ -211,7 +215,7 @@ export const bookProjectType: ProjectType = {
 };
 
 function bookHtmlPostprocessor() {
-  return (doc: Document): Promise<string[]> => {
+  return (doc: Document): Promise<HtmlPostProcessResult> => {
     // find the cover image
     const coverImage = doc.querySelector(".quarto-cover-image");
     // if the very next element is a section, move it into the section below the header
@@ -221,7 +225,7 @@ function bookHtmlPostprocessor() {
       nextEl.firstChild.after(coverImage?.parentNode);
     }
 
-    return Promise.resolve([]);
+    return Promise.resolve(kHtmlEmptyPostProcessResult);
   };
 }
 

--- a/src/project/types/types.ts
+++ b/src/project/types/types.ts
@@ -57,6 +57,9 @@ export interface ProjectType {
     options: RenderOptions,
     context: ProjectContext,
   ) => PandocRenderer;
+  supplementRender?: (
+    files: string[],
+  ) => string[];
   postRender?: (
     context: ProjectContext,
     incremental: boolean,

--- a/src/project/types/types.ts
+++ b/src/project/types/types.ts
@@ -58,7 +58,9 @@ export interface ProjectType {
     context: ProjectContext,
   ) => PandocRenderer;
   supplementRender?: (
+    project: ProjectContext,
     files: string[],
+    incremental: boolean,
   ) => string[];
   postRender?: (
     context: ProjectContext,

--- a/src/project/types/website/listing/website-listing-feed.ts
+++ b/src/project/types/website/listing/website-listing-feed.ts
@@ -126,7 +126,14 @@ export async function createFeed(
   const feedFiles: string[] = [];
 
   // Render the main feed
-  const rendered = await renderFeed(feed, items, options, project, stagedPath);
+  const rendered = await renderFeed(
+    siteUrl,
+    feed,
+    items,
+    options,
+    project,
+    stagedPath,
+  );
   if (rendered) {
     // Add a link to the feed
     // But we should put the correct unstaged / final link in the document
@@ -157,6 +164,7 @@ export async function createFeed(
   if (categoriesToRender) {
     for (const categoryToRender of categoriesToRender) {
       const rendered = await renderCategoryFeed(
+        siteUrl,
         categoryToRender,
         feed,
         items,
@@ -265,6 +273,7 @@ export function completeStagedFeeds(
 }
 
 async function renderCategoryFeed(
+  siteUrl: string,
   categoryToRender: { category: string; file: string; finalFile: string },
   feed: FeedMetadata,
   items: ListingItem[],
@@ -285,6 +294,7 @@ async function renderCategoryFeed(
   });
 
   return await renderFeed(
+    siteUrl,
     feed,
     categoryItems,
     options,
@@ -294,6 +304,7 @@ async function renderCategoryFeed(
 }
 
 async function renderFeed(
+  siteUrl: string,
   feed: FeedMetadata,
   items: ListingItem[],
   options: ListingFeedOptions,
@@ -306,7 +317,7 @@ async function renderFeed(
   for (const item of prepareItems(items, options)) {
     const inputTarget = await resolveInputTarget(project, item.path!, false);
 
-    const link = `${feed.link}${inputTarget?.outputHref}`;
+    const link = `${siteUrl}${inputTarget?.outputHref}`;
 
     const title = inputTarget?.outputHref
       ? placeholder(inputTarget?.outputHref)
@@ -498,6 +509,7 @@ function readRenderedContents(
   // Strip unacceptable elements
   const stripSelectors = [
     '*[aria-hidden="true"]', // Feeds should not contain aria hidden elements
+    "button.code-copy-button", // Code copy buttons looks weird and don't work
   ];
   stripSelectors.forEach((sel) => {
     const nodes = doc.querySelectorAll(sel);

--- a/src/project/types/website/listing/website-listing-feed.ts
+++ b/src/project/types/website/listing/website-listing-feed.ts
@@ -256,65 +256,70 @@ export function completeStagedFeeds(
           // Info about this feed file
           const [feedDir, feedStem] = dirAndStem(feedFile);
 
-          // Whether the staged file should be filled with full contents of the file
-          const fullContents = feedFile.endsWith(kFullStagedExt);
+          try {
+            // Whether the staged file should be filled with full contents of the file
+            const fullContents = feedFile.endsWith(kFullStagedExt);
 
-          // Read the staged file contents and replace any
-          // content with the rendered version from the document
-          let feedContents = Deno.readTextFileSync(feedFile);
-          const tagWithReplacements = [
-            {
-              tag: "title",
-              regex: kTitleRegex,
-              replaceValue: (rendered: RenderedContents) => {
-                return rendered.title;
+            // Read the staged file contents and replace any
+            // content with the rendered version from the document
+            let feedContents = Deno.readTextFileSync(feedFile);
+            const tagWithReplacements = [
+              {
+                tag: "title",
+                regex: kTitleRegex,
+                replaceValue: (rendered: RenderedContents) => {
+                  return rendered.title;
+                },
               },
-            },
-            {
-              tag: "description",
-              regex: kDescRegex,
-              replaceValue: (rendered: RenderedContents) => {
-                if (fullContents) {
-                  return `<![CDATA[ ${rendered.fullContents} ]]>`;
-                } else {
-                  return `<![CDATA[ ${rendered.firstPara} ]]>`;
-                }
+              {
+                tag: "description",
+                regex: kDescRegex,
+                replaceValue: (rendered: RenderedContents) => {
+                  if (fullContents) {
+                    return `<![CDATA[ ${rendered.fullContents} ]]>`;
+                  } else {
+                    return `<![CDATA[ ${rendered.firstPara} ]]>`;
+                  }
+                },
               },
-            },
-          ];
+            ];
 
-          tagWithReplacements.forEach((tagWithReplacement) => {
-            const regex = tagWithReplacement.regex;
-            const tag = tagWithReplacement.tag;
-            regex.lastIndex = 0;
+            tagWithReplacements.forEach((tagWithReplacement) => {
+              const regex = tagWithReplacement.regex;
+              const tag = tagWithReplacement.tag;
+              regex.lastIndex = 0;
 
-            let match = regex.exec(feedContents);
-            while (match) {
-              const relativePath = match[1];
-              const absolutePath = join(feedDir, relativePath);
-              const contents = contentReader(absolutePath);
-              if (contents) {
-                const replaceStr = placholderForReplace(tag, relativePath);
-                if (contents.title) {
-                  feedContents = feedContents.replace(
-                    replaceStr,
-                    `<${tag}>${
-                      tagWithReplacement.replaceValue(contents)
-                    }</${tag}>`,
-                  );
+              let match = regex.exec(feedContents);
+              while (match) {
+                const relativePath = match[1];
+                const absolutePath = join(feedDir, relativePath);
+                const contents = contentReader(absolutePath);
+                if (contents) {
+                  const replaceStr = placholderForReplace(tag, relativePath);
+                  if (contents.title) {
+                    feedContents = feedContents.replace(
+                      replaceStr,
+                      `<${tag}>${
+                        tagWithReplacement.replaceValue(contents)
+                      }</${tag}>`,
+                    );
+                  }
                 }
+                match = regex.exec(feedContents);
               }
-              match = regex.exec(feedContents);
-            }
-            regex.lastIndex = 0;
-          });
+              regex.lastIndex = 0;
+            });
 
-          // Move the completed feed to its final location
-          Deno.writeTextFileSync(
-            join(feedDir, `${feedStem}.${kFinalExt}`),
-            feedContents,
-          );
-          Deno.removeSync(feedFile);
+            // Move the completed feed to its final location
+            Deno.writeTextFileSync(
+              join(feedDir, `${feedStem}.${kFinalExt}`),
+              feedContents,
+            );
+          } catch {
+            warnOnce(`Unable to generate feed '${feedStem}.xml'`);
+          } finally {
+            Deno.removeSync(feedFile);
+          }
         }
       }
     });
@@ -552,17 +557,11 @@ const renderedContentReader = (project: ProjectContext, siteUrl: string) => {
   const renderedContent: Record<string, RenderedContents> = {};
   return (filePath: string): RenderedContents => {
     if (!renderedContent[filePath]) {
-      try {
-        renderedContent[filePath] = readRenderedContents(
-          filePath,
-          siteUrl,
-          project,
-        );
-      } catch {
-        warnOnce(
-          `Couldn't read the file ${filePath} when attempting to generate a feed. Please render the full project to ensure all rendered files are available.`,
-        );
-      }
+      renderedContent[filePath] = readRenderedContents(
+        filePath,
+        siteUrl,
+        project,
+      );
     }
     return renderedContent[filePath];
   };

--- a/src/project/types/website/listing/website-listing-feed.ts
+++ b/src/project/types/website/listing/website-listing-feed.ts
@@ -54,8 +54,8 @@ interface FeedImage {
 
 interface FeedMetadata {
   title: string;
-  link: string;
-  feedLink: string;
+  link: string; // links to the page that is hosting the feed
+  feedLink: string; // links to the feed itself (for example to provide atom with a link)
   description: string;
   image?: FeedImage;
   language?: string;
@@ -168,6 +168,7 @@ export async function createFeed(
         options.type === "full",
       ),
       finalFile: finalRelPath,
+      feedLink: `${siteUrl}/${finalRelPath}`,
     };
   });
 
@@ -285,7 +286,12 @@ export function completeStagedFeeds(
 
 async function renderCategoryFeed(
   siteUrl: string,
-  categoryToRender: { category: string; file: string; finalFile: string },
+  categoryToRender: {
+    category: string;
+    file: string;
+    finalFile: string;
+    feedLink: string;
+  },
   feed: FeedMetadata,
   items: ListingItem[],
   options: ListingFeedOptions,
@@ -293,10 +299,12 @@ async function renderCategoryFeed(
 ) {
   // Category title
   const feedMeta = { ...feed };
+
+  // Add the category filter
   feedMeta.link = feedMeta.link + "#category=" +
     encodeURI(categoryToRender.category);
   feedMeta.title = `${feedMeta.title} - ${categoryToRender.category}`;
-  feedMeta.feedLink = `${siteUrl}/${categoryToRender.finalFile}`;
+  feedMeta.feedLink = categoryToRender.feedLink;
 
   const categoryItems = items.filter((item) => {
     const categories = item[kFieldCategories];

--- a/src/project/types/website/listing/website-listing-feed.ts
+++ b/src/project/types/website/listing/website-listing-feed.ts
@@ -524,6 +524,7 @@ function readRenderedContents(
     });
   });
 
+  // Process code to apply styles for syntax highlighting
   const highlightingMap = defaultSyntaxHighlightingClassMap();
   const spanNodes = doc.querySelectorAll("code span");
   for (const spanNode of spanNodes) {
@@ -538,9 +539,40 @@ function readRenderedContents(
     }
   }
 
+  // Process math using webtex
+  const trimMath = (str: string) => {
+    // Text of math is prefixed by the below
+    if (str.length > 4 && (str.startsWith("\\[") || str.startsWith("\\("))) {
+      const trimStart = str.slice(2);
+      return trimStart.slice(0, trimStart.length - 2);
+    } else {
+      return str;
+    }
+  };
+
+  const mathNodes = doc.querySelectorAll("span.math");
+  for (const mathNode of mathNodes) {
+    const mathEl = mathNode as Element;
+    const math = trimMath(mathEl.innerText);
+    const imgEl = doc.createElement("IMG");
+    imgEl.setAttribute(
+      "src",
+      kWebTexUrl(math),
+    );
+    mathNode.parentElement?.replaceChild(imgEl, mathNode);
+  }
+
   return {
     title: titleText,
     fullContents: mainEl?.innerHTML,
     firstPara: mainEl?.querySelector("p")?.innerHTML,
   };
 }
+
+const kWebTexUrl = (
+  math: string,
+  type: "png" | "svg" | "gif" | "emf" | "pdf" = "png",
+) => {
+  const encodedMath = encodeURI(math);
+  return `https://latex.codecogs.com/${type}.latex?${encodedMath}`;
+};

--- a/src/project/types/website/listing/website-listing-feed.ts
+++ b/src/project/types/website/listing/website-listing-feed.ts
@@ -34,6 +34,9 @@ import { dirAndStem, resolvePathGlobs } from "../../../../core/path.ts";
 import { ProjectOutputFile } from "../../types.ts";
 import { kListing } from "./website-listing-read.ts";
 import { resolveInputTarget } from "../../../project-index.ts";
+import {
+  defaultSyntaxHighlightingClassMap,
+} from "../../../../command/render/pandoc-html.ts";
 
 // TODO: Localize
 const kUntitled = "untitled";
@@ -462,7 +465,10 @@ const renderedContentReader = (siteUrl: string) => {
   const renderedContent: Record<string, RenderedContents> = {};
   return (filePath: string): RenderedContents => {
     if (!renderedContent[filePath]) {
-      renderedContent[filePath] = readRenderedContents(filePath, siteUrl);
+      renderedContent[filePath] = readRenderedContents(
+        filePath,
+        siteUrl,
+      );
     }
     return renderedContent[filePath];
   };
@@ -517,6 +523,20 @@ function readRenderedContents(
       node.remove();
     });
   });
+
+  const highlightingMap = defaultSyntaxHighlightingClassMap();
+  const spanNodes = doc.querySelectorAll("code span");
+  for (const spanNode of spanNodes) {
+    const spanEl = spanNode as Element;
+
+    for (const clz of spanEl.classList) {
+      const styles = highlightingMap[clz];
+      if (styles) {
+        spanEl.setAttribute("style", styles.join(";\n"));
+        break;
+      }
+    }
+  }
 
   return {
     title: titleText,

--- a/src/project/types/website/listing/website-listing-feed.ts
+++ b/src/project/types/website/listing/website-listing-feed.ts
@@ -1,0 +1,229 @@
+/*
+* website-listing-feed.ts
+*
+* Copyright (C) 2020 by RStudio, PBC
+*
+*/
+
+import { join } from "path/mod.ts";
+import { warning } from "log/mod.ts";
+
+import { uniqBy } from "../../../../core/lodash.ts";
+import { Format } from "../../../../config/types.ts";
+import { renderEjs } from "../../../../core/ejs.ts";
+import { quartoConfig } from "../../../../core/quarto.ts";
+import { resourcePath } from "../../../../core/resources.ts";
+import { ProjectContext } from "../../../types.ts";
+import {
+  websiteBaseurl,
+  websiteDescription,
+  websiteTitle,
+} from "../website-config.ts";
+import {
+  kDescription,
+  kFieldAuthor,
+  kFieldCategories,
+  kFieldImage,
+  kItems,
+  ListingDescriptor,
+  ListingFeedOptions,
+  ListingItem,
+} from "./website-listing-shared.ts";
+import { dirAndStem } from "../../../../core/path.ts";
+
+// Feed Options
+/*
+
+listing:
+  feed:
+    items: <number> || 20
+    type: partial | full
+
+Creates a listing composed of all the items in the current page, sorted by date
+
+
+
+*/
+
+// TODO: Localize
+const kUntitled = "untitled";
+
+export const kDefaultItems = 20;
+
+interface FeedImage {
+  title: string;
+  url: string;
+  link?: string;
+  height?: number;
+  description?: string;
+}
+
+interface FeedMetadata {
+  title: string;
+  link: string;
+  description: string;
+  image?: FeedImage;
+  language?: string;
+
+  generator: string;
+  lastBuildDate: string;
+}
+
+interface FeedItem {
+  title: string;
+  link: string;
+  description: string;
+
+  categories?: string[];
+  authors?: string[];
+  guid: string;
+  pubDate: Date;
+  image?: string;
+}
+
+export async function createFeed(
+  source: string,
+  project: ProjectContext,
+  descriptors: ListingDescriptor[],
+  options: ListingFeedOptions,
+  format: Format,
+) {
+  // The path to the feed file
+  const [dir, stem] = dirAndStem(source);
+  const targetFile = options.type === "full"
+    ? `${stem}.xml.staged`
+    : `${stem}.xml`;
+  const feedPath = join(dir, targetFile);
+
+  // First, be sure that we have a site URL, otherwise we can't
+  // create a valid feed
+  const siteUrl = websiteBaseurl(project.config);
+  if (!siteUrl) {
+    // There is no `site-url`
+    warning(
+      "Unable to create a feed as the required `site-url` property is missing from this project.",
+    );
+    return;
+  }
+
+  // Find the feed metadata
+  const feedTitle = options.title || websiteTitle(project.config) ||
+    format.language[kUntitled] as string;
+  const feedDescription = options.description ||
+    format.metadata[kDescription] as string ||
+    websiteDescription(project.config) || format.language[kUntitled] as string;
+
+  // Create feed metadata
+  const feed: FeedMetadata = {
+    title: feedTitle,
+    description: feedDescription,
+    link: siteUrl,
+    generator: `quarto-${quartoConfig.version()}`,
+    lastBuildDate: new Date().toUTCString(),
+    language: options.language,
+  };
+
+  // Merge all the items
+  const items: ListingItem[] = [];
+  for (const descriptor of descriptors) {
+    items.push(...descriptor.items);
+  }
+
+  // Prepare the items to generate a feed
+  const feedItems = prepareItems(items, options).map((item) => {
+    const title = item.title || format.language[kUntitled];
+    const link = item.path!;
+    const description = item.description || "";
+    const categories = (Array.isArray(item[kFieldCategories])
+      ? item[kFieldCategories]
+      : []) as string[];
+    const authors = (Array.isArray(item[kFieldAuthor])
+      ? item[kFieldAuthor]
+      : []) as string[];
+    const pubDate = item.date ? new Date(item.date) : new Date();
+
+    return {
+      title,
+      link,
+      description,
+      categories,
+      authors,
+      guid: link,
+      image: item[kFieldImage],
+      pubDate,
+    } as FeedItem;
+  });
+
+  // The feed files that have been generated
+  const feedFiles: string[] = [];
+
+  // Compute the file to write to
+  await generateFeed(feed, feedItems, feedPath);
+
+  feedFiles.push(feedPath);
+
+  return feedFiles;
+}
+
+async function generateFeed(
+  feed: FeedMetadata,
+  feedItems: FeedItem[],
+  path: string,
+) {
+  const feedFile = await Deno.open(path, {
+    write: true,
+    create: true,
+  });
+  const textEncoder = new TextEncoder();
+
+  const preamble = renderEjs(
+    resourcePath("projects/website/listing/feed/preamble.ejs.md"),
+    {
+      feed,
+    },
+  );
+  await Deno.write(feedFile.rid, textEncoder.encode(preamble));
+
+  for (const feedItem of feedItems) {
+    const item = renderEjs(
+      resourcePath("projects/website/listing/feed/item.ejs.md"),
+      {
+        item: feedItem,
+      },
+    );
+    await Deno.write(feedFile.rid, textEncoder.encode(item));
+  }
+
+  // Render the postamble
+  const postamble = renderEjs(
+    resourcePath("projects/website/listing/feed/postamble.ejs.md"),
+    {
+      feed,
+    },
+  );
+  await Deno.write(feedFile.rid, textEncoder.encode(postamble));
+}
+
+function prepareItems(items: ListingItem[], options: ListingFeedOptions) {
+  const validItems = items.filter((item) => {
+    // TODO: Should we warn or error when we skip an item that doesn't have a path
+    return (item.title !== undefined && item.path !== undefined);
+  });
+
+  const uniqueItems = uniqBy(validItems, (item: ListingItem) => {
+    return item.path;
+  });
+
+  const sortedItems = uniqueItems.sort((a: ListingItem, b: ListingItem) => {
+    const aTimestamp = a.date ? new Date(a.date).valueOf() : -1;
+    const bTimestamp = b.date ? new Date(b.date).valueOf() : -1;
+    return aTimestamp - bTimestamp;
+  });
+
+  const itemCount = (options[kItems] || kDefaultItems);
+  if (sortedItems.length > itemCount) {
+    return sortedItems.slice(0, itemCount);
+  } else {
+    return sortedItems;
+  }
+}

--- a/src/project/types/website/listing/website-listing-feed.ts
+++ b/src/project/types/website/listing/website-listing-feed.ts
@@ -423,13 +423,9 @@ async function renderFeed(
     feedItems.push(feedItem);
   }
 
-  if (feedItems.length > 0) {
-    // Compute the file to write to
-    await generateFeed(feed, feedItems, feedPath);
-    return true;
-  } else {
-    return false;
-  }
+  // Compute the file to write to
+  await generateFeed(feed, feedItems, feedPath);
+  return true;
 }
 
 async function generateFeed(

--- a/src/project/types/website/listing/website-listing-feed.ts
+++ b/src/project/types/website/listing/website-listing-feed.ts
@@ -558,6 +558,15 @@ function readRenderedContents(
     });
   });
 
+  // String unacceptable links
+  const relativeLinkSel = 'a[href^="#"]';
+  const linkNodes = doc.querySelectorAll(relativeLinkSel);
+  linkNodes.forEach((linkNode) => {
+    const nodesToMove = linkNode.childNodes;
+    linkNode.after(...nodesToMove);
+    linkNode.remove();
+  });
+
   // Process code to apply styles for syntax highlighting
   const highlightingMap = defaultSyntaxHighlightingClassMap();
   const spanNodes = doc.querySelectorAll("code span");

--- a/src/project/types/website/listing/website-listing-feed.ts
+++ b/src/project/types/website/listing/website-listing-feed.ts
@@ -222,7 +222,6 @@ export async function createFeed(
       );
 
       if (rendered) {
-        addLinkTagToDocument(doc, feed, categoryToRender.finalFile);
         feedFiles.push(categoryToRender.file);
       }
     }
@@ -355,7 +354,6 @@ async function renderCategoryFeed(
   // Add the category filter
   feedMeta.link = feedMeta.link + "#category=" +
     encodeURI(categoryToRender.category);
-  feedMeta.title = `${feedMeta.title} - ${categoryToRender.category}`;
   feedMeta.feedLink = categoryToRender.feedLink;
   if (feedMeta.image) {
     feedMeta.image.link = feedMeta.link;

--- a/src/project/types/website/listing/website-listing-feed.ts
+++ b/src/project/types/website/listing/website-listing-feed.ts
@@ -565,6 +565,9 @@ const renderedContentReader = (project: ProjectContext, siteUrl: string) => {
   };
 };
 
+// This reads a rendered HTML file and extracts its contents.
+// The contents will be cleaned to make them conformant to any
+// RSS validators (I used W3 validator to identify problematic HTML)
 function readRenderedContents(
   filePath: string,
   siteUrl: string,
@@ -674,7 +677,6 @@ function readRenderedContents(
       return str;
     }
   };
-
   const mathNodes = doc.querySelectorAll("span.math");
   for (const mathNode of mathNodes) {
     const mathEl = mathNode as Element;

--- a/src/project/types/website/listing/website-listing-feed.ts
+++ b/src/project/types/website/listing/website-listing-feed.ts
@@ -139,9 +139,15 @@ export async function createFeed(
 
   // Categories to render
   const categoriesToRender = options[kFieldCategories]?.map((category) => {
+    const finalAbsPath = join(
+      dir,
+      `${stem}-${category.toLocaleLowerCase()}.xml`,
+    );
+    const finalRelPath = relative(project.dir, finalAbsPath);
     return {
       category,
       file: join(dir, `${stem}-${category.toLocaleLowerCase()}.${stagedExt}`),
+      finalFile: finalRelPath,
     };
   });
 
@@ -154,12 +160,12 @@ export async function createFeed(
   if (categoriesToRender) {
     for (const categoryToRender of categoriesToRender) {
       await renderCategoryFeed(
-        categoryToRender.category,
+        doc,
+        categoryToRender,
         feed,
         items,
         options,
         format,
-        categoryToRender.file,
       );
       feedFiles.push(categoryToRender.file);
     }
@@ -178,32 +184,34 @@ function addLinkTagToDocument(doc: Document, feed: FeedMetadata, path: string) {
 }
 
 async function renderCategoryFeed(
-  category: string,
+  doc: Document,
+  categoryToRender: { category: string; file: string; finalFile: string },
   feed: FeedMetadata,
   items: ListingItem[],
   options: ListingFeedOptions,
   format: Format,
-  feedPath: string,
 ) {
   // Category title
   const feedMeta = { ...feed };
-  feedMeta.title = `${feedMeta.title} - ${category}`;
+  feedMeta.title = `${feedMeta.title} - ${categoryToRender.category}`;
 
   const categoryItems = items.filter((item) => {
     const categories = item[kFieldCategories];
     if (categories) {
-      return (categories as string[]).includes(category);
+      return (categories as string[]).includes(categoryToRender.category);
     } else {
       return false;
     }
   });
+
+  addLinkTagToDocument(doc, feedMeta, categoryToRender.finalFile);
 
   await renderFeed(
     feed,
     categoryItems,
     options,
     format,
-    feedPath,
+    categoryToRender.file,
   );
 }
 

--- a/src/project/types/website/listing/website-listing-feed.ts
+++ b/src/project/types/website/listing/website-listing-feed.ts
@@ -351,6 +351,10 @@ async function renderCategoryFeed(
     encodeURI(categoryToRender.category);
   feedMeta.title = `${feedMeta.title} - ${categoryToRender.category}`;
   feedMeta.feedLink = categoryToRender.feedLink;
+  if (feedMeta.image) {
+    feedMeta.image.link = feedMeta.link;
+    feedMeta.image.title = feedMeta.title;
+  }
 
   // Find the most recent item (if any)
   const mostRecent = mostRecentItem(filteredItems);
@@ -646,6 +650,14 @@ function readRenderedContents(
         break;
       }
     }
+  }
+
+  // Apply a code background color
+  const codeStyle = "background: #f1f3f5;";
+  const codeBlockNodes = doc.querySelectorAll("div.sourceCode");
+  for (const codeBlockNode of codeBlockNodes) {
+    const codeBlockEl = codeBlockNode as Element;
+    codeBlockEl.setAttribute("style", codeStyle);
   }
 
   // Process math using webtex

--- a/src/project/types/website/listing/website-listing-feed.ts
+++ b/src/project/types/website/listing/website-listing-feed.ts
@@ -42,9 +42,6 @@ import {
 import { projectOutputDir } from "../../../project-shared.ts";
 import { imageContentType, imageSize } from "../../../../core/image.ts";
 
-// TODO: Localize
-const kUntitled = "untitled";
-
 export const kDefaultItems = 20;
 
 interface FeedImage {
@@ -102,12 +99,19 @@ export async function createFeed(
     return;
   }
 
+  const feedTitle = options.title || websiteTitle(project.config);
+  if (!feedTitle) {
+    // There is no `title`
+    warning(
+      "Unable to create a feed as the required `site > title` property is missing from this project.",
+    );
+    return;
+  }
+
   // Find the feed metadata
-  const feedTitle = options.title || websiteTitle(project.config) ||
-    format.language[kUntitled] as string;
   const feedDescription = options.description ||
     format.metadata[kDescription] as string ||
-    websiteDescription(project.config) || format.language[kUntitled] as string;
+    websiteDescription(project.config) || "";
 
   // Form the path to this document
   const projectRelInput = relative(project.dir, source);

--- a/src/project/types/website/listing/website-listing-project.ts
+++ b/src/project/types/website/listing/website-listing-project.ts
@@ -1,0 +1,96 @@
+/*
+* website-listing-project.ts
+*
+* Copyright (C) 2020 by RStudio, PBC
+*
+*/
+
+import { ensureDirSync } from "fs/mod.ts";
+import { dirname, join } from "path/mod.ts";
+
+import { projectScratchPath } from "../../../project-scratch.ts";
+import { ProjectContext } from "../../../types.ts";
+import { ListingDescriptor } from "./website-listing-shared.ts";
+
+const kListingDir = "listing";
+const kListingMapFile = "listing-cache.json";
+
+export type ProjRelativeListingPath = string;
+export type Glob = string;
+
+export type ListingMap = Record<ProjRelativeListingPath, Array<Glob>>;
+export interface ListingCache {
+  listingMap?: ListingMap;
+}
+
+// Adds data to the project listing cache
+// This should be called anytime that a listing is rendered
+export function cacheListingProjectData(
+  project: ProjectContext,
+  listingPath: ProjRelativeListingPath,
+  descriptors: ListingDescriptor[],
+) {
+  // Read the globs / files from contents
+  const listingContents = descriptors.flatMap((descriptor) => {
+    const contentItems = descriptor.listing.contents;
+    return contentItems.filter((item) => {
+      return typeof (item) === "string";
+    });
+  }) as string[];
+
+  // Store the globs in a dictionary (file > glob[])
+  const cache: ListingCache = readListingMap(project) || {};
+  const listingMap = cache.listingMap || {};
+
+  listingContents.forEach((content) => {
+    const globSet = new Set(listingMap[listingPath] || []);
+    globSet.add(content);
+    listingMap[listingPath] = [...globSet];
+  });
+
+  // Write it to scratch path
+  writeListingCache(project, {
+    listingMap,
+  });
+}
+
+// Read project listing cache
+export function listingProjectData(project: ProjectContext) {
+  return readListingMap(project);
+}
+
+// Clear project listing cache
+export function clearListingProjectData(project: ProjectContext) {
+  clearListingMap(project);
+}
+
+function clearListingMap(project: ProjectContext) {
+  const file = projectListingMapFile(project.dir);
+  try {
+    Deno.removeSync(file);
+  } catch {
+    // No op
+  }
+}
+
+function readListingMap(project: ProjectContext) {
+  const file = projectListingMapFile(project.dir);
+  try {
+    const mapRaw = Deno.readTextFileSync(file);
+    const data = JSON.parse(mapRaw);
+    return data as ListingCache;
+  } catch {
+    return {} as ListingCache;
+  }
+}
+
+function writeListingCache(project: ProjectContext, cache: ListingCache) {
+  const file = projectListingMapFile(project.dir);
+  ensureDirSync(dirname(file));
+  const mapJson = JSON.stringify(cache, undefined, 2);
+  Deno.writeTextFileSync(file, mapJson);
+}
+
+function projectListingMapFile(dir: string) {
+  return join(projectScratchPath(dir, kListingDir), kListingMapFile);
+}

--- a/src/project/types/website/listing/website-listing-read.ts
+++ b/src/project/types/website/listing/website-listing-read.ts
@@ -194,7 +194,7 @@ export async function readListings(
     } else if (feed) {
       // If its truthy, forward the default feed
       sharedOptions[kFeed] = {
-        type: "partial",
+        type: "full",
       };
     }
   }

--- a/src/project/types/website/listing/website-listing-read.ts
+++ b/src/project/types/website/listing/website-listing-read.ts
@@ -544,7 +544,7 @@ async function listItemFromFile(input: string, project: ProjectContext) {
 
   const date = documentMeta?.date
     ? new Date(documentMeta.date as string)
-    : filemodified;
+    : undefined;
   const author = Array.isArray(documentMeta?.author)
     ? documentMeta?.author
     : [documentMeta?.author];

--- a/src/project/types/website/listing/website-listing-read.ts
+++ b/src/project/types/website/listing/website-listing-read.ts
@@ -23,6 +23,7 @@ import {
 import {
   ColumnType,
   kCategoryStyle,
+  kFeed,
   kFieldAuthor,
   kFieldCategories,
   kFieldDate,
@@ -53,6 +54,7 @@ import {
   Listing,
   ListingDehydrated,
   ListingDescriptor,
+  ListingFeedOptions,
   ListingItem,
   ListingItemSource,
   ListingSharedOptions,
@@ -183,6 +185,19 @@ export async function readListings(
     [kFieldCategories]: !!categories,
     [kCategoryStyle]: categoryStyle,
   };
+
+  const feed = firstListingValue(kFeed, undefined);
+  if (feed !== undefined) {
+    if (typeof (feed) === "object") {
+      // If is an object, forward it along
+      sharedOptions[kFeed] = feed as ListingFeedOptions;
+    } else if (feed) {
+      // If its truthy, forward the default feed
+      sharedOptions[kFeed] = {
+        type: "partial",
+      };
+    }
+  }
 
   for (const listing of listings) {
     // Read the metadata for each of the listing files

--- a/src/project/types/website/listing/website-listing-shared.ts
+++ b/src/project/types/website/listing/website-listing-shared.ts
@@ -102,6 +102,7 @@ export interface ListingFeedOptions {
   [kType]?: "partial" | "full";
   [kLanguage]?: string;
   [kDescription]?: string;
+  [kFieldCategories]?: string[];
 }
 
 export interface ListingSharedOptions {

--- a/src/project/types/website/listing/website-listing-shared.ts
+++ b/src/project/types/website/listing/website-listing-shared.ts
@@ -103,6 +103,7 @@ export interface ListingFeedOptions {
   [kLanguage]?: string;
   [kDescription]?: string;
   [kFieldCategories]?: string[];
+  [kImage]?: string;
 }
 
 export interface ListingSharedOptions {

--- a/src/project/types/website/listing/website-listing-shared.ts
+++ b/src/project/types/website/listing/website-listing-shared.ts
@@ -6,7 +6,9 @@
 *
 */
 
+import { kTitle } from "../../../../config/constants.ts";
 import { Metadata } from "../../../../config/types.ts";
+import { kImage } from "../website-config.ts";
 
 // The list of columns to display
 export const kFields = "fields";
@@ -71,6 +73,13 @@ export const kCategoryStyle = "category-style";
 export const kSortAsc = "asc";
 export const kSortDesc = "desc";
 
+// Feed options
+export const kFeed = "feed";
+export const kItems = "items";
+export const kType = "type";
+export const kLanguage = "language";
+export const kDescription = "description";
+
 export interface ListingDescriptor {
   listing: Listing;
   items: ListingItem[];
@@ -87,9 +96,18 @@ export type CategoryStyle =
   | "category-unnumbered"
   | "category-cloud";
 
+export interface ListingFeedOptions {
+  [kTitle]?: string;
+  [kItems]?: number;
+  [kType]?: "partial" | "full";
+  [kLanguage]?: string;
+  [kDescription]?: string;
+}
+
 export interface ListingSharedOptions {
   [kFieldCategories]: boolean;
   [kCategoryStyle]: CategoryStyle;
+  [kFeed]?: ListingFeedOptions;
 }
 
 // The core listing type

--- a/src/project/types/website/listing/website-listing-shared.ts
+++ b/src/project/types/website/listing/website-listing-shared.ts
@@ -99,7 +99,7 @@ export type CategoryStyle =
 export interface ListingFeedOptions {
   [kTitle]?: string;
   [kItems]?: number;
-  [kType]?: "partial" | "full";
+  [kType]: "partial" | "full";
   [kLanguage]?: string;
   [kDescription]?: string;
   [kFieldCategories]?: string[];

--- a/src/project/types/website/listing/website-listing-shared.ts
+++ b/src/project/types/website/listing/website-listing-shared.ts
@@ -103,6 +103,7 @@ export interface ListingFeedOptions {
   [kDescription]?: string;
   [kFieldCategories]?: string[];
   [kImage]?: string;
+  [kLanguage]?: string;
 }
 
 export interface ListingSharedOptions {

--- a/src/project/types/website/listing/website-listing-shared.ts
+++ b/src/project/types/website/listing/website-listing-shared.ts
@@ -99,8 +99,7 @@ export type CategoryStyle =
 export interface ListingFeedOptions {
   [kTitle]?: string;
   [kItems]?: number;
-  [kType]: "partial" | "full";
-  [kLanguage]?: string;
+  [kType]: "summary" | "full";
   [kDescription]?: string;
   [kFieldCategories]?: string[];
   [kImage]?: string;

--- a/src/project/types/website/listing/website-listing.ts
+++ b/src/project/types/website/listing/website-listing.ts
@@ -184,7 +184,7 @@ export async function listingHtmlDependencies(
     const supporting: string[] = [];
     if (options[kFeed]) {
       const listingOptions = {
-        type: "partial",
+        type: "full",
         ...options[kFeed],
       } as ListingFeedOptions;
 

--- a/src/project/types/website/listing/website-listing.ts
+++ b/src/project/types/website/listing/website-listing.ts
@@ -35,6 +35,7 @@ import {
   kFieldCategories,
   Listing,
   ListingDescriptor,
+  ListingFeedOptions,
   ListingItem,
   ListingSharedOptions,
   ListingType,
@@ -127,12 +128,17 @@ export async function listingHtmlDependencies(
 
     const supporting: string[] = [];
     if (options[kFeed]) {
+      const listingOptions = {
+        type: "partial",
+        ...options[kFeed],
+      } as ListingFeedOptions;
+
       const feedAbsPaths = await createFeed(
         doc,
         source,
         project,
         listingDescriptors,
-        options[kFeed]!,
+        listingOptions,
         format,
       );
       if (feedAbsPaths) {

--- a/src/project/types/website/listing/website-listing.ts
+++ b/src/project/types/website/listing/website-listing.ts
@@ -6,7 +6,7 @@
 *
 */
 
-import { basename, relative } from "path/mod.ts";
+import { basename } from "path/mod.ts";
 import { Document } from "deno_dom/deno-dom-wasm-noinit.ts";
 import { existsSync } from "fs/mod.ts";
 
@@ -128,6 +128,7 @@ export async function listingHtmlDependencies(
     const supporting: string[] = [];
     if (options[kFeed]) {
       const feedAbsPaths = await createFeed(
+        doc,
         source,
         project,
         listingDescriptors,

--- a/src/project/types/website/listing/website-listing.ts
+++ b/src/project/types/website/listing/website-listing.ts
@@ -15,7 +15,6 @@ import {
   FormatDependency,
   FormatExtras,
   kDependencies,
-  kHtmlFinalizers,
   kHtmlPostprocessors,
   kMarkdownAfterBody,
   kSassBundles,
@@ -48,6 +47,7 @@ import { readListings } from "./website-listing-read.ts";
 import { categorySidebar } from "./website-listing-categories.ts";
 import { TempContext } from "../../../../core/temp.ts";
 import { createFeed } from "./website-listing-feed.ts";
+import { HtmlPostProcessResult } from "../../../../command/render/types.ts";
 
 export async function listingHtmlDependencies(
   source: string,
@@ -111,7 +111,9 @@ export async function listingHtmlDependencies(
   });
 
   // Create the post processor
-  const listingPostProcessor = async (doc: Document) => {
+  const listingPostProcessor = async (
+    doc: Document,
+  ): Promise<HtmlPostProcessResult> => {
     // Process the rendered listings into the document
     pipeline.processRenderedMarkdown(doc);
 
@@ -123,7 +125,7 @@ export async function listingHtmlDependencies(
       format,
     );
 
-    const resources: string[] = [];
+    const supporting: string[] = [];
     if (options[kFeed]) {
       const feedAbsPaths = await createFeed(
         source,
@@ -134,13 +136,13 @@ export async function listingHtmlDependencies(
       );
       if (feedAbsPaths) {
         feedAbsPaths.forEach((feedAbsPath) => {
-          resources.push(relative(project.dir, feedAbsPath));
+          supporting.push(feedAbsPath);
         });
       }
     }
 
     // No resource references to add
-    return Promise.resolve(resources);
+    return Promise.resolve({ resources: [], supporting });
   };
 
   return {

--- a/src/project/types/website/website-analytics.ts
+++ b/src/project/types/website/website-analytics.ts
@@ -12,6 +12,10 @@ import { projectTypeResourcePath } from "../../../core/resources.ts";
 import { TempContext } from "../../../core/temp.ts";
 import { ProjectContext } from "../../types.ts";
 import { kWebsite } from "./website-config.ts";
+import {
+  HtmlPostProcessResult,
+  kHtmlEmptyPostProcessResult,
+} from "../../../command/render/types.ts";
 
 // tracking id for google analytics
 // GA3 calls this 'tracking id'
@@ -175,7 +179,7 @@ export function cookieConsentDependencies(
             path: cssPath,
           }],
         },
-        htmlPostProcessor: (doc: Document) => {
+        htmlPostProcessor: (doc: Document): Promise<HtmlPostProcessResult> => {
           const anchorId = "open_preferences_center";
           // See if there is already a prefs link - if there isn't,
           // inject one
@@ -201,7 +205,7 @@ export function cookieConsentDependencies(
               footer.appendChild(anchorContainer);
             }
           }
-          return Promise.resolve([]);
+          return Promise.resolve(kHtmlEmptyPostProcessResult);
         },
       };
     } else {

--- a/src/project/types/website/website-config.ts
+++ b/src/project/types/website/website-config.ts
@@ -104,6 +104,7 @@ export interface OpenGraphConfig {
 
 type WebsiteConfigKey =
   | "title"
+  | "image"
   | "favicon"
   | "site-url"
   | "site-path"
@@ -199,6 +200,10 @@ export function websiteTitle(project?: ProjectConfig): string | undefined {
 
 export function websiteBaseurl(project?: ProjectConfig): string | undefined {
   return websiteConfigString(kSiteUrl, project);
+}
+
+export function websiteImage(project?: ProjectConfig): string | undefined {
+  return websiteConfigString(kImage, project);
 }
 
 export function websiteDescription(

--- a/src/project/types/website/website-config.ts
+++ b/src/project/types/website/website-config.ts
@@ -28,7 +28,6 @@ import { ProjectConfig, ProjectContext } from "../../types.ts";
 export const kWebsite = "website";
 
 export const kSiteUrl = "site-url";
-export const kSiteDescription = "site-description";
 export const kSitePath = "site-path";
 export const kSiteTitle = "title";
 export const kSiteFavicon = "favicon";
@@ -105,10 +104,10 @@ export interface OpenGraphConfig {
 type WebsiteConfigKey =
   | "title"
   | "image"
+  | "description"
   | "favicon"
   | "site-url"
   | "site-path"
-  | "site-description"
   | "repo-url"
   | "repo-branch"
   | "repo-actions"
@@ -209,7 +208,7 @@ export function websiteImage(project?: ProjectConfig): string | undefined {
 export function websiteDescription(
   project?: ProjectConfig,
 ): string | undefined {
-  return websiteConfigString(kSiteDescription, project);
+  return websiteConfigString(kDescription, project);
 }
 
 export function websitePath(project?: ProjectConfig): string {

--- a/src/project/types/website/website-config.ts
+++ b/src/project/types/website/website-config.ts
@@ -28,6 +28,7 @@ import { ProjectConfig, ProjectContext } from "../../types.ts";
 export const kWebsite = "website";
 
 export const kSiteUrl = "site-url";
+export const kSiteDescription = "site-description";
 export const kSitePath = "site-path";
 export const kSiteTitle = "title";
 export const kSiteFavicon = "favicon";
@@ -106,6 +107,7 @@ type WebsiteConfigKey =
   | "favicon"
   | "site-url"
   | "site-path"
+  | "site-description"
   | "repo-url"
   | "repo-branch"
   | "repo-actions"
@@ -197,6 +199,12 @@ export function websiteTitle(project?: ProjectConfig): string | undefined {
 
 export function websiteBaseurl(project?: ProjectConfig): string | undefined {
   return websiteConfigString(kSiteUrl, project);
+}
+
+export function websiteDescription(
+  project?: ProjectConfig,
+): string | undefined {
+  return websiteConfigString(kSiteDescription, project);
 }
 
 export function websitePath(project?: ProjectConfig): string {

--- a/src/project/types/website/website-meta.ts
+++ b/src/project/types/website/website-meta.ts
@@ -5,7 +5,6 @@
 *
 */
 
-import { existsSync } from "fs/exists.ts";
 import { Document, Element } from "../../../core/deno-dom.ts";
 import { dirname, join, relative } from "path/mod.ts";
 import { kDescription, kSubtitle, kTitle } from "../../../config/constants.ts";
@@ -17,7 +16,6 @@ import {
 } from "../../../config/types.ts";
 import { Metadata } from "../../../config/types.ts";
 import { mergeConfigs } from "../../../core/config.ts";
-import PngImage from "../../../core/png.ts";
 import { ProjectContext } from "../../types.ts";
 import {
   kCardStyle,
@@ -43,6 +41,7 @@ import {
   HtmlPostProcessResult,
   kHtmlEmptyPostProcessResult,
 } from "../../../command/render/types.ts";
+import { imageSize } from "../../../core/image.ts";
 
 const kCard = "card";
 
@@ -333,21 +332,6 @@ function imageMetadata(
       height: size?.height,
       width: size?.width,
     };
-  }
-}
-
-function imageSize(path: string) {
-  if (path !== undefined) {
-    if (path.endsWith(".png")) {
-      if (existsSync(path)) {
-        const imageData = Deno.readFileSync(path);
-        const png = new PngImage(imageData);
-        return {
-          height: png.height,
-          width: png.width,
-        };
-      }
-    }
   }
 }
 

--- a/src/project/types/website/website-meta.ts
+++ b/src/project/types/website/website-meta.ts
@@ -39,6 +39,10 @@ import {
 } from "./website-pipeline-md.ts";
 import { findPreviewImg } from "./util/discover-meta.ts";
 import { isAbsoluteRef } from "../../../core/http.ts";
+import {
+  HtmlPostProcessResult,
+  kHtmlEmptyPostProcessResult,
+} from "../../../command/render/types.ts";
 
 const kCard = "card";
 
@@ -76,7 +80,7 @@ export function metadataHtmlPostProcessor(
   extras: FormatExtras,
   pipeline: MarkdownPipeline,
 ) {
-  return (doc: Document): Promise<string[]> => {
+  return (doc: Document): Promise<HtmlPostProcessResult> => {
     // read document level metadata
     const pageMeta = pageMetadata(format, extras);
 
@@ -175,7 +179,7 @@ export function metadataHtmlPostProcessor(
     // Process any pipelined markdown
     pipeline.processRenderedMarkdown(doc);
 
-    return Promise.resolve([]);
+    return Promise.resolve(kHtmlEmptyPostProcessResult);
   };
 }
 

--- a/src/project/types/website/website-navigation.ts
+++ b/src/project/types/website/website-navigation.ts
@@ -110,6 +110,10 @@ import {
 } from "./website-pipeline-md.ts";
 import { engineValidExtensions } from "../../../execute/engine.ts";
 import { TempContext } from "../../../core/temp.ts";
+import {
+  HtmlPostProcessResult,
+  kHtmlEmptyPostProcessResult,
+} from "../../../command/render/types.ts";
 
 // static navigation (initialized during project preRender)
 const navigation: Navigation = {
@@ -357,7 +361,7 @@ function navigationHtmlPostprocessor(
   const offset = projectOffset(project, source);
   const href = inputFileHref(sourceRelative);
 
-  return async (doc: Document) => {
+  return async (doc: Document): Promise<HtmlPostProcessResult> => {
     // Process any markdown rendered through the render envelope
     markdownPipeline.processRenderedMarkdown(doc);
 
@@ -483,7 +487,7 @@ function navigationHtmlPostprocessor(
         removeChapterNumber(titleEl);
       }
     }
-    return Promise.resolve([]);
+    return Promise.resolve(kHtmlEmptyPostProcessResult);
   };
 }
 

--- a/src/project/types/website/website-resources.ts
+++ b/src/project/types/website/website-resources.ts
@@ -17,6 +17,7 @@ import { projectOffset } from "../../project-shared.ts";
 import { relative } from "path/mod.ts";
 import { inputFileHref } from "./website-shared.ts";
 import { websitePath } from "./website-config.ts";
+import { HtmlPostProcessResult } from "../../../command/render/types.ts";
 
 export function htmlResourceResolverPostprocessor(
   source: string,
@@ -26,11 +27,11 @@ export function htmlResourceResolverPostprocessor(
   const offset = projectOffset(project, source);
   const href = inputFileHref(sourceRelative);
 
-  return (doc: Document) => {
+  return (doc: Document): Promise<HtmlPostProcessResult> => {
     const forceRoot = href === "/404.html" ? websitePath(project.config) : null;
     // resolve resource refs
     const refs = resolveResourceRefs(doc, offset, forceRoot);
-    return Promise.resolve(refs);
+    return Promise.resolve({ resources: refs, supporting: [] });
   };
 }
 

--- a/src/project/types/website/website.ts
+++ b/src/project/types/website/website.ts
@@ -171,7 +171,7 @@ export const websiteProjectType: ProjectType = {
         htmlResourceResolverPostprocessor(source, project),
       ]);
 
-      // listings HTML dependencies
+      // listings extras
       const htmlListingDependencies = await listingHtmlDependencies(
         source,
         project,
@@ -282,6 +282,10 @@ export async function websitePostRender(
 
   // write redirecting index.html if there is none
   ensureIndexPage(context);
+
+  // 'Resolve' any listing RSS feeds that are staged
+  // Look for staged RSS feed files and inject full content into them
+  // exemplar: updateSearchIndex
 
   // generate any page aliases
   await updateAliases(context, outputFiles, incremental);

--- a/src/project/types/website/website.ts
+++ b/src/project/types/website/website.ts
@@ -63,7 +63,10 @@ import { htmlResourceResolverPostprocessor } from "./website-resources.ts";
 
 import { defaultProjectType } from "../project-default.ts";
 import { TempContext } from "../../../core/temp.ts";
-import { listingHtmlDependencies } from "./listing/website-listing.ts";
+import {
+  listingHtmlDependencies,
+  listingSupplementalFiles,
+} from "./listing/website-listing.ts";
 import { completeStagedFeeds } from "./listing/website-listing-feed.ts";
 
 export const websiteProjectType: ProjectType = {
@@ -109,6 +112,19 @@ export const websiteProjectType: ProjectType = {
 
   preRender: async (context: ProjectContext) => {
     await initWebsiteNavigation(context);
+  },
+
+  supplementRender: (
+    project: ProjectContext,
+    files: string[],
+    incremental: boolean,
+  ) => {
+    const listingSupplements = listingSupplementalFiles(
+      project,
+      files,
+      incremental,
+    );
+    return listingSupplements;
   },
 
   formatExtras: async (

--- a/src/project/types/website/website.ts
+++ b/src/project/types/website/website.ts
@@ -64,6 +64,7 @@ import { htmlResourceResolverPostprocessor } from "./website-resources.ts";
 import { defaultProjectType } from "../project-default.ts";
 import { TempContext } from "../../../core/temp.ts";
 import { listingHtmlDependencies } from "./listing/website-listing.ts";
+import { completeStagedFullFeeds } from "./listing/website-listing-feed.ts";
 
 export const websiteProjectType: ProjectType = {
   type: kWebsite,
@@ -279,6 +280,9 @@ export async function websitePostRender(
 
   // update search index
   updateSearchIndex(context, outputFiles, incremental);
+
+  // Any full content feeds need to be 'completed'
+  completeStagedFullFeeds(context, outputFiles, incremental);
 
   // write redirecting index.html if there is none
   ensureIndexPage(context);

--- a/src/project/types/website/website.ts
+++ b/src/project/types/website/website.ts
@@ -64,7 +64,7 @@ import { htmlResourceResolverPostprocessor } from "./website-resources.ts";
 import { defaultProjectType } from "../project-default.ts";
 import { TempContext } from "../../../core/temp.ts";
 import { listingHtmlDependencies } from "./listing/website-listing.ts";
-import { completeStagedFullFeeds } from "./listing/website-listing-feed.ts";
+import { completeStagedFeeds } from "./listing/website-listing-feed.ts";
 
 export const websiteProjectType: ProjectType = {
   type: kWebsite,
@@ -282,7 +282,7 @@ export async function websitePostRender(
   updateSearchIndex(context, outputFiles, incremental);
 
   // Any full content feeds need to be 'completed'
-  completeStagedFullFeeds(context, outputFiles, incremental);
+  completeStagedFeeds(context, outputFiles, incremental);
 
   // write redirecting index.html if there is none
   ensureIndexPage(context);

--- a/src/resources/projects/website/listing/feed/item.ejs.md
+++ b/src/resources/projects/website/listing/feed/item.ejs.md
@@ -9,7 +9,7 @@
   <category><%= category %></category>
   <% } %>
   <guid><%= item.guid %></guid>
-  <pubDate><%= item.pubDate %></pubDate>
+  <pubDate><%= item.pubDate.toUTCString() %></pubDate>
   <% if (item.image) { %>
     <% 
     const imgWidthAttr = item.imageHeight ? ` width="${item.imageWidth}` : '';

--- a/src/resources/projects/website/listing/feed/item.ejs.md
+++ b/src/resources/projects/website/listing/feed/item.ejs.md
@@ -12,9 +12,10 @@
   <pubDate><%= item.pubDate.toUTCString() %></pubDate>
   <% if (item.image) { %>
     <% 
-    const imgWidthAttr = item.imageHeight ? ` width="${item.imageWidth}` : '';
-    const imgHeightAttr = item.imageHeight ? ` height="${item.imageHeight}` : '';
+    const imgWidthAttr = item.imageHeight ? ` width="${item.imageWidth}"` : '';
+    const imgHeightAttr = item.imageHeight ? ` height="${item.imageHeight}"` : '';
+    const imgTypeAttr = item.imageContentType ? ` type="${item.imageContentType}"`: '';
     %>
-  <media:content url="<%- item.image %>" medium="image" type="image/png"<%- imgHeightAttr %><%- imgWidthAttr %>/>
+  <media:content url="<%- item.image %>" medium="image"<%= imgTypeAttr %><%= imgHeightAttr %><%= imgWidthAttr %>/>
   <% } %>
 </item>

--- a/src/resources/projects/website/listing/feed/item.ejs.md
+++ b/src/resources/projects/website/listing/feed/item.ejs.md
@@ -1,0 +1,20 @@
+<item>
+  <title><%= item.title %></title>
+  <% for (const author of item.authors) { %>
+  <dc:creator><%= author %></dc:creator>
+  <% } %>
+  <link><%= item.link %></link>
+  <description><%= item.description %></description>
+  <% for (const category of item.categories) { %>
+  <category><%= category %></category>
+  <% } %>
+  <guid><%= item.guid %></guid>
+  <pubDate><%= item.pubDate %></pubDate>
+  <% if (item.image) { %>
+    <% 
+    const imgWidthAttr = item.imageHeight ? ` width="${item.imageWidth}` : '';
+    const imgHeightAttr = item.imageHeight ? ` height="${item.imageHeight}` : '';
+    %>
+  <media:content url="<%- item.image %>" medium="image" type="image/png"<%- imgHeightAttr %><%- imgWidthAttr %>/>
+  <% } %>
+</item>

--- a/src/resources/projects/website/listing/feed/postamble.ejs.md
+++ b/src/resources/projects/website/listing/feed/postamble.ejs.md
@@ -1,0 +1,2 @@
+  </channel>
+</rss>

--- a/src/resources/projects/website/listing/feed/preamble.ejs.md
+++ b/src/resources/projects/website/listing/feed/preamble.ejs.md
@@ -9,7 +9,7 @@
 
 <title><%= feed.title %></title>
 <link><%- feed.link %></link>
-<atom:link href="<%- feed.link %>" rel="self" type="application/rss+xml"/>
+<atom:link href="<%- feed.feedLink %>" rel="self" type="application/rss+xml"/>
 <description><%= feed.description %></description>
 <% if (feed.language) { %><language><%= feed.language %></language><% } %>
 <generator><%= feed.generator %></generator>

--- a/src/resources/projects/website/listing/feed/preamble.ejs.md
+++ b/src/resources/projects/website/listing/feed/preamble.ejs.md
@@ -4,7 +4,6 @@
       xmlns:media="http://search.yahoo.com/mrss/" 
       xmlns:content="http://purl.org/rss/1.0/modules/content/" 
       xmlns:dc="http://purl.org/dc/elements/1.1/" 
-      xmlns:distill="https://distill.pub/journal/" 
       version="2.0">
 <channel>
 
@@ -12,6 +11,6 @@
 <link><%- feed.link %></link>
 <atom:link href="<%- feed.link %>" rel="self" type="application/rss+xml"/>
 <description><%= feed.description %></description>
-<language><%= feed.language %></language>
+<% if (feed.language) { %><language><%= feed.language %></language><% } %>
 <generator><%= feed.generator %></generator>
 <lastBuildDate><%= feed.lastBuildDate %></lastBuildDate>

--- a/src/resources/projects/website/listing/feed/preamble.ejs.md
+++ b/src/resources/projects/website/listing/feed/preamble.ejs.md
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<rss  xmlns:atom="http://www.w3.org/2005/Atom" 
+      xmlns:media="http://search.yahoo.com/mrss/" 
+      xmlns:content="http://purl.org/rss/1.0/modules/content/" 
+      xmlns:dc="http://purl.org/dc/elements/1.1/" 
+      xmlns:distill="https://distill.pub/journal/" 
+      version="2.0">
+<channel>
+
+<title><%= feed.title %></title>
+<link><%- feed.link %></link>
+<atom:link href="<%- feed.link %>" rel="self" type="application/rss+xml"/>
+<description><%= feed.description %></description>
+<language><%= feed.language %></language>
+<generator><%= feed.generator %></generator>
+<lastBuildDate><%= feed.lastBuildDate %></lastBuildDate>

--- a/src/resources/projects/website/listing/feed/preamble.ejs.md
+++ b/src/resources/projects/website/listing/feed/preamble.ejs.md
@@ -12,5 +12,12 @@
 <atom:link href="<%- feed.feedLink %>" rel="self" type="application/rss+xml"/>
 <description><%= feed.description %></description>
 <% if (feed.language) { %><language><%= feed.language %></language><% } %>
+<% if (feed.image) { %><image>
+<url><%= feed.image.url %></url>
+<title><%= feed.image.title %></title>
+<link><%= feed.image.link %></link>
+<% if (feed.image.height) { %><height><%= feed.image.height %></height><% } %>
+<% if (feed.image.width) { %><width><%= feed.image.width %></width><% } %>
+</image><% } %>
 <generator><%= feed.generator %></generator>
 <lastBuildDate><%= feed.lastBuildDate %></lastBuildDate>


### PR DESCRIPTION
- Generate feeds for listing pages (optionally)
- Feeds support `partial` or `full-content`
- Feeds are page level, so will collect all the items from any listings on the page
- You can also generate category specific feeds like so:
```
listing:
  feed:
    categories:
      - category1
      - category2
```
- In addition, now listing pages will automatically render whenever a page they reference is rendered (or when a new file that matches their contents is rendered).