### PR TITLE
`quarto use template`: Ensure Correct Owner Namespace in Extensions

### DIFF
--- a/src/command/use/commands/template.ts
+++ b/src/command/use/commands/template.ts
@@ -21,6 +21,8 @@ import { templateFiles } from "../../../extension/template.ts";
 import { Command } from "cliffy/command/mod.ts";
 import { initYamlIntelligenceResourcesFromFilesystem } from "../../../core/schema/utils.ts";
 import { createTempContext } from "../../../core/temp.ts";
+import { copyExtensions } from "../../../extension/install.ts";
+import { kExtensionDir } from "../../../extension/extension-shared.ts";
 
 const kRootTemplateName = "template.qmd";
 
@@ -68,6 +70,12 @@ async function useTemplate(
 
     // Copy the files
     await withSpinner({ message: "Copying files..." }, async () => {
+      // Copy extensions
+      const extDir = join(stagedDir, kExtensionDir);
+      if (existsSync(extDir)) {
+        copyExtensions(source, extDir, outputDirectory);
+      }
+
       for (const fileToCopy of filesToCopy) {
         const isDir = Deno.statSync(fileToCopy).isDirectory;
         const rel = relative(stagedDir, fileToCopy);

--- a/src/extension/install.ts
+++ b/src/extension/install.ts
@@ -230,16 +230,24 @@ async function unzipAndStage(
 
   // Make the final directory we're staging into
   const finalDir = join(archiveDir, "staged");
-  const finalExtensionsDir = join(finalDir, "_extensions");
+  copyExtensions(source, extensionsDir, finalDir);
+
+  return finalDir;
+}
+
+export function copyExtensions(
+  source: ExtensionSource,
+  srcDir: string,
+  targetDir: string,
+) {
+  const finalExtensionsDir = join(targetDir, kExtensionDir);
   const finalExtensionTargetDir = source.owner
     ? join(finalExtensionsDir, source.owner)
     : finalExtensionsDir;
   ensureDirSync(finalExtensionTargetDir);
 
   // Move extensions into the target directory (root or owner)
-  readAndCopyExtensions(extensionsDir, finalExtensionTargetDir);
-
-  return finalDir;
+  readAndCopyExtensions(srcDir, finalExtensionTargetDir);
 }
 
 // Reads the extensions from an extensions directory and copies

--- a/src/extension/template.ts
+++ b/src/extension/template.ts
@@ -45,4 +45,5 @@ const kBuiltInExcludes = [
   "CHANGELOG.md",
   "COPYRIGHT",
   "LICENSE",
+  "_extensions",
 ];


### PR DESCRIPTION
We were previously free riding on just copying the file structure from source (which used to have owner name space). Now we need to explicitly read and write extensions to process the namespace properly.