### PR TITLE
Use proper root directory when resolving external resources

### DIFF
--- a/src/command/render/pandoc.ts
+++ b/src/command/render/pandoc.ts
@@ -1045,6 +1045,7 @@ async function resolveExtras(
         inputDir,
         libDir,
         doc,
+        project,
       );
     };
 

--- a/src/command/render/render-files.ts
+++ b/src/command/render/render-files.ts
@@ -304,6 +304,7 @@ export async function renderFiles(
           dirname(context.target.source),
           context.libDir,
           tempContext,
+          project,
         );
         if (extras[kIncludeInHeader]) {
           executeResult.includes[kIncludeInHeader] = [

--- a/src/execute/ojs/compile.ts
+++ b/src/execute/ojs/compile.ts
@@ -787,6 +787,7 @@ export async function ojsCompile(
     dirname(options.source),
     options.libDir,
     options.temp,
+    project,
   );
 
   const ojsBundleTempFiles = [];


### PR DESCRIPTION
The root directory is used to prevent dependencies from being injected from outside the current directory. We were previously using the input directory, but in the case of project renders, we need to use the project directory instead (e.g. any children of a project can refer to anything within the project itself).