### PR TITLE
Ensure forward slash are used in source path

### DIFF
--- a/src/project/types/website/website-navigation.ts
+++ b/src/project/types/website/website-navigation.ts
@@ -11,7 +11,7 @@ import * as ld from "../../../core/lodash.ts";
 
 import { Document, Element } from "../../../core/deno-dom.ts";
 
-import { safeExistsSync } from "../../../core/path.ts";
+import { pathWithForwardSlashes, safeExistsSync } from "../../../core/path.ts";
 import { resourcePath } from "../../../core/resources.ts";
 import { renderEjs } from "../../../core/ejs.ts";
 import { warnOnce } from "../../../core/log.ts";
@@ -482,7 +482,12 @@ function navigationHtmlPostprocessor(
     }
 
     // handle repo links
-    handleRepoLinks(doc, sourceRelative, language, project.config);
+    handleRepoLinks(
+      doc,
+      pathWithForwardSlashes(sourceRelative),
+      language,
+      project.config,
+    );
 
     // remove section numbers from sidebar if they have been turned off in the project file
     const numberSections =


### PR DESCRIPTION
As on windows it would use backward slash not suitable for HTML href

This is what I got before this change 
````diff
-<div class="toc-actions"><div><i class="bi bi-github"></i></div><div class="action-links"><p><a href="https://github.com/quarto-dev/quarto-web/edit/main/docs/faq/rmarkdown.qmd" class="toc-action">Edit this page</a></p><p><a href="https://github.com/quarto-dev/quarto-web/issues/new" class="toc-action">Report an issue</a></p></div></div></nav>
+<div class="toc-actions"><div><i class="bi bi-github"></i></div><div class="action-links"><p><a href="https://github.com/quarto-dev/quarto-web/edit/main/docs\faq\rmarkdown.qmd" class="toc-action">Edit this page</a></p><p><a href="https://github.com/quarto-dev/quarto-web/issues/new" class="toc-action">Report an issue</a></p></div></div></nav>
````

Look at the `href` link. I believe the source path to `qmd` should be transformed with forward slash to be processed in repoActionLink

