### PR TITLE
Escape special chars in raw LaTeX caption

### DIFF
--- a/src/resources/filters/common/string.lua
+++ b/src/resources/filters/common/string.lua
@@ -28,7 +28,7 @@ function split(str, sep)
 end
 
 -- escape string by converting using Pandoc
-function inlineEscape(str, format)
+function stringEscape(str, format)
   local doc = pandoc.Pandoc({pandoc.Para(str)})
   return pandoc.write(doc, 'latex')
 end

--- a/src/resources/filters/common/string.lua
+++ b/src/resources/filters/common/string.lua
@@ -26,3 +26,9 @@ function split(str, sep)
   
   return fields
 end
+
+-- escape string by converting using Pandoc
+function inlineEscape(str, format)
+  local doc = pandoc.Pandoc({pandoc.Para(str)})
+  return pandoc.write(doc, 'latex')
+end

--- a/src/resources/filters/quarto-pre/table-captions.lua
+++ b/src/resources/filters/quarto-pre/table-captions.lua
@@ -214,7 +214,7 @@ function applyLatexTableCaption(latex, tblCaption, tblLabel, tablePattern)
     captionText = pandoc.utils.stringify(tblCaption)
   end
   -- escape special characters for LaTeX
-  captionText = inlineEscape(captionText, "latex")
+  captionText = stringEscape(captionText, "latex")
   if #tblLabel > 0 then
     captionText = captionText .. " {#" .. tblLabel .. "}"
   end

--- a/src/resources/filters/quarto-pre/table-captions.lua
+++ b/src/resources/filters/quarto-pre/table-captions.lua
@@ -213,6 +213,8 @@ function applyLatexTableCaption(latex, tblCaption, tblLabel, tablePattern)
   if #tblCaption > 0 then
     captionText = pandoc.utils.stringify(tblCaption)
   end
+  -- escape special characters for LaTeX
+  captionText = inlineEscape(captionText, "latex")
   if #tblLabel > 0 then
     captionText = captionText .. " {#" .. tblLabel .. "}"
   end


### PR DESCRIPTION
This complement the fix in #810 for LaTeX format where `%` needs to be escaped in LaTeX to `\%`

I suggest to generalize to any special char in LaTeX which are 10 I think `{ } % & $ # _ ^ ~ \`. 

This first proposal does not implement a escaping function in LUA but is directly using Pandoc to convert a string to LaTeX so that it gets escaped. 

Maybe that is to risky to do that and implementing our escape function is safer ? You'll tell me and I'll adapt

Tested example that works now 

````markdown
---
format: 
  pdf:
    keep-tex: true
---

```{r}
#| label: tbl-rel-diff
#| tbl-cap: "Median and 95% confidence interval"
kableExtra::kbl(head(iris))
```
````

