### PR TITLE
`quarto tools` help page improvment

### DIFF
--- a/src/command/tools/cmd.ts
+++ b/src/command/tools/cmd.ts
@@ -34,7 +34,7 @@ export const toolsCommand = new Command()
     uninstall
     update
     
-Use 'quarto tools' with no arguments to show the status of all tools.`,
+`,
   )
   .example(
     "Install TinyTex",

--- a/src/command/tools/cmd.ts
+++ b/src/command/tools/cmd.ts
@@ -31,6 +31,7 @@ export const toolsCommand = new Command()
 
   commands:
     install
+    info
     uninstall
     update
     
@@ -51,6 +52,10 @@ export const toolsCommand = new Command()
   .example(
     "Show tool status",
     "quarto tools list",
+  )
+  .example(
+    "Get information for a tool (JSON output)",
+    "quarto tools info tinytex",
   )
   // deno-lint-ignore no-explicit-any
   .action(async (_options: any, command: string, tool?: string) => {


### PR DESCRIPTION
* `quarto tools list` is the way to list all status following change in d3a6418
* `quarto tools info` was not documented (I looked for it in one of the github discussion we had to find the syntax)