### PR TITLE
Fix "Other" keyword in ayu-mirage

### DIFF
--- a/src/resources/pandoc/highlight-styles/ayu-mirage.theme
+++ b/src/resources/pandoc/highlight-styles/ayu-mirage.theme
@@ -140,7 +140,7 @@
             "selected-text-color": "#f29e74",
             "text-color": "#f29e74"
         },
-        "Others": {
+        "Other": {
             "selected-text-color": "#5ccfe6",
             "text-color": "#5ccfe6"
         },


### PR DESCRIPTION
Fixes keyword so color correctly applied to `.ot` code spans.