### PR TITLE
default to `wrap: preserve` in hugo format to preserve shortcodes

### DIFF
--- a/src/format/formats.ts
+++ b/src/format/formats.ts
@@ -18,6 +18,7 @@ import {
   kPreferHtml,
   kVariant,
   kWarning,
+  kWrap,
 } from "../config/constants.ts";
 
 import { Format } from "../config/types.ts";
@@ -213,6 +214,7 @@ function hugoFormat(): Format {
     pandoc: {
       to: "gfm",
       [kHtmlMathMethod]: "webtex",
+      [kWrap]: "preserve",
     },
   });
 }


### PR DESCRIPTION
With default pandoc behavior `--wrap=auto` which is the current behavior, Hugo shortcodes would be split in two lines which seems to cause issue

Example from @linogaliana

````markdown
---
title: "Untitled"
format: hugo
---

# Introduction

{{% box status="warning" title="Warning" icon="fa fa-exclamation-triangle" %}}

Using a hugo shortchode 

{{% /box %}}

```` 

we currently have this 

````markdown
---
title: "Untitled"
format: hugo
---

Untitled
================

# Introduction

{{% box status="warning" title="Warning" icon="fa
fa-exclamation-triangle" %}}

Using a hugo shortchode

{{% /box %}}

````

with the PR changing the default, we correctly keep the full line 

````markdown
---
title: "Untitled"
format: hugo
---

Untitled
================

# Introduction

{{% box status="warning" title="Warning" icon="fa fa-exclamation-triangle" %}}

Using a hugo shortchode

{{% /box %}}

````

Current workaround is to add `wrap: preserve` in `_quarto.yml` for a hugo blog project. 

@jjallaire if this change seems fine to you, can the doc be updated for this ?
Or is it auto generated ? 
https://quarto.org/docs/reference/formats/markdown/hugo.html#text-output
