### PR TITLE
ensure external links opened in separate window when document rendered in iframe

### DIFF
--- a/src/command/preview/preview.ts
+++ b/src/command/preview/preview.ts
@@ -592,11 +592,11 @@ function htmlFileRequestHandlerOptions(
           file = format.formatPreviewFile(file, format);
         }
         const fileContents = await Deno.readFile(file);
-        return reloader.injectClient(fileContents, inputFile);
+        return reloader.injectClient(req, fileContents, inputFile);
       } else if (isTextContent(file)) {
         const html = await textPreviewHtml(file, req);
         const fileContents = new TextEncoder().encode(html);
-        return reloader.injectClient(fileContents, inputFile);
+        return reloader.injectClient(req, fileContents, inputFile);
       }
     },
   };

--- a/src/core/http-devserver.ts
+++ b/src/core/http-devserver.ts
@@ -179,11 +179,21 @@ function devserverHtmlResourcePath(resource: string) {
   return resourcePath(`editor/devserver/devserver-${resource}.html`);
 }
 
-export function isViewerIFrameRequest(url?: string | null) {
-  const isViewer = url && (
-    url.includes("capabilities=") || // rstudio viewer
-    url.includes("vscodeBrowserReqId=") || // vscode simple browser
-    url.includes("quartoPreviewReqId=") // generic embedded browser
-  );
-  return isViewer;
+export function isViewerIFrameRequest(req: Request) {
+
+  for (const url of [req.url, req.referrer]) {
+
+    const isViewer = url && (
+      url.includes("capabilities=") || // rstudio viewer
+      url.includes("vscodeBrowserReqId=") || // vscode simple browser
+      url.includes("quartoPreviewReqId=") // generic embedded browser
+    );
+
+    if (isViewer) {
+      return true;
+    }
+
+  }
+
+  return false;
 }

--- a/src/core/pdfjs.ts
+++ b/src/core/pdfjs.ts
@@ -64,7 +64,7 @@ export function pdfJsFileHandler(
           basename(pdfFile()),
         );
       // always hide the sidebar in the viewer pane
-      const isViewer = isViewerIFrameRequest(req.headers.get("Referer"));
+      const isViewer = isViewerIFrameRequest(req);
 
       if (isViewer) {
         viewerJs = viewerJs.replace(

--- a/src/core/pdfjs.ts
+++ b/src/core/pdfjs.ts
@@ -7,6 +7,7 @@
 
 import { basename, join } from "path/mod.ts";
 import { md5Hash } from "./hash.ts";
+import { isViewerIFrameRequest } from "./http-devserver.ts";
 import { FileResponse } from "./http.ts";
 import { contentType } from "./mime.ts";
 import { pathWithForwardSlashes } from "./path.ts";
@@ -63,12 +64,8 @@ export function pdfJsFileHandler(
           basename(pdfFile()),
         );
       // always hide the sidebar in the viewer pane
-      const referrer = req.headers.get("Referer");
-      const isViewer = referrer && (
-        referrer.includes("capabilities=") || // rstudio viewer
-        referrer.includes("vscodeBrowserReqId=") || // vscode simple browser
-        referrer.includes("quartoPreviewReqId=") // generic embedded browser
-      );
+      const isViewer = isViewerIFrameRequest(req.headers.get("Referer"));
+
       if (isViewer) {
         viewerJs = viewerJs.replace(
           "sidebarView: sidebarView",

--- a/src/project/serve/serve.ts
+++ b/src/project/serve/serve.ts
@@ -339,7 +339,7 @@ export async function serveProject(
     },
 
     // handle html file requests w/ re-renders
-    onFile: async (file: string) => {
+    onFile: async (file: string, req: Request) => {
       // if this is an html file or a pdf then re-render (using the freezer)
       if (isHtmlContent(file) || isPdfContent(file)) {
         // find the input file associated with this output and render it
@@ -425,6 +425,7 @@ export async function serveProject(
             relative(watcher.project().dir, inputFile),
           );
           return watcher.injectClient(
+            req,
             fileContents,
             projInputFile,
           );
@@ -466,7 +467,7 @@ export async function serveProject(
       }
       return {
         print,
-        response: watcher.injectClient(body),
+        response: watcher.injectClient(req, body),
       };
     },
   };
@@ -521,11 +522,11 @@ export async function serveProject(
     // install custom handler for pdfjs
     handlerOptions.onFile = pdfJsFileHandler(
       pdfOutputFile!,
-      async (file: string) => {
+      async (file: string, req: Request) => {
         // inject watcher client for html
         if (isHtmlContent(file)) {
           const fileContents = await Deno.readFile(file);
-          return watcher.injectClient(fileContents);
+          return watcher.injectClient(req, fileContents);
         } else {
           return undefined;
         }

--- a/src/project/serve/types.ts
+++ b/src/project/serve/types.ts
@@ -12,6 +12,7 @@ export interface ProjectWatcher {
   handle: (req: Request) => boolean;
   connect: (req: Request) => Promise<Response | undefined>;
   injectClient: (
+    req: Request,
     file: Uint8Array,
     inputFile?: string,
   ) => FileResponse;

--- a/src/project/serve/watch.ts
+++ b/src/project/serve/watch.ts
@@ -332,8 +332,8 @@ export function watchProject(
       return devServer.handle(req);
     },
     connect: devServer.connect,
-    injectClient: (file: Uint8Array, inputFile?: string) => {
-      return devServer.injectClient(file, inputFile);
+    injectClient: (req: Request, file: Uint8Array, inputFile?: string) => {
+      return devServer.injectClient(req, file, inputFile);
     },
     hasClients: () => devServer.hasClients(),
     reloadClients: async (output: boolean, reloadTarget?: string) => {

--- a/src/resources/editor/devserver/devserver-iframe.html
+++ b/src/resources/editor/devserver/devserver-iframe.html
@@ -2,10 +2,8 @@
 <script type="text/javascript">
 (function() {
 
-  // save document origin (this might change as a page is navigated)
-  // e.g. in Quarto books so we need to know the original value
-  var origin = document.location.origin;
-  var search = window.location.search;
+  var origin = "<%- origin %>";
+  var search = "<%- search %>";
 
   function isLocalHref(href) {
     return href.startsWith(origin);
@@ -30,7 +28,6 @@
 
     var isRStudio = search.includes("capabilities=");
     if (isRStudio) {
-      console.log("Hello from quarto-cli");
       linkEl.target = "_blank";
     }
 

--- a/src/resources/editor/devserver/devserver-iframe.html
+++ b/src/resources/editor/devserver/devserver-iframe.html
@@ -1,6 +1,15 @@
 
-<script type="application/javascript">
+<script type="text/javascript">
+(function() {
 
-  console.log("hello, iframe");
+  // Ensure that external links open in a new window by default.
+  var links = document.getElementsByTagName("a");
+  for (var i = 0; i < links.length; i++) {
+    if (!links[i].href.startsWith(document.location.origin)) {
+      links[i].target = "_blank";
+    }
+  }
+
+})();
 
 </script>

--- a/src/resources/editor/devserver/devserver-iframe.html
+++ b/src/resources/editor/devserver/devserver-iframe.html
@@ -2,31 +2,50 @@
 <script type="text/javascript">
 (function() {
 
-  // Ensure that external links open in a new window by default.
-  var links = document.getElementsByTagName("a");
-  for (var i = 0; i < links.length; i++) {
-    var link = links[i];
-    if (!link.href.startsWith(document.location.origin)) {
-      // vscode
-      if (window.location.search.includes("quartoPreviewReqId=")) {
-        var url = link.href;
-        link.onclick = function(ev) {
-          if (window.parent.postMessage) {
-            window.parent.postMessage({
-              type: "openExternal",
-              url: url
-            }, "*");
-          }
-          ev.preventDefault();
-          ev.stopPropagation();
-          return false;
-        };
-      // rstudio
-      } else if (window.location.search.includes("capabilities=")) {
-        link.target = "_blank";
+  // save document origin (this might change as a page is navigated)
+  // e.g. in Quarto books so we need to know the original value
+  var origin = document.location.origin;
+  var search = window.location.search;
+
+  function isLocalHref(href) {
+    return href.startsWith(origin);
+  }
+
+  function ensureLinkOpensInNewWindow(linkEl) {
+
+    var useOpenExternalMessage =
+      search.includes("quartoPreviewReqId=") &&
+      window.parent.postMessage;
+
+    if (useOpenExternalMessage) {
+      linkEl.addEventListener("click", function(event) {
+        window.parent.postMessage({
+          type: "openExternal",
+          url: linkEl.href,
+        }, "*");
+        event.preventDefault();
+        return false;
+      });
+    }
+
+    var isRStudio = search.includes("capabilities=");
+    if (isRStudio) {
+      console.log("Hello from quarto-cli");
+      linkEl.target = "_blank";
+    }
+
+  }
+
+  function initialize() {
+    var linkEls = document.getElementsByTagName("a");
+    for (var linkEl of linkEls) {
+      if (!isLocalHref(linkEl.href)) {
+        ensureLinkOpensInNewWindow(linkEl);
       }
     }
   }
+
+  initialize();
 
 })();
 

--- a/src/resources/editor/devserver/devserver-iframe.html
+++ b/src/resources/editor/devserver/devserver-iframe.html
@@ -5,8 +5,26 @@
   // Ensure that external links open in a new window by default.
   var links = document.getElementsByTagName("a");
   for (var i = 0; i < links.length; i++) {
-    if (!links[i].href.startsWith(document.location.origin)) {
-      links[i].target = "_blank";
+    var link = links[i];
+    if (!link.href.startsWith(document.location.origin)) {
+      // vscode
+      if (window.location.search.includes("quartoPreviewReqId=")) {
+        var url = link.href;
+        link.onclick = function(ev) {
+          if (window.parent.postMessage) {
+            window.parent.postMessage({
+              type: "openExternal",
+              url: url
+            }, "*");
+          }
+          ev.preventDefault();
+          ev.stopPropagation();
+          return false;
+        };
+      // rstudio
+      } else if (window.location.search.includes("capabilities=")) {
+        link.target = "_blank";
+      }
     }
   }
 

--- a/src/resources/editor/devserver/devserver-iframe.html
+++ b/src/resources/editor/devserver/devserver-iframe.html
@@ -1,0 +1,6 @@
+
+<script type="application/javascript">
+
+  console.log("hello, iframe");
+
+</script>


### PR DESCRIPTION
This PR ensures that, for Quarto documents previewed to HTML which are hosted within an iframe, that external links are opened with an external browser, rather than having an attempted navigation occur within the iframe.

Tested with https://github.com/jjallaire/hopr.