### PR TITLE
ignoring error stream when searching through registry on windows

### DIFF
--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -38,6 +38,7 @@ export async function registryReadString(
   const result = await execProcess({
     cmd,
     stdout: "piped",
+    stderr: "null",
   });
   if (result.success && result.stdout) {
     const typePos = result.stdout?.indexOf(kTypeString);


### PR DESCRIPTION
Otherwise, an erreur is shown when doing `quarto check knitr` about registry key not found.

Before the change
````
❯ quarto check knitr
Check file:///C:/Users/chris/Documents/DEV_R/quarto-cli/src/quarto.ts

(|) Checking R installation...........Erreur´┐¢: Erreur´┐¢: le syst´┐¢me n'a pas trouv´┐¢ la cl´┐¢ ou la valeur de Registre sp´┐¢cifi´┐¢e.
[>] Checking R installation...........OK
      Version: 4.1.2
      Path: C:/PROGRA~1/R/R-41~1.2
      LibPaths:
        - C:/Users/chris/R/win-library/4.1
        - C:/Program Files/R/R-4.1.2/library
      rmarkdown: (None)

      The rmarkdown package is not available in this R installation.
      Install with install.packages("rmarkdown")
````

After the change

```
❯ quarto check knitr
Check file:///C:/Users/chris/Documents/DEV_R/quarto-cli/src/quarto.ts

[>] Checking R installation...........OK
      Version: 4.1.2
      Path: C:/PROGRA~1/R/R-41~1.2
      LibPaths:
        - C:/Users/chris/R/win-library/4.1
        - C:/Program Files/R/R-4.1.2/library
      rmarkdown: (None)

      The rmarkdown package is not available in this R installation.
      Install with install.packages("rmarkdown")
```