### PR TITLE
Improve PDF code block display

### DIFF
--- a/src/resources/filters/common/colors.lua
+++ b/src/resources/filters/common/colors.lua
@@ -23,3 +23,52 @@ kBackgroundColorImportant = "f7dddc"
 kBackgroundColorWarning = "fcefdc"
 kBackgroundColorTip = "ccf1e3"
 kBackgroundColorCaution = "ffe5d0"
+
+local xcolors = {
+  'red',
+  'green',
+  'blue',
+  'cyan',
+  'magenta',
+  'yellow',
+  'black',
+  'gray',
+  'white',
+  'darkgray',
+  'lightgray',
+  'brown',
+  'lime',
+  'olive',
+  'orange',
+  'pink',
+  'purple',
+  'teal',
+  'violet'
+}
+
+function latexXColor(color) 
+  -- remove any hash at the front
+  color = pandoc.utils.stringify(color)
+  color = color:gsub("#","")
+
+  -- is if this is a named color we know, use that
+  if tcontains(xcolors, color) then
+    return '{named}{' .. color .. '}'
+  end
+
+  -- otherwise treat it as an HTML color
+  return "{HTML}{" .. color .. "}"
+end
+
+-- converts a hex string to a RGB
+function hextoRgb(hex)
+  -- remove any leading #
+  hex = hex:gsub("#","")
+
+  -- convert to 
+  return {
+    red = tonumber("0x"..hex:sub(1,2)), 
+    green = tonumber("0x"..hex:sub(3,4)), 
+    blue = tonumber("0x"..hex:sub(5,6))
+  }
+end

--- a/src/resources/filters/layout/layout.lua
+++ b/src/resources/filters/layout/layout.lua
@@ -46,6 +46,7 @@ import("../common/meta.lua")
 import("../common/table.lua")
 import("../common/debug.lua")
 import("../common/lunacolors.lua")
+import("../common/colors.lua")
 import("../common/log.lua")
 -- [/import]
 


### PR DESCRIPTION
- default behavior remains identical
   - left code block border
   - if non-adaptive highlight-style is specific, it provides formatting

- we now respect `code-block-bg` and user can provide named or hex colors