### PR TITLE
Improve the creation of citations

### DIFF
--- a/src/core/csl.ts
+++ b/src/core/csl.ts
@@ -5,7 +5,18 @@
 *
 */
 
-import { parsePandocDate } from "./date.ts";
+import { formatDate, parsePandocDate } from "./date.ts";
+
+export const kPdfUrl = "pdf-url";
+export const kAbstractUrl = "abstract-url";
+export const kEIssn = "eissn";
+
+export interface CSLExtras {
+  [kPdfUrl]?: string;
+  [kAbstractUrl]?: string;
+  [kEIssn]?: string;
+  keywords?: string[];
+}
 
 export interface CSL extends Record<string, unknown> {
   // The id. This is technically required, but some providers (like crossref) don't provide
@@ -32,6 +43,8 @@ export interface CSL extends Record<string, unknown> {
   // Array of Contributors
   author?: CSLName[];
 
+  editor?: CSLName[];
+
   // Earliest of published-print and published-online
   issued?: CSLDate;
 
@@ -39,7 +52,7 @@ export interface CSL extends Record<string, unknown> {
   "container-title"?: string;
 
   // Short titles of the containing work (usually a book or journal)
-  "short-container-title"?: string;
+  "container-title-short"?: string;
 
   // Issue number of an article's journal
   issue?: string;
@@ -66,7 +79,9 @@ export interface CSL extends Record<string, unknown> {
   // primarily because they may need to be sanitized
   ISSN?: string;
   ISBN?: string;
+  PMID?: string;
   "original-title"?: string;
+  "collection-title"?: string;
   "short-title"?: string;
   subtitle?: string;
   subject?: string;
@@ -247,7 +262,8 @@ export function cslDate(dateRaw: unknown): CSLDate | undefined {
           date.getMonth() + 1,
           date.getDate(),
         ]],
-        raw: dateRaw,
+        literal: formatDate(date, "YYYY-MM-DD"),
+        raw: formatDate(date, "YYYY-MM-DD"),
       };
     }
     return undefined;

--- a/src/format/html/format-html-appendix.ts
+++ b/src/format/html/format-html-appendix.ts
@@ -326,12 +326,12 @@ function creativeCommonsUrl(license: string, lang?: string) {
 }
 
 async function generateCite(input: string, format: Format, offset?: string) {
-  const entry = documentCSL(input, format, "webpage", offset);
-  if (entry) {
+  const { csl } = documentCSL(input, format, "webpage", offset);
+  if (csl) {
     // Render the HTML and BibTeX form of this document
     const cslPath = getCSLPath(input, format);
-    const html = await renderHtml(entry, cslPath);
-    const bibtex = await renderBibTex(entry);
+    const html = await renderHtml(csl, cslPath);
+    const bibtex = await renderBibTex(csl);
     return {
       html,
       bibtex,

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -10014,6 +10014,11 @@ var require_yaml_intelligence_resources = __commonJS({
                   description: "Abstract of the item (e.g. the abstract of a journal article)"
                 }
               },
+              "abstract-url": {
+                string: {
+                  description: "A url to the abstract for this item."
+                }
+              },
               accessed: {
                 ref: "csl-date",
                 description: "Date the item has been accessed."
@@ -10227,6 +10232,11 @@ var require_yaml_intelligence_resources = __commonJS({
                 },
                 hidden: true
               },
+              "fulltext-url": {
+                string: {
+                  description: "A url to the full text for this item."
+                }
+              },
               genre: {
                 string: {
                   description: {
@@ -10422,6 +10432,11 @@ var require_yaml_intelligence_resources = __commonJS({
               producer: {
                 ref: "csl-person",
                 description: "Producer (e.g. of a television or radio broadcast)."
+              },
+              "public-url": {
+                string: {
+                  description: "A public url for this item."
+                }
               },
               publisher: {
                 string: {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -10015,6 +10015,11 @@ try {
                     description: "Abstract of the item (e.g. the abstract of a journal article)"
                   }
                 },
+                "abstract-url": {
+                  string: {
+                    description: "A url to the abstract for this item."
+                  }
+                },
                 accessed: {
                   ref: "csl-date",
                   description: "Date the item has been accessed."
@@ -10228,6 +10233,11 @@ try {
                   },
                   hidden: true
                 },
+                "fulltext-url": {
+                  string: {
+                    description: "A url to the full text for this item."
+                  }
+                },
                 genre: {
                   string: {
                     description: {
@@ -10423,6 +10433,11 @@ try {
                 producer: {
                   ref: "csl-person",
                   description: "Producer (e.g. of a television or radio broadcast)."
+                },
+                "public-url": {
+                  string: {
+                    description: "A public url for this item."
+                  }
                 },
                 publisher: {
                   string: {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -2993,6 +2993,11 @@
               "description": "Abstract of the item (e.g. the abstract of a journal article)"
             }
           },
+          "abstract-url": {
+            "string": {
+              "description": "A url to the abstract for this item."
+            }
+          },
           "accessed": {
             "ref": "csl-date",
             "description": "Date the item has been accessed."
@@ -3206,6 +3211,11 @@
             },
             "hidden": true
           },
+          "fulltext-url": {
+            "string": {
+              "description": "A url to the full text for this item."
+            }
+          },
           "genre": {
             "string": {
               "description": {
@@ -3401,6 +3411,11 @@
           "producer": {
             "ref": "csl-person",
             "description": "Producer (e.g. of a television or radio broadcast)."
+          },
+          "public-url": {
+            "string": {
+              "description": "A public url for this item."
+            }
           },
           "publisher": {
             "string": {

--- a/src/resources/schema/definitions.yml
+++ b/src/resources/schema/definitions.yml
@@ -1340,6 +1340,9 @@
       abstract:
         string:
           description: Abstract of the item (e.g. the abstract of a journal article)
+      abstract-url:
+        string:
+          description: A url to the abstract for this item.
       accessed:
         ref: csl-date
         description: Date the item has been accessed.
@@ -1510,6 +1513,9 @@
             Assigned by the CSL processor; Empty in non-note-based styles or when the item hasn't 
             been cited in any preceding notes in a document
         hidden: true
+      fulltext-url:
+        string:
+          description: A url to the full text for this item.
       genre:
         string:
           description:
@@ -1672,6 +1678,9 @@
       producer:
         ref: csl-person
         description: Producer (e.g. of a television or radio broadcast).
+      public-url:
+        string:
+          description: A public url for this item.
       publisher:
         string:
           description: The publisher of the item.

--- a/tests/docs/scholar/test.qmd
+++ b/tests/docs/scholar/test.qmd
@@ -1,0 +1,37 @@
+---
+title: Document Title
+author:
+  - name: Charles Teague
+    affiliation: Macalester College
+date: 2020/05/21
+keywords: [keyword1, keyword2]
+abstract: |
+  Just so you know, i am always playing your covers in my restaurant. Its snowing now, everything is calm. Everyone is quiet, drinking their teas and coffees. Fire is burning and the woods are cracking. The river flows below and everyone is looking outside the window. Your covers bring memories to people, it makes them think about life. You sir are not only playing a guitar, you are hitting every single note in our minds. Thank you for your hard work and dedication.
+google-scholar: true
+citation:
+  container-title: Container Title
+  container-title-short: "C. Title."
+  citation-key: Teague2020
+  isbn: 123123-123131
+  issn: 12313-12312-23
+  issue: 53
+  issued: 2021/05/23
+  volume: 1
+  number: 7
+  page-first: 23
+  page-last: 29
+  type: report
+  doi: 10-12312-123
+  editor:
+    - Don Draper
+  abstract-url: https://www.google.org/abstract
+  public-url: https://www.quarto.org/public
+  fulltext-url: https://www.quarto.org/fulltext
+  collection-title: foo
+  
+---
+
+## Section 1
+
+To me Hans Zimmer is one of the greatest composers of our time when it comes to channeling emotions. You were able to express these emotions, usually expressed by a whole orchestra, with one instrument only. It sounds so natural, as if this has always been the original version.
+Thank you for this great interpretation.

--- a/tests/smoke/scholar/render-scholar.test.ts
+++ b/tests/smoke/scholar/render-scholar.test.ts
@@ -1,0 +1,18 @@
+/*
+* render-scholar.test.ts
+*
+* Copyright (C) 2020 by RStudio, PBC
+*
+*/
+import { docs, outputForInput } from "../../utils.ts";
+import { ensureHtmlElements } from "../../verify.ts";
+import { testRender } from "../render/render.ts";
+
+const input = docs("scholar/test.qmd");
+const output = outputForInput(input, "html");
+testRender(input, "html", false, [
+  ensureHtmlElements(output.outputPath, [
+    "meta[name=citation_keywords]",
+    "meta[name=citation_publication_date]",
+  ]),
+]);


### PR DESCRIPTION
Bug #1609 has a number of great suggestions for improving citation metadata for documents. This addresses most of those suggestions, generating additional `citation_` meta tags based upon document citation data as well as making our handling of citation data more consistent.

We will newly output:
`citation_abstract`
`citation_doi`
`citation_pmid`
`citation_language`
`citation_keywords`
`citation_pdf_url`
`citation_public_url`
`citation_abstract_url`
`citation_fulltext_url`
`citation_journal_abbrev`
`citation_publisher`

Based upon the `type` specified:
`citation_conference_title`/`citation_conference`
`citation_dissertation_institution`
`citation_book_title`

General approach is to allow specification of citation data with names and structure that corresponds with CSL schema and to map those values onto the appropriate meta names (rather than matching the meta names directly).
