### PR TITLE
Set height: 100% on logo to correctly scale in footer

### DIFF
--- a/src/resources/formats/revealjs/plugins/support/footer.css
+++ b/src/resources/formats/revealjs/plugins/support/footer.css
@@ -4,6 +4,7 @@
   bottom: 0;
   right: 12px;
   max-height: 2.2rem;
+  height: 100%;
   width: auto;
 }
 


### PR DESCRIPTION
Currently, the footer logo is not correctly scaled for SVG with very high width 

````markdown
---
title: "this is my presentation"
format:
  revealjs:
    logo: logo.svg
    footer: "this is my presentation"
---

```{r, include = FALSE}
xfun::download_file("https://upload.wikimedia.org/wikipedia/commons/d/d0/RStudio_logo_flat.svg", output = "logo.svg")
```
````

![image](https://user-images.githubusercontent.com/6791940/153468970-f9440af3-65ac-408d-bed4-355e52a80eb2.png)


This PR just add a CSS rule `height: 100%` so that the image is scaled, but limited to `max-height`. 

This results in 
![image](https://user-images.githubusercontent.com/6791940/153469882-682ffea5-2812-4dfb-a75e-0ebbfd7fb152.png)

Would that be a correct workaround ? 

Let's note that this issue arise only with svg not with png.
