### PR TITLE
Improve Supplemental File Reloading

### DIFF
--- a/package/src/import_map.json
+++ b/package/src/import_map.json
@@ -10,6 +10,7 @@
     "log/": "https://deno.land/std@0.122.0/log/",
     "path/": "https://deno.land/std@0.122.0/path/",
     "streams/": "https://deno.land/std@0.122.0/streams/",
+    "textproto/": "https://deno.land/std@0.122.0/textproto/",
     "uuid/": "https://deno.land/std@0.122.0/uuid/",
     "cliffy/": "https://deno.land/x/cliffy@v0.19.3/",
     "deno_dom/": "https://deno.land/x/deno_dom@v0.1.20-alpha/",

--- a/src/core/file.ts
+++ b/src/core/file.ts
@@ -8,6 +8,7 @@
 import { TextProtoReader } from "textproto/mod.ts";
 import { BufReader } from "io/mod.ts";
 import { exists } from "fs/mod.ts";
+import { execProcess } from "./process.ts";
 
 export async function visitLines(
   path: string,
@@ -33,5 +34,17 @@ export async function visitLines(
     } finally {
       file.close();
     }
+  }
+}
+
+export async function touch(path: string) {
+  if (Deno.build.os === "windows") {
+    // Touch the file be rewriting it
+    const contents = await Deno.readTextFile(path);
+    await Deno.writeTextFile(path, contents);
+  } else {
+    await execProcess({
+      cmd: ["touch", path],
+    });
   }
 }

--- a/src/project/serve/watch.ts
+++ b/src/project/serve/watch.ts
@@ -266,7 +266,7 @@ export function watchProject(
       }
 
       // see if there is a reload target (last html file modified)
-      const lastHtmlFile = (ld.uniq(modified) as string[]).reverse().find(
+      const lastHtmlFile = modified.reverse().find(
         (file) => {
           return extname(file) === ".html";
         },

--- a/src/project/types/types.ts
+++ b/src/project/types/types.ts
@@ -62,7 +62,14 @@ export interface ProjectType {
     project: ProjectContext,
     files: string[],
     incremental: boolean,
-  ) => string[];
+  ) => {
+    files: string[];
+    onRenderComplete?: (
+      project: ProjectContext,
+      files: string[],
+      incremental: boolean,
+    ) => Promise<void>;
+  };
   postRender?: (
     context: ProjectContext,
     incremental: boolean,


### PR DESCRIPTION
Supplemental file providers can now also provide a hook that will be called back when the render is complete. The website listing feature will now use this hook to 'touch' any of the inputs to make sure that the file watcher see those changes last.