### PR TITLE
Code Copy Button Improvements

### DIFF
--- a/news/changelog-1.2.md
+++ b/news/changelog-1.2.md
@@ -43,6 +43,9 @@
 - Properly maintain dark/light state when navigating between pages
 - Fix `code-copy` button issue when `page-layout` is full with no visible `toc` (#2388)
 - Add support for scss variables to better control the table of contents appearance (`$toc-color`,`$toc-font-size`,`$toc-active-border`,`$toc-inactive-border`)
+- Provide more explicit code-copy feedback using a tooltip
+- Improve coloring of code copy button when using various `highlight-styles`.
+- Support scss variables to customize the code copy button using `$btn-code-copy-color`, `$btn-code-copy-color-active`
 
 ## PDF Format
 

--- a/src/format/html/format-html-shared.ts
+++ b/src/format/html/format-html-shared.ts
@@ -27,6 +27,7 @@ import {
 
 import { formatResourcePath } from "../../core/resources.ts";
 import { Document, Element } from "../../core/deno-dom.ts";
+import { ConsoleHandler } from "../../vendor/deno.land/std@0.153.0/log/handlers.ts";
 
 // features that are enabled by default for 'html'. setting
 // all of these to false will yield the minimal html output
@@ -122,6 +123,12 @@ export const quartoRules = () =>
     "_quarto-rules.scss",
   ));
 
+export const quartoCopyCodeDefaults = () =>
+  Deno.readTextFileSync(formatResourcePath(
+    "html",
+    "_quarto-variables-copy-code.scss",
+  ));
+
 export const quartoCopyCodeRules = () =>
   Deno.readTextFileSync(formatResourcePath(
     "html",
@@ -199,8 +206,10 @@ export const quartoBaseLayer = (
   codeFilename = false,
 ) => {
   const rules: string[] = [quartoRules()];
+  const defaults: string[] = [quartoDefaults(format), quartoVariables()];
   if (codeCopy) {
     rules.push(quartoCopyCodeRules());
+    defaults.push(quartoCopyCodeDefaults());
   }
   if (tabby) {
     rules.push(quartoTabbyRules());
@@ -217,10 +226,7 @@ export const quartoBaseLayer = (
 
   return {
     uses: quartoUses(),
-    defaults: [
-      quartoDefaults(format),
-      quartoVariables(),
-    ].join("\n"),
+    defaults: defaults.join("\n"),
     functions: quartoFunctions(),
     mixins: "",
     rules: rules.join("\n"),

--- a/src/resources/formats/html/_quarto-rules-copy-code.scss
+++ b/src/resources/formats/html/_quarto-rules-copy-code.scss
@@ -13,7 +13,7 @@
 }
 
 .code-copy-button-tooltip {
-  font-size: 0.6em;
+  font-size: 0.75em;
 }
 
 #{$code-copy-selector} .code-copy-button > .bi::before {
@@ -22,8 +22,8 @@
   width: 1rem;
   content: "";
   vertical-align: -0.125em;
-  @if variable-exists(text-muted) {
-    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#{colorToRGB($text-muted)}" viewBox="0 0 16 16"><path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1v-1z"/><path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"/></svg>');
+  @if variable-exists(btn-code-copy-color) {
+    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#{colorToRGB($btn-code-copy-color)}" viewBox="0 0 16 16"><path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1v-1z"/><path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"/></svg>');
   } @else {
     background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1v-1z"/><path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"/></svg>');
   }
@@ -32,18 +32,18 @@
 }
 
 #{$code-copy-selector} .code-copy-button-checked > .bi::before {
-  @if variable-exists(text-muted) {
-    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#{colorToRGB($text-muted)}" viewBox="0 0 16 16"><path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z"/></svg>');
+  @if variable-exists(btn-code-copy-color) {
+    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#{colorToRGB($btn-code-copy-color)}" viewBox="0 0 16 16"><path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z"/></svg>');
   } @else {
     background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z"/></svg>');
   }
 }
 
-@if variable-exists(link-color) {
+@if variable-exists(btn-code-copy-color-active) {
   #{$code-copy-selector} .code-copy-button:hover > .bi::before {
-    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#{colorToRGB($link-color)}" viewBox="0 0 16 16"><path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1v-1z"/><path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"/></svg>');
+    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#{colorToRGB($btn-code-copy-color-active)}" viewBox="0 0 16 16"><path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1v-1z"/><path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"/></svg>');
   }
   #{$code-copy-selector} .code-copy-button-checked:hover > .bi::before {
-    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#{colorToRGB($link-color)}"  viewBox="0 0 16 16"><path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z"/></svg>');
+    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#{colorToRGB($btn-code-copy-color-active)}"  viewBox="0 0 16 16"><path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z"/></svg>');
   }
 }

--- a/src/resources/formats/html/_quarto-rules-copy-code.scss
+++ b/src/resources/formats/html/_quarto-rules-copy-code.scss
@@ -12,6 +12,10 @@
   outline: none;
 }
 
+.code-copy-button-tooltip {
+  font-size: 0.6em;
+}
+
 #{$code-copy-selector} .code-copy-button > .bi::before {
   display: inline-block;
   height: 1rem;

--- a/src/resources/formats/html/_quarto-variables-copy-code.scss
+++ b/src/resources/formats/html/_quarto-variables-copy-code.scss
@@ -1,0 +1,7 @@
+// code block colors
+$btn-code-copy-color: $text-muted !default;
+$btn-code-copy-color-active: if(
+  variable-exists(link-color),
+  $link-color,
+  #0d6efd
+) !default;

--- a/src/resources/formats/html/templates/quarto-html.ejs
+++ b/src/resources/formats/html/templates/quarto-html.ejs
@@ -188,6 +188,7 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
     }
   });
 
+
   clipboard.on('success', function(e) {
     // button target
     const button = e.trigger;
@@ -197,7 +198,28 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
     button.classList.add('code-copy-button-checked');
     var currentTitle = button.getAttribute("title");
     button.setAttribute("title", "<%- language['copy-button-tooltip-success'] %>");
+
+
+    let tooltip;
+    if (window.bootstrap) {
+      button.setAttribute("data-bs-toggle", "tooltip");
+      button.setAttribute("data-bs-placement", "left");
+      button.setAttribute("data-bs-title", "<%- language['copy-button-tooltip-success'] %>");
+
+      tooltip = new bootstrap.Tooltip(button, 
+        { trigger: "manual", 
+          customClass: "code-copy-button-tooltip",
+          offset: [0, -8]});
+      tooltip.show();    
+    }
+
     setTimeout(function() {
+      if (tooltip) {
+        tooltip.hide();
+        button.removeAttribute("data-bs-title");
+        button.removeAttribute("data-bs-toggle");
+        button.removeAttribute("data-bs-placement");
+      }
       button.setAttribute("title", currentTitle);
       button.classList.remove('code-copy-button-checked');
     }, 1000);


### PR DESCRIPTION
### New Color (derived from the `highlight-style` so always works)
We now use the text highlight style to select colors for the code copy button. Users may override this with the SCSS variables :
`$btn-code-copy-color`
`$btn-code-copy-color-active`

![Screen Shot 2022-09-22 at 2 09 05 PM](https://user-images.githubusercontent.com/261654/191820682-b0e378a5-1aab-4e98-a2fe-5191f7e4e799.png)

### Tooltip feedback (like Github, confirms copy)
We now provide stronger copy feedback in the form of a BS tooltip. If BS is not present we don't show this tooltip.

![Screen Shot 2022-09-22 at 2 09 07 PM](https://user-images.githubusercontent.com/261654/191820661-25979a29-41b7-4f24-ad36-0a3db5c437b0.png)

Fixes #1359, #1360