### PR TITLE
Update doc to `quarto serve -h`

### DIFF
--- a/src/command/serve/cmd.ts
+++ b/src/command/serve/cmd.ts
@@ -33,11 +33,11 @@ export const serveCommand = new Command()
   )
   .example(
     "Serve an interactive Shiny document",
-    "quarto run dashboard.Rmd",
+    "quarto serve dashboard.Rmd",
   )
   .example(
     "Serve a document without rendering",
-    "quarto run dashboard.Rmd --no-render",
+    "quarto serve dashboard.Rmd --no-render",
   )
   // deno-lint-ignore no-explicit-any
   .action(async (options: any, input: string) => {


### PR DESCRIPTION
Following discussion on Slack, `quarto run` is now use for something else and it should be `quarto serve` here, right ? 

