### PR TITLE
use host in preview and serve

### DIFF
--- a/src/command/preview/preview.ts
+++ b/src/command/preview/preview.ts
@@ -178,7 +178,7 @@ export async function preview(
       relative(projectOutputDir(project), result.outputFile),
     )
     : "";
-  const url = `http://localhost:${options.port}/${initialPath}`;
+  const url = `http://${options.host}:${options.port}/${initialPath}`;
   if (
     options.browser &&
     !isRStudioServer() && !isRStudioWorkbench() && !isJupyterHubServer() &&
@@ -188,7 +188,7 @@ export async function preview(
   }
 
   // print status
-  await printBrowsePreviewMessage(options.port!, initialPath);
+  await printBrowsePreviewMessage(options.host!, options.port!, initialPath);
 
   // watch for src changes in dev mode
   monitorQuartoSrcChanges(stopServer);

--- a/src/command/render/render-shared.ts
+++ b/src/command/render/render-shared.ts
@@ -139,7 +139,7 @@ export function printWatchingForChangesMessage() {
   info("Watching files for changes", { format: colors.green });
 }
 
-export async function printBrowsePreviewMessage(port: number, path: string) {
+export async function printBrowsePreviewMessage(host: string, port: number, path: string) {
   if (isJupyterHubServer()) {
     const httpReferrer = `${
       jupyterHubHttpReferrer() || "<jupyterhub-server-url>/"
@@ -154,10 +154,10 @@ export async function printBrowsePreviewMessage(port: number, path: string) {
     (isJupyterServer() || isVSCodeTerminal()) && isRStudioWorkbench()
   ) {
     const url = await rswURL(port, path);
-    info(`\nPreview server: http://localhost:${port}/`);
+    info(`\nPreview server: http://${host}:${port}/`);
     info(`\nBrowse at ${url}`, { format: colors.green });
   } else {
-    const url = `http://localhost:${port}/${path}`;
+    const url = `http://${host}:${port}/${path}`;
     if (!isRStudioServer()) {
       info(`Browse at `, {
         newline: false,

--- a/src/command/render/render-shared.ts
+++ b/src/command/render/render-shared.ts
@@ -139,6 +139,14 @@ export function printWatchingForChangesMessage() {
   info("Watching files for changes", { format: colors.green });
 }
 
+
+export async function renderURL(host: string, port: number, path: string) {
+  // render 127.0.0.1 as localhost as not to break existing unit tests (see #947)
+  const showHost = host == "127.0.0.1" ? "localhost" : host;
+  const url = `http://${showHost}:${port}/${path}`;
+  return url
+}
+
 export async function printBrowsePreviewMessage(host: string, port: number, path: string) {
   if (isJupyterHubServer()) {
     const httpReferrer = `${
@@ -153,11 +161,12 @@ export async function printBrowsePreviewMessage(host: string, port: number, path
   } else if (
     (isJupyterServer() || isVSCodeTerminal()) && isRStudioWorkbench()
   ) {
+    const previewURL = renderURL(host, port, path = "")
     const url = await rswURL(port, path);
-    info(`\nPreview server: http://${host}:${port}/`);
+    info(`\nPreview server: ${previewURL}`);
     info(`\nBrowse at ${url}`, { format: colors.green });
   } else {
-    const url = `http://${host}:${port}/${path}`;
+    const url = renderURL(host, port, path);
     if (!isRStudioServer()) {
       info(`Browse at `, {
         newline: false,

--- a/src/command/render/render-shared.ts
+++ b/src/command/render/render-shared.ts
@@ -140,7 +140,7 @@ export function printWatchingForChangesMessage() {
 }
 
 
-export async function renderURL(host: string, port: number, path: string) {
+export function renderURL(host: string, port: number, path: string) {
   // render 127.0.0.1 as localhost as not to break existing unit tests (see #947)
   const showHost = host == "127.0.0.1" ? "localhost" : host;
   const url = `http://${showHost}:${port}/${path}`;

--- a/src/core/port.ts
+++ b/src/core/port.ts
@@ -10,7 +10,7 @@ import * as ld from "./lodash.ts";
 import { randomInt } from "./random.ts";
 import { sleep } from "./wait.ts";
 
-export const kLocalhost = "localhost";
+export const kLocalhost = "127.0.0.1";
 
 const kMinPort = 3000;
 const kMaxPort = 8000;

--- a/src/core/port.ts
+++ b/src/core/port.ts
@@ -10,7 +10,7 @@ import * as ld from "./lodash.ts";
 import { randomInt } from "./random.ts";
 import { sleep } from "./wait.ts";
 
-export const kLocalhost = "127.0.0.1";
+export const kLocalhost = "localhost";
 
 const kMinPort = 3000;
 const kMaxPort = 8000;

--- a/src/project/serve/serve.ts
+++ b/src/project/serve/serve.ts
@@ -470,7 +470,7 @@ export async function serveProject(
   };
 
   // compute site url
-  const siteUrl = `http://localhost:${options.port}/`;
+  const siteUrl = `http://${options.host}:${options.port}/`;
 
   // print status
   printWatchingForChangesMessage();
@@ -499,6 +499,7 @@ export async function serveProject(
 
   // print browse url and open browser if requested
   printBrowsePreviewMessage(
+    options.host!,
     options.port!,
     (targetPath && targetPath !== "index.html") ? targetPath : "",
   );


### PR DESCRIPTION
The documentation website of [Viash](https://viash.io) urgently needs a makeover, and I was looking into using quarto to create it. However, I ran into the issue of the `--host` parameter not being passed along inside of the code. This means I can't access the web server from inside a container.

## Demonstration of the issue

I set up a new website. For this example, I'll be using Viash to make the Docker container build a little bit easier:

```bash
quarto create-project mysite --type website
cd mysite

# download viash
mkdir bin
wget https://github.com/viash-io/viash/releases/download/0.5.11/viash -O bin/viash
chmod +x viash
```
I created a [Viash component](https://github.com/rcannood/quarto-cli/blob/viash_configs/src/viash_configs/quarto_preview/config.vsh.yaml) (which is a script + a description of the CLI + a Docker container spec) to make running quarto preview easier.

When I run the Viash component, I get:

```bash
$ bin/viash run https://raw.githubusercontent.com/rcannood/quarto-cli/viash_configs/src/viash_configs/quarto_preview/config.vsh.yaml
```

    [notice] Checking if Docker image is available at 'quarto_preview:latest'
    [warning] Could not pull from 'quarto_preview:latest'. Docker image doesn't exist or is not accessible.
    [notice] Building container 'quarto_preview:latest' with Dockerfile
    
    Preparing to preview
    
    Watching files for changes
    Browse at http://localhost:4444/


When I try to browse `http://localhost:4444/`, it fails because the web server is bound to 127.0.0.1.

## Demonstration of the solution

This [Viash component](https://github.com/rcannood/quarto-cli/blob/viash_configs/src/viash_configs/quarto_preview_fix/config.vsh.yaml) uses my fork of quarto.

This time, I will build the component explicitly into an executable. The Docker container build will take a bit longer because it's building quarto from source.

```bash
viash build https://raw.githubusercontent.com/rcannood/quarto-cli/viash_configs/src/viash_configs/quarto_preview_fixed/config.vsh.yaml -o bin --setup cachedbuild
```
    [notice] Building container 'quarto_preview_fix:latest' with Dockerfile

When I run the Viash component, I get:
```bash
# need to clean up previous preview first
bin/quarto_preview_fix
```

    Terminating existing preview server....DONE

```bash
bin/quarto_preview_fix
```
    Preparing to preview
    
    Watching files for changes
    Browse at http://172.17.0.2:4444/

Browsing this link now works.

Sidenote: The executable generated by Viash now works as a standalone executable which uses a Docker container in the backend. 