### PR TITLE
[reveal] do not apply auto-stretch if aside is used

### DIFF
--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -645,15 +645,17 @@ function applyStretch(doc: Document, autoStretch: boolean) {
       const image = images[0];
       const imageEl = image as Element;
 
-      // screen out early specials divs (layout panels, columns, fragments, ...)
       if (
+        // screen out early specials divs (layout panels, columns, fragments, ...)
         findParent(imageEl, (el: Element) => {
           return el.classList.contains("column") ||
             el.classList.contains("quarto-layout-panel") ||
             el.classList.contains("fragment") ||
             el.classList.contains(kOutputLocationSlide) ||
             !!el.className.match(/panel-/);
-        })
+        }) ||
+        // Do not autostrech if an aside is used
+        slideEl.querySelectorAll("aside").length !== 0
       ) {
         continue;
       }

--- a/tests/docs/reveal/stretch.qmd
+++ b/tests/docs/reveal/stretch.qmd
@@ -235,3 +235,11 @@ plot(cars)
 ```
 
 :::
+
+## With aside on slide  {#aside}
+
+![Caption](https://revealjs.com/images/logo/reveal-black-text.svg)
+
+::: {.aside}
+Something here as an aside
+:::

--- a/tests/smoke/render/render-reveal.test.ts
+++ b/tests/smoke/render/render-reveal.test.ts
@@ -66,5 +66,6 @@ testRender(input, "revealjs", false, [
     "#custom-divs-caption img.r-stretch",
     "#custom-divs-knitr img.r-stretch",
     "#custom-divs-knitr-caption img.r-stretch",
+    "#aside img.r-stretch",
   ]),
 ]);


### PR DESCRIPTION
Closes #1013

This means that any image on a slide with an aside must be manually sized according to the remaining space. If the image size is too big in the first place, the aside part will not be out of window below the image but above the image and its caption

![image](https://user-images.githubusercontent.com/6791940/171203168-8695826d-1b52-4a28-95a4-aea73a0351be.png)
