### PR TITLE
Fix flickering sidebar collapsed contents

### DIFF
--- a/src/resources/formats/html/quarto.js
+++ b/src/resources/formats/html/quarto.js
@@ -275,7 +275,7 @@ window.document.addEventListener("DOMContentLoaded", function (_event) {
         const convertToMenu = () => {
           for (const child of el.children) {
             child.style.opacity = 0;
-            child.style.display = "none";
+            child.style.overflow = "hidden";
           }
 
           const toggleContainer = window.document.createElement("div");
@@ -378,7 +378,7 @@ window.document.addEventListener("DOMContentLoaded", function (_event) {
         const convertToSidebar = () => {
           for (const child of el.children) {
             child.style.opacity = 1;
-            child.style.display = null;
+            child.style.overflow = null;
           }
 
           const placeholderEl = window.document.getElementById(


### PR DESCRIPTION
When display is set to none, the height effectively becomes 0, so the content may no longer overlay hidden regions (since the collapsed regions height effectively becomes 0). We were doing this to prevent ‘scrollable content’ from showing scrollbars even when the content wasn’t visible, so instead, just toggle the overflow, which should result in the sidebars having height, not being visible, and not showing scrollbars.

Addresses: #2019, #1995
