### PR TITLE
add safeRemoveSync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ package/dist/**
 .env
 # deno_std library
 src/resources/deno_std/cache
+src/vendor-*

--- a/src/command/render/freeze.ts
+++ b/src/command/render/freeze.ts
@@ -20,7 +20,7 @@ import { cloneDeep } from "../../core/lodash.ts";
 import { inputFilesDir } from "../../core/render.ts";
 import { TempContext } from "../../core/temp.ts";
 import { md5Hash } from "../../core/hash.ts";
-import { removeIfEmptyDir, removeIfExists } from "../../core/path.ts";
+import { removeIfEmptyDir, removeIfExists, safeRemoveIfExists } from "../../core/path.ts";
 
 import {
   kIncludeAfterBody,
@@ -202,11 +202,7 @@ export function pruneProjectFreezerDir(
   // find a way to do force this
   files.map((file) => {
     const filePath = join(freezerDir, dir, file);
-    try {
-      removeIfExists(filePath);
-    } catch {
-      //
-    }
+    safeRemoveIfExists(filePath);
   });
   removeIfEmptyDir(join(freezerDir, dir));
 }

--- a/src/command/render/project.ts
+++ b/src/command/render/project.ts
@@ -371,7 +371,7 @@ export async function renderProject(
             }
           }
           if (!keepLibsDir) {
-            Deno.removeSync(libDirFull, { recursive: true });
+            safeRemoveIfExists(libDirFull);
           }
         } else {
           if (keepLibsDir) {

--- a/src/command/render/project.ts
+++ b/src/command/render/project.ts
@@ -46,7 +46,7 @@ import {
 } from "./freeze.ts";
 import { resourceFilesFromRenderedFile } from "./resources.ts";
 import { inputFilesDir } from "../../core/render.ts";
-import { removeIfEmptyDir, removeIfExists } from "../../core/path.ts";
+import { removeIfEmptyDir, removeIfExists, safeRemoveIfExists } from "../../core/path.ts";
 import { handlerForScript } from "../../core/run/run.ts";
 import { execProcess } from "../../core/process.ts";
 import { parseShellRunCommand } from "../../core/run/shell.ts";
@@ -366,7 +366,7 @@ export async function renderProject(
               const targetDir = join(outputDirAbsolute, copyDir);
               copyMinimal(srcDir, targetDir);
               if (!keepLibsDir) {
-                removeIfExists(srcDir);
+                safeRemoveIfExists(srcDir);
               }
             }
           }

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -14,6 +14,8 @@ import {
   join,
 } from "path/mod.ts";
 
+import { warning } from "log/mod.ts";
+
 import { existsSync } from "fs/exists.ts";
 import { expandGlobSync } from "fs/expand_glob.ts";
 
@@ -27,6 +29,14 @@ export const kSkipHidden = /[/\\][\.]/;
 export function removeIfExists(file: string) {
   if (existsSync(file)) {
     Deno.removeSync(file, { recursive: true });
+  }
+}
+
+export function safeRemoveIfExists(file: string) {
+  try {
+    removeIfExists(file);
+  } catch (error) {
+    warning(`Error removing file ${file}: ${error.message}`);
   }
 }
 

--- a/src/core/temp.ts
+++ b/src/core/temp.ts
@@ -8,7 +8,7 @@
 import { warning } from "log/mod.ts";
 import { join } from "path/mod.ts";
 import { ensureDirSync } from "fs/mod.ts";
-import { removeIfExists } from "./path.ts";
+import { removeIfExists, safeRemoveIfExists } from "./path.ts";
 import { TempContext } from "./temp-types.ts";
 
 export type { TempContext } from "./temp-types.ts";
@@ -53,11 +53,7 @@ export function createTempContext(options?: Deno.MakeTempOptions) {
     },
     cleanup: () => {
       if (dir) {
-        try {
-          removeIfExists(dir);
-        } catch (error) {
-          warning(`Error removing temp dir at ${dir}: ${error.message}`);
-        }
+        safeRemoveIfExists(dir);
         dir = undefined;
       }
     },


### PR DESCRIPTION
Affter the problem in https://github.com/quarto-dev/quarto-cli/issues/188 popped up again, I refactored the solution by @jjallaire from the first time the bug appeared into a function `safeRemoveIfExists`.

It doesn't crash when a removal is unsuccessful, but instead logs a warning. I only replaced `removeIfExists` in places where I actually saw errors in practice. More might come up along the way.

Since a similar mechanism was already in place for `src/core/temp.ts`, I used the new function there as well.