### PR TITLE
Ignore yaml separators surrounded by empty lines

### DIFF
--- a/src/core/lib/break-quarto-md.ts
+++ b/src/core/lib/break-quarto-md.ts
@@ -171,7 +171,7 @@ export async function breakQuartoMd(
 
   const inPlainText = () => !inCodeCell && !inCode && !inMathBlock && !inYaml;
 
-  const isYamlDelimiter = (line: string, index: number) => {
+  const isYamlDelimiter = (line: string, index: number, skipHRs?: boolean) => {
     if (!yamlRegEx.test(line)) {
       return false;
     }
@@ -179,6 +179,7 @@ export async function breakQuartoMd(
     // if a yaml delimiter is surrounded by whitespace-only lines,
     // then it is actually an HR element; treat it as such.
     if (
+      skipHRs &&
       index > 0 && srcLines[index - 1].substring.trim() === "" &&
       index < srcLines.length - 1 && srcLines[index + 1].substring.trim() === ""
     ) {
@@ -195,7 +196,7 @@ export async function breakQuartoMd(
     const directiveMatch = isBlockShortcode(line.substring);
     // yaml front matter
     if (
-      isYamlDelimiter(line.substring, i) &&
+      isYamlDelimiter(line.substring, i, !inYaml) &&
       !inCodeCell && !inCode && !inMathBlock
     ) {
       if (inYaml) {

--- a/src/core/lib/break-quarto-md.ts
+++ b/src/core/lib/break-quarto-md.ts
@@ -171,6 +171,23 @@ export async function breakQuartoMd(
 
   const inPlainText = () => !inCodeCell && !inCode && !inMathBlock && !inYaml;
 
+  const isYamlDelimiter = (line: string, index: number) => {
+    if (!yamlRegEx.test(line)) {
+      return false;
+    }
+
+    // if a yaml delimiter is surrounded by whitespace-only lines,
+    // then it is actually an HR element; treat it as such.
+    if (
+      index > 0 && srcLines[index - 1].substring.trim() === "" &&
+      index < srcLines.length - 1 && srcLines[index + 1].substring.trim() === ""
+    ) {
+      return false;
+    }
+
+    return true;
+  };
+
   const srcLines = rangedLines(src.value, true);
 
   for (let i = 0; i < srcLines.length; ++i) {
@@ -178,8 +195,8 @@ export async function breakQuartoMd(
     const directiveMatch = isBlockShortcode(line.substring);
     // yaml front matter
     if (
-      yamlRegEx.test(line.substring) && !inCodeCell && !inCode &&
-      !inMathBlock
+      isYamlDelimiter(line.substring, i) &&
+      !inCodeCell && !inCode && !inMathBlock
     ) {
       if (inYaml) {
         lineBuffer.push(line);

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -27652,11 +27652,11 @@ async function breakQuartoMd(src, validate2 = false) {
   const tickCount = (s) => Array.from(s.split(" ")[0] || "").filter((c) => c === "`").length;
   let inYaml = false, inMathBlock = false, inCodeCell = false, inCode = 0;
   const inPlainText = () => !inCodeCell && !inCode && !inMathBlock && !inYaml;
-  const isYamlDelimiter = (line, index) => {
+  const isYamlDelimiter = (line, index, skipHRs) => {
     if (!yamlRegEx.test(line)) {
       return false;
     }
-    if (index > 0 && srcLines[index - 1].substring.trim() === "" && index < srcLines.length - 1 && srcLines[index + 1].substring.trim() === "") {
+    if (skipHRs && index > 0 && srcLines[index - 1].substring.trim() === "" && index < srcLines.length - 1 && srcLines[index + 1].substring.trim() === "") {
       return false;
     }
     return true;
@@ -27665,7 +27665,7 @@ async function breakQuartoMd(src, validate2 = false) {
   for (let i = 0; i < srcLines.length; ++i) {
     const line = srcLines[i];
     const directiveMatch = isBlockShortcode(line.substring);
-    if (isYamlDelimiter(line.substring, i) && !inCodeCell && !inCode && !inMathBlock) {
+    if (isYamlDelimiter(line.substring, i, !inYaml) && !inCodeCell && !inCode && !inMathBlock) {
       if (inYaml) {
         lineBuffer.push(line);
         await flushLineBuffer("raw", i);

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -27652,11 +27652,20 @@ async function breakQuartoMd(src, validate2 = false) {
   const tickCount = (s) => Array.from(s.split(" ")[0] || "").filter((c) => c === "`").length;
   let inYaml = false, inMathBlock = false, inCodeCell = false, inCode = 0;
   const inPlainText = () => !inCodeCell && !inCode && !inMathBlock && !inYaml;
+  const isYamlDelimiter = (line, index) => {
+    if (!yamlRegEx.test(line)) {
+      return false;
+    }
+    if (index > 0 && srcLines[index - 1].substring.trim() === "" && index < srcLines.length - 1 && srcLines[index + 1].substring.trim() === "") {
+      return false;
+    }
+    return true;
+  };
   const srcLines = rangedLines(src.value, true);
   for (let i = 0; i < srcLines.length; ++i) {
     const line = srcLines[i];
     const directiveMatch = isBlockShortcode(line.substring);
-    if (yamlRegEx.test(line.substring) && !inCodeCell && !inCode && !inMathBlock) {
+    if (isYamlDelimiter(line.substring, i) && !inCodeCell && !inCode && !inMathBlock) {
       if (inYaml) {
         lineBuffer.push(line);
         await flushLineBuffer("raw", i);

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -27666,11 +27666,20 @@ ${sourceContext}`;
     const tickCount = (s) => Array.from(s.split(" ")[0] || "").filter((c) => c === "`").length;
     let inYaml = false, inMathBlock = false, inCodeCell = false, inCode = 0;
     const inPlainText = () => !inCodeCell && !inCode && !inMathBlock && !inYaml;
+    const isYamlDelimiter = (line, index) => {
+      if (!yamlRegEx.test(line)) {
+        return false;
+      }
+      if (index > 0 && srcLines[index - 1].substring.trim() === "" && index < srcLines.length - 1 && srcLines[index + 1].substring.trim() === "") {
+        return false;
+      }
+      return true;
+    };
     const srcLines = rangedLines(src.value, true);
     for (let i = 0; i < srcLines.length; ++i) {
       const line = srcLines[i];
       const directiveMatch = isBlockShortcode(line.substring);
-      if (yamlRegEx.test(line.substring) && !inCodeCell && !inCode && !inMathBlock) {
+      if (isYamlDelimiter(line.substring, i) && !inCodeCell && !inCode && !inMathBlock) {
         if (inYaml) {
           lineBuffer.push(line);
           await flushLineBuffer("raw", i);

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -27666,11 +27666,11 @@ ${sourceContext}`;
     const tickCount = (s) => Array.from(s.split(" ")[0] || "").filter((c) => c === "`").length;
     let inYaml = false, inMathBlock = false, inCodeCell = false, inCode = 0;
     const inPlainText = () => !inCodeCell && !inCode && !inMathBlock && !inYaml;
-    const isYamlDelimiter = (line, index) => {
+    const isYamlDelimiter = (line, index, skipHRs) => {
       if (!yamlRegEx.test(line)) {
         return false;
       }
-      if (index > 0 && srcLines[index - 1].substring.trim() === "" && index < srcLines.length - 1 && srcLines[index + 1].substring.trim() === "") {
+      if (skipHRs && index > 0 && srcLines[index - 1].substring.trim() === "" && index < srcLines.length - 1 && srcLines[index + 1].substring.trim() === "") {
         return false;
       }
       return true;
@@ -27679,7 +27679,7 @@ ${sourceContext}`;
     for (let i = 0; i < srcLines.length; ++i) {
       const line = srcLines[i];
       const directiveMatch = isBlockShortcode(line.substring);
-      if (isYamlDelimiter(line.substring, i) && !inCodeCell && !inCode && !inMathBlock) {
+      if (isYamlDelimiter(line.substring, i, !inYaml) && !inCodeCell && !inCode && !inMathBlock) {
         if (inYaml) {
           lineBuffer.push(line);
           await flushLineBuffer("raw", i);

--- a/tests/unit/break-quarto-md/break-quarto-md.test.ts
+++ b/tests/unit/break-quarto-md/break-quarto-md.test.ts
@@ -127,3 +127,28 @@ Then some text.
   const cells = (await breakQuartoMd(qmd, false)).cells;
   assert(cells.length === 2);
 });
+
+unitTest("break-quarto-md - hr cells", async () => {
+  await initYamlIntelligenceResourcesFromFilesystem();
+  const qmd = `---
+title: "Untitled"
+format: html
+editor: visual
+keep-md: true
+---
+
+
+Hello, an hr.
+
+---
+
+Hello, another thing.
+
+---
+
+And what about this?
+`;
+
+  const cells = (await breakQuartoMd(qmd, false)).cells;
+  assert(cells.length <= 2 || cells[2].cell_type === "markdown");
+});


### PR DESCRIPTION
This addresses #1304 by checking explicitly for empty lines surrounding yaml separators.