### PR TITLE
Correctly find R in registry when first key searched is not found

### DIFF
--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -18,7 +18,7 @@ export async function registryReadString(
   // if an array is passed then call each one in turn
   if (Array.isArray(root)) {
     for (const r of root) {
-      const val = registryReadString(r, key, value);
+      const val = await registryReadString(r, key, value);
       if (val !== undefined) {
         return val;
       }


### PR DESCRIPTION
I think this is needed for this to correctly work 
https://github.com/quarto-dev/quarto-cli/blob/d29e5dab8908569c1a888a389bca1c3effbe0ff6/src/core/registry.ts#L21-L24

Otherwise `val` will be a Promise and `val !== undefined` not what it expected

This issue appeared following https://github.com/quarto-dev/quarto-cli/commit/966fd980313795e7f995b0b1098657821e417bd5 as `HKCU` does not have the key, but `HKLM` does. At least on my computer as I got

````powershell
❯ quarto check knitr
[>] Checking R installation...........(None)

      Unable to locate an installed version of R.
      Install R from https://cloud.r-project.org/
````

This does not solve probably https://github.com/quarto-dev/quarto-cli/issues/1225 but related to its debugging. 

Adding an `await` here makes sense right ? 

