### PR TITLE
bash script to resolve the path of quarto dir is not correct

### DIFF
--- a/package/scripts/common/quarto
+++ b/package/scripts/common/quarto
@@ -4,8 +4,9 @@
 SOURCE="${BASH_SOURCE[0]}"
 if [ -h "$SOURCE" ]; then
   while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    PREV_DIR="$(dirname "$SOURCE")"
     SOURCE="$(readlink "$SOURCE")"
-    SCRIPT_PATH="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+    SCRIPT_PATH="$( cd -P "${PREV_DIR}/$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
     [[ $SOURCE != /* ]] && SOURCE="$SCRIPT_PATH/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
   done
 else

--- a/package/scripts/common/quarto
+++ b/package/scripts/common/quarto
@@ -6,8 +6,14 @@ if [ -h "$SOURCE" ]; then
   while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
     PREV_DIR="$(dirname "$SOURCE")"
     SOURCE="$(readlink "$SOURCE")"
-    SCRIPT_PATH="$( cd -P "${PREV_DIR}/$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
-    [[ $SOURCE != /* ]] && SOURCE="$SCRIPT_PATH/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+    SOURCE_NAME="$(basename "$SOURCE")"
+    # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+    if [[ $SOURCE != /* ]]; then
+      SCRIPT_PATH="$( cd -P "${PREV_DIR}/$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+      SOURCE="$SCRIPT_PATH/$SOURCE_NAME"
+    else
+      SCRIPT_PATH="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+    fi
   done
 else
   SCRIPT_PATH="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"


### PR DESCRIPTION
`SCRIPT_PATH` can not be parsed is the softlink is in relative path rather than absolute path.