### PR TITLE
Don’t include HTML dependencies (from R execution) unless we’re targe…

### DIFF
--- a/src/resources/rmd/execute.R
+++ b/src/resources/rmd/execute.R
@@ -383,7 +383,7 @@ dependencies_from_render <- function(input, files_dir, knit_meta, format) {
   # get extras (e.g. html dependencies)
   # only include these html extras if we're targeting a format that
   # supports html (widgets) like this or that prefers html (e.g. Hugo)
-  if (is_pandoc_html_format(format) | format$render$`prefer-html`) {
+  if (is_pandoc_html_format(format) || format$render$`prefer-html`) {
     extras <- rmarkdown:::html_extras_for_document(
       knit_meta,
       runtime,

--- a/src/resources/rmd/execute.R
+++ b/src/resources/rmd/execute.R
@@ -332,7 +332,7 @@ knitr_cache_dir <- function(input, format) {
 pandoc_includes <- function(input, format, output, files_dir, knit_meta, tempDir) {
 
   # get dependencies from render 
-  dependencies <- dependencies_from_render(input, files_dir, knit_meta)
+  dependencies <- dependencies_from_render(input, files_dir, knit_meta, format)
 
   # embed shiny_prerendered dependencies
   if (!is.null(dependencies$shiny)) {
@@ -351,7 +351,7 @@ pandoc_includes <- function(input, format, output, files_dir, knit_meta, tempDir
 }
 
 # get dependencies implied by the result of render (e.g. html dependencies)
-dependencies_from_render <- function(input, files_dir, knit_meta) {
+dependencies_from_render <- function(input, files_dir, knit_meta, format) {
 
   # check for runtime
   front_matter <- rmarkdown::yaml_front_matter(input)
@@ -381,12 +381,18 @@ dependencies_from_render <- function(input, files_dir, knit_meta) {
   }
 
   # get extras (e.g. html dependencies)
-  extras <- rmarkdown:::html_extras_for_document(
-    knit_meta,
-    runtime,
-    resolver,
-    list() # format deps
-  )
+  # only include these html extras if we're targeting a format that
+  # supports html (widgets) like this or that prefers html (e.g. Hugo)
+  if (is_pandoc_html_format(format) | format$render$`prefer-html`) {
+    extras <- rmarkdown:::html_extras_for_document(
+      knit_meta,
+      runtime,
+      resolver,
+      list() # format deps
+    )
+  } else {
+    extras = {}
+  }
 
   # filter out bootstrap
   extras$dependencies <- Filter(


### PR DESCRIPTION
…ting HTML output

This should fix #1378

Testing with:

````
---
always_allow_html: true
---

```{r}
htmltools::tagList(rmarkdown::html_dependency_font_awesome())
htmltools::div(class="dummy", 
               htmltools::p("HTML content"))
```


```{=html}
<i class="fas fa-user"></i>
```
````

Which should properly output a font awesome icon for HTML while not including any HTML output (including in header) for pdf/latex.