### PR TITLE
`code-block-border-left: false` correctly deactivate unnecessary meta insertion

### DIFF
--- a/src/resources/filters/layout/meta.lua
+++ b/src/resources/filters/layout/meta.lua
@@ -28,7 +28,7 @@ function layoutMetaInject()
       local kCodeBlockBackground = 'code-block-bg'
 
       -- Track whether to show a border or background
-      local useCodeBlockBorder = (adaptiveTextHighlighting and meta[kCodeBlockBorderLeft] == nil and meta[kCodeBlockBackground] == nil) or meta[kCodeBlockBorderLeft] ~= nil
+      local useCodeBlockBorder = (adaptiveTextHighlighting and meta[kCodeBlockBorderLeft] == nil and meta[kCodeBlockBackground] == nil) or not meta[kCodeBlockBorderLeft] == false
       local useCodeBlockBg = meta[kCodeBlockBackground] ~= nil
 
       -- if we're going to display a border or background

--- a/src/resources/filters/layout/meta.lua
+++ b/src/resources/filters/layout/meta.lua
@@ -28,8 +28,9 @@ function layoutMetaInject()
       local kCodeBlockBackground = 'code-block-bg'
 
       -- Track whether to show a border or background
-      local useCodeBlockBorder = (adaptiveTextHighlighting and meta[kCodeBlockBorderLeft] == nil and meta[kCodeBlockBackground] == nil) or not meta[kCodeBlockBorderLeft] == false
-      local useCodeBlockBg = meta[kCodeBlockBackground] ~= nil
+      -- Both options could be undefined, true / false or set to a color value
+      local useCodeBlockBorder = (adaptiveTextHighlighting and meta[kCodeBlockBorderLeft] == nil and meta[kCodeBlockBackground] == nil) or (meta[kCodeBlockBorderLeft] ~= nil and meta[kCodeBlockBorderLeft] ~= false)
+      local useCodeBlockBg = meta[kCodeBlockBackground] ~= nil and meta[kCodeBlockBackground] ~= false
 
       -- if we're going to display a border or background
       -- we need to inject color handling as well as the 


### PR DESCRIPTION
This is targeting the deactivation of this feature 
https://quarto.org/docs/authoring/article-layout.html#code-blocks

`code-block-border-left: false` was still not preventing the insertion of all the Meta for LaTeX in the document, which is causing issues for custom templates.

(for context, PLOS template does not work with the `breakable` option in `tcolorbox` and I can't work around that except deactivating) 

My understanding is that if `code-block-border-left: false` is passed, then some content should not be included. Currently test is
```
meta['code-block-border-left'] != nil
```
which will be TRUE even if `code-block-border-left: false`

If I misunderstood this feature, please ignore, but I'll be happy to understand how this works so that I can't correctly adapt for our template to work. 

cc @dragonstyle 
