### PR TITLE
Avoid using unicode characters directly in hooks.R

### DIFF
--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -781,7 +781,7 @@ partition_yaml_options <- function(engine, code) {
     asy = "//",
     haskell = "--",
     dot = "//",
-    apl = "⍝"
+    apl = "\u235D"
   )
   comment_chars <- knitr_engine_comment_chars[[engine]] %||% "#"
   comment_start <- paste0(comment_chars[[1]], "| ")


### PR DESCRIPTION
because this can cause `source()` problems on Windows, e.g., https://d.cosx.org/d/423447

Also fixes #2184.