### PR TITLE
fix references to configure-linux.sh in create-release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -61,7 +61,7 @@ jobs:
 
     - name: Configure
       run: |
-        ./configure-linux.sh
+        ./configure.sh
 
     - name: Prepare Distribution
       run: |
@@ -93,7 +93,7 @@ jobs:
 
     - name: Configure
       run: |
-        ./configure-linux.sh
+        ./configure.sh
 
     - name: Prepare Distribution
       run: |


### PR DESCRIPTION
#1687 consolidated the configure-mac.sh and configure-linux.sh scripts into configure.sh. The installer setup got missed somehow in the renaming. This fixes it.
