### PR TITLE
disconsider speaker notes when applying stretch rules

### DIFF
--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -665,7 +665,7 @@ function applyStretch(doc: Document, autoStretch: boolean) {
             !!el.className.match(/panel-/);
         }) ||
         // Do not autostrech if an aside is used
-        slideEl.querySelectorAll("aside").length !== 0
+        slideEl.querySelectorAll("aside:not(.notes)").length !== 0
       ) {
         continue;
       }


### PR DESCRIPTION
This closes #1487 . Since speaker notes never appear on slide, we probably shouldn't include them in the selection that ignores the stretch treatment.