### PR TITLE
fixes #1344

### DIFF
--- a/src/resources/vendor/import_map.json
+++ b/src/resources/vendor/import_map.json
@@ -2,6 +2,7 @@
   "imports": {
     "https://deno.land/std@0.91.0/": "./deno-land/std@0-91-0/",
     "https://deno.land/std@0.93.0/": "./deno-land/std@0-93-0/",
+    "https://deno.land/x/cache@0.2.12/": "./deno-land/x/cache@0-2-12/",
     "puppeteer/": "./deno-land/x/puppeteer@9-0-2/",
     "https://dev.jspm.io/": "./dev-jspm-io/",
     "https://dev.jspm.io/jszip@3.5.0": "./dev-jspm-io/jszip@3.5.0.js"

--- a/src/resources/vendor/import_map_deno_vendor.json
+++ b/src/resources/vendor/import_map_deno_vendor.json
@@ -2,6 +2,7 @@
   "imports": {
     "https://deno.land/std@0.91.0/": "./deno.land/std@0.91.0/",
     "https://deno.land/std@0.93.0/": "./deno.land/std@0.93.0/",
+    "https://deno.land/x/cache@0.2.12/": "./deno-land/x/cache@0.2.12/",
     "puppeteer/": "./deno.land/x/puppeteer@9.0.2/",
     "https://dev.jspm.io/": "./dev.jspm.io/",
     "https://dev.jspm.io/jszip@3.5.0": "./dev.jspm.io/jszip@3.5.0.js"


### PR DESCRIPTION
We were missing a reference to `cache` in the import map that is needed because of dynamic imports. This commit adds the entry to the import map (we already had it in the vendor directory).