### PR TITLE
Fix path issues with `output-file`

### DIFF
--- a/src/execute/engine-shared.ts
+++ b/src/execute/engine-shared.ts
@@ -5,14 +5,17 @@
 *
 */
 
-import { dirname, join } from "path/mod.ts";
+import { dirname, isAbsolute, join } from "path/mod.ts";
 
 import { restorePreservedHtml } from "../core/jupyter/preserve.ts";
 import { PostProcessOptions } from "./types.ts";
 
 export function postProcessRestorePreservedHtml(options: PostProcessOptions) {
   // read the output file
-  const outputPath = join(dirname(options.target.input), options.output);
+
+  const outputPath = isAbsolute(options.output)
+    ? options.output
+    : join(dirname(options.target.input), options.output);
   let output = Deno.readTextFileSync(outputPath);
 
   // substitute

--- a/src/project/project-index.ts
+++ b/src/project/project-index.ts
@@ -5,7 +5,7 @@
 *
 */
 
-import { dirname, join, relative } from "path/mod.ts";
+import { dirname, extname, join, relative } from "path/mod.ts";
 import { existsSync } from "fs/mod.ts";
 
 import * as ld from "../core/lodash.ts";
@@ -194,11 +194,12 @@ export async function inputFileForOutputFile(
     if (index) {
       const hasOutput = Object.keys(index.formats).some((key) => {
         const format = index.formats[key];
-        if (format.pandoc[kOutputFile]) {
+        const outputFile = formatOutputFile(format);
+        if (outputFile) {
           const formatOutputPath = join(
             outputDir!,
             dirname(inputRelative),
-            format.pandoc[kOutputFile]!,
+            outputFile,
           );
           return output === formatOutputPath;
         }


### PR DESCRIPTION
This addresses https://github.com/quarto-dev/quarto-cli/issues/2045. Note that given the location of the change and the risk of unintended side effects, this warrants careful consideration before merging.