### PR TITLE
EJS template should be empty if not feature is selected (minimal HTML)

### DIFF
--- a/src/format/html/format-html.ts
+++ b/src/format/html/format-html.ts
@@ -399,14 +399,14 @@ export async function htmlFormatExtras(
   if (quartoHtmlRequired) {
     // html orchestration script
     const quartoHtmlScript = temp.createFile();
-    Deno.writeTextFileSync(
-      quartoHtmlScript,
-      renderEjs(
-        formatResourcePath("html", join("templates", "quarto-html.ejs")),
-        options,
-      ),
+    const renderedHtml = renderEjs(
+      formatResourcePath("html", join("templates", "quarto-html.ejs")),
+      options,
     );
-    includeAfterBody.push(quartoHtmlScript);
+    if (renderedHtml.trim() !== "") {
+      Deno.writeTextFileSync(quartoHtmlScript, renderedHtml);
+      includeAfterBody.push(quartoHtmlScript);
+    }
   }
 
   // utterances

--- a/src/resources/formats/html/templates/quarto-html.ejs
+++ b/src/resources/formats/html/templates/quarto-html.ejs
@@ -1,5 +1,5 @@
 <% if (darkMode !== undefined || tabby || anchors || copyCode || codeTools || tippy || hoverFootnotes || hoverCitations || linkExternalIcon || linkExternalNewwindow) { %> 
-<script type="application/javascript">
+<script id = "quarto-html-after-body" type="application/javascript">
 
 window.document.addEventListener("DOMContentLoaded", function (event) {
 

--- a/src/resources/formats/html/templates/quarto-html.ejs
+++ b/src/resources/formats/html/templates/quarto-html.ejs
@@ -1,3 +1,4 @@
+<% if (darkMode !== undefined || tabby || anchors || copyCode || codeTools || tippy || hoverFootnotes || hoverCitations || linkExternalIcon || linkExternalNewwindow) { %> 
 <script type="application/javascript">
 
 window.document.addEventListener("DOMContentLoaded", function (event) {
@@ -327,3 +328,4 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
 });
 
 </script>
+<% } %>

--- a/tests/docs/minimal.qmd
+++ b/tests/docs/minimal.qmd
@@ -1,0 +1,8 @@
+---
+title: Hello Callout!
+format:
+  html:
+    minimal: true
+---
+
+This file will be with no Quarto feature https://quarto.org/docs/output-formats/html-basics.html#minimal-html

--- a/tests/smoke/render/render-minimal.test.ts
+++ b/tests/smoke/render/render-minimal.test.ts
@@ -1,0 +1,19 @@
+/*
+* render-callout.test.ts
+*
+* Copyright (C) 2020 by RStudio, PBC
+*
+*/
+
+import { docs, outputForInput } from "../../utils.ts";
+import { ensureHtmlElements } from "../../verify.ts";
+import { testRender } from "./render.ts";
+
+const input = docs("minimal.qmd");
+const htmlOutput = outputForInput(input, "html");
+
+testRender(input, "html", false, [
+  ensureHtmlElements(htmlOutput.outputPath, [], [
+    "script#quarto-html-after-body",
+  ]),
+]);


### PR DESCRIPTION
I found this while trying to create a new format. Currently setting `minimal: true` will lead to include this in after body part

````
<script type="application/javascript">
window.document.addEventListener("DOMContentLoaded", function (event) {
});
</script>
````

This is because all variable is false in `quarto-html.ejs`

As discussed @dragonstyle I think it is best to not include this at all. This PR makes sure we don't include an unnecessary script tag if all is false. 

I added an id in the element and a test also. 