### PR TITLE
Adding more information to the error when the chrome process has errored

### DIFF
--- a/src/core/cri/cri.ts
+++ b/src/core/cri/cri.ts
@@ -88,7 +88,15 @@ export async function criClient(appPath?: string, port?: number) {
   const browser = Deno.run({ cmd, stdout: "piped", stderr: "piped" });
 
   if (!(await waitForServer(port as number))) {
-    throw new Error("Couldn't find open server");
+    let msg = "Couldn't find open server.";
+    // Printing more error information if chrome process errored
+    if (!(await browser.status()).success) {
+      const rawError = await browser.stderrOutput();
+      const errorString = new TextDecoder().decode(rawError);
+      msg = msg + "\n" + `Chrome process error: ${errorString}`;
+    }
+
+    throw new Error(msg);
   }
 
   // deno-lint-ignore no-explicit-any


### PR DESCRIPTION
It will allow us to get more information in bug report like in #1822

It does not solve our chromium install issue though, but first step to understand what the issue is for user (and us when they open issue).

This is what we get now for example
````
$ quarto render --to pdf
Check file:///root/projects/quarto-cli/src/quarto.ts
[1/4] index.qmd
[2/4] intro.qmd
ERROR: Couldn't find open server.
Chrome process error: /root/.local/share/quarto/chromium/linux-869685/chrome-linux/chrome: error while loading shared libraries: libnss3.so: cannot open shared object file: No such file or directory
````

