### PR TITLE
Invalid href when output-file contains a ‘.’ in its name

### DIFF
--- a/src/core/render.ts
+++ b/src/core/render.ts
@@ -8,6 +8,7 @@
 import { kOutputExt, kOutputFile } from "../config/constants.ts";
 import { Format } from "../config/types.ts";
 import { dirAndStem } from "./path.ts";
+import { extname } from "path/mod.ts";
 
 export function inputFilesDir(input: string) {
   const [_, stem] = dirAndStem(input);
@@ -27,8 +28,23 @@ export function figuresDir(pandocTo?: string) {
 export function formatOutputFile(format: Format) {
   let outputFile = format.pandoc[kOutputFile];
   if (outputFile) {
-    if (!outputFile.match(/\..+$/) && format.render[kOutputExt]) {
-      outputFile = `${outputFile}.${format.render[kOutputExt]}`;
+    if (format.render[kOutputExt]) {
+      // Don't append the output extension if the same output
+      // extension is already present. If you update this logic,
+      // be sure to contemplate files with names like:
+      // file.name.ipynb
+      // which should result in an output file like:
+      // file.name.html
+      const existingExtension = extname(outputFile);
+
+      // If there the output file has no extension, or already has this
+      // extension, don't append it, otherwise add it.
+      if (
+        !existingExtension ||
+        existingExtension.substring(1) !== format.render[kOutputExt]
+      ) {
+        outputFile = `${outputFile}.${format.render[kOutputExt]}`;
+      }
     }
   }
   return outputFile;


### PR DESCRIPTION
If the output the output file is simple, like:

```
output-file: test
```

we automatically would generate the output file `test.html`.

but if the `output-file` contains a `.`, then we would not append the extension (thinking that it already had one), resulting in a case like:

```
output-file: file.name
```

producing a file named `file.name` rather than `file.name.html`.

This will amend the behavior do the appending for any file without an extension or if the appending won’t result in duplicate extensions (e.g. `file.html.html`).