### PR TITLE
patch template to allow scrolling in revealjs higlighted code blocks

### DIFF
--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -293,11 +293,12 @@ export function revealjsFormat() {
               [kTemplatePatches]: [
                 extraConfigPatch,
                 revealRequireJsPatch,
-                /* TODO: Remove when the fix is available in Pandoc https://github.com/jgm/pandoc/pull/7670 */
+                /* TODO: Remove when the template has changed in Pandoc
+                    https://github.com/jgm/pandoc/blob/master/data/templates/default.revealjs#L22 */
                 (template: string) => {
                   template = template.replace(
-                    /(disableLayout: )false/,
-                    "$1$disableLayout$",
+                    /.reveal .sourceCode {/,
+                    ".reveal div.sourceCode {",
                   );
                   return template;
                 },

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -297,8 +297,8 @@ export function revealjsFormat() {
                     https://github.com/jgm/pandoc/blob/master/data/templates/default.revealjs#L22 */
                 (template: string) => {
                   template = template.replace(
-                    /.reveal .sourceCode {/,
-                    ".reveal div.sourceCode {",
+                    /\s*\.reveal \.sourceCode \{[^}]+\}/m,
+                    "",
                   );
                   return template;
                 },


### PR DESCRIPTION
This will be to remove when pandoc's template changes. This also removed a previous patched not needed anymore

closes #434

For context and documentation,  this is something that happened following a Pandoc change in template, and we never dealt with the change. See our dicussion https://github.com/quarto-dev/quarto-cli/pull/147#discussion_r735591791

The initial fix was 
````css
.reveal .sourceCode {
    overflow: visible;
}
````
needed for the line numbering by Pandoc to work - It was introduced in Quarto in the PR at first but now it is included in Pandoc template. However, this mess up with scrolling as discussed in the PR #147 and we never put back support. It conflicted with the scrolling that should be on each fragmented `<code>` element for the scrolling detection to work. 

Correct fix seems to be more precise as we are doing in Quarto targetting the div only
https://github.com/quarto-dev/quarto-cli/blob/a8e82471fde620f848bd6e21e98a069a41ce71d7/src/resources/formats/revealjs/styles.html#L3-L6

So for now I am patching the template by removing the rule, as we already have it ourselves before Pandoc included it 

I'll PR a fix in Pandoc also as I think this is still an issue for them. On our side I think it is ok. At least the example works fine now with scrolling and we still get the line numbers

````markdown
---
title: demo line number
format: revealjs
---

```{.r code-line-numbers="|3-4|6-7|12-16|26-29"}
library(shiny)

# Define UI for application that draws a histogram
ui <- fluidPage(

    # Application title
    titlePanel("Old Faithful Geyser Data"),

    # Sidebar with a slider input for number of bins 
    sidebarLayout(
        sidebarPanel(
            sliderInput("bins",
                        "Number of bins:",
                        min = 1,
                        max = 50,
                        value = 30)
        ),

        # Show a plot of the generated distribution
        mainPanel(
           plotOutput("distPlot")
        )
    )
)

# Define server logic required to draw a histogram
server <- function(input, output) {

    output$distPlot <- renderPlot({
        # generate bins based on input$bins from ui.R
        x    <- faithful[, 2]
        bins <- seq(min(x), max(x), length.out = input$bins + 1)

        # draw the histogram with the specified number of bins
        hist(x, breaks = bins, col = 'darkgray', border = 'white')
    })
}

# Create the shiny app
shinyApp(ui = ui, server = server)
```
````
