### PR TITLE
make utils.dump more robust to pandoc internal objects. Closes #2254

### DIFF
--- a/news/changelog-1.2.md
+++ b/news/changelog-1.2.md
@@ -40,3 +40,7 @@
 ## Bibliography output
 
 - Now support formats `bibtex`, `biblatex`, and `csljson`. When rendered to one of these formats any citations within the document will be rendered as the specified bibliography format.
+
+## Lua Filters
+
+- harden `quarto.utils.dump` so it works with pandoc's builtin global variables (#2254)

--- a/src/resources/filters/common/debug.lua
+++ b/src/resources/filters/common/debug.lua
@@ -36,17 +36,12 @@ function tdump (tbl, indent, refs)
   end
 end
 
--- "asLua" knows about pandoc opaque objects and converts them to Lua
--- objects ahead of debug printing
 function asLua(o)
   if type(o) ~= 'userdata' then
     return o
   end
-  local p = string.format("%p", o)
-
-  -- we check equality against the addresses to work around
-  -- https://github.com/jgm/pandoc/issues/8267
-  if p == string.format("%p", PANDOC_READER_OPTIONS) then
+  
+  if rawequal(o, PANDOC_READER_OPTIONS) then
     return {
       abbreviations = o.abbreviations,
       columns = o.columns,
@@ -58,7 +53,7 @@ function asLua(o)
       tab_stop = o.tab_stop,
       track_changes = o.track_changes,
     }
-  elseif p == string.format("%p", PANDOC_WRITER_OPTIONS) then
+  elseif rawequal(o, PANDOC_WRITER_OPTIONS) then
     return {
       cite_method = o.cite_method,
       columns = o.columns,

--- a/src/resources/filters/common/debug.lua
+++ b/src/resources/filters/common/debug.lua
@@ -1,15 +1,6 @@
 -- debug.lua
 -- Copyright (C) 2020 by RStudio, PBC
 
--- dump an object to stdout
-function dump(o)
-  if type(o) == 'table' then
-    tdump(o)
-  else
-    print(tostring(o) .. "\n")
-  end
-end
-
 -- improved formatting for dumping tables
 function tdump (tbl, indent, refs)
   if not refs then refs = {} end
@@ -27,8 +18,9 @@ function tdump (tbl, indent, refs)
   for k, v in pairs(tbl) do
     empty = false
     formatting = string.rep("  ", indent) .. k .. ": "
+    v = asLua(v)
     if type(v) == "table" then
-      print(formatting)
+      print(formatting .. "table: " .. address)
       refs[address] = true
       tdump(v, indent+1, refs)
     elseif type(v) == 'boolean' then
@@ -44,4 +36,88 @@ function tdump (tbl, indent, refs)
   end
 end
 
+-- "asLua" knows about pandoc opaque objects and converts them to Lua
+-- objects ahead of debug printing
+function asLua(o)
+  if type(o) ~= 'userdata' then
+    return o
+  end
+  local p = string.format("%p", o)
 
+  -- we check equality against the addresses to work around
+  -- https://github.com/jgm/pandoc/issues/8267
+  if p == string.format("%p", PANDOC_READER_OPTIONS) then
+    return {
+      abbreviations = o.abbreviations,
+      columns = o.columns,
+      default_image_extension = o.default_image_extension,
+      extensions = o.extensions,
+      indented_code_classes = o.indented_code_classes,
+      standalone = o.standalone,
+      strip_comments = o.strip_comments,
+      tab_stop = o.tab_stop,
+      track_changes = o.track_changes,
+    }
+  elseif p == string.format("%p", PANDOC_WRITER_OPTIONS) then
+    return {
+      cite_method = o.cite_method,
+      columns = o.columns,
+      dpi = o.dpi,
+      email_obfuscation = o.email_obfuscation,
+      epub_chapter_level = o.epub_chapter_level,
+      epub_fonts = o.epub_fonts,
+      epub_metadata = o.epub_metadata,
+      epub_subdirectory = o.epub_subdirectory,
+      extensions = o.extensions,
+      highlight_style = o.highlight_style,
+      html_math_method = o.html_math_method,
+      html_q_tags = o.html_q_tags,
+      identifier_prefix = o.identifier_prefix,
+      incremental = o.incremental,
+      listings = o.listings,
+      number_offset = o.number_offset,
+      number_sections = o.number_sections,
+      prefer_ascii = o.prefer_ascii,
+      reference_doc = o.reference_doc,
+      reference_links = o.reference_links,
+      reference_location = o.reference_location,
+      section_divs = o.section_divs,
+      setext_headers = o.setext_headers,
+      slide_level = o.slide_level,
+      tab_stop = o.tab_stop,
+      table_of_contents = o.table_of_contents,
+      template = o.template,
+      toc_depth = o.toc_depth,
+      top_level_division = o.top_level_division,
+      variables = o.variables,
+      wrap_text = o.wrap_text
+    }
+  end
+  v = tostring(o)
+  if string.find(v, "^pandoc CommonState") then
+    return {
+      input_files = o.input_files,
+      output_file = o.output_file,
+      log = o.log,
+      request_headers = o.request_headers,
+      resource_path = o.resource_path,
+      source_url = o.source_url,
+      user_data_dir = o.user_data_dir,
+      trace = o.trace,
+      verbosity = o.verbosity
+    }
+  elseif string.find(v, "^pandoc LogMessage") then
+    return v
+  end
+  return o
+end
+
+-- dump an object to stdout
+local function dump(o)
+  o = asLua(o)
+  if type(o) == 'table' then
+    tdump(o)
+  else
+    print(tostring(o) .. "\n")
+  end
+end

--- a/src/resources/pandoc/datadir/_utils.lua
+++ b/src/resources/pandoc/datadir/_utils.lua
@@ -1,5 +1,6 @@
--- debug.lua
+-- _utils.lua
 -- Copyright (C) 2020 by RStudio, PBC
+
 -- improved formatting for dumping tables
 function tdump (tbl, indent, refs)
   if not refs then refs = {} end
@@ -17,6 +18,7 @@ function tdump (tbl, indent, refs)
   for k, v in pairs(tbl) do
     empty = false
     formatting = string.rep("  ", indent) .. k .. ": "
+    v = asLua(v)
     if type(v) == "table" then
       print(formatting .. "table: " .. address)
       refs[address] = true
@@ -34,8 +36,85 @@ function tdump (tbl, indent, refs)
   end
 end
 
+-- "asLua" knows about pandoc opaque objects and converts them to Lua
+-- objects ahead of debug printing
+function asLua(o)
+  if type(o) ~= 'userdata' then
+    return o
+  end
+  local p = string.format("%p", o)
+
+  -- we check equality against the addresses to work around
+  -- https://github.com/jgm/pandoc/issues/8267
+  if p == string.format("%p", PANDOC_READER_OPTIONS) then
+    return {
+      abbreviations = o.abbreviations,
+      columns = o.columns,
+      default_image_extension = o.default_image_extension,
+      extensions = o.extensions,
+      indented_code_classes = o.indented_code_classes,
+      standalone = o.standalone,
+      strip_comments = o.strip_comments,
+      tab_stop = o.tab_stop,
+      track_changes = o.track_changes,
+    }
+  elseif p == string.format("%p", PANDOC_WRITER_OPTIONS) then
+    return {
+      cite_method = o.cite_method,
+      columns = o.columns,
+      dpi = o.dpi,
+      email_obfuscation = o.email_obfuscation,
+      epub_chapter_level = o.epub_chapter_level,
+      epub_fonts = o.epub_fonts,
+      epub_metadata = o.epub_metadata,
+      epub_subdirectory = o.epub_subdirectory,
+      extensions = o.extensions,
+      highlight_style = o.highlight_style,
+      html_math_method = o.html_math_method,
+      html_q_tags = o.html_q_tags,
+      identifier_prefix = o.identifier_prefix,
+      incremental = o.incremental,
+      listings = o.listings,
+      number_offset = o.number_offset,
+      number_sections = o.number_sections,
+      prefer_ascii = o.prefer_ascii,
+      reference_doc = o.reference_doc,
+      reference_links = o.reference_links,
+      reference_location = o.reference_location,
+      section_divs = o.section_divs,
+      setext_headers = o.setext_headers,
+      slide_level = o.slide_level,
+      tab_stop = o.tab_stop,
+      table_of_contents = o.table_of_contents,
+      template = o.template,
+      toc_depth = o.toc_depth,
+      top_level_division = o.top_level_division,
+      variables = o.variables,
+      wrap_text = o.wrap_text
+    }
+  end
+  v = tostring(o)
+  if string.find(v, "^pandoc CommonState") then
+    return {
+      input_files = o.input_files,
+      output_file = o.output_file,
+      log = o.log,
+      request_headers = o.request_headers,
+      resource_path = o.resource_path,
+      source_url = o.source_url,
+      user_data_dir = o.user_data_dir,
+      trace = o.trace,
+      verbosity = o.verbosity
+    }
+  elseif string.find(v, "^pandoc LogMessage") then
+    return v
+  end
+  return o
+end
+
 -- dump an object to stdout
 local function dump(o)
+  o = asLua(o)
   if type(o) == 'table' then
     tdump(o)
   else

--- a/src/resources/pandoc/datadir/_utils.lua
+++ b/src/resources/pandoc/datadir/_utils.lua
@@ -42,11 +42,8 @@ function asLua(o)
   if type(o) ~= 'userdata' then
     return o
   end
-  local p = string.format("%p", o)
-
-  -- we check equality against the addresses to work around
-  -- https://github.com/jgm/pandoc/issues/8267
-  if p == string.format("%p", PANDOC_READER_OPTIONS) then
+  
+  if rawequal(o, PANDOC_READER_OPTIONS) then
     return {
       abbreviations = o.abbreviations,
       columns = o.columns,
@@ -58,7 +55,7 @@ function asLua(o)
       tab_stop = o.tab_stop,
       track_changes = o.track_changes,
     }
-  elseif p == string.format("%p", PANDOC_WRITER_OPTIONS) then
+  elseif rawequal(o, PANDOC_WRITER_OPTIONS) then
     return {
       cite_method = o.cite_method,
       columns = o.columns,


### PR DESCRIPTION
This Lua filter produces a good output now:

```
Pandoc = function(doc)
  quarto.utils.dump({
    PANDOC_READER_OPTIONS = PANDOC_READER_OPTIONS,
    PANDOC_WRITER_OPTIONS = PANDOC_WRITER_OPTIONS,
    PANDOC_VERSION = PANDOC_VERSION,
    FORMAT = FORMAT,
    PANDOC_VERSION = PANDOC_VERSION,
    PANDOC_API_VERSION = PANDOC_API_VERSION,
    PANDOC_SCRIPT_FILE = PANDOC_SCRIPT_FILE,
    PANDOC_STATE = PANDOC_STATE,
    pandoc = pandoc,
    lpeg = lpeg,
    re = re  
  })
end 
```

