### PR TITLE
fix order of filters described in the comment

### DIFF
--- a/src/command/render/filters.ts
+++ b/src/command/render/filters.ts
@@ -519,8 +519,8 @@ export async function resolveFilters(
   // user filters
   // extension filters
   // quarto-filters <quarto>
-  // citeproc
   // quarto-finalizer
+  // citeproc
 
   const quartoFilters: string[] = [];
   quartoFilters.push(quartoPreFilter());


### PR DESCRIPTION
Based on initial change in 225a0cbc5842ab8c796b37c1a558e692f580ce48 about the filters order

I just noticed this while trying to check our filters order. Based on code  and 225a0cbc5842ab8c796b37c1a558e692f580ce48 , `citeproc`  is at the very end and our comment should be fixed  for our futur self I believe. 
