### PR TITLE
Configure the Github Issue chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report an error or unexpected behavior you saw while using this package
+description: Report an error or unexpected behavior
 labels: [bug]
 
 body:
@@ -7,14 +7,15 @@ body:
     attributes:
       value: |
         Welcome to the quarto GitHub repo.
-        
+
         We are always happy to hear feedback from our users.
-        
+
         Quarto is under active development! If convenient, we'd appreciate if you could check that the issue persists on the [latest nightly release](https://github.com/quarto-dev/quarto-cli/releases).
 
-        Finally, so that we can get the most out of your bug report, consider reading [this webpage](https://quarto.org/bug-reports.html) on improving bug reports.
-        
+        Finally, so that we can get the most out of your bug report, consider reading [this webpage](https://quarto.org/bug-reports.html) on improving bug reports.
+
         Thank you for using Quarto!
+
   - type: textarea
     attributes:
       label: Bug description
@@ -27,7 +28,7 @@ body:
         print("Hello Quarto!")
         ```
         ````
-        
+
   - type: checkboxes
     attributes:
       label: Checklist
@@ -35,6 +36,6 @@ body:
         When filing a bug report, if possible, please keep the following in mind so we have as much info as possible:
       options:
         - label: Please include a minimal, fully reproducible example in a single .qmd file? Please provide the whole file rather than the snippet you believe is causing the issue.
-        - label: "Please [format your issue](https://yihui.org/issue/#please-format-your-issue-correctly) so it is easier for us to read the bug report."
+        - label: "Please [format your issue](https://quarto.org/bug-reports.html#formatting-make-githubs-markdown-work-for-us) so it is easier for us to read the bug report."
         - label: Please document the RStudio IDE version you're running (if applicable), by providing the value displayed in the "About RStudio" main menu dialog?
         - label: Please document the operating system you're running. If on Linux, please provide the specific distribution.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Issue guide
+    url: https://quarto.org/bug-reports.html
+    about: First time here or need a refresh? Please consult the issue guide before posting.
+  - name: Ask a question
+    url: https://github.com/quarto-dev/quarto-cli/discussions/categories/q-a
+    about: Please ask and answer questions in our Discussion board
+  - name: Share an idea, a missing feature or anything else
+    url: https://github.com/quarto-dev/quarto-cli/discussions/
+    about: Please give us any feedback in our Discussion board


### PR DESCRIPTION
To add some more choices when a user go to the issue workflow

Doc about this Github feature in https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

The proposal is to have something like in **rmarkdown** (https://github.com/rstudio/rmarkdown/issues/new/choose) 
![image](https://user-images.githubusercontent.com/6791940/188452036-58cf1315-e8ac-45fd-9071-819f0a44ee9d.png)

or in RStudio IDE (https://github.com/rstudio/rstudio/issues/new/choose)
![image](https://user-images.githubusercontent.com/6791940/188452170-c458ae51-4f03-4ea1-9bad-75753ebe4773.png)

Proposal: 

* Issues are opened in the repo following the template
* Link to issue guide is shared from the chooser so that user know where to find it even before opening an issue
* Questions should be opened to https://github.com/quarto-dev/quarto-cli/discussions/categories/q-a so we share a link to the category directly
* Any type of feedback can be shared in our Dicussion board, and the last link point to Discussion. 

The two last could be merged in one link.

`blank_issues_enabled: false` means it is not possible to open a blank issue - I think it is valid as we allow discussion board for anything so that if someone does not want to open a Bug, then it will be a new discussion (we could convert to issue). 

This is a first proposal to have a more welcoming page when someone click on "New Issue" in this repo. 