### PR TITLE
add `iso` alias for `date-format`

### DIFF
--- a/src/core/date.ts
+++ b/src/core/date.ts
@@ -19,7 +19,7 @@ export const kToday = "today";
 export const rSysDate = "`r Sys.time()`";
 export const kNow = "now";
 
-export type DateFormat = "full" | "long" | "medium" | "short" | string;
+export type DateFormat = "full" | "long" | "medium" | "short" | "iso" | string;
 export type TimeFormat = "full" | "long" | "medium" | "short";
 
 export function today(): Date {
@@ -100,6 +100,7 @@ export const formatDate = (
     }
     return date.toLocaleString(dayjs.locale(), options);
   } else {
+    if (dateStyle === "iso") dateStyle = "YYYY-MM-DD";
     return dayjs(date).format(dateStyle);
   }
 };


### PR DESCRIPTION
@dragonstyle Following discussion with @sellorm , here is a PR to add `date-format: iso` as an alias for `date-format: YYYY-MM-DD` 

````markdown
---
title: "Test"
date: 2022-04-10
format: html
---

# test

````

![image](https://user-images.githubusercontent.com/6791940/162241054-ae789b10-cbd9-4235-bfb3-f6dfa51432b4.png)


````markdown
---
title: "Test"
date: 2022-04-10
date-format: iso
format: html
---

# test
````
![image](https://user-images.githubusercontent.com/6791940/162240753-59061686-575b-4297-b423-070018ecaf61.png)

* Do you need tests for that ? I don't think there is any for the date features. Could add some if you want. 
* YAML validation does not have yet support for `date-format` it seems. There are some descriptions, but no value for autocompletion yet. We could probably add some ?
* Another option would be to use [`toISOString()`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) method but it will return the full isodatetime format. I think using `YYYY-MM-DD` is easier and better. 
* Seems like this is the only place to tweak - when (if) merged, I'll update the doc site.
