### PR TITLE
Correctly query registry key on Windows for finding chrome

### DIFF
--- a/src/command/render/latexmk/texlive.ts
+++ b/src/command/render/latexmk/texlive.ts
@@ -9,10 +9,11 @@ import { existsSync } from "fs/mod.ts";
 
 import * as ld from "../../../core/lodash.ts";
 
-import { execProcess, safeWindowsExec } from "../../../core/process.ts";
+import { execProcess } from "../../../core/process.ts";
 import { kLatexHeaderMessageOptions } from "./types.ts";
 import { lines } from "../../../core/text.ts";
 import { tinyTexInstallDir } from "../../tools/tools/tinytex-info.ts";
+import { requireQuoting, safeWindowsExec } from "../../../core/windows.ts";
 
 // Determines whether TexLive is installed and callable on this system
 export async function hasTexLive(): Promise<boolean> {
@@ -301,31 +302,6 @@ async function verifyPackageInstalled(
     ],
   );
   return result.stdout?.trim() === pkg;
-}
-
-// On Windows, determine and apply double quoting on args that needs it
-// Do nothing on other OS.
-function requireQuoting(
-  args: string[],
-) {
-  let requireQuoting = false;
-  if (Deno.build.os === "windows") {
-    // On Windows, we need to check if arguments may need quoting to avoid issue with Deno.Run()
-    // https://github.com/quarto-dev/quarto-cli/issues/336
-    const shellCharReg = new RegExp("[ <>()|\\:&;#?*']");
-    args = args.map((a) => {
-      if (shellCharReg.test(a)) {
-        requireQuoting = true;
-        return `"${a}"`;
-      } else {
-        return a;
-      }
-    });
-  }
-  return {
-    status: requireQuoting,
-    args: args,
-  };
 }
 
 // Execute correctly tlmgr <cmd> <args>

--- a/src/core/process.ts
+++ b/src/core/process.ts
@@ -8,7 +8,6 @@
 import { MuxAsyncIterator, pooledMap } from "async/mod.ts";
 import { iterateReader } from "streams/mod.ts";
 import { info } from "log/mod.ts";
-import { removeIfExists } from "./path.ts";
 
 export interface ProcessResult {
   success: boolean;
@@ -173,22 +172,4 @@ async function processOutput(
     outputText += text;
   }
   return outputText;
-}
-
-// Execute a program on Windows by writing command line
-// to a tempfile and execute the file with CMD
-export async function safeWindowsExec(
-  program: string,
-  args: string[],
-  fnExec: (cmdExec: string[]) => Promise<ProcessResult>,
-) {
-  const tempFile = Deno.makeTempFileSync(
-    { prefix: "quarto-safe-exec", suffix: ".bat" },
-  );
-  try {
-    Deno.writeTextFileSync(tempFile, [program, ...args].join(" ") + "\n");
-    return await fnExec(["cmd", "/c", tempFile]);
-  } finally {
-    removeIfExists(tempFile);
-  }
 }

--- a/src/core/windows.ts
+++ b/src/core/windows.ts
@@ -19,11 +19,11 @@ export async function readRegistryKey(
   registryPath: string,
   keyname: string | "(Default)",
 ) {
+  const defaultKeyname = keyname === "(Default)";
   // Build the the reg command
   const args = ["query", registryPath];
-  if (keyname === "(Default)") {
+  if (defaultKeyname) {
     args.push("/ve");
-    keyname = "\\(Default\\)";
   } else {
     args.push("/v");
     args.push(keyname);
@@ -47,8 +47,8 @@ export async function readRegistryKey(
   if (result.success) {
     // Parse the output to read the value
     const output = result.stdout;
-    const regexStr =
-      ` *${keyname} *(?:REG_SZ|REG_MULTI_SZ|REG_EXPAND_SZ|REG_DWORD|REG_BINARY|REG_NONE) *(.*)$`;
+    const regexStr = (defaultKeyname ? "" : ` *${keyname}`) +
+      ` *(?:REG_SZ|REG_MULTI_SZ|REG_EXPAND_SZ|REG_DWORD|REG_BINARY|REG_NONE) *(.*)$`;
     const match = output?.match(RegExp(regexStr, "m"));
     if (match) {
       return match[1];


### PR DESCRIPTION
Fix #868

There was 2 issues: 
1. Quoting issue with `Deno.run()` as we encountered with `tlmgr` in the past
2. Localized output value of `reg.exe query` which made our regex matching failed

For the first, I refactored the fix for `tlmgr` by making the wrapper `safeWindowsExec` available in `windows.ts` so that we can reuse it. Basically the trick is to quote the arguments that needs it (`requireQuoting()`), then write the command to execute into a `.bat` file using `Deno.run()`

For the second, I understand we don't need to search for `Default` in the returned key when `/ve` is used on the query as only the default will be returned. So when `(Default)` keyname issued, we ignore it in the regex. 

This solve the issue on Windows. Hopefully, it is not breaking anything elsewhere. 

Side notes: 

I took some time before submitting the PR as we discussed with @dragonstyle making the quoting on Windows more generic as this is a known issue with `Deno.run()`. Idea was to make `execProcess()` supports this. However, it is a bit more complex that I though and this seems to lead to change the way `execProcess()` is called, and we use that in a lot of places. 

That is only the second time we are encountering this and we now have a pattern using `requireQuoting()` and then `safeExecWindows()` when needed. Maybe that is enough for now ? 
Anyway, I could still continue this rewrite, but it would probably be good in another PR. 
