### PR TITLE
[R] Add namespace to functions from utils

### DIFF
--- a/src/resources/capabilities/knitr.R
+++ b/src/resources/capabilities/knitr.R
@@ -8,7 +8,7 @@ for (lib in .libPaths())
   cat(paste0('  - ', shQuote(lib)), "\n")
 cat("rmarkdown: ")
 if (requireNamespace("rmarkdown", quietly = TRUE)) {
-  cat(paste0('\"', as.character(packageVersion("rmarkdown")), '\"'))
+  cat(paste0('\"', as.character(utils::packageVersion("rmarkdown")), '\"'))
 } else {
   cat("null")
 }

--- a/src/resources/rmd/patch.R
+++ b/src/resources/rmd/patch.R
@@ -3,7 +3,7 @@
 
 # check whether knitr has native yaml chunk option parsing
 knitr_has_yaml_chunk_options <- function() {
-  packageVersion("knitr") >= "1.37.2"
+  utils::packageVersion("knitr") >= "1.37.2"
 }
 
 # only works w/ htmltools >= 0.5.0.9003 so overwrite in the meantime


### PR DESCRIPTION
Fixes #2187 by adding `utils::` to `packageVersion()`

Should we add tests somehow for this special case where defaults R packages are not loaded ? See #2187 description. 

It seems it would only affect `check` feature as loading **rmarkdown** when rendering would correctly load the required packages IMO