### PR TITLE
Do not apply autostretch if image uses absolute positioning

### DIFF
--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -707,7 +707,9 @@ function applyStretch(doc: Document, autoStretch: boolean) {
           !hasStretchClass(imageEl) &&
           // if height is already set, we do nothing
           !imageEl.getAttribute("style")?.match("height:") &&
-          !imageEl.hasAttribute("height")
+          !imageEl.hasAttribute("height") &&
+          // do not add when .absolute is used
+          !imageEl.classList.contains("absolute")
         ) {
           imageEl.classList.add("r-stretch");
         }

--- a/tests/docs/reveal/stretch.qmd
+++ b/tests/docs/reveal/stretch.qmd
@@ -243,3 +243,9 @@ plot(cars)
 ::: {.aside}
 Something here as an aside
 :::
+
+## No auto stretch if absolue is used {#absolute}
+
+See the feature https://quarto.org/docs/presentations/revealjs/advanced.html#absolute-position from
+
+![](https://quarto.org/quarto.png){.absolute width=500}

--- a/tests/smoke/render/render-reveal.test.ts
+++ b/tests/smoke/render/render-reveal.test.ts
@@ -67,6 +67,7 @@ testRender(input, "revealjs", false, [
     "#custom-divs-knitr img.r-stretch",
     "#custom-divs-knitr-caption img.r-stretch",
     "#aside img.r-stretch",
+    "#absolute img.r-stretch",
   ]),
 ]);
 


### PR DESCRIPTION
This solves #1238 

@jjallaire I think when `.absolute` is used it makes sense not to apply auto stretch so I added the filtering of image with this class. 

I let you see if you consider this good for v1 or not. 
