### PR TITLE
Fix #593: recognize position specifier in latexTablePattern

### DIFF
--- a/src/resources/filters/quarto-pre/table-captions.lua
+++ b/src/resources/filters/quarto-pre/table-captions.lua
@@ -4,7 +4,7 @@
 kTblCap = "tbl-cap"
 kTblSubCap = "tbl-subcap"
 
-local latexTablePattern = "(\\begin{table}(\\[.*?\\])?)(.*)(\\end{table})"
+local latexTablePattern = "(\\begin{table}(\[.*?\])?)(.*)(\\end{table})"
 local latexLongtablePattern = "(\\begin{longtable})(.*)(\\end{longtable})"
 local latexTabularPattern = "(\\begin{tabular})(.*)(\\end{tabular})"
 

--- a/src/resources/filters/quarto-pre/table-captions.lua
+++ b/src/resources/filters/quarto-pre/table-captions.lua
@@ -4,7 +4,7 @@
 kTblCap = "tbl-cap"
 kTblSubCap = "tbl-subcap"
 
-local latexTablePattern = "(\\begin{table})(.*)(\\end{table})"
+local latexTablePattern = "(\\begin{table}(\\[.*?\\])?)(.*)(\\end{table})"
 local latexLongtablePattern = "(\\begin{longtable})(.*)(\\end{longtable})"
 local latexTabularPattern = "(\\begin{tabular})(.*)(\\end{tabular})"
 


### PR DESCRIPTION
This is just a guess!

You may also need to make a similar change to the LongTablePattern. CTAN documentation says this has some options too, either [c], [l] or [r].