### PR TITLE
[reveal] Narrow support of autostretch to specific cases

### DIFF
--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -670,72 +670,78 @@ function applyStretch(doc: Document, autoStretch: boolean) {
           nodeEl.nodeName === "DIV" && nodeEl.classList.contains("cell") ||
           // on other divs (custom divs) when explicitly opt-in
           nodeEl.nodeName === "DIV" && hasStretchClass(nodeEl)
-        ) {
+      ) {
 
-        // add stretch class if not already when auto-stretch is set
-        if (
-          autoStretch === true &&
-          !hasStretchClass(imageEl) &&
-          // if height is already set, we do nothing
-          !imageEl.getAttribute("style")?.match("height:") &&
-          !imageEl.hasAttribute("height")
-        ) {
-          imageEl.classList.add("r-stretch");
-        }
-
-        // If <img class="stetch"> is not a direct child of <section>, move it
-        if (
-          hasStretchClass(imageEl) &&
-          imageEl.parentNode?.nodeName !== "SECTION"
-        ) {
-          // Remove element then maybe remove its parents if empty
-          const removeEmpty = function (el: Element) {
-            const parentEl = el.parentElement;
-            parentEl?.removeChild(el);
-            if (
-              parentEl?.innerText.trim() === "" &&
-              // Stop at section leveal and do not remove empty slides
-              parentEl?.nodeName !== "SECTION"
-            ) {
-              removeEmpty(parentEl);
-            }
-          };
-
-          // Figure environment ? Get caption and alignment
-          const quartoFig = slideEl.querySelector("div.quarto-figure");
-          const caption = doc.createElement("p");
-          if (quartoFig) {
-            // Get alignment
-            const align = quartoFig.className.match(
-              "quarto-figure-(center|left|right)",
-            );
-            if (align) imageEl.classList.add(align[0]);
-            // Get Caption
-            const figCaption = nodeEl.querySelector("figcaption");
-            if (figCaption) {
-              caption.classList.add("caption");
-              caption.innerHTML = figCaption.innerHTML;
-            }
+          // for custom divs, remove stretch class as it should only be present on img
+          if (nodeEl.nodeName === "DIV" && hasStretchClass(nodeEl)) {
+            nodeEl.classList.remove("r-stretch")
+            nodeEl.classList.remove("stretch")
           }
 
-          // Target position of image
-          // first level after the element
-          const nextEl = nodeEl.nextElementSibling;
-          // Remove image from its parent
-          removeEmpty(imageEl);
-          // insert at target position
-          slideEl.insertBefore(image, nextEl);
-
-          // If there was a caption processed add it after
-          if (caption.classList.contains("caption")) {
-            slideEl.insertBefore(
-              caption,
-              imageEl.nextElementSibling,
-            );
+          // add stretch class if not already when auto-stretch is set
+          if (
+            autoStretch === true &&
+            !hasStretchClass(imageEl) &&
+            // if height is already set, we do nothing
+            !imageEl.getAttribute("style")?.match("height:") &&
+            !imageEl.hasAttribute("height")
+          ) {
+            imageEl.classList.add("r-stretch");
           }
-          // Remove container if still there
-          if (quartoFig) removeEmpty(quartoFig);
-        }
+
+          // If <img class="stetch"> is not a direct child of <section>, move it
+          if (
+            hasStretchClass(imageEl) &&
+            imageEl.parentNode?.nodeName !== "SECTION"
+          ) {
+            // Remove element then maybe remove its parents if empty
+            const removeEmpty = function (el: Element) {
+              const parentEl = el.parentElement;
+              parentEl?.removeChild(el);
+              if (
+                parentEl?.innerText.trim() === "" &&
+                // Stop at section leveal and do not remove empty slides
+                parentEl?.nodeName !== "SECTION"
+              ) {
+                removeEmpty(parentEl);
+              }
+            };
+
+            // Figure environment ? Get caption and alignment
+            const quartoFig = slideEl.querySelector("div.quarto-figure");
+            const caption = doc.createElement("p");
+            if (quartoFig) {
+              // Get alignment
+              const align = quartoFig.className.match(
+                "quarto-figure-(center|left|right)",
+              );
+              if (align) imageEl.classList.add(align[0]);
+              // Get Caption
+              const figCaption = nodeEl.querySelector("figcaption");
+              if (figCaption) {
+                caption.classList.add("caption");
+                caption.innerHTML = figCaption.innerHTML;
+              }
+            }
+
+            // Target position of image
+            // first level after the element
+            const nextEl = nodeEl.nextElementSibling;
+            // Remove image from its parent
+            removeEmpty(imageEl);
+            // insert at target position
+            slideEl.insertBefore(image, nextEl);
+
+            // If there was a caption processed add it after
+            if (caption.classList.contains("caption")) {
+              slideEl.insertBefore(
+                caption,
+                imageEl.nextElementSibling,
+              );
+            }
+            // Remove container if still there
+            if (quartoFig) removeEmpty(quartoFig);
+          }
       }
     }
   }

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -627,7 +627,7 @@ function applyStretch(doc: Document, autoStretch: boolean) {
       const image = images[0];
       const imageEl = image as Element;
 
-      // screen out images inside layout panels and columns
+      // screen out early specials divs (layout panels, columns, fragments, ...)
       if (
         findParent(imageEl, (el: Element) => {
           return el.classList.contains("column") ||
@@ -651,78 +651,91 @@ function applyStretch(doc: Document, autoStretch: boolean) {
       const nodeEl = selNode;
 
       // Do not apply stretch if this is an inline image among text
-      if (
-        !nodeEl || (nodeEl.nodeName === "P" && nodeEl.childNodes.length > 1)
-      ) {
+      if (!nodeEl || (nodeEl.nodeName === "P" && nodeEl.childNodes.length > 1)) {
         continue;
       }
 
-      // add stretch class if not already when auto-stretch is set
-      const hasStretchClass = function (imageEl: Element): boolean {
-        return imageEl.classList.contains("stretch") ||
-          imageEl.classList.contains("r-stretch");
+      const hasStretchClass = function (el: Element): boolean {
+        return el.classList.contains("stretch") || el.classList.contains("r-stretch");
       };
-      if (
-        autoStretch === true &&
-        !hasStretchClass(imageEl) &&
-        // if height is already set, we do nothing
-        !imageEl.getAttribute("style")?.match("height:") &&
-        !imageEl.hasAttribute("height")
-      ) {
-        imageEl.classList.add("r-stretch");
-      }
-      // If <img class="stetch"> is not a direct child of <section>, move it
-      if (
-        hasStretchClass(imageEl) &&
-        imageEl.parentNode?.nodeName !== "SECTION"
-      ) {
-        // Remove element then maybe remove its parents if empty
-        const removeEmpty = function (el: Element) {
-          const parentEl = el.parentElement;
-          parentEl?.removeChild(el);
-          if (
-            parentEl?.innerText.trim() === "" &&
-            // Stop at section leveal and do not remove empty slides
-            parentEl?.nodeName !== "SECTION"
-          ) {
-            removeEmpty(parentEl);
-          }
-        };
 
-        // Figure environment ? Get caption and alignment
-        const quartoFig = slideEl.querySelector("div.quarto-figure");
-        const caption = doc.createElement("p");
-        if (quartoFig) {
-          // Get alignment
-          const align = quartoFig.className.match(
-            "quarto-figure-(center|left|right)",
-          );
-          if (align) imageEl.classList.add(align[0]);
-          // Get Caption
-          const figCaption = nodeEl.querySelector("figcaption");
-          if (figCaption) {
-            caption.classList.add("caption");
-            caption.innerHTML = figCaption.innerHTML;
-          }
+      // Only apply auto stretch on specific known structures
+      // and avoid applying automatically on custom divs
+      if (
+          // on <p><img> (created by Pandoc)
+          nodeEl.nodeName === "P" ||
+          // on quarto figure divs
+          nodeEl.nodeName === "DIV" && nodeEl.classList.contains("quarto-figure") ||
+          // on computation output created image
+          nodeEl.nodeName === "DIV" && nodeEl.classList.contains("cell") ||
+          // on other divs (custom divs) when explicitly opt-in
+          nodeEl.nodeName === "DIV" && hasStretchClass(nodeEl)
+        ) {
+
+        // add stretch class if not already when auto-stretch is set
+        if (
+          autoStretch === true &&
+          !hasStretchClass(imageEl) &&
+          // if height is already set, we do nothing
+          !imageEl.getAttribute("style")?.match("height:") &&
+          !imageEl.hasAttribute("height")
+        ) {
+          imageEl.classList.add("r-stretch");
         }
 
-        // Target position of image
-        // first level after the element
-        const nextEl = nodeEl.nextElementSibling;
-        // Remove image from its parent
-        removeEmpty(imageEl);
-        // insert at target position
-        slideEl.insertBefore(image, nextEl);
+        // If <img class="stetch"> is not a direct child of <section>, move it
+        if (
+          hasStretchClass(imageEl) &&
+          imageEl.parentNode?.nodeName !== "SECTION"
+        ) {
+          // Remove element then maybe remove its parents if empty
+          const removeEmpty = function (el: Element) {
+            const parentEl = el.parentElement;
+            parentEl?.removeChild(el);
+            if (
+              parentEl?.innerText.trim() === "" &&
+              // Stop at section leveal and do not remove empty slides
+              parentEl?.nodeName !== "SECTION"
+            ) {
+              removeEmpty(parentEl);
+            }
+          };
 
-        // If there was a caption processed add it after
-        if (caption.classList.contains("caption")) {
-          slideEl.insertBefore(
-            caption,
-            imageEl.nextElementSibling,
-          );
+          // Figure environment ? Get caption and alignment
+          const quartoFig = slideEl.querySelector("div.quarto-figure");
+          const caption = doc.createElement("p");
+          if (quartoFig) {
+            // Get alignment
+            const align = quartoFig.className.match(
+              "quarto-figure-(center|left|right)",
+            );
+            if (align) imageEl.classList.add(align[0]);
+            // Get Caption
+            const figCaption = nodeEl.querySelector("figcaption");
+            if (figCaption) {
+              caption.classList.add("caption");
+              caption.innerHTML = figCaption.innerHTML;
+            }
+          }
+
+          // Target position of image
+          // first level after the element
+          const nextEl = nodeEl.nextElementSibling;
+          // Remove image from its parent
+          removeEmpty(imageEl);
+          // insert at target position
+          slideEl.insertBefore(image, nextEl);
+
+          // If there was a caption processed add it after
+          if (caption.classList.contains("caption")) {
+            slideEl.insertBefore(
+              caption,
+              imageEl.nextElementSibling,
+            );
+          }
+          // Remove container if still there
+          if (quartoFig) removeEmpty(quartoFig);
         }
-        // Remove container if still there
-        if (quartoFig) removeEmpty(quartoFig);
       }
     }
   }

--- a/tests/docs/reveal/stretch.qmd
+++ b/tests/docs/reveal/stretch.qmd
@@ -183,3 +183,53 @@ plot(cars)
 ## {#no-content-caption}
 
 ![A logo](https://revealjs.com/images/logo/reveal-black-text.svg)
+
+## No auto stretch if nested {#custom-divs-simple}
+
+::: {.custom-block}
+
+Some content with an image below
+
+![](https://revealjs.com/images/logo/reveal-black-text.svg)
+
+:::
+
+## No auto stretch if nested 2 {#custom-divs-caption}
+
+::: {.custom-block}
+
+Some content with an image below
+
+![A logo](https://revealjs.com/images/logo/reveal-black-text.svg)
+
+:::
+
+## No auto stretch if nested 3 {#custom-divs-knitr}
+
+::: {.custom-block}
+
+```{r, echo = FALSE}
+plot(cars)
+```
+
+:::
+
+## No auto stretch if nested 4 {#custom-divs-knitr-caption}
+
+::: {.custom-block}
+
+```{r, echo = FALSE, fig.cap = "Caption"}
+plot(cars)
+```
+
+:::
+
+## Nested in div supports opt-in  {#custom-divs-opt-in}
+
+::: {.custom-block .r-stretch}
+
+```{r, echo = FALSE, fig.cap = "Caption"}
+plot(cars)
+```
+
+:::

--- a/tests/docs/reveal/stretch.qmd
+++ b/tests/docs/reveal/stretch.qmd
@@ -228,6 +228,8 @@ plot(cars)
 
 ::: {.custom-block .r-stretch}
 
+Some content
+
 ```{r, echo = FALSE, fig.cap = "Caption"}
 plot(cars)
 ```

--- a/tests/smoke/render/render-reveal.test.ts
+++ b/tests/smoke/render/render-reveal.test.ts
@@ -50,6 +50,7 @@ testRender(input, "revealjs", false, [
     "#knitr-no-caption-and-content > img.r-stretch + div.cell",
     "#no-content > img.r-stretch",
     "#no-content-caption > img.r-stretch + p.caption",
+    "#custom-divs-opt-in > img.r-stretch + p.caption",
   ], [
     "#columns img.r-stretch",
     "#more-than-one img.r-stretch",
@@ -60,5 +61,10 @@ testRender(input, "revealjs", false, [
     "#block-layout img.r-stretch",
     "#block-layout2 img.r-stretch",
     "#fig-tab-layout img.r-stretch",
+    "#custom-divs-simple img.r-stretch",
+    "#custom-divs-caption img.r-stretch",
+    "#custom-divs-caption img.r-stretch",
+    "#custom-divs-knitr img.r-stretch",
+    "#custom-divs-knitr-caption img.r-stretch",
   ]),
 ]);

--- a/tests/smoke/render/render-reveal.test.ts
+++ b/tests/smoke/render/render-reveal.test.ts
@@ -50,7 +50,7 @@ testRender(input, "revealjs", false, [
     "#knitr-no-caption-and-content > img.r-stretch + div.cell",
     "#no-content > img.r-stretch",
     "#no-content-caption > img.r-stretch + p.caption",
-    "#custom-divs-opt-in > img.r-stretch + p.caption",
+    "#custom-divs-opt-in > div.custom-block:not(.r-stretch) + img.r-stretch + p.caption",
   ], [
     "#columns img.r-stretch",
     "#more-than-one img.r-stretch",


### PR DESCRIPTION
This will close #877

We were too generic in our approach of detecting single <img> in slides and moving it to <section> level with class `r-stretch` added. This would break images set in custom divs. 

With this change, we are doing `auto-stretch` only for setup we know that should work. See https://github.com/quarto-dev/quarto-cli/issues/877#issuecomment-1127435945 for details. Those setup are all at `<section>` level already; 

1. Single image in slides not nested under any structure
2. image with caption, that will be in Quarto figure divs 
3. image created from Code cells, which will be in special divs 

If any of the above is nested under something else (like with custom class divs), we don't apply auto-stretch, unless the first level divs has `r-stretch` class on it. In that case, the img in the div will be unwrapped **and put below the custom div**. 

As before, special div for Quarto feature are ignored: layout, columns, fragments, output-location, ... 

I added some tests for this support, which shows an example presentation. 

Is this now the expected behavior ? 