### PR TITLE
Add colors for tokens with null text color in a11y-dark theme

### DIFF
--- a/src/resources/pandoc/highlight-styles/a11y-dark.theme
+++ b/src/resources/pandoc/highlight-styles/a11y-dark.theme
@@ -4,7 +4,7 @@
             "line-number-color": "#97947a",
                 "line-number-background-color": null,
                     "_comments": [
-                        "Last update: Mar 08, 2022 (revision 1)",
+                        "Last update: Aug 24, 2022 (revision 1.1)",
                         "This file has been adapted from: https://github.com/ericwbailey/a11y-syntax-highlighting#a11y-dark",
                         "Also see: https://github.com/ericwbailey/a11y-syntax-highlighting/blob/main/dist/highlight/a11y-dark.css"
                     ],
@@ -106,14 +106,14 @@
                             "underline": false
         },
         "BuiltIn": {
-            "text-color": null,
+            "text-color": "#f5ab35",
                 "background-color": null,
                     "bold": false,
                         "italic": false,
                             "underline": false
         },
         "Extension": {
-            "text-color": null,
+            "text-color": "#ffd700",
                 "background-color": null,
                     "bold": false,
                         "italic": false,
@@ -155,7 +155,7 @@
                             "underline": false
         },
         "Import": {
-            "text-color": null,
+            "text-color": "#f8f8f2",
                 "background-color": null,
                     "bold": false,
                         "italic": false,


### PR DESCRIPTION
Previously, when tokens in the highlighting theme had `"text-color": null`, the CSS would render such that the equivalent `code span` class would be empty, and use the default highlighting color for the theme. In rendering with the latest dev version of quarto (though I'm not sure when/where the change was introduced), the `code span` now uses the color set by the default theme in quarto for that token.

In this PR, I've added appropriate colors for previously `null` classes in a11y-dark, since the color from quarto (`#008800`) has very low contrast with the a11y-dark theme's background color.

Here's a screenshot of HTML rendered with the latest version of quarto with the theme _without_ the changes made in this PR:
<img width="764" alt="image" src="https://user-images.githubusercontent.com/831732/186403976-bb420f5e-e283-4436-ae52-10ec4265e8db.png">
