### PR TITLE
Allow pagebreaks in callout boxes in PDF

### DIFF
--- a/src/resources/filters/quarto-pre/callout.lua
+++ b/src/resources/filters/quarto-pre/callout.lua
@@ -297,6 +297,7 @@ function latexCalloutBoxDefault(caption, type, icon)
 
   -- generate options
   local options = {
+    breakable = "",
     colframe = frameColor,
     colbacktitle = color ..'!10!white',
     coltitle = 'black',
@@ -320,7 +321,7 @@ function latexCalloutBoxDefault(caption, type, icon)
   end
 
   -- the core latex for the box
-  local beginInlines = { pandoc.RawInline('latex', '\\begin{tcolorbox}[standard jigsaw,' .. tColorOptions(options) .. ']\n') }
+  local beginInlines = { pandoc.RawInline('latex', '\\begin{tcolorbox}[enhanced jigsaw, ' .. tColorOptions(options) .. ']\n') }
   local endInlines = { pandoc.RawInline('latex', '\n\\end{tcolorbox}') }
 
   -- Add the captions and contents
@@ -348,6 +349,7 @@ function latexCalloutBoxSimple(caption, type, icon)
 
   -- generate options
   local options = {
+    breakable = "",
     colframe = colorFrame,
     colback = 'white',
     opacityback = 0,
@@ -360,7 +362,7 @@ function latexCalloutBoxSimple(caption, type, icon)
   }
 
   -- the core latex for the box
-  local beginInlines = { pandoc.RawInline('latex', '\\begin{tcolorbox}[standard jigsaw, ' .. tColorOptions(options) .. ']\n') }
+  local beginInlines = { pandoc.RawInline('latex', '\\begin{tcolorbox}[enhanced jigsaw, ' .. tColorOptions(options) .. ']\n') }
   local endInlines = { pandoc.RawInline('latex', '\n\\end{tcolorbox}') }
 
   -- generate the icon and use a minipage to position it


### PR DESCRIPTION
Following changes to the options passed to `tcolorbox`:
- Add `breakable` option so that boxes will break to span across pagebreaks
- Change `standard jigsaw` -> `enhanced jigsaw`, so that partial boxes do not close.

To address issue https://github.com/quarto-dev/quarto-cli/issues/817