### PR TITLE
fix typo

### DIFF
--- a/src/command/render/filters.ts
+++ b/src/command/render/filters.ts
@@ -109,7 +109,7 @@ export function filterParamsJson(
   return JSON.stringify(params);
 }
 
-export function removeFilterParmas(metadata: Metadata) {
+export function removeFilterParams(metadata: Metadata) {
   delete metadata[kQuartoParams];
 }
 

--- a/src/command/render/pandoc.ts
+++ b/src/command/render/pandoc.ts
@@ -74,7 +74,7 @@ import {
 import {
   filterParamsJson,
   quartoInitFilter,
-  removeFilterParmas,
+  removeFilterParams,
 } from "./filters.ts";
 import {
   kAbstract,
@@ -1128,7 +1128,7 @@ function runPandocMessage(
     delete printMetadata.format;
 
     // remove filter params
-    removeFilterParmas(printMetadata);
+    removeFilterParams(printMetadata);
     // print message
     if (Object.keys(printMetadata).length > 0) {
       info("metadata", { bold: true });


### PR DESCRIPTION
removeFilterParams was removeFilterParmas.

Found this by chance while looking through the source code to find a solution for https://github.com/quarto-dev/quarto-cli/discussions/1000