### PR TITLE
Add support for using Microsoft Edge instead of Chrome on Windows

### DIFF
--- a/src/core/puppeteer.ts
+++ b/src/core/puppeteer.ts
@@ -227,6 +227,9 @@ async function findChrome(): Promise<string | undefined> {
           `HKCR\\${regKeys[i]}\\shell\\open\\command`,
           "(Default)",
         );
+        // TODO: simplify this
+        if (path) path = path.match(/".*"/);
+        if (path) path = path[0];
         if (path) break;
       }
     }

--- a/src/core/puppeteer.ts
+++ b/src/core/puppeteer.ts
@@ -209,17 +209,26 @@ async function findChrome(): Promise<string | undefined> {
     }
   } else if (Deno.build.os === "windows") {
     // Try the HKLM key
-    path = await readRegistryKey(
-      "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.exe",
-      "(Default)",
-    );
+    const programs = ["chrome.exe", "msedge.exe"];
+    for (let i = 0; i < programs.length; i++) {
+      path = await readRegistryKey(
+        "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\" +
+          programs[i],
+        "(Default)",
+      );
+      if (path) break;
+    }
 
     // Try the HKCR key
     if (!path) {
-      path = await readRegistryKey(
-        "HKCR\\ChromeHTML\\shell\\open\\command",
-        "(Default)",
-      );
+      const regKeys = ["ChromeHTML", "MSEdgeHTM"];
+      for (let i = 0; i < regKeys.length; i++) {
+        path = await readRegistryKey(
+          `HKCR\\${regKeys[i]}\\shell\\open\\command`,
+          "(Default)",
+        );
+        if (path) break;
+      }
     }
   }
   return path;

--- a/src/core/puppeteer.ts
+++ b/src/core/puppeteer.ts
@@ -9,6 +9,7 @@ import { readRegistryKey } from "./windows.ts";
 import { which } from "./path.ts";
 import { error, info } from "log/mod.ts";
 import { fetcher } from "../command/tools/tools/chromium.ts";
+import { existsSync } from "https://deno.land/std@0.138.0/fs/mod.ts";
 
 // deno-lint-ignore no-explicit-any
 let puppeteerImport: any = undefined;
@@ -216,7 +217,7 @@ async function findChrome(): Promise<string | undefined> {
           programs[i],
         "(Default)",
       );
-      if (path) break;
+      if (path && existsSync(path)) break;
     }
 
     // Try the HKCR key
@@ -229,7 +230,7 @@ async function findChrome(): Promise<string | undefined> {
         );
         path = path?.match(/"(.*)"/);
         path = path ? path[1] : undefined;
-        if (path) break;
+        if (path && existsSync(path)) break;
       }
     }
   }

--- a/src/core/puppeteer.ts
+++ b/src/core/puppeteer.ts
@@ -227,9 +227,8 @@ async function findChrome(): Promise<string | undefined> {
           `HKCR\\${regKeys[i]}\\shell\\open\\command`,
           "(Default)",
         );
-        // TODO: simplify this
-        if (path) path = path.match(/".*"/);
-        if (path) path = path[0];
+        path = path?.match(/"(.*)"/);
+        path = path ? path[1] : undefined;
         if (path) break;
       }
     }


### PR DESCRIPTION
This closes #972

* It will add search for EDGE on windows, in addition of Chrome to that our pupeteer related feature works.
* It fixes an issue with the registry key return by search in `HKCR`: Command line argument where returned and we need only program path.
* I added a test existence for program path returned to avoid calling a non-working program. 

I tested interactively on my Windows 11 using default Diagram example of Quarto (https://quarto.org/docs/authoring/diagrams.html)

I did not add that yet, but we probably would like to add tests specific for Windows for this part of the code.

@cscheid do you think it would be a good idea to add a check to `http://localhost:<remote_port>/json/version` for a minimal version requirement ? 

Also, for this MSEDGE feature, I am just wondering how to handle possible older version of EDGE if we want to fail on them gracefully. I would need to find an old Windows system to test that.