### PR TITLE
Fix contrast for a11y-light token with default code-block bg

### DIFF
--- a/news/changelog-1.2.md
+++ b/news/changelog-1.2.md
@@ -49,3 +49,4 @@
 - Improve YAML validation error messages on values of type object (#2191)
 - Upgrade esbuild to 0.15.6
 - Implement --help option for quarto preview and quarto run
+- Increase contrast for a11y-light theme to work with default code-block background (#2067)

--- a/src/resources/pandoc/highlight-styles/a11y-light.theme
+++ b/src/resources/pandoc/highlight-styles/a11y-light.theme
@@ -4,7 +4,7 @@
             "line-number-color": "#767676",
                 "line-number-background-color": null,
                     "_comments": [
-                        "Last update: Mar 12, 2022 (revision 1)",
+                        "Last update: Aug 23, 2022 (revision 1.1)",
                         "This file has been adapted from: https://github.com/ericwbailey/a11y-syntax-highlighting#a11y-light",
                         "Also see: https://github.com/ericwbailey/a11y-syntax-highlighting/blob/main/dist/highlight/a11y-light.css"
                     ],
@@ -29,7 +29,7 @@
                             "underline": false
         },
         "Attribute": {
-            "text-color": "#aa5d00",
+            "text-color": "#a55a00",
                 "background-color": null,
                     "bold": false,
                         "italic": false,
@@ -99,7 +99,7 @@
                             "underline": false
         },
         "Variable": {
-            "text-color": "#aa5d00",
+            "text-color": "#a55a00",
                 "background-color": null,
                     "bold": false,
                         "italic": false,
@@ -176,7 +176,7 @@
                             "underline": false
         },
         "Float": {
-            "text-color": "#aa5d00",
+            "text-color": "#a55a00",
                 "background-color": null,
                     "bold": false,
                         "italic": false,


### PR DESCRIPTION
Re-do of PR #2067, now with 95 fewer commits!