### PR TITLE
Bugfix/issue 2314

### DIFF
--- a/news/changelog-1.2.md
+++ b/news/changelog-1.2.md
@@ -18,6 +18,7 @@
 - support `revealjs` and `html` formats in `width` builtin, fallback gracefully otherwise (#2058)
 - Don't emit `ojs_define` HTML in non-html formats (#2338)
 - Support jszip and exceljs (#1981)
+- Hide `code-fold` chrome when OJS code is hidden (#2134)
 
 ## Extensions
 

--- a/src/command/render/codetools.ts
+++ b/src/command/render/codetools.ts
@@ -274,13 +274,18 @@ export function codeToolsPostprocessor(format: Format) {
           }
 
           // if code is statically hidden, hide code-tools chrome as well.
-          // note that we're querying on pre.hidden and not div.hidden
-          // because the hidden class hasn't been hoisted to the parent by
-          // the html postprocessor yet.
+
+          // note that we're querying on pre.hidden and div.hidden both
+          //
+          // because for regular code cells, the hidden class hasn't been
+          // hoisted to the parent by the html postprocessor yet,
+          // but for OJS cells, they're emitted as hidden from the start.
 
           for (
             const el of Array.from(
-              doc.querySelectorAll("details div pre.hidden"),
+              doc.querySelectorAll(
+                "details div pre.hidden",
+              ),
             )
           ) {
             const det = el.parentElement!.parentElement;
@@ -329,9 +334,12 @@ function resolveCodeTools(format: Format, doc: Document): CodeTools {
   // if we have requested toggle, make sure there are things to toggle
   if (codeToolsResolved.toggle) {
     const codeDetails = doc.querySelector(".cell > details > .sourceCode");
-    const codeHidden = doc.querySelector(".cell .sourceCode.hidden");
-    codeToolsResolved.toggle = codeToolsResolved.toggle &&
-      (!!codeDetails || !!codeHidden);
+
+    // we don't OJS hidden cells in this check, since when echo: false, we emit them hidden
+    const codeHidden = doc.querySelector(
+      ".cell .sourceCode.hidden:not(div pre.js)",
+    );
+    codeToolsResolved.toggle = !!codeDetails || !!codeHidden;
   }
 
   // return resolved

--- a/src/resources/filters/quarto-post/foldcode.lua
+++ b/src/resources/filters/quarto-post/foldcode.lua
@@ -18,8 +18,12 @@ function foldCode()
               if fold == "show" then
                 open = " open"
               end
+              local style = ""
+              if block.attr.classes:includes("hidden") then
+                style = ' class="hidden"'
+              end
               local beginPara = pandoc.Plain({
-                pandoc.RawInline("html", "<details" .. open .. ">\n<summary>"),
+                pandoc.RawInline("html", "<details" .. open .. style .. ">\n<summary>"),
               })
               
               if not isEmpty(summary) then


### PR DESCRIPTION
Closes #2314.

In addition, closes a `code-tools` bug related to the same overall problem. On a configuration where

```yaml
code-tools: true
code-fold: false
```

OJS code with `echo: false` would be hidden (properly, as it always is), but our `code-tools` toggle would still appear, and "show all code" would cause the hidden OJS code to show. This PR fixes that issue as well.