### PR TITLE
Remove `template-partials` from metadata

### DIFF
--- a/src/command/render/pandoc.ts
+++ b/src/command/render/pandoc.ts
@@ -141,6 +141,7 @@ import { resourcesFromMetadata } from "./resources.ts";
 import { resolveSassBundles } from "./pandoc-html.ts";
 import {
   cleanTemplatePartialMetadata,
+  kTemplatePartials,
   readPartials,
   stageTemplate,
 } from "./template.ts";
@@ -491,6 +492,9 @@ export async function runPandoc(
           partials,
         },
       );
+
+      // Clean out partials from metadata, they are not needed downstream
+      delete options.format.metadata[kTemplatePartials];
 
       allDefaults[kTemplate] = stagedTemplate;
     } else {


### PR DESCRIPTION
It is resolved when the template and partials are all staged, so it no longer needs to be present downstream (for pandoc / lua).

Note that the underlying issue this causes is an informational message in pandoc because the strings in the metadata.yml file are treated as markdown, so this string looks like a set of LaTeX raws on windows.

Addresses #1367