### PR TITLE
Write tlmgr command in a tempfile on Windows and execute the file

### DIFF
--- a/src/command/render/latexmk/texlive.ts
+++ b/src/command/render/latexmk/texlive.ts
@@ -54,7 +54,7 @@ export async function findPackages(
     } else {
       const result = await tlmgrCommand(
         "search",
-        [...args, ...(opts || []), `"${searchTerm}"`],
+        [...args, ...(opts || []), searchTerm],
         true,
       );
 
@@ -289,6 +289,8 @@ async function tlmgrCommand(
   let cmdExec: string[];
   let tempFile: string | undefined;
   if (Deno.build.os === "windows") {
+    // quote args on Windows
+    args = args.map((a) => `"${a}"`);
     // writing to a file to exectute to avoid quoting issue with Deno
     // https://github.com/quarto-dev/quarto-cli/issues/336
     const lines = ["tlmgr", cmd, ...args];

--- a/src/command/render/latexmk/texlive.ts
+++ b/src/command/render/latexmk/texlive.ts
@@ -281,7 +281,7 @@ async function verifyPackageInstalled(
   return result.stdout?.trim() === pkg;
 }
 
-function tlmgrCommand(
+async function tlmgrCommand(
   cmd: string,
   args: string[],
   _quiet?: boolean,
@@ -301,20 +301,17 @@ function tlmgrCommand(
     cmdExec = ["tlmgr", cmd, ...args];
   }
   try {
-    const result = execProcess(
+    const result = await execProcess(
       {
         cmd: cmdExec,
         stdout: "piped",
         stderr: "piped",
       },
     );
-    result.finally(() => {
-      if (Deno.build.os === "windows" && tempFile) {
-        removeIfExists(tempFile);
-      }
-    });
     return result;
   } catch {
     return Promise.reject();
+  } finally {
+    if (tempFile) removeIfExists(tempFile);
   }
 }

--- a/src/command/render/latexmk/texlive.ts
+++ b/src/command/render/latexmk/texlive.ts
@@ -293,18 +293,17 @@ async function safeTlmgrExec(
   if (Deno.build.os === "windows") {
     // On Windows writing the command to a file to avoid quoting issue with Deno
     // https://github.com/quarto-dev/quarto-cli/issues/336
-    let tempFile: string | undefined;
+    // Quoting every argument for CMD
+    args = args.map((a) => `"${a}"`);
+    const lines = ["tlmgr", cmd, ...args];
+    const tempFile = Deno.makeTempFileSync(
+      { prefix: "tlmgr-cmd", suffix: ".bat" },
+    );
     try {
-      // Quoting every argument for CMD
-      args = args.map((a) => `"${a}"`);
-      const lines = ["tlmgr", cmd, ...args];
-      tempFile = Deno.makeTempFileSync(
-        { prefix: "tlmgr-cmd", suffix: ".bat" },
-      );
       Deno.writeTextFileSync(tempFile, lines.join(" ") + "\n");
       return await execTlmgr(["cmd", "/c", tempFile]);
     } finally {
-      if (tempFile) removeIfExists(tempFile);
+      removeIfExists(tempFile);
     }
   } else {
     return execTlmgr(["tlmgr", cmd, ...args]);

--- a/src/command/render/latexmk/texlive.ts
+++ b/src/command/render/latexmk/texlive.ts
@@ -12,18 +12,10 @@ import { kLatexHeaderMessageOptions } from "./types.ts";
 import { lines } from "../../../core/text.ts";
 import { removeIfExists } from "../../../core/path.ts";
 
-const tlmgr = Deno.build.os === "windows"
-  ? ["cmd.exe", "/c", "tlmgr"]
-  : ["tlmgr"];
-
 // Determines whether TexLive is installed and callable on this system
 export async function hasTexLive(): Promise<boolean> {
   try {
-    const result = await execProcess({
-      cmd: [...tlmgr, "--version"],
-      stdout: "piped",
-      stderr: "piped",
-    });
+    const result = await tlmgrCommand("--version", []);
     return result.code === 0;
   } catch {
     return false;


### PR DESCRIPTION
This PR fixes #336

Due to  some quoting issue with `Deno.Run()` , we have an error with `tlmgr` when passed to `cmd /c`.
Writing to a file prevent any quoting difficulty.

With this PR 

* It builds the command and write it to a file on Windows
* It will run `cmd /c tempfile.bat` instead of the command passed as a string.


