### PR TITLE
Increase contrast for a11y-light token

### DIFF
--- a/news/changelog-1.2.md
+++ b/news/changelog-1.2.md
@@ -140,7 +140,7 @@
 - Improve YAML validation error messages on values of type object (#2191)
 - Upgrade esbuild to 0.15.6
 - Implement --help option for quarto preview and quarto run
-- Increase contrast for a11y-light theme to work with default code-block background (#2067)
+- Increase contrast for a11y-light theme to work with default code-block background (#2067, #2528)
 - Upgrade to deno 1.25.1, which should lead to a 2-3x speedup in quarto startup time
 - Use deno arm64 native binaries on macOS
 - Set working dir to `QUARTO_WORKING_DIR` variable if provided.

--- a/src/resources/pandoc/highlight-styles/a11y-light.theme
+++ b/src/resources/pandoc/highlight-styles/a11y-light.theme
@@ -71,7 +71,7 @@
                             "underline": false
         },
         "Operator": {
-            "text-color": "#007faa",
+            "text-color": "#00769e",
                 "background-color": null,
                     "bold": false,
                         "italic": false,
@@ -204,7 +204,7 @@
                             "underline": false
         },
         "SpecialChar": {
-            "text-color": "#007faa",
+            "text-color": "#00769e",
                 "background-color": null,
                     "bold": false,
                         "italic": false,


### PR DESCRIPTION
* Increases contrast so WCAG compliant when "a11y" is specified (uses default Quarto code block bg color), vs when "a11y-light" is specified (uses a11y-light code block bg color).
