### PR TITLE
Fix hostname addr type convertation and update info output

### DIFF
--- a/src/command/preview/cmd.ts
+++ b/src/command/preview/cmd.ts
@@ -159,7 +159,7 @@ export const previewCommand = new Command()
     }
     const hostPos = args.indexOf("--host");
     if (hostPos !== -1) {
-      options.host = parseInt(args[hostPos + 1]);
+      options.host = String(args[hostPos + 1]);
       args.splice(hostPos, 2);
     }
     const renderPos = args.indexOf("--render");

--- a/src/command/preview/preview.ts
+++ b/src/command/preview/preview.ts
@@ -141,13 +141,13 @@ export async function preview(
       relative(projectOutputDir(project), result.outputFile),
     )
     : "";
-  const url = `http://localhost:${options.port}/${initialPath}`;
+  const url = `http://${options.host}:${options.port}/${initialPath}`;
   if (options.browse && !isRStudioServer() && !isJupyterHubServer()) {
     await openUrl(url);
   }
 
   // print status
-  printBrowsePreviewMessage(options.port, initialPath);
+  printBrowsePreviewMessage(options.host, options.port, initialPath);
 
   // serve project
   for await (const conn of listener) {

--- a/src/command/preview/preview.ts
+++ b/src/command/preview/preview.ts
@@ -141,7 +141,7 @@ export async function preview(
       relative(projectOutputDir(project), result.outputFile),
     )
     : "";
-  const url = `http://${options.host}:${options.port}/${initialPath}`;
+  const url = `http://localhost:${options.port}/${initialPath}`;
   if (options.browse && !isRStudioServer() && !isJupyterHubServer()) {
     await openUrl(url);
   }

--- a/src/command/render/render-shared.ts
+++ b/src/command/render/render-shared.ts
@@ -181,7 +181,7 @@ export function printWatchingForChangesMessage() {
   info("Watching files for changes", { format: colors.green });
 }
 
-export function printBrowsePreviewMessage(port: number, path: string) {
+export function printBrowsePreviewMessage(host: string, port: number, path: string) {
   if (isJupyterHubServer()) {
     const httpReferrer = `${
       jupyterHubHttpReferrer() || "<jupyterhub-server-url>/"
@@ -193,7 +193,7 @@ export function printBrowsePreviewMessage(port: number, path: string) {
       },
     );
   } else {
-    const url = `http://localhost:${port}/${path}`;
+    const url = `http://${host}:${port}/${path}`;
     if (!isRStudioServer()) {
       info(`Browse at `, {
         newline: false,

--- a/src/project/serve/serve.ts
+++ b/src/project/serve/serve.ts
@@ -396,7 +396,7 @@ export async function serveProject(
   };
 
   // compute site url
-  const siteUrl = `http://localhost:${options.port}/`;
+  const siteUrl = `http://${options.host}:${options.port}/`;
 
   // print status
   printWatchingForChangesMessage();
@@ -425,6 +425,7 @@ export async function serveProject(
 
   // print browse url and open browser if requested
   printBrowsePreviewMessage(
+    options.host,
     options.port,
     (targetPath && targetPath !== "index.html") ? targetPath : "",
   );

--- a/src/project/serve/serve.ts
+++ b/src/project/serve/serve.ts
@@ -396,7 +396,7 @@ export async function serveProject(
   };
 
   // compute site url
-  const siteUrl = `http://${options.host}:${options.port}/`;
+  const siteUrl = `http://localhost:${options.port}/`;
 
   // print status
   printWatchingForChangesMessage();


### PR DESCRIPTION
## Information for help:

- `quarto-cli` version: 0.9.39 (download from github release page)

## What I want to do:

I'm using `quarto` to create a project in my **remote server** and write my documents. Then I hope to use `quarto` to host and preview generated website. I try to specify a public address as hostname to preview arguments, which I could browse site from my **local laptop**. But I found it does't work and show the wrong url path.

```
$ quarto preview --port 4485 --host 0.0.0.0 --no-navigate --no-browser
Preparing to preview

Watching files for changes
Browse at http://localhost:4485/
```

## What I found:

After my debugging, I found `quarto` preview subcommod didn't [recognize host correctly](https://github.com/quarto-dev/quarto-cli/blob/12abf43f89b39ffa36404842ad09a04b8cba5e16/src/command/preview/cmd.ts#L162). And url output `printBrowsePreviewMessage` has no hostname passed.

## What I did:

1. Replace `parseInt` with `String` when parsing arguments
2. Add a new arg `host` to function `printBrowsePreviewMessage()` and update all codes called `printBrowsePreviewMessage()`
3. [Modified but reverted] Update `http://localhost:${options.port}/` to `http://${options.host}:${options.port}/`, but later I realized this is used for opening local browser, so I reverted back again.

That's all, thx
