### PR TITLE
[reveal] Apply a fix for fenced div starting with a header

### DIFF
--- a/src/resources/filters/quarto-post/reveal.lua
+++ b/src/resources/filters/quarto-post/reveal.lua
@@ -3,10 +3,15 @@
 
 function reveal()
   if _quarto.format.isRevealJsOutput() then
-    return {
-      Div = applyPosition,
-      Span = applyPosition,
-      Image = applyPosition
+    return combineFilters{
+      {
+        Div = applyPosition,
+        Span = applyPosition,
+        Image = applyPosition
+      },
+      {
+        Div = fencedDivFix
+      }
     }
   else
     return {}
@@ -40,4 +45,17 @@ function asCssSize(size)
   else
     return size
   end
+end
+
+function fencedDivFix(el)
+  -- to solve https://github.com/quarto-dev/quarto-cli/issues/976
+  -- until Pandoc may deal with it https://github.com/jgm/pandoc/issues/8098
+  if el.content[1] and el.content[1].t == "Header" and el.attr.classes:includes("fragment") then
+    level = PANDOC_WRITER_OPTIONS.slide_level
+    if level and el.content[1].level > level then
+      -- This will prevent Pandoc to create a <section>
+      el.content:insert(1, pandoc.RawBlock("html", "<!-- -->"))
+    end
+  end
+  return el
 end

--- a/tests/docs/reveal/fragments.qmd
+++ b/tests/docs/reveal/fragments.qmd
@@ -1,0 +1,19 @@
+---
+format: revealjs
+---
+
+# Text 1
+
+## Text 2 {#slide-2}
+
+Text.
+
+::: {.fragment}
+### Text 3
+
+Text.
+:::
+
+## Final Text
+
+Text.

--- a/tests/smoke/render/render-reveal.test.ts
+++ b/tests/smoke/render/render-reveal.test.ts
@@ -5,7 +5,7 @@
 *
 */
 
-import { docs, outputForInput } from "../../utils.ts";
+import { docs, fileLoader, outputForInput } from "../../utils.ts";
 import { ensureHtmlElements } from "../../verify.ts";
 import { testRender } from "./render.ts";
 
@@ -68,4 +68,12 @@ testRender(input, "revealjs", false, [
     "#custom-divs-knitr-caption img.r-stretch",
     "#aside img.r-stretch",
   ]),
+]);
+
+// fragments
+const fragmentsDiv = fileLoader("reveal")("fragments.qmd", "revealjs");
+testRender(fragmentsDiv.input, "revealjs", false, [
+  ensureHtmlElements(fragmentsDiv.output.outputPath, [
+    "#slide-2 > div.fragment > h3",
+  ], []),
 ]);


### PR DESCRIPTION
To overcome a current Pandoc limitation which makes fenced divs followed by a header a section, even if header below `--slide-level`

This closes #976 and as discussed there, it has been fixed in current Pandoc dev version, but we won't probably make an update of Pandoc version before conference. This PR adds the workaround described in https://github.com/quarto-dev/quarto-cli/issues/976#issuecomment-1144792316 

It adds a comment line right after the Div block:  Do you think this could cause an issue with our other filters ? 
`````markdown
:::: {.fragment}
<!-- -->
### Header

Content 
:::
`````

Other solution is to add an `id` on the fragment div 
````markdown
:::: {.fragment #q-frag-1}
### Header

Content 
:::
````

but I felt it was more complex to generate some random id than add comment line. 

Regarding the where for this filter, I have put that in the quarto post part really so that it applies latest and avoid issues. It could have been even considered a fix workaround to run last in quarto filter fininalizer but not sure this was design for this. 

Also, I did add the new small filter in the current `reveal.lua` file to avoid creating another one for reveal.
I just add some struggle to see how to apply two filter function on Div within one quarto filter file that will be combine together. cc @dragonstyle I did not manage to catch you live this week, so I couldn't ask directly. 

Usually a filter can return a list of list for that. Something like 
````lua
return {
  { Div = do_something, Code = do_something()},
  { Div = do_another_thing_after_first}
}
````
but this is not working within our internal Lua filter that will be combined by Quarto using `combineFilters()`

Hopefully, my own usage of `combineFilters` this way is ok. 
