### PR TITLE
Update css rule to center items in toggler container

### DIFF
--- a/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
@@ -1365,6 +1365,7 @@ div.callout.callout-style-default > .callout-header {
 
 .quarto-toggle-container {
   display: flex;
+  align-items: center;
 }
 
 // dark mode


### PR DESCRIPTION
This PR proposes a fix for the issue with the theme toggler not being centred. I've decided to add the `align-items` rule to `.quarto-toggle-container` rule since this is already a flex container.

Before the icon would look like this:

<img width="245" alt="Screenshot 2022-07-16 at 10 21 39" src="https://user-images.githubusercontent.com/3131401/179347562-c45cdb7e-9d4b-4344-82ab-2af3bd0d20b8.png">

Now it looks like this:

<img width="161" alt="Screenshot 2022-07-16 at 10 24 25" src="https://user-images.githubusercontent.com/3131401/179347573-82610d76-9bed-46f4-9926-9077d24d021b.png">

Let me know if you are happy with this or if you would like me to change anything 😄 

Fixes: #1422