### PR TITLE
fix Source case in create-release.yml

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: source
+          name: Source
           path: ./quarto-${{needs.configure.outputs.version}}.tar.gz
 
   make-tarball:
@@ -322,7 +322,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./source/quarto-${{needs.configure.outputs.version}}.tar.gz
+          asset_path: ./Source/quarto-${{needs.configure.outputs.version}}.tar.gz
           asset_name: quarto-${{needs.configure.outputs.version}}.tar.gz
           asset_content_type: application/gzip
 


### PR DESCRIPTION
Latest installer generation failed during checksum generation - https://github.com/quarto-dev/quarto-cli/runs/7941617017?check_suite_focus=true - looks to be a case issue.