### PR TITLE
[revealjs] Get target position before removing image and its empty parents.

### DIFF
--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -650,13 +650,13 @@ function applyStretch(doc: Document, autoStretch: boolean) {
           }
         }
 
+        // Target position of image
+        // first level after the element
+        const nextEl = nodeEl.nextElementSibling;
         // Remove image from its parent
         removeEmpty(imageEl);
-        // insert at first level after the element
-        slideEl.insertBefore(
-          image,
-          nodeEl.nextElementSibling,
-        );
+        // insert at target position
+        slideEl.insertBefore(image, nextEl);
 
         // If there was a caption processed add it after
         if (caption.classList.contains("caption")) {


### PR DESCRIPTION
When only a plot in a chunk, the whole first level node will be removed but this node is required for getting target position. 

We get the position first, before removing and use this to move the image at first level right in place of the removed node.

Reported by @mine-cetinkaya-rundel with this simple reprex
````markdown
---
format: revealjs
---

```{r}
plot(cars)
```

```{r}
1 + 1
```
````

