### PR TITLE
Supplemental Files Can Filter Formats

### DIFF
--- a/src/command/render/render-shared.ts
+++ b/src/command/render/render-shared.ts
@@ -36,7 +36,10 @@ import {
 } from "../../core/platform.ts";
 import { isProjectInputFile } from "../../project/project-shared.ts";
 
-import { setInitializer, initState } from "../../core/lib/yaml-validation/state.ts";
+import {
+  initState,
+  setInitializer,
+} from "../../core/lib/yaml-validation/state.ts";
 import { initPrecompiledModules } from "../../core/lib/yaml-validation/deno-init-precompiled-modules.ts";
 
 export async function render(
@@ -79,7 +82,7 @@ export async function render(
   }
 
   // otherwise it's just a file render
-  const result = await renderFiles([path], options);
+  const result = await renderFiles([{ path }], options);
 
   // get partitioned markdown if we had result files
   const engine = fileExecutionEngine(path);

--- a/src/command/render/types.ts
+++ b/src/command/render/types.ts
@@ -115,6 +115,11 @@ export interface PandocRenderer {
   onComplete: (error?: boolean, quiet?: boolean) => Promise<RenderFilesResult>;
 }
 
+export interface RenderFile {
+  path: string;
+  formats?: string[];
+}
+
 export interface RenderFilesResult {
   files: RenderedFile[];
   error?: Error;

--- a/src/project/types/book/book-render.ts
+++ b/src/project/types/book/book-render.ts
@@ -477,7 +477,7 @@ export async function bookIncrementalRenderAll(
   for (let i = 0; i < files.length; i++) {
     // get contexts (formats)
     const contexts = await renderContexts(
-      files[i],
+      { path: files[i] },
       options,
       false,
       context,

--- a/src/project/types/types.ts
+++ b/src/project/types/types.ts
@@ -9,6 +9,7 @@ import { Format, FormatExtras, PandocFlags } from "../../config/types.ts";
 import { Metadata } from "../../config/types.ts";
 import {
   PandocRenderer,
+  RenderFile,
   RenderFlags,
   RenderOptions,
 } from "../../command/render/types.ts";
@@ -60,10 +61,10 @@ export interface ProjectType {
   ) => PandocRenderer;
   supplementRender?: (
     project: ProjectContext,
-    files: string[],
+    files: RenderFile[],
     incremental: boolean,
   ) => {
-    files: string[];
+    files: RenderFile[];
     onRenderComplete?: (
       project: ProjectContext,
       files: string[],

--- a/src/project/types/website/website.ts
+++ b/src/project/types/website/website.ts
@@ -70,6 +70,7 @@ import {
 import { completeStagedFeeds } from "./listing/website-listing-feed.ts";
 import { aboutHtmlDependencies } from "./about/website-about.ts";
 import { resolveFormatForGiscus } from "./website-giscus.ts";
+import { RenderFile } from "../../../command/render/types.ts";
 
 export const kSiteTemplateDefault = "default";
 export const kSiteTemplateBlog = "blog";
@@ -101,7 +102,7 @@ export const websiteProjectType: ProjectType = {
 
   supplementRender: (
     project: ProjectContext,
-    files: string[],
+    files: RenderFile[],
     incremental: boolean,
   ) => {
     const listingSupplements = listingSupplementalFiles(


### PR DESCRIPTION
When a supplemental file is contributed to a render, it can now includes foramts that go along with it (so that it won’t be forced to render in an unsupported format). For example, when a listing gets added to the render of a revealjs document, it still needs to render as an html document rather than as a revealjs presentation.

https://github.com/quarto-dev/quarto-cli/issues/375