### PR TITLE
[Windows] Improve R finding for special installation

### DIFF
--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -95,7 +95,10 @@ export async function which(cmd: string) {
     { cmd: args, stderr: "piped", stdout: "piped" },
   );
   if (result.code === 0) {
-    return result.stdout?.trim();
+    return Deno.build.os === "windows"
+      // WHERE return all files found, only first is kept
+      ? result.stdout?.split("\n")[0].trim()
+      : result.stdout?.trim();
   } else {
     return undefined;
   }


### PR DESCRIPTION
This fixes #995

After some tests with R installation with Scoop and rig on Windows, here are some ajustement in what we are doing.
With this change:  
* Scoop or rig installation will be found when in terminal for PATH or registry version
* They will also be found inside RStudio where `R_HOME` is set and takes precedence. 

For `scoop`, as described in #995, the installation will not add a `Rscript.exe` file in `R_HOME/bin`, they will be in `R_HOME/bin/x64` only. I kept the adjustment simple for now by adding directly the path to `x64` folder if none is found in root `bin` folder. This is really scoped to the specific issue. If we want more generic approach, it could be clever to search for the `Rscript.exe` within the `R_HOME` folder and take the first one found. Could be done by refactoring the search in program files 
https://github.com/quarto-dev/quarto-cli/blob/abb46a31904665e3774319520e7d8473c869290d/src/core/resources.ts#L97-L106
If needed, I'll add that. 

For `rig`, it took me more time to test because I found a few issues that messed up my system; They are reported in https://github.com/r-lib/rig.  It helps though identified one thing: `which()` uses `CMD /C WHERE <binary>`. This command on windows will return all the files found, and not just the only one like `which` on Linux.  I added a handling of this: we are keeping only the first path returned. 

Regarding search in registry, , I noticed a few things that I was not sure : 

* Is there a reason to no read the version install path in two steps ? 
https://github.com/quarto-dev/quarto-cli/blob/abb46a31904665e3774319520e7d8473c869290d/src/core/resources.ts#L76-L93
`Software\\R-core\\R` as a `InstallPath` value directly. So I was wondering by curiosity. I did not change anything as this is working fine currently. 

* Slightly unrelated, we have two sets of registry reading functions: in `registry.ts` and in `windows.ts`. Should we try refactor into one set for easier upkeep in the future ? Asking because I fixed one issue in the past in `windows.ts` for chrome finding, but not the other that I wasn't aware of. 
