### PR TITLE
Only check for keep-source when code-tools.source is not an external url

### DIFF
--- a/src/command/render/codetools.ts
+++ b/src/command/render/codetools.ts
@@ -315,8 +315,9 @@ function resolveCodeTools(format: Format, doc: Document): CodeTools {
       : codeTools?.caption || kCodeCaption,
   };
 
-  // if we have request source, make sure we are able to keep source
-  if (codeToolsResolved.source) {
+  // if we have request source without an external url,
+  // make sure we are able to keep source
+  if (codeToolsResolved.source === true) {
     codeToolsResolved.source = !!format.render[kKeepSource];
   }
 

--- a/tests/docs/code-tools/code-tools-activated.qmd
+++ b/tests/docs/code-tools/code-tools-activated.qmd
@@ -1,0 +1,10 @@
+---
+title: "with code tools"
+format: 
+  html:
+    code-tools: true
+---
+
+```{r}
+1 + 2
+```

--- a/tests/docs/code-tools/code-tools-external-source.qmd
+++ b/tests/docs/code-tools/code-tools-external-source.qmd
@@ -1,0 +1,11 @@
+---
+title: "with code tools"
+format: 
+  html:
+    code-tools: 
+      source: https://github.com/quarto-dev/quarto-web/blob/main/index.qmd
+---
+
+```{r}
+1 + 2
+```

--- a/tests/docs/code-tools/code-tools-toggle.qmd
+++ b/tests/docs/code-tools/code-tools-toggle.qmd
@@ -1,0 +1,12 @@
+---
+title: "with code tools"
+format: 
+  html:
+    code-fold: true
+    code-tools:
+      toggle: true
+---
+
+```{r}
+1 + 2
+```

--- a/tests/smoke/render/render-code-tools.test.ts
+++ b/tests/smoke/render/render-code-tools.test.ts
@@ -1,0 +1,36 @@
+/*
+* render-r.test.ts
+*
+* Copyright (C) 2020 by RStudio, PBC
+*
+*/
+
+import { fileLoader } from "../../utils.ts";
+import { ensureHtmlElements } from "../../verify.ts";
+import { testRender } from "./render.ts";
+
+let doc = fileLoader("code-tools")(
+  "code-tools-activated.qmd",
+  "html",
+);
+testRender(doc.input, "html", false, [
+  ensureHtmlElements(doc.output.outputPath, [
+    "div.quarto-title-block button#quarto-code-tools-source",
+    "div#quarto-embedded-source-code-modal",
+  ]),
+]);
+
+doc = fileLoader("code-tools")("code-tools-toggle.qmd", "html");
+testRender(doc.input, "html", false, [
+  ensureHtmlElements(doc.output.outputPath, [
+    "div.quarto-title-block button#quarto-code-tools-menu",
+    "div.cell > details",
+  ]),
+]);
+
+doc = fileLoader("code-tools")("code-tools-external-source.qmd", "html");
+testRender(doc.input, "html", false, [
+  ensureHtmlElements(doc.output.outputPath, [
+    "div.quarto-title-block button#quarto-code-tools-source[data-quarto-source-url]",
+  ]),
+]);


### PR DESCRIPTION
This fixes #1371

I believe `keep-source` capabilities should not be checked when a url is provided in `code-tools.source` as the button will contain a link to the external source. Only if `code-tools.source` is TRUE that this is relevant to set it back to false if keeping source is not possible. 

