### PR TITLE
[knitr] Correctly handle code-line-numbers=false in R chunk

### DIFF
--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -380,7 +380,7 @@ knitr_hooks <- function(format, resourceDir, handledLanguages) {
     }
     lineNumbers <- options[["code-line-numbers"]]
     if (!is.null(lineNumbers)) {
-      attr <- paste(attr, paste0('code-line-numbers="', as.character(lineNumbers), '"'))
+      attr <- paste(attr, paste0('code-line-numbers="', tolower(as.character(lineNumbers)), '"'))
     }
 
     lang <- tolower(options$engine)

--- a/tests/docs/code-highlighting/code-line-number-knitr.qmd
+++ b/tests/docs/code-highlighting/code-line-number-knitr.qmd
@@ -1,0 +1,21 @@
+---
+title: "Plot Test"
+format: html
+code-line-numbers: true
+knitr:
+  opts_chunk: 
+      eval: false
+---
+
+# with line number comment {#with-numbering}
+
+```{r}
+1 + 2
+```
+
+# no line number comment {#no-numbering}
+
+```{r}
+#| code-line-numbers: false
+1 + 2
+```

--- a/tests/smoke/render/render-code-highlighting.test.ts
+++ b/tests/smoke/render/render-code-highlighting.test.ts
@@ -1,0 +1,22 @@
+/*
+* render-r.test.ts
+*
+* Copyright (C) 2020 by RStudio, PBC
+*
+*/
+
+import { fileLoader } from "../../utils.ts";
+import { ensureHtmlElements } from "../../verify.ts";
+import { testRender } from "./render.ts";
+
+const doc = fileLoader("code-highlighting")(
+  "code-line-number-knitr.qmd",
+  "html",
+);
+testRender(doc.input, "html", false, [
+  ensureHtmlElements(
+    doc.output.outputPath,
+    ["#with-numbering div.cell-code > pre.number-lines"],
+    ["#no-numbering div.cell-code > pre.number-lines"],
+  ),
+]);


### PR DESCRIPTION
I found this while trying different examples. 

I believe `code-line-numbers: false` should correct not number lines when set on a chunk. It was currently not working because R will transform `FALSE` to `"FALSE"` and Lua filter is filtering on `"false"`