### PR TITLE
Fix pagebreak feature that currently broke last quarto release for qmd with knitr

### DIFF
--- a/package/src/common/prepare-dist.ts
+++ b/package/src/common/prepare-dist.ts
@@ -139,6 +139,7 @@ function inlineFilters(config: Configuration) {
     { name: "layout" },
     { name: "quarto-post" },
     { name: "authors" },
+    { name: "pagebreak", dir: "rmarkdown" },
   ];
 
   filtersToInline.forEach((filter) => {


### PR DESCRIPTION
This was first reported in https://community.rstudio.com/t/error-while-rendering-first-quarto-document/135656/6 
I can reproduce this error by rendering `hello.qmd` with latest github release of quarto 0.9.324

```
Error running filter C:/Users/chris/scoop/apps/quarto/current/share/filters/rmarkdown/pagebreak.lua:
cannot open C:/Users/chris/scoop/apps/quarto/current/share/filters/rmarkdown/pagebreak.lua: No such file or directory
```` 

The distribution does not bundle anymore the lua filter, which breaks the Pandoc rendering. 

I see this morning that there was some work yesterday on pagebreak by @cscheid, which was reverted at some point. (3f03dbc79ba0acc8919ecbbc5e74641724d7f204, 263380c9b2440743e561a6fc77c7c220b25cbfd7, faeaf59db513da9d01056bda33fa909f53b7546a, e47e54f17149e26f3e6510236ba15b48231b9106 which all follow #740). Except for the `prepare-dist.ts` change. This PR fixes this by putting back the rmarkdown pagebreak filter in the distribution. 

I did not found PR for the pagebreak feature, so less easy to revert everything, but I think this is the last change missing to be revert. 

@jjallaire I don't know yet how to build a new release so I am doing this PR for you to see and rebuild a working release.

Regarding pagebreak feature, I adapted the filter for **rmarkdown**, so you need help making it work more generally for all format, do not hesitate. 

