### PR TITLE
Attempt to fix authors localization

### DIFF
--- a/src/resources/filters/common/authors.lua
+++ b/src/resources/filters/common/authors.lua
@@ -100,7 +100,7 @@ local kPostalCode = 'postal-code'
 -- labels contains the suggested labels for the various elements which 
 -- are localized and should correctly deal with plurals, etc...
 local kLabels = 'labels'
-local kAuthorLbl = 'author'
+local kAuthorLbl = 'authors'
 local kAffiliationLbl = 'affiliation'
 local kPublishedLbl = 'published'
 local kDoiLbl = 'doi'


### PR DESCRIPTION
Fixes #2485.

## Description

Not sure if this is a correct fix, but here's why I think so:

- `kAuthorLbl`, which was defined as `'author'`, is only used in this one file
- the English value `"Authors"` is written in a field named `authors`
- the localized value is written in a field whose name is the value of `kAuthorLbl`, in an apparent attempt to overwrite the value

## Checklist

I have (if applicable):

- [X] filed a [contributor agreement](../CONTRIBUTING.md).
- [X] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
