### PR TITLE
[reveal] Set background color of div in `output-location: column`

### DIFF
--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -257,6 +257,7 @@ section.has-dark-background {
 
 .reveal .column-output-location .column:first-of-type div.sourceCode {
   height: 100%;
+  background-color: $code-block-bg;
 }
 
 .reveal blockquote {


### PR DESCRIPTION
So that it is the same as code block background color as we are extending the height to whole column height

## Why ? 

Currently we have 
![image](https://user-images.githubusercontent.com/6791940/177740071-fdd95594-4658-4819-bd28-30e0e1fe06cc.png)

I suggest we do this (this is the PR)
![image](https://user-images.githubusercontent.com/6791940/177740211-00ed9b27-5d42-4b2b-b6f5-d64b63f6dbe5.png)

But we could also do this if you think it is better
![image](https://user-images.githubusercontent.com/6791940/177740341-407bd422-4837-4854-86e2-87f1e394a2e9.png)

<details>
<summary>Code for test</summary>

````markdown
---
title: "Untitled"
format: revealjs
---

## Slide 1

```{r}
#| output-location: column
#| echo: true
plot(iris)
```
````

</details>