### PR TITLE
Typo in `self-contained` YAML description

### DIFF
--- a/src/resources/schema/document-render.yml
+++ b/src/resources/schema/document-render.yml
@@ -72,7 +72,7 @@
     short: "Produce a standalone HTML file with no external dependencies"
     long: |
       Produce a standalone HTML file with no external dependencies. Note that
-      this option has been decrecated in favor of `embed-resources`.
+      this option has been deprecated in favor of `embed-resources`.
 
 - name: self-contained-math
   tags:


### PR DESCRIPTION
I believe this is the source where all comes from. 

Especially this should close quarto-dev/quarto-web#406 once we regenerate all the files. 

I am not sure of the all workflow though. 

Is this correctly the only file to modify ? Are the update to JS files with reference description automatic  ? 

Also, are the files in quarto-web correctly generated from this YAML ? 

Hopefully I got it right.