### PR TITLE
[revealjs] do not move speaker notes as other asides

### DIFF
--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -583,7 +583,7 @@ function revealHtmlPostprocessor(format: Format) {
     const slides = doc.querySelectorAll("section.slide");
     for (const slide of slides) {
       const slideEl = slide as Element;
-      const asides = slideEl.querySelectorAll("aside");
+      const asides = slideEl.querySelectorAll("aside:not(.notes)");
       const asideDivs = slideEl.querySelectorAll("div.aside");
       const footnotes = slideEl.querySelectorAll('a[role="doc-noteref"]');
       if (asides.length > 0 || asideDivs.length > 0 || footnotes.length > 0) {


### PR DESCRIPTION
Fix #459

Pandoc support fenced divs of class notes in revealjs to create  speaker notes 
https://pandoc.org/MANUAL.html#speaker-notes

They are translated to HTML as `<aside class="notes">` for revealjs to pick them up (https://revealjs.com/speaker-view/), so we need to ignore them in our post process and not move those aside. 

I am suprised that we want to move more than `div.aside` element created using 
````markdown
::: aside
Some additional commentary of more peripheral interest.
:::
````

but maybe I am missing something, so fix here is to just ignore `aside` with class `notes`. 

I'll try to add test for this example so that we check it does not break in the future