### PR TITLE
[reveal] Do not reverse out .smaller effect on code blocks

### DIFF
--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -331,11 +331,6 @@ $panel-sidebar-padding: 0.5em;
   font-size: calc(#{$revealjs-h3-font-size} / #{$presentation-font-smaller});
 }
 
-.reveal.smaller .slides pre,
-.reveal .slides section.smaller pre {
-  font-size: calc(#{$code-block-font-size} / #{$presentation-font-smaller});
-}
-
 .reveal .slide-number {
   color: $link-color;
   background-color: $body-bg;


### PR DESCRIPTION
With this PR `.smaller` on slide with reduce font size for code block too. 
````markdown
---
format: revealjs
---

## mtcars

### A sub header

Some content

```{r}
mtcars
```

## mtcars - smaller {.smaller}

### A sub header

Some content

```{r}
#| classes: smaller
mtcars
```
````

This looks now like this 


![reveal-smaller](https://user-images.githubusercontent.com/6791940/154314094-6c0f4e11-08c4-4060-b217-fff8a29cff1e.gif)

Headers are not made smaller in font size as discussed. Difference with current behavior is that `<pre>` are not make smaller in fonts, as text content.

@mine-cetinkaya-rundel is this ok to you ? 
