### PR TITLE
Adapt regex to correctly match table environments in LaTeX 

### DIFF
--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -1465,13 +1465,13 @@ end
 
 local latexTableWithOptionsPattern = "(\\begin{table}%[%w+%])(.*)(\\end{table})"
 local latexTablePattern = "(\\begin{table})(.*)(\\end{table})"
-local latexLongtablePatternwWithPosAndAlign = "(\\begin{longtable}%[[^%]]+%]{.*})(.*)(\\end{longtable})"
+local latexLongtablePatternwWithPosAndAlign = "(\\begin{longtable}%[[^%]]+%]{.-})(.*)(\\end{longtable})"
 local latexLongtablePatternWithPos = "(\\begin{longtable}%[[^%]]+%])(.*)(\\end{longtable})"
-local latexLongtablePatternWithAlign = "(\\begin{longtable}{.*})(.*)(\\end{longtable})"
+local latexLongtablePatternWithAlign = "(\\begin{longtable}{.-})(.*)(\\end{longtable})"
 local latexLongtablePattern = "(\\begin{longtable})(.*)(\\end{longtable})"
-local latexTabularPatternWithPosAndAlign = "(\\begin{tabular}%[[^%]]+%]{.*})(.*)(\\end{tabular})"
+local latexTabularPatternWithPosAndAlign = "(\\begin{tabular}%[[^%]]+%]{.-})(.*)(\\end{tabular})"
 local latexTabularPatternWithPos = "(\\begin{tabular}%[[^%]]+%])(.*)(\\end{tabular})"
-local latexTabularPatternWithAlign = "(\\begin{tabular}{.*})(.*)(\\end{tabular})"
+local latexTabularPatternWithAlign = "(\\begin{tabular}{.-})(.*)(\\end{tabular})"
 local latexTabularPattern = "(\\begin{tabular})(.*)(\\end{tabular})"
 
 local latexTablePatterns = pandoc.List({


### PR DESCRIPTION
Fixes #1093

It seems like I need to use special `.-` pattern to match correctly the table environment part. 

<details>
<summary>Qmd file </summary>

````markdown
---
title: "test"
format: pdf
keep-tex: true
keep-md: true
---

```{r}
#| label: tbl-one
#| tbl-cap: "A table"
#| echo: fenced

mtcars[1:2,] |> tibble::rownames_to_column() |> gt::gt(rowname_col = "rowname")
```

````

</details>

**gt** produces the following table
````latex
\captionsetup[table]{labelformat=empty,skip=1pt}
\begin{longtable}{r|rrrrrrrrrrr}
\toprule
\multicolumn{1}{l}{} & mpg & cyl & disp & hp & drat & wt & qsec & vs & am & gear & carb \\ 
\midrule
Mazda RX4 & 21 & 6 & 160 & 110 & 3.9 & 2.620 & 16.46 & 0 & 1 & 4 & 4 \\ 
Mazda RX4 Wag & 21 & 6 & 160 & 110 & 3.9 & 2.875 & 17.02 & 0 & 1 & 4 & 4 \\ 
\bottomrule
\end{longtable}
````

And Quarto was inserting in the wrong place causing issue in LaTeX
````latex
\hypertarget{tbl-one}{}
\captionsetup[table]{labelformat=empty,skip=1pt}
\begin{longtable}{r|rrrrrrrrrrr}
\toprule
\multicolumn{1}{l}{}
\caption{\label{tbl-one}A table }\tabularnewline
 & mpg & cyl & disp & hp & drat & wt & qsec & vs & am & gear & carb \\ 
\midrule
Mazda RX4 & 21 & 6 & 160 & 110 & 3.9 & 2.620 & 16.46 & 0 & 1 & 4 & 4 \\ 
Mazda RX4 Wag & 21 & 6 & 160 & 110 & 3.9 & 2.875 & 17.02 & 0 & 1 & 4 & 4 \\ 
\bottomrule
\end{longtable}
````

Changing the regex correctly place the table after `\begin{longtable}{r|rrrrrrrrrrr}`

````latex
\hypertarget{tbl-one}{}
\captionsetup[table]{labelformat=empty,skip=1pt}
\begin{longtable}{r|rrrrrrrrrrr}
\caption{\label{tbl-one}A table }\tabularnewline

\toprule
\multicolumn{1}{l}{} & mpg & cyl & disp & hp & drat & wt & qsec & vs & am & gear & carb \\ 
\midrule
Mazda RX4 & 21 & 6 & 160 & 110 & 3.9 & 2.620 & 16.46 & 0 & 1 & 4 & 4 \\ 
Mazda RX4 Wag & 21 & 6 & 160 & 110 & 3.9 & 2.875 & 17.02 & 0 & 1 & 4 & 4 \\ 
\bottomrule
\end{longtable}
````

