### PR TITLE
[knitr] Add knitr internal function that handle the prompt chunk option

### DIFF
--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -340,8 +340,11 @@ knitr_hooks <- function(format, resourceDir, handledLanguages) {
     }
   })
   knit_hooks$source <- function(x, options) {
+
+    # How knitr handles the prompt option for R chunks
+    x <- knitr:::hilight_source(x, "markdown", options)
     x <- knitr:::one_string(c('', x))
-    
+
     # leave verbatim alone
     if (options[["engine"]] %in% c("verbatim", "embed")) {
       return(paste0('\n\n````', options[["lang"]] %||% 'default', x, '\n````', '\n\n'))

--- a/tests/docs/test-knitr-options.qmd
+++ b/tests/docs/test-knitr-options.qmd
@@ -20,3 +20,29 @@ knit: quarto render
 #| comment: $
 1 + 2
 ```
+
+# With option {#prompt}
+
+```{r}
+#| prompt: true
+1 + 2
+```
+
+```{r}
+#| collapse: true
+#| prompt: true
+1 + 2
+```
+
+# Without prompt {#no-prompt}
+
+```{r}
+#| prompt: false
+1 + 2
+```
+
+```{r}
+#| collapse: true
+#| prompt: false
+1 + 2
+```

--- a/tests/smoke/render/render-r.test.ts
+++ b/tests/smoke/render/render-r.test.ts
@@ -27,7 +27,7 @@ testRender(docs("test.Rmd"), "html", false, [
   },
 }, ["--execute-params", "docs/params.yml"]);
 
-const knitrOptions = fileLoader()("test-knitr-options.Rmd", "html");
+const knitrOptions = fileLoader()("test-knitr-options.qmd", "html");
 testRender(knitrOptions.input, "html", false, [
   ensureHtmlSelectorSatisfies(
     knitrOptions.output.outputPath,
@@ -41,6 +41,20 @@ testRender(knitrOptions.input, "html", false, [
     "#comment-change code",
     (nodeList) => {
       return /\n\$ \[1\] 3/.test(nodeList[0].textContent);
+    },
+  ),
+  ensureHtmlSelectorSatisfies(
+    knitrOptions.output.outputPath,
+    "#prompt code.sourceCode",
+    (nodeList) => {
+      return Array.from(nodeList).every((e) => /^>/.test(e.textContent));
+    },
+  ),
+  ensureHtmlSelectorSatisfies(
+    knitrOptions.output.outputPath,
+    "#no-prompt code.sourceCode",
+    (nodeList) => {
+      return Array.from(nodeList).every((e) => /^[^>]/.test(e.textContent));
     },
   ),
 ]);


### PR DESCRIPTION
As we are rewriting the markdown source hook, the prompt option was not taken into account as part of knitr's source hook.

It happens in knitr in `knitr:::hilight_source()` so I used that in order to not rewrite too much knitr inside Quarto as we are already doing. 

With `knitr:::hilight_source()`, when `markdown` is passed it will only check the `options$prompt` or return the content unmodified. If you prefer that we take only the part that does that in knitr we could also copy the code
https://github.com/yihui/knitr/blob/ae6ab6e2a781c071626c3b1d04ed802a2ee4afc2/R/highlight.R#L22-L28

But in the future, refactoring a bit both **knitr** and Quarto for better compatibility without much duplication should be beneficial (tracked in https://github.com/yihui/knitr/issues/2125)

I added test for this too. 

This closes #1035 