### PR TITLE
Smart glob handling incorrectly ignoring `!`

### DIFF
--- a/tests/unit/glob.test.ts
+++ b/tests/unit/glob.test.ts
@@ -1,0 +1,52 @@
+/*
+* glob.test.ts
+*
+* Copyright (C) 2020 by RStudio, PBC
+*
+*/
+import { assert, assertEquals } from "testing/asserts.ts";
+import { filterPaths } from "../../src/core/path.ts";
+import { unitTest } from "../test.ts";
+
+unitTest(
+  "globs",
+  //deno-lint-ignore require-await
+  async () => {
+    const paths = [
+      "/test.qmd",
+      "/test2.qmd",
+      "/test3.qmd",
+      "/folder/test.qmd",
+      "/folder/test2.qmd",
+      "/folder/test.txt",
+    ];
+
+    const globDescs = [
+      { globs: ["*.qmd"], includes: 5, excludes: 0 },
+      { globs: ["**"], includes: 6, excludes: 0 },
+      { globs: ["*.qmd", "!folder"], includes: 5, excludes: 0 },
+      { globs: ["*.qmd", "!folder/"], includes: 5, excludes: 3 },
+      { globs: ["test*.*", "!folder/"], includes: 6, excludes: 3 },
+      { globs: ["test*.*", "!*.txt"], includes: 6, excludes: 1 },
+      { globs: ["folder/*.txt"], includes: 1, excludes: 0 },
+      { globs: ["folder/*.*", "!*.txt"], includes: 3, excludes: 1 },
+      { globs: ["folder/**"], includes: 3, excludes: 0 },
+      { globs: ["test2.*", "!folder/"], includes: 2, excludes: 3 },
+    ];
+    for (const globDesc of globDescs) {
+      const filtered = filterPaths("/", paths, globDesc.globs);
+      assert(
+        filtered.include.length === globDesc.includes,
+        `Globs [${
+          globDesc.globs.join(",")
+        }] result in the wrong number of 'includes' matches.`,
+      );
+      assert(
+        filtered.exclude.length === globDesc.excludes,
+        `Globs [${
+          globDesc.globs.join(",")
+        }] result in the wrong number of 'excludes' matches.`,
+      );
+    }
+  },
+);


### PR DESCRIPTION
We are attempting to detect globs, and ! would normally qualify, but we clip off the ‘!’ and pass the rest as an exclude. As a result, the smart glob handling doesn’t kick in. This change always uses smart globbing for exlcudes unless the called explicitly asks for strict globbing.

Includes unit test.

Addresses #1394