### PR TITLE
Manually handle rgl plots. 

### DIFF
--- a/src/resources/rmd/patch.R
+++ b/src/resources/rmd/patch.R
@@ -163,6 +163,8 @@ if (utils::packageVersion("knitr") >= "1.32.8") {
       knitr:::sew.list(x, options, ...)
     } else if (inherits(x, "recordedplot")) {
       knitr:::sew.recordedplot(x, options, ...)
+    } else if (inherits(x, "rglRecordedplot") && requireNamespace("rgl")) {
+      rgl:::sew.rglRecordedplot(x, options, ...)
     } else {
       # this works generically for recent versions of R however
       # not for R < 3.5


### PR DESCRIPTION
This partially fixes #1800, by adding the `rgl:::sew.rglRecordedplot` method to the list of explicit methods.

Notes:

- It gets scroll bars when displayed in the HTML output (not in RStudio).  Presumably this could be adjusted somehow.  rgl canvases use `fig.width*dpi/fig.retina` and `fig.height*dpi/fig.retina` to set the set the size, but I don't know what the adjustment should be to avoid the scroll bars.
- As far as I can see from a slightly outdated copy of CRAN, no other CRAN packages set `sew` methods, so this might be the only change needed. 