### PR TITLE
tinytex and tinytex-releases have moved to rstudio organization

### DIFF
--- a/src/command/render/latexmk/pdf.ts
+++ b/src/command/render/latexmk/pdf.ts
@@ -142,13 +142,13 @@ async function initialCompileLatex(
 
     // Check whether it suceeded. We'll consider it a failure if there is an error status or output is missing despite a success status
     // (PNAS Template may eat errors when missing packages exists)
-    // See: https://github.com/yihui/tinytex/blob/6c0078f2c3c1319a48b71b61753f09c3ec079c0a/R/latex.R#L216
+    // See: https://github.com/rstudio/tinytex/blob/6c0078f2c3c1319a48b71b61753f09c3ec079c0a/R/latex.R#L216
     const success = response.result.code === 0 &&
       (!response.output || existsSync(response.output));
 
     if (success) {
       // See whether there are warnings about hyphenation
-      // See (https://github.com/yihui/tinytex/commit/0f2007426f730a6ed9d45369233c1349a69ddd29)
+      // See (https://github.com/rstudio/tinytex/commit/0f2007426f730a6ed9d45369233c1349a69ddd29)
       const logText = Deno.readTextFileSync(response.log);
       const missingHyphenationFile = findMissingHyphenationFiles(logText);
       if (missingHyphenationFile) {
@@ -324,7 +324,7 @@ async function makeBibliographyIntermediates(
         //
         if (Deno.build.os === "windows") {
           if (bibCommand !== "biber" && !hasTexLive()) {
-            // See https://github.com/yihui/tinytex/blob/b2d1bae772f3f979e77fca9fb5efda05855b39d2/R/latex.R#L284
+            // See https://github.com/rstudio/tinytex/blob/b2d1bae772f3f979e77fca9fb5efda05855b39d2/R/latex.R#L284
             // Strips the '.bib' from any match and returns the string without the bib extension
             // Replace any '.bib' in bibdata in windows auxData
             const fixedAuxFileData = auxFileData.replaceAll(

--- a/src/command/render/latexmk/texlive.ts
+++ b/src/command/render/latexmk/texlive.ts
@@ -55,7 +55,7 @@ export async function findPackages(
       );
     }
     // Special case for a known package
-    // https://github.com/yihui/tinytex/blob/33cbe601ff671fae47c594250de1d22bbf293b27/R/latex.R#L470
+    // https://github.com/rstudio/tinytex/blob/33cbe601ff671fae47c594250de1d22bbf293b27/R/latex.R#L470
     if (searchTerm === "fandol") {
       results.push("fandol");
     } else {

--- a/src/command/tools/tools/tinytex.ts
+++ b/src/command/tools/tools/tinytex.ts
@@ -40,7 +40,7 @@ const kDefaultRepos = [
 ];
 
 // Different packages
-const kTinyTexRepo = "yihui/tinytex-releases";
+const kTinyTexRepo = "rstudio/tinytex-releases";
 // const kPackageMinimal = "TinyTeX-0"; // smallest
 // const kPackageDefault = "TinyTeX-1"; // Compiles most RMarkdown
 const kPackageMaximal = "TinyTeX"; // Compiles 80% of documents


### PR DESCRIPTION
This was part of the last release: https://github.com/rstudio/tinytex/releases/tag/v0.39

This PR update links in comment and the repo variable for TinyTeX downloads. Redirects will be in play for some time so everything is fine, but I prefer to do the change now as I am thinking about this. 

cc @yihui 