### PR TITLE
Improve support of specific knitr engines for source output 

### DIFF
--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -339,7 +339,7 @@ knitr_hooks <- function(format, resourceDir, handledLanguages) {
     x <- knitr:::one_string(c('', x))
     
     # leave verbatim alone
-    if (identical(options[["engine"]], "verbatim")) {
+    if (options[["engine"]] %in% c("verbatim", "embed")) {
       return(paste0('\n\n````', options[["lang"]] %||% 'default', x, '\n````', '\n\n'))
     }
     

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -272,7 +272,7 @@ knitr_hooks <- function(format, resourceDir, handledLanguages) {
                      "layout", "layout-nrow", "layout-ncol", "layout-align", "layout-valign", 
                      "output", "include.hidden", "source.hidden", "plot.hidden", "output.hidden")
     other_opts <- c("eval", "out.width", "yaml.code", "code", "params.src", "original.params.src", 
-                    "fenced.echo", "chunk.echo",
+                    "fenced.echo", "chunk.echo", "lang",
                     "out.width.px", "out.height.px", "indent", "class.source", 
                     "class.output", "class.message", "class.warning", "class.error", "attr.source", 
                     "attr.output", "attr.message", "attr.warning", "attr.error")

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -339,8 +339,8 @@ knitr_hooks <- function(format, resourceDir, handledLanguages) {
     x <- knitr:::one_string(c('', x))
     
     # leave verbatim alone
-    if (identical(options[["engine"]], "default")) {
-      return(paste0('\n\n````default', x, '\n````', '\n\n'))
+    if (identical(options[["engine"]], "verbatim")) {
+      return(paste0('\n\n````', options[["lang"]] %||% 'default', x, '\n````', '\n\n'))
     }
     
     class <- options$class.source


### PR DESCRIPTION
it should not be pass through so that it does not end up into the div when pass as a knitr option. 

This option is new from knitr 1.38 (https://github.com/yihui/knitr/blob/master/NEWS.md#changes-in-knitr-version-138)

I don't think this option `lang` has any effect in Quarto yet. So we have a difference in behavior between **knitr** in R Markdown and in Quarto. 

With **knitr**, `lang` is used in various place to change the language that will be applied as class to the code chunk in Markdown. Default is the engine. Sometimes it needs to be tweaked.

Example: 

````markdown
```{verbatim, lang = "js"}
console.log('test')
```
````

This is used in **knitr** to output a code chunk of class `js`

````markdown
```{bash, lang = "default"}
pwd
```
````

This is used to execute a chunk as bash but highlight as a default block. 


So this PR only makes sure that the option is correctly identified a knitr option. I'll make another one (or just continue in this one if you prefer) to make the recent engine (`verbatim`, `embed`, `comment`, ...) works correctly. They are not really working as expected I believe (mainly because we overwrite the source hook I think). 






