### PR TITLE
support raw html tables in all formats

### DIFF
--- a/src/config/format.ts
+++ b/src/config/format.ts
@@ -119,7 +119,16 @@ export function isIpynbOutput(format: FormatPandoc) {
 
 export function isMarkdownOutput(
   format: FormatPandoc,
-  flavors = ["markdown", "gfm", "commonmark"],
+  flavors = [
+    "markdown",
+    "markdown_github",
+    "markdown_mmd",
+    "markdown_phpextra",
+    "markdown_strict",
+    "gfm",
+    "commonmark",
+    "markua",
+  ],
 ) {
   const to = (format.to || "").replace(/[\+\-_].*$/, "");
   return flavors.includes(to) || isIpynbOutput(format);

--- a/src/core/jupyter/display-data.ts
+++ b/src/core/jupyter/display-data.ts
@@ -79,6 +79,14 @@ export function displayDataMimeType(
       kTextHtml,
     );
   }
+
+  // if there is an html table then add html (as we can read this directly
+  // into the pandoc AST in our lua filters)
+  if (displayDataHasHtmlTable(output) && !displayPriority.includes(kTextHtml)) {
+    displayPriority.push(kTextHtml);
+  }
+
+  // always add text/plain
   displayPriority.push(
     kTextPlain,
   );
@@ -90,6 +98,17 @@ export function displayDataMimeType(
     }
   }
   return null;
+}
+
+export function displayDataHasHtmlTable(output: JupyterOutputDisplayData) {
+  const html = output.data[kTextHtml] as string[] || undefined;
+  if (html) {
+    const htmlLower = html.map((line) => line.toLowerCase());
+    return htmlLower.some((line) => !!line.match(/<[Tt][Aa][Bb][Ll][Ee]/)) &&
+      htmlLower.some((line) => !!line.match(/\/<[Tt][Aa][Bb][Ll][Ee]/));
+  } else {
+    return false;
+  }
 }
 
 export function displayDataIsImage(mimeType: string) {

--- a/src/resources/filters/common/pandoc.lua
+++ b/src/resources/filters/common/pandoc.lua
@@ -55,6 +55,31 @@ function isEpubOutput()
   return tcontains(formats, FORMAT)
 end
 
+-- check for markdown output
+function isMarkdownOutput()
+  local formats = {
+    "markdown",
+    "markdown_github",
+    "markdown_mmd", 
+    "markdown_phpextra",
+    "markdown_strict",
+    "gfm",
+    "commonmark",
+    "markua"
+  }
+  return tcontains(formats, FORMAT)
+end
+
+-- check for markdown with raw_html enabled
+function isMarkdownWithHtmlOutput()
+  return isMarkdownOutput() and tcontains(PANDOC_WRITER_OPTIONS.extensions, "raw_html")
+end
+
+-- check for ipynb output
+function isIpynbOutput()
+  return FORMAT == "ipynb"
+end
+
 -- check for html output
 function isHtmlOutput()
   local formats = {

--- a/src/resources/filters/quarto-pre/quarto-pre.lua
+++ b/src/resources/filters/quarto-pre/quarto-pre.lua
@@ -54,6 +54,7 @@ import("shortcodes.lua")
 import("shortcodes-handlers.lua")
 import("outputs.lua")
 import("figures.lua")
+import("table-rawhtml.lua")
 import("table-captions.lua")
 import("table-colwidth.lua")
 import("theorems.lua")
@@ -79,6 +80,7 @@ return {
   readIncludes(),
   initOptions(),
   shortCodes(),  
+  tableRawhtml(),
   tableColwidthCell(),
   tableColwidth(),
   hidden(),

--- a/src/resources/filters/quarto-pre/table-rawhtml.lua
+++ b/src/resources/filters/quarto-pre/table-rawhtml.lua
@@ -1,0 +1,21 @@
+-- table-rawhtml.lua
+-- Copyright (C) 2020 by RStudio, PBC
+
+function tableRawhtml() 
+  return {
+    RawBlock = function(el)
+      if isRawHtml(el) then
+        -- if we have a raw html table in a format that doesn't handle raw_html
+        -- then have pandoc parse the table into a proper AST table block
+        if not isHtmlOutput() and not isMarkdownWithHtmlOutput() and not isIpynbOutput() then
+          local tableBegin,tableBody,tableEnd = el.text:match(htmlTablePattern())
+          if tableBegin then
+            local tableHtml = tableBegin .. "\n" .. tableBody .. "\n" .. tableEnd
+            local tableDoc = pandoc.read(tableHtml, "html")
+            return tableDoc.blocks[1]
+          end
+        end
+      end
+    end
+  }
+end


### PR DESCRIPTION
If we have a raw html table in a format that doesn't handle raw_html then have pandoc parse the table into a proper AST table block.

The motivation for this is to resolve this issue: https://github.com/quarto-dev/quarto-cli/issues/724. 

ipynb files are not executed by default when rendered (as the output is already embedded and it may not even be possible to re-execute given the rendering environment, availability of dependencies, etc.). This means that we need to rely on the representation created in the interactive notebook. For tables, this will often be HTML. Without attempting to interpret the HTML, this makes ipynb files with tables un-renderable to non-HTML formats (e.g. pdf, docx, ec.)

This PR has two main changes:

1) When marshaling from` ipynb` to `md` prior to rendering, include raw HTML output if it includes a `<table>` tag.

2) For formats that can't render HTML tables natively (e.g. pdf, docx, rtf, odt, etc.), read raw HTML tables into the pandoc AST (which allows them to be rendered in their native format)

