### PR TITLE
Lua filter utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ package/dist/**
 .env
 # deno_std library
 src/resources/deno_std/cache
+src/vendor-*

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -1666,4 +1666,5 @@ quarto = {
    resolvePath = resolvePathExt
   },
   json = json,
+  base64 = base64,
 }


### PR DESCRIPTION
this PR exports `quarto.base64` together with the already exported `quarto.utils` and `quarto.json` for use in lua filters. This is helpful for writing filters that can create self-contained htmls.