### PR TITLE
[knitr] empty comment option must be kept and not overwritten

### DIFF
--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -96,7 +96,7 @@ knitr_hooks <- function(format, resourceDir, handledLanguages) {
   opts_hooks[["collapse"]] <- function(options) {
     if (isTRUE(options[["collapse"]])) {
       comment <- options[["comment"]]
-      if (is.null(comment) || !nzchar(comment) || is.na(comment)) {
+      if (is.null(comment) || is.na(comment)) {
         options[["comment"]] <- "##"
       }
     }

--- a/tests/docs/test-knitr-options.Rmd
+++ b/tests/docs/test-knitr-options.Rmd
@@ -1,0 +1,22 @@
+---
+title: "Plot Test"
+knit: quarto render
+---
+
+# collapse and empty comment {#comment-empty}
+
+```{r}
+#| collapse: true
+#| prompt: true
+#| comment: ""
+1 + 2
+```
+
+# collapse and specific comment {#comment-change}
+
+```{r}
+#| collapse: true
+#| prompt: true
+#| comment: $
+1 + 2
+```

--- a/tests/smoke/render/render-r.test.ts
+++ b/tests/smoke/render/render-r.test.ts
@@ -5,8 +5,8 @@
 *
 */
 
-import { docs } from "../../utils.ts";
-import { fileExists } from "../../verify.ts";
+import { docs, fileLoader } from "../../utils.ts";
+import { ensureHtmlSelectorSatisfies, fileExists } from "../../verify.ts";
 import { testRender } from "./render.ts";
 
 const plotPath = "docs/test_files/figure-html";
@@ -26,3 +26,21 @@ testRender(docs("test.Rmd"), "html", false, [
     return Deno.remove(plotPath, { recursive: true });
   },
 }, ["--execute-params", "docs/params.yml"]);
+
+const knitrOptions = fileLoader()("test-knitr-options.Rmd", "html");
+testRender(knitrOptions.input, "html", false, [
+  ensureHtmlSelectorSatisfies(
+    knitrOptions.output.outputPath,
+    "#comment-empty code",
+    (nodeList) => {
+      return /\n\[1\] 3/.test(nodeList[0].textContent);
+    },
+  ),
+  ensureHtmlSelectorSatisfies(
+    knitrOptions.output.outputPath,
+    "#comment-change code",
+    (nodeList) => {
+      return /\n\$ \[1\] 3/.test(nodeList[0].textContent);
+    },
+  ),
+]);


### PR DESCRIPTION
This fixes part of #1035 

we don't need to check this as `comment = ""` is a valid user value. The default is still `comment = NA` which will still add `##` when `collapse = TRUE` to solve #140

I took the time to add tests for knitr options in a new file. I'll add more tests in that one. 