### PR TITLE
add output-location: column and column-fragment

### DIFF
--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -958,6 +958,8 @@
         "enum": [
           "default",
           "fragment",
+          "column",
+          "column-fragment",
           "slide"
         ]
       },

--- a/src/resources/filters/quarto-pre/output-location.lua
+++ b/src/resources/filters/quarto-pre/output-location.lua
@@ -36,6 +36,28 @@ local function slideOutputLocation(block)
   return partitionCell(block, "output-location-slide")
 end
 
+local function columnOutputLocation(el)
+  local codeDiv = pandoc.Div({ el.content[1] }, el.attr)
+  local outputDiv = pandoc.Div(tslice(el.content, 2, #el.content), el.attr)
+  codeDiv.attr.classes:insert("column")
+  outputDiv.attr.identifier = ""
+  outputDiv.attr.classes:insert("column")
+  columns = pandoc.Div( {codeDiv, outputDiv} )
+  columns.attr.classes:insert("columns")
+  return { columns }
+end
+
+local function columnFragmentOutputLocation(el)
+  local codeDiv = pandoc.Div({ el.content[1] }, el.attr)
+  local outputDiv = pandoc.Div(tslice(el.content, 2, #el.content), el.attr)
+  codeDiv.attr.classes:insert("column")
+  outputDiv.attr.identifier = ""
+  outputDiv.attr.classes:insert("column")
+  outputDiv.attr.classes:insert("fragment")
+  columns = pandoc.Div( {codeDiv, outputDiv} )
+  columns.attr.classes:insert("columns")
+  return { columns }
+end
 
 function outputLocation()
   if isRevealJsOutput() then
@@ -49,6 +71,10 @@ function outputLocation()
             if outputLocationCellHasCode(block) then
               if outputLoc == "fragment" then
                 tappend(newBlocks, fragmentOutputLocation(block))
+              elseif outputLoc == "column" then
+                tappend(newBlocks, columnOutputLocation(block))
+              elseif outputLoc == "column-fragment" then
+                tappend(newBlocks, columnFragmentOutputLocation(block))
               elseif outputLoc == "slide" then
                 tappend(newBlocks, slideOutputLocation(block))
               else


### PR DESCRIPTION
I found that when making presentations about code it is common to want to present code and output in a two-column layout (instead of vertically stacked), so I extended the output-location filter (https://quarto.org/docs/presentations/revealjs/#output-location) by two options `column` and `column-fragment`. Maybe this is useful for others as well :)

````
```{r}
#| echo: true
#| output-location: column

library(ggplot2)

ggplot(mpg, aes(displ, hwy, colour = class)) + 
  geom_point()
```
````

![image](https://user-images.githubusercontent.com/17450586/161026538-fa3dbc48-0c95-4a33-93cc-224986804e8c.png)
