### PR TITLE
More natural Japanese when copying is completed

### DIFF
--- a/src/resources/language/_language-ja.yml
+++ b/src/resources/language/_language-ja.yml
@@ -33,7 +33,7 @@ code-tools-view-source: "ソースコードを表示"
 code-tools-source-code: "ソースコード"
 
 copy-button-tooltip: "コピー"
-copy-button-tooltip-success: "完了"
+copy-button-tooltip-success: "コピーしました"
 
 repo-action-links-edit: "編集"
 repo-action-links-source: "ソースコード"


### PR DESCRIPTION
In Japanese, I felt that it is not very common to display "完了" when copying is complete.
For example, https://zenn.dev/, which is popular in Japan, displays "コピーしました！".

![image](https://user-images.githubusercontent.com/50911393/192552896-b2a06b49-8d18-4331-8f85-47b2652bd4e7.png)

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](../CONTRIBUTING.md).
