### PR TITLE
revert css change to button

### DIFF
--- a/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
@@ -1591,7 +1591,7 @@ nav[role="doc-toc"].slow > * {
   }
 }
 
-main.content button:not(.code-copy-button), .btn.btn-quarto, div.cell-output-display .btn-quarto {
+.btn.btn-quarto, div.cell-output-display .btn-quarto {
   @include button-variant(
     $btn-bg,
     $btn-bg,


### PR DESCRIPTION
This fixes the issue that can be seen [on the quarto.org website](https://quarto.org/docs/interactive/ojs/examples/layout.html).

We'll need to eventually offer a styled `button`, but @dragonstyle and I think this is best served by shortcodes (which can then simply emit the right bootstrap classes).