### PR TITLE
Correctly support multiple classes on title

### DIFF
--- a/src/project/types/book/book-render.ts
+++ b/src/project/types/book/book-render.ts
@@ -365,7 +365,7 @@ async function mergeExecutedFiles(
                 const keyValueStr = attr.keyvalue.map((kv) => {
                   const escapedValue = kv[1].replaceAll(/"/gm, '\\"');
                   return `${kv[0]}="${escapedValue}" `;
-                });
+                }).join("");
                 const attrContents = `${idStr}${clzStr}${keyValueStr}`.trim();
                 attrStr = `{${attrContents}}`;
               }

--- a/src/project/types/book/book-render.ts
+++ b/src/project/types/book/book-render.ts
@@ -361,7 +361,7 @@ async function mergeExecutedFiles(
                 const idStr = attr.id !== "" ? `#${attr.id} ` : "";
                 const clzStr = attr.classes.map((clz) => {
                   return `.${clz} `;
-                });
+                }).join("");
                 const keyValueStr = attr.keyvalue.map((kv) => {
                   const escapedValue = kv[1].replaceAll(/"/gm, '\\"');
                   return `${kv[0]}="${escapedValue}" `;


### PR DESCRIPTION
fixes #1297

When multiple classes are provided on heading e.g
````
# Preface {.unnumbered .unlisted}
````

we need to correctly rewrite the markdown from the parsed file to create valid Pandoc markdown. 

By default in string interpolation, `array.join(',')` will be used. So we apply joining with no separator in the step before
