### PR TITLE
Forward paths to bibinputs as well as texinputs

### DIFF
--- a/src/command/render/latexmk/latex.ts
+++ b/src/command/render/latexmk/latex.ts
@@ -135,6 +135,7 @@ export async function runBibEngine(
   input: string,
   cwd: string,
   pkgMgr?: PackageManager,
+  texInputDirs?: string[],
   quiet?: boolean,
 ): Promise<LatexCommandReponse> {
   const [dir, stem] = dirAndStem(input);
@@ -151,6 +152,7 @@ export async function runBibEngine(
     {
       pkgMgr,
       cwd,
+      texInputDirs,
     },
     quiet,
   );
@@ -190,6 +192,7 @@ async function runLatexCommand(
     // note this  //
     runOptions.env = runOptions.env || {};
     runOptions.env["TEXINPUTS"] = `${context.texInputDirs.join(";")};`;
+    runOptions.env["BSTINPUTS"] = `${context.texInputDirs.join(";")};`;
   }
 
   // Run the command

--- a/src/command/render/latexmk/pdf.ts
+++ b/src/command/render/latexmk/pdf.ts
@@ -81,6 +81,7 @@ export async function generatePdf(mkOptions: LatexmkOptions): Promise<string> {
     mkOptions.engine.bibEngine || "citeproc",
     pkgMgr,
     mkOptions.outputDir,
+    mkOptions.texInputDirs,
     mkOptions.quiet,
   );
 
@@ -291,6 +292,7 @@ async function makeBibliographyIntermediates(
   engine: string,
   pkgMgr: PackageManager,
   outputDir?: string,
+  texInputDirs?: string[],
   quiet?: boolean,
 ) {
   // Generate bibliography (including potentially installing missing packages)
@@ -349,6 +351,7 @@ async function makeBibliographyIntermediates(
           auxBibPath,
           cwd,
           pkgMgr,
+          texInputDirs,
           quiet,
         );
 


### PR DESCRIPTION
Without this, the texinput path will not be used to resolve BST files