### PR TITLE
fix(language): `title-block-affiliation-*` and `code-tools-*-all-code`

### DIFF
--- a/src/resources/language/_language-fr.yml
+++ b/src/resources/language/_language-fr.yml
@@ -13,8 +13,8 @@ appendix-attribution-cite-as: "Veuillez citer ce travail comme suit :"
 
 title-block-author-single: "Auteur"
 title-block-author-plural: "Auteurs"
-title-block-affiliation-single: "Association"
-title-block-affiliation-plural: "Les associations"
+title-block-affiliation-single: "Affiliation"
+title-block-affiliation-plural: "Affiliations"
 title-block-published: "Date de publication"
 
 callout-tip-caption: "Astuce"

--- a/src/resources/language/_language-fr.yml
+++ b/src/resources/language/_language-fr.yml
@@ -26,8 +26,8 @@ callout-caution-caption: "Mise en garde"
 code-summary: "Code"
 
 code-tools-menu-caption: "Code"
-code-tools-show-all-code: "Montrer tous les codes"
-code-tools-hide-all-code: "Cacher tous les codes"
+code-tools-show-all-code: "Montrer tout le code"
+code-tools-hide-all-code: "Cacher tout le code"
 code-tools-view-source: "Voir les sources"
 code-tools-source-code: "Code source"
 


### PR DESCRIPTION
This PR changes the following translations:

- `title-block-affiliation-*` 
   Affiliation is also the french word for affiliation.
  "Association" does not have the same meaning and thus is not suitable here.

- `code-tools-*-all-code`  
   "Montrer tout le code" instead of "Montrer tous les codes", because even if the latter is correct, when we talk about a global entity we use the former.
   Here, the option is to show/hide the code everywhere, this is not exactly the same as "show/hide every pieces of code".
