### PR TITLE
Proposal for fix to #688: new include keys for metadata and variables

### DIFF
--- a/src/command/render/filters.ts
+++ b/src/command/render/filters.ts
@@ -190,7 +190,6 @@ function extractIncludeParams(
     [kIncludeBeforeBody]: beforeBodyFiles.map(pandocMetadataPath),
     [kIncludeAfterBody]: afterBodyFiles.map(pandocMetadataPath),
   };
-  console.log({ result });
   return result;
 }
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -420,10 +420,6 @@ export const kDocumentClass = "documentclass";
 export const kClassOption = "classoption";
 export const kSlideLevel = "slide-level";
 
-export const kSmartIncludeInHeader = "add-to-header";
-export const kSmartIncludeBeforeBody = "add-before-body";
-export const kSmartIncludeAfterBody = "add-after-body";
-
 export const kTheme = "theme";
 export const kCrossref = "crossref";
 export const kCrossrefChapters = "chapters";

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -420,6 +420,10 @@ export const kDocumentClass = "documentclass";
 export const kClassOption = "classoption";
 export const kSlideLevel = "slide-level";
 
+export const kSmartIncludeInHeader = "add-to-header";
+export const kSmartIncludeBeforeBody = "add-before-body";
+export const kSmartIncludeAfterBody = "add-after-body";
+
 export const kTheme = "theme";
 export const kCrossref = "crossref";
 export const kCrossrefChapters = "chapters";

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -10512,9 +10512,9 @@ var require_yaml_intelligence_resources = __commonJS({
           anyOf: [
             {
               record: {
-                content: {
+                text: {
                   string: {
-                    description: "Content to add to includes"
+                    description: "Textual content to add to includes"
                   }
                 }
               }
@@ -12472,48 +12472,6 @@ var require_yaml_intelligence_resources = __commonJS({
       ],
       "schema/document-includes.yml": [
         {
-          name: "add-to-header",
-          disabled: [
-            "$office-all",
-            "$jats-all",
-            "ipynb"
-          ],
-          schema: {
-            maybeArrayOf: {
-              ref: "smart-include"
-            }
-          },
-          description: "Content or files to include at the end of the document header."
-        },
-        {
-          name: "add-before-body",
-          disabled: [
-            "$office-all",
-            "$jats-all",
-            "ipynb"
-          ],
-          schema: {
-            maybeArrayOf: {
-              ref: "smart-include"
-            }
-          },
-          description: "Content or files to include at the beginning of the document body (e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command in LaTeX).."
-        },
-        {
-          name: "add-after-body",
-          disabled: [
-            "$office-all",
-            "$jats-all",
-            "ipynb"
-          ],
-          schema: {
-            maybeArrayOf: {
-              ref: "smart-include"
-            }
-          },
-          description: "Content or files to include at the end of the document body (e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command in LaTeX).."
-        },
-        {
           name: "header-includes",
           disabled: [
             "$office-all",
@@ -12557,9 +12515,16 @@ var require_yaml_intelligence_resources = __commonJS({
             "ipynb"
           ],
           schema: {
-            maybeArrayOf: "path"
+            maybeArrayOf: {
+              anyOf: [
+                "path",
+                {
+                  ref: "smart-include"
+                }
+              ]
+            }
           },
-          description: "Include contents of files, verbatim, at the beginning of the document body\n(e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command \nin LaTeX).\n"
+          description: 'Include contents at the beginning of the document body\n(e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command \nin LaTeX).\n\nA string value or an object with key "file" indicates a filename whose contents are to be included\n\nAn object with key "text" indicates textual content to be included\n'
         },
         {
           name: "include-after-body",
@@ -12569,9 +12534,16 @@ var require_yaml_intelligence_resources = __commonJS({
             "ipynb"
           ],
           schema: {
-            maybeArrayOf: "path"
+            maybeArrayOf: {
+              anyOf: [
+                "path",
+                {
+                  ref: "smart-include"
+                }
+              ]
+            }
           },
-          description: "Include contents of files, verbatim, at the end of the document body (before\nthe `</body>` tag in HTML, or the `\\end{document}` command in LaTeX).\n"
+          description: 'Include contents at the end of the document body (before\nthe `</body>` tag in HTML, or the `\\end{document}` command in LaTeX).\n\nA string value or an object with key "file" indicates a filename whose contents are to be included\n\nAn object with key "text" indicates textual content to be included\n'
         },
         {
           name: "include-in-header",
@@ -12581,9 +12553,16 @@ var require_yaml_intelligence_resources = __commonJS({
             "ipynb"
           ],
           schema: {
-            maybeArrayOf: "path"
+            maybeArrayOf: {
+              anyOf: [
+                "path",
+                {
+                  ref: "smart-include"
+                }
+              ]
+            }
           },
-          description: "Include contents of files, verbatim, at the end of the header. This can\nbe used, for example, to include special CSS or JavaScript in HTML \ndocuments.\n"
+          description: 'Include contents at the end of the header. This can\nbe used, for example, to include special CSS or JavaScript in HTML \ndocuments.\n\nA string value or an object with key "file" indicates a filename whose contents are to be included\n\nAn object with key "text" indicates textual content to be included\n'
         },
         {
           name: "resources",
@@ -17227,8 +17206,8 @@ var require_yaml_intelligence_resources = __commonJS({
           long: "Title of the volume of the item or container holding the item.\nAlso use for titles of periodical special issues, special sections,\nand the like."
         },
         "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
-        "Content to add to includes",
-        "Filename to add to includes",
+        "Textual content to add to includes",
+        "Name of file with content to add to includes",
         {
           short: "Unique label for code cell",
           long: "Unique label for code cell. Used when other code needs to refer to\nthe cell (e.g.&nbsp;for cross references <code>fig-samples</code> or\n<code>tbl-summary</code>)"
@@ -17728,15 +17707,12 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         "Indicates that computational output should not be written within\ndivs. This is necessary for some formats (e.g.&nbsp;<code>pptx</code>) to\nproperly layout figures.",
         "Disable merging of string based and file based includes (some\nformats, specifically ePub, do not correctly handle this merging)",
-        "Content or files to include at the end of the document header.",
-        "Content or files to include at the beginning of the document body\n(e.g.&nbsp;after the <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX)..",
-        "Content or files to include at the end of the document body\n(e.g.&nbsp;after the <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX)..",
         "Content to include at the end of the document header.",
         "Content to include at the beginning of the document body (e.g.&nbsp;after\nthe <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX).",
         "Content to include at the end of the document body (before the\n<code>&lt;/body&gt;</code> tag in HTML, or the\n<code>\\end{document}</code> command in LaTeX).",
-        "Include contents of files, verbatim, at the beginning of the document\nbody (e.g.&nbsp;after the <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX).",
-        "Include contents of files, verbatim, at the end of the document body\n(before the <code>&lt;/body&gt;</code> tag in HTML, or the\n<code>\\end{document}</code> command in LaTeX).",
-        "Include contents of files, verbatim, at the end of the header. This\ncan be used, for example, to include special CSS or JavaScript in HTML\ndocuments.",
+        "Include contents at the beginning of the document body (e.g.&nbsp;after\nthe <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX).\nA string value or an object with key \u201Cfile\u201D indicates a filename\nwhose contents are to be included\nAn object with key \u201Ctext\u201D indicates textual content to be\nincluded",
+        "Include contents at the end of the document body (before the\n<code>&lt;/body&gt;</code> tag in HTML, or the\n<code>\\end{document}</code> command in LaTeX).\nA string value or an object with key \u201Cfile\u201D indicates a filename\nwhose contents are to be included\nAn object with key \u201Ctext\u201D indicates textual content to be\nincluded",
+        "Include contents at the end of the header. This can be used, for\nexample, to include special CSS or JavaScript in HTML documents.\nA string value or an object with key \u201Cfile\u201D indicates a filename\nwhose contents are to be included\nAn object with key \u201Ctext\u201D indicates textual content to be\nincluded",
         "Path (or glob) to files to publish with this document.",
         {
           short: "Text to be in a running header.",

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -10506,6 +10506,29 @@ var require_yaml_intelligence_resources = __commonJS({
               }
             }
           }
+        },
+        {
+          id: "smart-include",
+          anyOf: [
+            {
+              record: {
+                content: {
+                  string: {
+                    description: "Content to add to includes"
+                  }
+                }
+              }
+            },
+            {
+              record: {
+                file: {
+                  string: {
+                    description: "Name of file with content to add to includes"
+                  }
+                }
+              }
+            }
+          ]
         }
       ],
       "schema/document-about.yml": [
@@ -12448,6 +12471,48 @@ var require_yaml_intelligence_resources = __commonJS({
         }
       ],
       "schema/document-includes.yml": [
+        {
+          name: "add-to-header",
+          disabled: [
+            "$office-all",
+            "$jats-all",
+            "ipynb"
+          ],
+          schema: {
+            maybeArrayOf: {
+              ref: "smart-include"
+            }
+          },
+          description: "Content or files to include at the end of the document header."
+        },
+        {
+          name: "add-before-body",
+          disabled: [
+            "$office-all",
+            "$jats-all",
+            "ipynb"
+          ],
+          schema: {
+            maybeArrayOf: {
+              ref: "smart-include"
+            }
+          },
+          description: "Content or files to include at the beginning of the document body (e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command in LaTeX).."
+        },
+        {
+          name: "add-after-body",
+          disabled: [
+            "$office-all",
+            "$jats-all",
+            "ipynb"
+          ],
+          schema: {
+            maybeArrayOf: {
+              ref: "smart-include"
+            }
+          },
+          description: "Content or files to include at the end of the document body (e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command in LaTeX).."
+        },
         {
           name: "header-includes",
           disabled: [
@@ -17162,6 +17227,8 @@ var require_yaml_intelligence_resources = __commonJS({
           long: "Title of the volume of the item or container holding the item.\nAlso use for titles of periodical special issues, special sections,\nand the like."
         },
         "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
+        "Content to add to includes",
+        "Filename to add to includes",
         {
           short: "Unique label for code cell",
           long: "Unique label for code cell. Used when other code needs to refer to\nthe cell (e.g.&nbsp;for cross references <code>fig-samples</code> or\n<code>tbl-summary</code>)"
@@ -17661,6 +17728,9 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         "Indicates that computational output should not be written within\ndivs. This is necessary for some formats (e.g.&nbsp;<code>pptx</code>) to\nproperly layout figures.",
         "Disable merging of string based and file based includes (some\nformats, specifically ePub, do not correctly handle this merging)",
+        "Content or files to include at the end of the document header.",
+        "Content or files to include at the beginning of the document body\n(e.g.&nbsp;after the <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX)..",
+        "Content or files to include at the end of the document body\n(e.g.&nbsp;after the <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX)..",
         "Content to include at the end of the document header.",
         "Content to include at the beginning of the document body (e.g.&nbsp;after\nthe <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX).",
         "Content to include at the end of the document body (before the\n<code>&lt;/body&gt;</code> tag in HTML, or the\n<code>\\end{document}</code> command in LaTeX).",
@@ -27040,7 +27110,7 @@ async function breakQuartoMd(src, validate2 = false) {
   const yamlRegEx = /^---\s*$/;
   const startCodeCellRegEx = new RegExp("^\\s*```+\\s*\\{([=A-Za-z]+)( *[ ,].*)?\\}\\s*$");
   const startCodeRegEx = /^```/;
-  const endCodeRegEx = /^```+\s*$/;
+  const endCodeRegEx = /^\s*```+\s*$/;
   const delimitMathBlockRegEx = /^\$\$/;
   let language = "";
   let directiveParams = void 0;

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -10507,6 +10507,29 @@ try {
                 }
               }
             }
+          },
+          {
+            id: "smart-include",
+            anyOf: [
+              {
+                record: {
+                  content: {
+                    string: {
+                      description: "Content to add to includes"
+                    }
+                  }
+                }
+              },
+              {
+                record: {
+                  file: {
+                    string: {
+                      description: "Name of file with content to add to includes"
+                    }
+                  }
+                }
+              }
+            ]
           }
         ],
         "schema/document-about.yml": [
@@ -12449,6 +12472,48 @@ try {
           }
         ],
         "schema/document-includes.yml": [
+          {
+            name: "add-to-header",
+            disabled: [
+              "$office-all",
+              "$jats-all",
+              "ipynb"
+            ],
+            schema: {
+              maybeArrayOf: {
+                ref: "smart-include"
+              }
+            },
+            description: "Content or files to include at the end of the document header."
+          },
+          {
+            name: "add-before-body",
+            disabled: [
+              "$office-all",
+              "$jats-all",
+              "ipynb"
+            ],
+            schema: {
+              maybeArrayOf: {
+                ref: "smart-include"
+              }
+            },
+            description: "Content or files to include at the beginning of the document body (e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command in LaTeX).."
+          },
+          {
+            name: "add-after-body",
+            disabled: [
+              "$office-all",
+              "$jats-all",
+              "ipynb"
+            ],
+            schema: {
+              maybeArrayOf: {
+                ref: "smart-include"
+              }
+            },
+            description: "Content or files to include at the end of the document body (e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command in LaTeX).."
+          },
           {
             name: "header-includes",
             disabled: [
@@ -17163,6 +17228,8 @@ try {
             long: "Title of the volume of the item or container holding the item.\nAlso use for titles of periodical special issues, special sections,\nand the like."
           },
           "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
+          "Content to add to includes",
+          "Filename to add to includes",
           {
             short: "Unique label for code cell",
             long: "Unique label for code cell. Used when other code needs to refer to\nthe cell (e.g.&nbsp;for cross references <code>fig-samples</code> or\n<code>tbl-summary</code>)"
@@ -17662,6 +17729,9 @@ try {
           },
           "Indicates that computational output should not be written within\ndivs. This is necessary for some formats (e.g.&nbsp;<code>pptx</code>) to\nproperly layout figures.",
           "Disable merging of string based and file based includes (some\nformats, specifically ePub, do not correctly handle this merging)",
+          "Content or files to include at the end of the document header.",
+          "Content or files to include at the beginning of the document body\n(e.g.&nbsp;after the <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX)..",
+          "Content or files to include at the end of the document body\n(e.g.&nbsp;after the <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX)..",
           "Content to include at the end of the document header.",
           "Content to include at the beginning of the document body (e.g.&nbsp;after\nthe <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX).",
           "Content to include at the end of the document body (before the\n<code>&lt;/body&gt;</code> tag in HTML, or the\n<code>\\end{document}</code> command in LaTeX).",
@@ -27054,7 +27124,7 @@ ${heading}`;
     const yamlRegEx = /^---\s*$/;
     const startCodeCellRegEx = new RegExp("^\\s*```+\\s*\\{([=A-Za-z]+)( *[ ,].*)?\\}\\s*$");
     const startCodeRegEx = /^```/;
-    const endCodeRegEx = /^```+\s*$/;
+    const endCodeRegEx = /^\s*```+\s*$/;
     const delimitMathBlockRegEx = /^\$\$/;
     let language = "";
     let directiveParams = void 0;

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -10513,9 +10513,9 @@ try {
             anyOf: [
               {
                 record: {
-                  content: {
+                  text: {
                     string: {
-                      description: "Content to add to includes"
+                      description: "Textual content to add to includes"
                     }
                   }
                 }
@@ -12473,48 +12473,6 @@ try {
         ],
         "schema/document-includes.yml": [
           {
-            name: "add-to-header",
-            disabled: [
-              "$office-all",
-              "$jats-all",
-              "ipynb"
-            ],
-            schema: {
-              maybeArrayOf: {
-                ref: "smart-include"
-              }
-            },
-            description: "Content or files to include at the end of the document header."
-          },
-          {
-            name: "add-before-body",
-            disabled: [
-              "$office-all",
-              "$jats-all",
-              "ipynb"
-            ],
-            schema: {
-              maybeArrayOf: {
-                ref: "smart-include"
-              }
-            },
-            description: "Content or files to include at the beginning of the document body (e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command in LaTeX).."
-          },
-          {
-            name: "add-after-body",
-            disabled: [
-              "$office-all",
-              "$jats-all",
-              "ipynb"
-            ],
-            schema: {
-              maybeArrayOf: {
-                ref: "smart-include"
-              }
-            },
-            description: "Content or files to include at the end of the document body (e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command in LaTeX).."
-          },
-          {
             name: "header-includes",
             disabled: [
               "$office-all",
@@ -12558,9 +12516,16 @@ try {
               "ipynb"
             ],
             schema: {
-              maybeArrayOf: "path"
+              maybeArrayOf: {
+                anyOf: [
+                  "path",
+                  {
+                    ref: "smart-include"
+                  }
+                ]
+              }
             },
-            description: "Include contents of files, verbatim, at the beginning of the document body\n(e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command \nin LaTeX).\n"
+            description: 'Include contents at the beginning of the document body\n(e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command \nin LaTeX).\n\nA string value or an object with key "file" indicates a filename whose contents are to be included\n\nAn object with key "text" indicates textual content to be included\n'
           },
           {
             name: "include-after-body",
@@ -12570,9 +12535,16 @@ try {
               "ipynb"
             ],
             schema: {
-              maybeArrayOf: "path"
+              maybeArrayOf: {
+                anyOf: [
+                  "path",
+                  {
+                    ref: "smart-include"
+                  }
+                ]
+              }
             },
-            description: "Include contents of files, verbatim, at the end of the document body (before\nthe `</body>` tag in HTML, or the `\\end{document}` command in LaTeX).\n"
+            description: 'Include contents at the end of the document body (before\nthe `</body>` tag in HTML, or the `\\end{document}` command in LaTeX).\n\nA string value or an object with key "file" indicates a filename whose contents are to be included\n\nAn object with key "text" indicates textual content to be included\n'
           },
           {
             name: "include-in-header",
@@ -12582,9 +12554,16 @@ try {
               "ipynb"
             ],
             schema: {
-              maybeArrayOf: "path"
+              maybeArrayOf: {
+                anyOf: [
+                  "path",
+                  {
+                    ref: "smart-include"
+                  }
+                ]
+              }
             },
-            description: "Include contents of files, verbatim, at the end of the header. This can\nbe used, for example, to include special CSS or JavaScript in HTML \ndocuments.\n"
+            description: 'Include contents at the end of the header. This can\nbe used, for example, to include special CSS or JavaScript in HTML \ndocuments.\n\nA string value or an object with key "file" indicates a filename whose contents are to be included\n\nAn object with key "text" indicates textual content to be included\n'
           },
           {
             name: "resources",
@@ -17228,8 +17207,8 @@ try {
             long: "Title of the volume of the item or container holding the item.\nAlso use for titles of periodical special issues, special sections,\nand the like."
           },
           "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
-          "Content to add to includes",
-          "Filename to add to includes",
+          "Textual content to add to includes",
+          "Name of file with content to add to includes",
           {
             short: "Unique label for code cell",
             long: "Unique label for code cell. Used when other code needs to refer to\nthe cell (e.g.&nbsp;for cross references <code>fig-samples</code> or\n<code>tbl-summary</code>)"
@@ -17729,15 +17708,12 @@ try {
           },
           "Indicates that computational output should not be written within\ndivs. This is necessary for some formats (e.g.&nbsp;<code>pptx</code>) to\nproperly layout figures.",
           "Disable merging of string based and file based includes (some\nformats, specifically ePub, do not correctly handle this merging)",
-          "Content or files to include at the end of the document header.",
-          "Content or files to include at the beginning of the document body\n(e.g.&nbsp;after the <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX)..",
-          "Content or files to include at the end of the document body\n(e.g.&nbsp;after the <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX)..",
           "Content to include at the end of the document header.",
           "Content to include at the beginning of the document body (e.g.&nbsp;after\nthe <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX).",
           "Content to include at the end of the document body (before the\n<code>&lt;/body&gt;</code> tag in HTML, or the\n<code>\\end{document}</code> command in LaTeX).",
-          "Include contents of files, verbatim, at the beginning of the document\nbody (e.g.&nbsp;after the <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX).",
-          "Include contents of files, verbatim, at the end of the document body\n(before the <code>&lt;/body&gt;</code> tag in HTML, or the\n<code>\\end{document}</code> command in LaTeX).",
-          "Include contents of files, verbatim, at the end of the header. This\ncan be used, for example, to include special CSS or JavaScript in HTML\ndocuments.",
+          "Include contents at the beginning of the document body (e.g.&nbsp;after\nthe <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX).\nA string value or an object with key \u201Cfile\u201D indicates a filename\nwhose contents are to be included\nAn object with key \u201Ctext\u201D indicates textual content to be\nincluded",
+          "Include contents at the end of the document body (before the\n<code>&lt;/body&gt;</code> tag in HTML, or the\n<code>\\end{document}</code> command in LaTeX).\nA string value or an object with key \u201Cfile\u201D indicates a filename\nwhose contents are to be included\nAn object with key \u201Ctext\u201D indicates textual content to be\nincluded",
+          "Include contents at the end of the header. This can be used, for\nexample, to include special CSS or JavaScript in HTML documents.\nA string value or an object with key \u201Cfile\u201D indicates a filename\nwhose contents are to be included\nAn object with key \u201Ctext\u201D indicates textual content to be\nincluded",
           "Path (or glob) to files to publish with this document.",
           {
             short: "Text to be in a running header.",

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -3482,6 +3482,29 @@
           }
         }
       }
+    },
+    {
+      "id": "smart-include",
+      "anyOf": [
+        {
+          "record": {
+            "content": {
+              "string": {
+                "description": "Content to add to includes"
+              }
+            }
+          }
+        },
+        {
+          "record": {
+            "file": {
+              "string": {
+                "description": "Name of file with content to add to includes"
+              }
+            }
+          }
+        }
+      ]
     }
   ],
   "schema/document-about.yml": [
@@ -5424,6 +5447,48 @@
     }
   ],
   "schema/document-includes.yml": [
+    {
+      "name": "add-to-header",
+      "disabled": [
+        "$office-all",
+        "$jats-all",
+        "ipynb"
+      ],
+      "schema": {
+        "maybeArrayOf": {
+          "ref": "smart-include"
+        }
+      },
+      "description": "Content or files to include at the end of the document header."
+    },
+    {
+      "name": "add-before-body",
+      "disabled": [
+        "$office-all",
+        "$jats-all",
+        "ipynb"
+      ],
+      "schema": {
+        "maybeArrayOf": {
+          "ref": "smart-include"
+        }
+      },
+      "description": "Content or files to include at the beginning of the document body (e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command in LaTeX).."
+    },
+    {
+      "name": "add-after-body",
+      "disabled": [
+        "$office-all",
+        "$jats-all",
+        "ipynb"
+      ],
+      "schema": {
+        "maybeArrayOf": {
+          "ref": "smart-include"
+        }
+      },
+      "description": "Content or files to include at the end of the document body (e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command in LaTeX).."
+    },
     {
       "name": "header-includes",
       "disabled": [
@@ -10138,6 +10203,8 @@
       "long": "Title of the volume of the item or container holding the item.\nAlso use for titles of periodical special issues, special sections,\nand the like."
     },
     "Disambiguating year suffix in author-date styles (e.g.&nbsp;“a” in “Doe,\n1999a”).",
+    "Content to add to includes",
+    "Filename to add to includes",
     {
       "short": "Unique label for code cell",
       "long": "Unique label for code cell. Used when other code needs to refer to\nthe cell (e.g.&nbsp;for cross references <code>fig-samples</code> or\n<code>tbl-summary</code>)"
@@ -10637,6 +10704,9 @@
     },
     "Indicates that computational output should not be written within\ndivs. This is necessary for some formats (e.g.&nbsp;<code>pptx</code>) to\nproperly layout figures.",
     "Disable merging of string based and file based includes (some\nformats, specifically ePub, do not correctly handle this merging)",
+    "Content or files to include at the end of the document header.",
+    "Content or files to include at the beginning of the document body\n(e.g.&nbsp;after the <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX)..",
+    "Content or files to include at the end of the document body\n(e.g.&nbsp;after the <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX)..",
     "Content to include at the end of the document header.",
     "Content to include at the beginning of the document body (e.g.&nbsp;after\nthe <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX).",
     "Content to include at the end of the document body (before the\n<code>&lt;/body&gt;</code> tag in HTML, or the\n<code>\\end{document}</code> command in LaTeX).",

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -3488,9 +3488,9 @@
       "anyOf": [
         {
           "record": {
-            "content": {
+            "text": {
               "string": {
-                "description": "Content to add to includes"
+                "description": "Textual content to add to includes"
               }
             }
           }
@@ -5448,48 +5448,6 @@
   ],
   "schema/document-includes.yml": [
     {
-      "name": "add-to-header",
-      "disabled": [
-        "$office-all",
-        "$jats-all",
-        "ipynb"
-      ],
-      "schema": {
-        "maybeArrayOf": {
-          "ref": "smart-include"
-        }
-      },
-      "description": "Content or files to include at the end of the document header."
-    },
-    {
-      "name": "add-before-body",
-      "disabled": [
-        "$office-all",
-        "$jats-all",
-        "ipynb"
-      ],
-      "schema": {
-        "maybeArrayOf": {
-          "ref": "smart-include"
-        }
-      },
-      "description": "Content or files to include at the beginning of the document body (e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command in LaTeX).."
-    },
-    {
-      "name": "add-after-body",
-      "disabled": [
-        "$office-all",
-        "$jats-all",
-        "ipynb"
-      ],
-      "schema": {
-        "maybeArrayOf": {
-          "ref": "smart-include"
-        }
-      },
-      "description": "Content or files to include at the end of the document body (e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command in LaTeX).."
-    },
-    {
       "name": "header-includes",
       "disabled": [
         "$office-all",
@@ -5533,9 +5491,16 @@
         "ipynb"
       ],
       "schema": {
-        "maybeArrayOf": "path"
+        "maybeArrayOf": {
+          "anyOf": [
+            "path",
+            {
+              "ref": "smart-include"
+            }
+          ]
+        }
       },
-      "description": "Include contents of files, verbatim, at the beginning of the document body\n(e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command \nin LaTeX).\n"
+      "description": "Include contents at the beginning of the document body\n(e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command \nin LaTeX).\n\nA string value or an object with key \"file\" indicates a filename whose contents are to be included\n\nAn object with key \"text\" indicates textual content to be included\n"
     },
     {
       "name": "include-after-body",
@@ -5545,9 +5510,16 @@
         "ipynb"
       ],
       "schema": {
-        "maybeArrayOf": "path"
+        "maybeArrayOf": {
+          "anyOf": [
+            "path",
+            {
+              "ref": "smart-include"
+            }
+          ]
+        }
       },
-      "description": "Include contents of files, verbatim, at the end of the document body (before\nthe `</body>` tag in HTML, or the `\\end{document}` command in LaTeX).\n"
+      "description": "Include contents at the end of the document body (before\nthe `</body>` tag in HTML, or the `\\end{document}` command in LaTeX).\n\nA string value or an object with key \"file\" indicates a filename whose contents are to be included\n\nAn object with key \"text\" indicates textual content to be included\n"
     },
     {
       "name": "include-in-header",
@@ -5557,9 +5529,16 @@
         "ipynb"
       ],
       "schema": {
-        "maybeArrayOf": "path"
+        "maybeArrayOf": {
+          "anyOf": [
+            "path",
+            {
+              "ref": "smart-include"
+            }
+          ]
+        }
       },
-      "description": "Include contents of files, verbatim, at the end of the header. This can\nbe used, for example, to include special CSS or JavaScript in HTML \ndocuments.\n"
+      "description": "Include contents at the end of the header. This can\nbe used, for example, to include special CSS or JavaScript in HTML \ndocuments.\n\nA string value or an object with key \"file\" indicates a filename whose contents are to be included\n\nAn object with key \"text\" indicates textual content to be included\n"
     },
     {
       "name": "resources",
@@ -10203,8 +10182,8 @@
       "long": "Title of the volume of the item or container holding the item.\nAlso use for titles of periodical special issues, special sections,\nand the like."
     },
     "Disambiguating year suffix in author-date styles (e.g.&nbsp;“a” in “Doe,\n1999a”).",
-    "Content to add to includes",
-    "Filename to add to includes",
+    "Textual content to add to includes",
+    "Name of file with content to add to includes",
     {
       "short": "Unique label for code cell",
       "long": "Unique label for code cell. Used when other code needs to refer to\nthe cell (e.g.&nbsp;for cross references <code>fig-samples</code> or\n<code>tbl-summary</code>)"
@@ -10704,15 +10683,12 @@
     },
     "Indicates that computational output should not be written within\ndivs. This is necessary for some formats (e.g.&nbsp;<code>pptx</code>) to\nproperly layout figures.",
     "Disable merging of string based and file based includes (some\nformats, specifically ePub, do not correctly handle this merging)",
-    "Content or files to include at the end of the document header.",
-    "Content or files to include at the beginning of the document body\n(e.g.&nbsp;after the <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX)..",
-    "Content or files to include at the end of the document body\n(e.g.&nbsp;after the <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX)..",
     "Content to include at the end of the document header.",
     "Content to include at the beginning of the document body (e.g.&nbsp;after\nthe <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX).",
     "Content to include at the end of the document body (before the\n<code>&lt;/body&gt;</code> tag in HTML, or the\n<code>\\end{document}</code> command in LaTeX).",
-    "Include contents of files, verbatim, at the beginning of the document\nbody (e.g.&nbsp;after the <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX).",
-    "Include contents of files, verbatim, at the end of the document body\n(before the <code>&lt;/body&gt;</code> tag in HTML, or the\n<code>\\end{document}</code> command in LaTeX).",
-    "Include contents of files, verbatim, at the end of the header. This\ncan be used, for example, to include special CSS or JavaScript in HTML\ndocuments.",
+    "Include contents at the beginning of the document body (e.g.&nbsp;after\nthe <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX).\nA string value or an object with key “file” indicates a filename\nwhose contents are to be included\nAn object with key “text” indicates textual content to be\nincluded",
+    "Include contents at the end of the document body (before the\n<code>&lt;/body&gt;</code> tag in HTML, or the\n<code>\\end{document}</code> command in LaTeX).\nA string value or an object with key “file” indicates a filename\nwhose contents are to be included\nAn object with key “text” indicates textual content to be\nincluded",
+    "Include contents at the end of the header. This can be used, for\nexample, to include special CSS or JavaScript in HTML documents.\nA string value or an object with key “file” indicates a filename\nwhose contents are to be included\nAn object with key “text” indicates textual content to be\nincluded",
     "Path (or glob) to files to publish with this document.",
     {
       "short": "Text to be in a running header.",

--- a/src/resources/schema/definitions.yml
+++ b/src/resources/schema/definitions.yml
@@ -1777,9 +1777,9 @@
 - id: smart-include
   anyOf:
     - record:
-        content:
+        text:
           string:
-            description: Content to add to includes
+            description: Textual content to add to includes
     - record:
         file:
           string:

--- a/src/resources/schema/definitions.yml
+++ b/src/resources/schema/definitions.yml
@@ -1773,3 +1773,14 @@
       year-suffix:
         string:
           description: Disambiguating year suffix in author-date styles (e.g. "a" in "Doe, 1999a").
+
+- id: smart-include
+  anyOf:
+    - record:
+        content:
+          string:
+            description: Content to add to includes
+    - record:
+        file:
+          string:
+            description: Name of file with content to add to includes

--- a/src/resources/schema/document-includes.yml
+++ b/src/resources/schema/document-includes.yml
@@ -1,24 +1,3 @@
-- name: add-to-header
-  disabled: [$office-all, $jats-all, ipynb]
-  schema:
-    maybeArrayOf:
-      ref: smart-include
-  description: Content or files to include at the end of the document header.
-
-- name: add-before-body
-  disabled: [$office-all, $jats-all, ipynb]
-  schema:
-    maybeArrayOf:
-      ref: smart-include
-  description: Content or files to include at the beginning of the document body (e.g. after the `<body>` tag in HTML, or the `\begin{document}` command in LaTeX)..
-
-- name: add-after-body
-  disabled: [$office-all, $jats-all, ipynb]
-  schema:
-    maybeArrayOf:
-      ref: smart-include
-  description: Content or files to include at the end of the document body (e.g. after the `<body>` tag in HTML, or the `\begin{document}` command in LaTeX)..
-
 - name: header-includes
   disabled: [$office-all, $jats-all, ipynb]
   schema:
@@ -40,28 +19,49 @@
 - name: include-before-body
   disabled: [$office-all, $jats-all, ipynb]
   schema:
-    maybeArrayOf: path
+    maybeArrayOf:
+      anyOf:
+        - path
+        - ref: smart-include
   description: |
-    Include contents of files, verbatim, at the beginning of the document body
+    Include contents at the beginning of the document body
     (e.g. after the `<body>` tag in HTML, or the `\begin{document}` command 
     in LaTeX).
+
+    A string value or an object with key "file" indicates a filename whose contents are to be included
+
+    An object with key "text" indicates textual content to be included
 
 - name: include-after-body
   disabled: [$office-all, $jats-all, ipynb]
   schema:
-    maybeArrayOf: path
+    maybeArrayOf:
+      anyOf:
+        - path
+        - ref: smart-include
   description: |
-    Include contents of files, verbatim, at the end of the document body (before
+    Include contents at the end of the document body (before
     the `</body>` tag in HTML, or the `\end{document}` command in LaTeX).
+
+    A string value or an object with key "file" indicates a filename whose contents are to be included
+
+    An object with key "text" indicates textual content to be included
 
 - name: include-in-header
   disabled: [$office-all, $jats-all, ipynb]
   schema:
-    maybeArrayOf: path
+    maybeArrayOf:
+      anyOf:
+        - path
+        - ref: smart-include
   description: |
-    Include contents of files, verbatim, at the end of the header. This can
+    Include contents at the end of the header. This can
     be used, for example, to include special CSS or JavaScript in HTML 
     documents.
+
+    A string value or an object with key "file" indicates a filename whose contents are to be included
+
+    An object with key "text" indicates textual content to be included
 
 - name: resources
   schema:

--- a/src/resources/schema/document-includes.yml
+++ b/src/resources/schema/document-includes.yml
@@ -1,3 +1,24 @@
+- name: add-to-header
+  disabled: [$office-all, $jats-all, ipynb]
+  schema:
+    maybeArrayOf:
+      ref: smart-include
+  description: Content or files to include at the end of the document header.
+
+- name: add-before-body
+  disabled: [$office-all, $jats-all, ipynb]
+  schema:
+    maybeArrayOf:
+      ref: smart-include
+  description: Content or files to include at the beginning of the document body (e.g. after the `<body>` tag in HTML, or the `\begin{document}` command in LaTeX)..
+
+- name: add-after-body
+  disabled: [$office-all, $jats-all, ipynb]
+  schema:
+    maybeArrayOf:
+      ref: smart-include
+  description: Content or files to include at the end of the document body (e.g. after the `<body>` tag in HTML, or the `\begin{document}` command in LaTeX)..
+
 - name: header-includes
   disabled: [$office-all, $jats-all, ipynb]
   schema:


### PR DESCRIPTION
Proposal for improving the configuration syntax in includes (as described in https://quarto.org/docs/output-formats/html-basics.html#includes).

I’ve had a user comment (correctly, in my view) that distinguishing between file includes and inline includes through this scheme is very confusing:

```
inline:
  header-includes
  include-before
  include-after
file:
  include-in-header
  include-before-body
  include-after-body
```

In addition to those, this PR adds support to this more explicit style:

```
---
format: 
  html:
    include-in-header:
      - text: "<style>body { color: blue }</style>" # textual inclusion
      - file: my-style.html # include contents of file
    include-before-body: preamble.html # old style is still supported
    include-after-body:
      text: "<p>postamble</p>" # single-entry is also supported
---
```

