### PR TITLE
add ojs_define to julia

### DIFF
--- a/src/resources/jupyter/lang/julia/setup.jl
+++ b/src/resources/jupyter/lang/julia/setup.jl
@@ -63,5 +63,29 @@ catch e
   @warn "Run path init:" exception=(e, catch_backtrace())
 end
 
+# ojs_define support
+try
+  # if DataFrames and JSONTables are available, 
+  # use it to convert dataframes to json automatically
+  import JSON, DataFrames, JSONTables
+
+  function ojs_define(; kwargs...)
+    convert(x) = x
+    convert(x::DataFrames.AbstractDataFrame) = JSONTables.ArrayTable(Tables.rows(x))
+  
+    content = Dict("contents" => [Dict("name" => k, "value" => convert(v)) for (k, v) in kwargs])
+    tag = "<script type='ojs-define'>$(JSON.write(content))</script>"
+    IJulia.display(MIME("text/html"), tag)
+  end
+catch e
+  import JSON
+  
+  function ojs_define(; kwargs...)
+    content = Dict("contents" => [Dict("name" => k, "value" => v) for (k, v) in kwargs])
+    tag = "<script type='ojs-define'>$(JSON.json(content))</script>"
+    IJulia.display(MIME("text/html"), tag)
+  end
+end
+
 # don't return kernel dependencies (b/c Revise should take care of dependencies)
 nothing


### PR DESCRIPTION
Addresses #1203.

This version of `ojs_define` uses JSON instead of JSON3 (since this is already a dependency of ours in IJulia), and only uses DataFrames and JSONTables when those exist.

Note that this PR adds `JSON.jl` as a Julia requirement for quarto. Since `JSON.jl` is already a dependency of IJulia, this shouldn't make the installation any harder, but we need to change the website documentation (which [I have](https://github.com/quarto-dev/quarto-web/blob/main/docs/computations/julia.qmd))