### PR TITLE
Support for Extension Embedding

### DIFF
--- a/src/command/install/cmd.ts
+++ b/src/command/install/cmd.ts
@@ -25,6 +25,10 @@ export const installCommand = new Command()
     "--no-prompt",
     "Do not prompt to confirm actions",
   )
+  .option(
+    "--embed <extensionId>",
+    "Embed this extension within another extension (used when authoring extensions).",
+  )
   .description(
     "Installs an extension or global dependency.",
   )
@@ -53,14 +57,23 @@ export const installCommand = new Command()
     "quarto install tool",
   )
   .action(
-    async (options: { prompt?: boolean }, type: string, target?: string) => {
+    async (
+      options: { prompt?: boolean; embed?: string },
+      type: string,
+      target?: string,
+    ) => {
       await initYamlIntelligenceResourcesFromFilesystem();
       const temp = createTempContext();
       try {
         if (type.toLowerCase() === "extension") {
           // Install an extension
           if (target) {
-            await installExtension(target, temp, options.prompt !== false);
+            await installExtension(
+              target,
+              temp,
+              options.prompt !== false,
+              options.embed,
+            );
           } else {
             info("Please provide an extension name, url, or path.");
           }

--- a/src/command/remove/cmd.ts
+++ b/src/command/remove/cmd.ts
@@ -80,6 +80,8 @@ export const removeCommand = new Command()
 
           const resolveTargetDir = () => {
             if (options.embed) {
+              // We're removing an embedded extension, lookup the extension
+              // and use its path
               const context = createExtensionContext();
               const extension = context.extension(
                 options.embed,
@@ -91,6 +93,7 @@ export const removeCommand = new Command()
                 throw new Error(`Unable to find extension '${options.embed}.`);
               }
             } else {
+              // Just use the current directory
               return workingDir;
             }
           };

--- a/src/command/remove/cmd.ts
+++ b/src/command/remove/cmd.ts
@@ -83,7 +83,7 @@ export const removeCommand = new Command()
               const context = createExtensionContext();
               const extension = context.extension(
                 options.embed,
-                join(workingDir, "test.qmd"),
+                workingDir,
               );
               if (extension) {
                 return extension?.path;

--- a/src/command/remove/cmd.ts
+++ b/src/command/remove/cmd.ts
@@ -25,6 +25,7 @@ import {
   selectTool,
 } from "../../tools/tools-console.ts";
 import { haveArrowKeys } from "../../core/platform.ts";
+import { join } from "path/mod.ts";
 
 export const removeCommand = new Command()
   .hidden()
@@ -34,6 +35,10 @@ export const removeCommand = new Command()
   .option(
     "--no-prompt",
     "Do not prompt to confirm actions",
+  )
+  .option(
+    "--embed <extensionId>",
+    "Remove this extension from within another extension (used when authoring extensions).",
   )
   .description(
     "Removes an extension or global dependency.",
@@ -59,7 +64,11 @@ export const removeCommand = new Command()
     "quarto remove tool",
   )
   .action(
-    async (options: { prompt?: boolean }, type: string, target?: string) => {
+    async (
+      options: { prompt?: boolean; embed?: string },
+      type: string,
+      target?: string,
+    ) => {
       await initYamlIntelligenceResourcesFromFilesystem();
       const temp = createTempContext();
       const extensionContext = createExtensionContext();
@@ -67,7 +76,25 @@ export const removeCommand = new Command()
       try {
         if (type.toLowerCase() === "extension") {
           // Not provided, give the user a list to select from
-          const targetDir = Deno.cwd();
+          const workingDir = Deno.cwd();
+
+          const resolveTargetDir = () => {
+            if (options.embed) {
+              const context = createExtensionContext();
+              const extension = context.extension(
+                options.embed,
+                join(workingDir, "test.qmd"),
+              );
+              if (extension) {
+                return extension?.path;
+              } else {
+                throw new Error(`Unable to find extension '${options.embed}.`);
+              }
+            } else {
+              return workingDir;
+            }
+          };
+          const targetDir = resolveTargetDir();
 
           // Process extension
           if (target) {

--- a/src/command/update/cmd.ts
+++ b/src/command/update/cmd.ts
@@ -24,6 +24,10 @@ export const updateCommand = new Command()
     "--no-prompt",
     "Do not prompt to confirm actions",
   )
+  .option(
+    "--embed <extensionId>",
+    "Embed this extension within another extension (used when authoring extensions).",
+  )
   .description(
     "Updates an extension or global dependency.",
   )
@@ -52,14 +56,23 @@ export const updateCommand = new Command()
     "quarto update tool",
   )
   .action(
-    async (options: { prompt?: boolean }, type: string, target?: string) => {
+    async (
+      options: { prompt?: boolean; embed?: string },
+      type: string,
+      target?: string,
+    ) => {
       await initYamlIntelligenceResourcesFromFilesystem();
       const temp = createTempContext();
       try {
         if (type.toLowerCase() === "extension") {
           // Install an extension
           if (target) {
-            await installExtension(target, temp, options.prompt !== false);
+            await installExtension(
+              target,
+              temp,
+              options.prompt !== false,
+              options.embed,
+            );
           } else {
             info("Please provide an extension name, url, or path.");
           }

--- a/src/extension/extension-shared.ts
+++ b/src/extension/extension-shared.ts
@@ -5,7 +5,7 @@
 *
 */
 import SemVer from "semver/mod.ts";
-import { Metadata, PandocFilter } from "../config/types.ts";
+import { Metadata, QuartoFilter } from "../config/types.ts";
 import { ProjectContext } from "../project/types.ts";
 
 export const kCommon = "common";
@@ -24,7 +24,7 @@ export interface Extension extends Record<string, unknown> {
   path: string;
   contributes: {
     shortcodes?: string[];
-    filters?: PandocFilter[];
+    filters?: QuartoFilter[];
     format?: Record<string, unknown>;
   };
 }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -129,13 +129,13 @@ const loadExtension = (
     } else {
       // This extension doesn't have an _extension file
       throw new Error(
-        `Extension ${extension} is missing the expected _extensions.yml file.`,
+        `The extension '${extension}' is missing the expected '_extensions.yml' file.`,
       );
     }
   } else {
     // There is no extension with this name!
     throw new Error(
-      `Unable to find extension ${extension}. Please ensure that the extension is installed.`,
+      `Unable to read the extension '${extension}'.\nPlease ensure that you provided the correct id and that the extension is installed.`,
     );
   }
 };
@@ -404,7 +404,7 @@ function readExtension(
       return resolveFilter(embeddedExtensions, extensionDir, filter);
     },
   );
-  const format = contributes?.format as Metadata || [];
+  const format = contributes?.format as Metadata || {};
 
   // Process the special 'common' key by merging it
   // into any key that isn't 'common' and then removing it
@@ -505,7 +505,7 @@ function validateExtensionPath(
   const resolves = existsSync(join(dir, path));
   if (!resolves) {
     throw Error(
-      `Failed to resolve referenced ${type} ${path} - path does not exist.\nIf you attempting to use another extension within this extension, please ensure the referenced extension is embedded properly.`,
+      `Failed to resolve referenced ${type} ${path} - path does not exist.\nIf you attempting to use another extension within this extension, please install the extension using the 'quarto install --embedded' command.`,
     );
   }
   return resolves;
@@ -535,7 +535,7 @@ function toExtensionId(extension: string) {
   }
 }
 
-const extensionFile = (dir: string) => {
+export const extensionFile = (dir: string) => {
   return ["_extension.yml", "_extension.yaml"]
     .map((file) => join(dir, file))
     .find(existsSync);

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -140,6 +140,8 @@ const loadExtension = (
   }
 };
 
+// Searches extensions for an extension(s) with a specified
+// Id and which optionally contributes specific extension elements
 function findExtensions(
   extensions: Extension[],
   extensionId: ExtensionId,
@@ -436,6 +438,9 @@ function readExtension(
   };
 }
 
+// This will resolve a shortcode contributed by this extension
+// loading embedded extensions and replacing the extension name
+// with the contributed shortcode paths
 function resolveShortcode(
   embeddedExtensions: Extension[],
   dir: string,
@@ -464,6 +469,9 @@ function resolveShortcode(
   }
 }
 
+// This will replace the given QuartoFilter with one more resolved filters,
+// loading embedded extensions (if referenced) and replacing the extension
+// name with any filters that the embedded extension provides.
 function resolveFilter(
   embeddedExtensions: Extension[],
   dir: string,
@@ -493,6 +501,9 @@ function resolveFilter(
   }
 }
 
+// Validates that the path exists. For filters and short codes used in extensions,
+// either the item should resolve using an embedded extension, or the path
+// should exist. You cannot reference a non-existent file in an extension
 function validateExtensionPath(
   type: "filter" | "shortcode",
   dir: string,

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -324,7 +324,7 @@ export function discoverExtensionPath(
   };
 
   // Start in the source directory
-  const sourceDir = dirname(input);
+  const sourceDir = Deno.statSync(input).isDirectory ? input : dirname(input);
   const sourceDirAbs = Deno.realPathSync(sourceDir);
 
   if (project && isSubdir(project.dir, sourceDirAbs)) {
@@ -393,7 +393,10 @@ function readExtension(
   const embeddedExtensions = existsSync(join(extensionDir, kExtensionDir))
     ? readExtensions(join(extensionDir, kExtensionDir))
     : [];
+
   // The items that can be contributed
+  // Resolve shortcodes and filters (these might come from embedded extension)
+  // Note that resolving will throw if the extension cannot be resolved
   const shortcodes = (contributes?.shortcodes as string[] || []).flatMap((
     shortcode,
   ) => {
@@ -417,13 +420,6 @@ function readExtension(
     );
   });
   delete format[kCommon];
-
-  // For each of the formats, see if the filters or shortcode
-  // have extensions that need to be resolved
-  // For both shortcodes and filters, I need to resolve all filters or remove them from the list (and warn)
-  // For filters, they _must_ resolve into a file, otherwise they will be removed
-
-  //read extensions and resolve shortcode / filter extensions
 
   // Create the extension data structure
   return {

--- a/src/extension/install.ts
+++ b/src/extension/install.ts
@@ -109,7 +109,7 @@ async function determineInstallDir(
   if (embed) {
     // We're embeddeding this within an extension, perform some validation
     const context = createExtensionContext();
-    const extension = context.extension(embed, join(dir, "test.qmd"));
+    const extension = context.extension(embed, dir);
     if (extension) {
       if (Object.keys(extension?.contributes.format || {}).length > 0) {
         return extension?.path;

--- a/src/extension/install.ts
+++ b/src/extension/install.ts
@@ -107,9 +107,13 @@ async function determineInstallDir(
   embed?: string,
 ) {
   if (embed) {
-    // We're embeddeding this within an extension, perform some validation
+    // We're embeddeding this within an extension
+    const extensionName = embed;
     const context = createExtensionContext();
-    const extension = context.extension(embed, dir);
+
+    // Load the extension to be sure it exists and then
+    // use its path as the target for installation
+    const extension = context.extension(extensionName, dir);
     if (extension) {
       if (Object.keys(extension?.contributes.format || {}).length > 0) {
         return extension?.path;
@@ -124,6 +128,8 @@ async function determineInstallDir(
       );
     }
   } else {
+    // We're not embeddeding, check if we're in a project
+    // and offer to use that directory if we are
     const project = await projectContext(dir);
     if (project && project.dir !== dir) {
       const question = "Install extension into project?";

--- a/src/extension/install.ts
+++ b/src/extension/install.ts
@@ -17,11 +17,7 @@ import { copyTo } from "../core/copy.ts";
 import { Extension, kExtensionDir } from "./extension-shared.ts";
 import { withSpinner } from "../core/console.ts";
 import { downloadWithProgress } from "../core/download.ts";
-import {
-  createExtensionContext,
-  extensionFile,
-  readExtensions,
-} from "./extension.ts";
+import { createExtensionContext, readExtensions } from "./extension.ts";
 import { info } from "log/mod.ts";
 import { ExtensionSource, extensionSource } from "./extension-host.ts";
 

--- a/src/extension/remove.ts
+++ b/src/extension/remove.ts
@@ -4,8 +4,22 @@
 * Copyright (C) 2020 by RStudio, PBC
 *
 */
-import { Extension } from "./extension-shared.ts";
+import { basename, dirname } from "path/mod.ts";
+import { removeIfEmptyDir } from "../core/path.ts";
+import { Extension, kExtensionDir } from "./extension-shared.ts";
 
-export function removeExtension(extension: Extension) {
-  return Deno.remove(extension.path, { recursive: true });
+export async function removeExtension(extension: Extension) {
+  // Delete the extension
+  await Deno.remove(extension.path, { recursive: true });
+
+  // Remove the container directory, if empty
+  const extensionDir = dirname(extension.path);
+  removeIfEmptyDir(extensionDir);
+
+  // If the parent directory is an _extensions directory which is itself empty
+  // remove that too
+  const parentDir = dirname(extensionDir);
+  if (parentDir && basename(parentDir) === kExtensionDir) {
+    removeIfEmptyDir(parentDir);
+  }
 }

--- a/src/format/formats-shared.ts
+++ b/src/format/formats-shared.ts
@@ -8,7 +8,6 @@
 import { mergeConfigs } from "../core/config.ts";
 
 import {
-  kBiblioConfig,
   kCache,
   kCodeFold,
   kCodeLineNumbers,


### PR DESCRIPTION
Add support for the ability to embed extensions within other extensions. To install an extension into another extension, use:

`quarto install extension <ext-to-install> --embed <ext-to-embed-within>`

Embedding is only supported for format extensions (e.g. formats can embed the filters / shortcodes from other extensions).

The `quarto update` and `quarto remove` command also accept an optional `--embed` argument.
