### PR TITLE
Add support for draft documents

### DIFF
--- a/src/format/html/format-html-shared.ts
+++ b/src/format/html/format-html-shared.ts
@@ -45,6 +45,8 @@ export const kComments = "comments";
 export const kHypothesis = "hypothesis";
 export const kUtterances = "utterances";
 
+export const kDraft = "draft";
+
 export const kDocumentCss = "document-css";
 export const kBootstrapDependencyName = "bootstrap";
 

--- a/src/project/types/website/website-search.ts
+++ b/src/project/types/website/website-search.ts
@@ -29,6 +29,7 @@ import { ProjectOutputFile } from "../types.ts";
 import {
   clipboardDependency,
   kBootstrapDependencyName,
+  kDraft,
 } from "../../../format/html/format-html-shared.ts";
 import { projectOutputDir } from "../../project-shared.ts";
 import { projectOffset } from "../../project-shared.ts";
@@ -152,7 +153,10 @@ export function updateSearchIndex(
       const href = relative(outputDir, file);
 
       // if this is excluded then remove and return
-      if (outputFile.format.metadata[kSearch] === false) {
+      if (
+        outputFile.format.metadata[kSearch] === false ||
+        outputFile.format.metadata[kDraft]
+      ) {
         searchDocs = searchDocs.filter((doc) => {
           return doc.href !== href &&
             !doc.href.startsWith(href + "#");


### PR DESCRIPTION
Draft documents in websites are excluded from:
- listings
- search
- sitemap

Denote a draft using `draft: true` in the frontmatter.