### PR TITLE
Patches for Deno 1.24 compatibility

### DIFF
--- a/configuration
+++ b/configuration
@@ -8,7 +8,7 @@
 
 
 # Binary dependencies
-export DENO=v1.22.0
+export DENO=v1.24.0
 export DENO_DOM=v0.1.17-alpha
 export PANDOC=2.18
 export DARTSASS=1.32.8

--- a/src/core/deno-dom.ts
+++ b/src/core/deno-dom.ts
@@ -58,7 +58,7 @@ export async function initDenoDom() {
 
         const utf8Encoder = new TextEncoder();
         const utf8Decoder = new TextDecoder();
-        const usizeBytes = dylib.symbols.deno_dom_usize_len() as number;
+        const usizeBytes = Number(dylib.symbols.deno_dom_usize_len());
         const isBigEndian = Boolean(
           dylib.symbols.deno_dom_is_big_endian() as number,
         );

--- a/src/project/serve/serve.ts
+++ b/src/project/serve/serve.ts
@@ -567,8 +567,9 @@ function acquirePreviewLock(project: ProjectContext) {
         { newline: false },
       );
       try {
-        Deno.kill(pid, "SIGTERM");
-        Deno.sleepSync(3000);
+        setTimeout(() => {
+            Deno.kill(pid, "SIGTERM");
+        }, 3000);
       } catch {
         //
       } finally {

--- a/src/project/types/website/listing/website-listing.ts
+++ b/src/project/types/website/listing/website-listing.ts
@@ -242,7 +242,7 @@ export async function listingHtmlDependencies(
     const supporting: string[] = [];
     if (options[kFeed]) {
       const listingOptions = {
-        type: "full",
+        //type: "full",
         ...options[kFeed],
       } as ListingFeedOptions;
 

--- a/src/project/types/website/website-giscus.ts
+++ b/src/project/types/website/website-giscus.ts
@@ -74,7 +74,7 @@ export async function resolveFormatForGiscus(
         }
         if (giscusOptions[kGiscusCategoryId] === undefined) {
           giscusOptions[kGiscusCategoryId] = getDiscussionCategoryId(
-            giscusOptions[kGiscusCategoryId] as string,
+            String(giscusOptions[kGiscusCategoryId]),
             giscusMeta,
           );
         }

--- a/src/publish/netlify/api/core/CancelablePromise.ts
+++ b/src/publish/netlify/api/core/CancelablePromise.ts
@@ -22,7 +22,7 @@ export interface OnCancel {
 }
 
 export class CancelablePromise<T> implements Promise<T> {
-  readonly [Symbol.toStringTag]: string;
+  readonly [Symbol.toStringTag]!: string;
 
   private _isResolved: boolean;
   private _isRejected: boolean;


### PR DESCRIPTION
Deno 1.24 is here.
Proposed PR fixes #1174

There are just a few places [yet] where quarto has build issues against new Deno version. Although with these changes compilation process ends successfully, I had no opportunity for thoughtful testing of quarto. So treat it as unstable.
