### PR TITLE
Adapt regex for latex table environment

### DIFF
--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -1557,7 +1557,7 @@ local function resolveServiceWorkers(serviceworkers)
  end
 
 
-local latexTableWithOptionsPattern = "(\\begin{table}%[%w+%])(.*)(\\end{table})"
+local latexTableWithOptionsPattern = "(\\begin{table}%[[^%]]+%])(.*)(\\end{table})"
 local latexTablePattern = "(\\begin{table})(.*)(\\end{table})"
 local latexLongtablePatternwWithPosAndAlign = "(\\begin{longtable}%[[^%]]+%]{.-})(.*)(\\end{longtable})"
 local latexLongtablePatternWithPos = "(\\begin{longtable}%[[^%]]+%])(.*)(\\end{longtable})"


### PR DESCRIPTION
to support position option like in `\begin{table}[h!]`

fixes #2295

I did not add tests in this PR for this as I am encountering several issues with current tests unfortunately. It seems some of our feature does not work correctly with **knitr** LaTeX table. I'll open new issues and follow up to add more tests on this. 
