### PR TITLE
Code tools shouldn’t muck with background color

### DIFF
--- a/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
@@ -900,7 +900,7 @@ nav li code:not(.sourceCode) {
   div.sourceCode {
   margin: 0;
   padding: 0.2rem 0.2rem;
-  background-color: inherit;
+  border-radius: 0px;
   border: none;
 }
 


### PR DESCRIPTION
Since the code is being highlighted, it is possible that it will only be functional against a specifically colored background (especially dark or light). We should respect the background color if we’re going to highlight the code.

Additionally, since the code div is contained within a popup, remove any border radius so it fills the container edge to edge.

PR opened for discussion.

![Screen Shot 2022-07-13 at 9 06 16 AM](https://user-images.githubusercontent.com/261654/178740608-92743bdd-78c1-4986-8058-f8736b5ca988.png)

Addresses #1370
