### PR TITLE
Improve handling of empty sidebar sections and items

### DIFF
--- a/src/project/project-config.ts
+++ b/src/project/project-config.ts
@@ -59,6 +59,10 @@ export function normalizeSidebarItem(
       // case
       item.sectionId = `${kQuartoSidebarPrefix}${context.counter}`;
       delete item.section;
+
+      // If this is a section, we should insist that it have 'contents'
+      // even if they are empty.
+      item.contents = item.contents || [];
     }
 
     // handle subitems

--- a/src/resources/projects/website/templates/sidebaritem.ejs
+++ b/src/resources/projects/website/templates/sidebaritem.ejs
@@ -14,22 +14,31 @@
   <% isCollapsed = collapse <= depth  && !item.expanded %>
 
   <li class="sidebar-item sidebar-item-section">
-    <div class="sidebar-item-container"> 
-      <% if (item.href) { %>
-        <a href="<%- item.href %>" class="sidebar-item-text sidebar-link<%- item.active ? " active" : "" %>"><%= item.text %></a>
-      <% } else { %> 
-        <a class="sidebar-item-text sidebar-link text-start<%- isCollapsed ? " collapsed" : "" %>" data-bs-toggle="collapse" data-bs-target="#<%- sectionId %>" aria-expanded="<%- isCollapsed ? "false" : "true" %>"><%= item.text %></a>
-      <% }  %>      
-      <a class="sidebar-item-toggle text-start<%- isCollapsed ?  " collapsed" : "" %>" data-bs-toggle="collapse" data-bs-target="#<%- sectionId %>" aria-expanded="<%- isCollapsed ? "false" : "true" %>">
-        <i class="bi bi-chevron-right ms-2"></i>
-      </a>
-    </div>
-    <ul id="<%- sectionId %>" class="collapse list-unstyled sidebar-section depth<%-depth%> <%- isCollapsed ? "" : "show" %>">  
-      <% item.contents.forEach(subItem => { %>
-        <% partial('sidebaritem.ejs', { item: subItem, depth: depth + 1, collapse: collapse, borderColor: borderColor }) %>
-       <% }) %>
-    </ul>
+    <% if (item.contents.length > 0) { %>
+      <div class="sidebar-item-container"> 
+          <% if (item.href) { %>
+            <a href="<%- item.href %>" class="sidebar-item-text sidebar-link<%- item.active ? " active" : "" %>"><%= item.text %></a>
+          <% } else { %> 
+            <a class="sidebar-item-text sidebar-link text-start<%- isCollapsed ? " collapsed" : "" %>" data-bs-toggle="collapse" data-bs-target="#<%- sectionId %>" aria-expanded="<%- isCollapsed ? "false" : "true" %>"><%= item.text %></a>
+          <% }  %>      
+          <a class="sidebar-item-toggle text-start<%- isCollapsed ?  " collapsed" : "" %>" data-bs-toggle="collapse" data-bs-target="#<%- sectionId %>" aria-expanded="<%- isCollapsed ? "false" : "true" %>">
+            <i class="bi bi-chevron-right ms-2"></i>
+          </a> 
+      </div>
+      <ul id="<%- sectionId %>" class="collapse list-unstyled sidebar-section depth<%-depth%> <%- isCollapsed ? "" : "show" %>">  
+        <% item.contents.forEach(subItem => { %>
+          <% partial('sidebaritem.ejs', { item: subItem, depth: depth + 1, collapse: collapse, borderColor: borderColor }) %>
+        <% }) %>
+      </ul>
+    <% } else { %>
+      <span class="sidebar-item-text sidebar-link text-start"><%= item.text %></span>
+    <% } %>
+
   </li>
 <% } else if (item.text && item.text.match(/^\-+$/)) { %>
 <li class="px-0"><hr class="sidebar-divider hi <%- borderColor %>"></li>
+<% } else if (item.text) { %>
+  <li class="sidebar-item">
+  <%= item.text %>
+  </li>
 <% } %>


### PR DESCRIPTION
-> Allow the concept of an empty section (previously, we just ignored sections without any content. Now we emit them).

-> Allow items that don’t link to anything and aren’t separators (previously, we would ignore them).

Addresses #1400

### Docked
![Screen Shot 2022-07-14 at 5 43 01 PM](https://user-images.githubusercontent.com/261654/179091460-e2f615a6-1a95-46c7-af50-fdaac0512eb8.png)


### Floating
![Screen Shot 2022-07-14 at 5 45 24 PM](https://user-images.githubusercontent.com/261654/179091554-b242ccff-8335-4e3a-bed5-7fc9b593c911.png)

