### PR TITLE
Add content conditional on the output formats

### DIFF
--- a/src/resources/filters/quarto-pre/conditional-content.lua
+++ b/src/resources/filters/quarto-pre/conditional-content.lua
@@ -1,0 +1,29 @@
+-- conditional-content.lua
+--
+
+local function matchAny(str, patternList)
+    for _, pattern in ipairs(patternList) do
+        local w = str:match(pattern)
+        if w then return w end
+    end
+end
+
+local webFormats = {'html','revealjs'}
+local printFormats = {'latex','docx','pdf','opendocument','odt','beamer'}
+
+function conditionalContent()
+  return {
+
+    -- discard the content of a div if the output format doesn't match
+    Div = function(div)
+      if div.classes:includes('web-only') and matchAny(FORMAT,  webFormats) or
+        div.classes:includes('print-only') and matchAny(FORMAT, printFormats) then
+          return div
+      else
+        return {}
+      end
+    end,
+
+  }
+end
+

--- a/src/resources/filters/quarto-pre/conditional-content.lua
+++ b/src/resources/filters/quarto-pre/conditional-content.lua
@@ -15,13 +15,13 @@ function conditionalContent()
   return {
 
     -- discard the content of a div if the output format doesn't match
-    Div = function(div)
-      if div.classes:includes('web-only') and matchAny(FORMAT,  webFormats) or
-        div.classes:includes('print-only') and matchAny(FORMAT, printFormats) then
-          return div
-      else
+  Div = function(div)
+    if (div.classes:includes('web-only') and not matchAny(FORMAT,  webFormats) or
+      div.classes:includes('print-only') and not matchAny(FORMAT, printFormats)) then
         return {}
-      end
+    else
+      return div
+    end
     end,
 
   }

--- a/src/resources/filters/quarto-pre/quarto-pre.lua
+++ b/src/resources/filters/quarto-pre/quarto-pre.lua
@@ -70,6 +70,7 @@ import("panel-input.lua")
 import("panel-layout.lua")
 import("hidden.lua")
 import("line-numbers.lua")
+import("conditional-content.lua")
 -- [/import]
 
 initParams()
@@ -77,6 +78,7 @@ initParams()
 return {
   readIncludes(),
   initOptions(),
+  conditionalContent(),
   shortCodes(),  
   tableColwidthCell(),
   tableColwidth(),


### PR DESCRIPTION
Discussion: see #373

This PR adds a a lua-filter which allows the following syntax:

````
:::web-only
Hello from the digital version.
:::

:::print-only
Hello from the print version.
:::
````
to include content for only a specific output format. This comes in handy when e.g. embedding video directly in html / web formats, which could then be replaced by a link or description in a print format.

The filter runs before other quarto filters so that we can use e.g. shortcodes in conditional blocks:

````
:::web-only
Hello from the digital version.
You are reading {{< meta title >}}.
:::
````