### PR TITLE
allow latex environments in markdown math

### DIFF
--- a/news/changelog-1.2.md
+++ b/news/changelog-1.2.md
@@ -2,7 +2,7 @@
 
 - Always ignore .ipynb inputs when they have a corresponding .qmd
 - Correctly interpret cell metadata with `false` values
-- Render text/latex outputs consisting entirely of $ math as markdown math
+- Render text/latex outputs as markdown math when they consist entirely of $ math, or are wrapped in a LaTeX environment block (such as \begin{align} ... \end{align})
 - Use IPython 7.14 import syntax in `ojs_define`
 - Correct handling of multiple attachments in Jupyter Notebook classic
 - Prevent overwrite of source .ipynb when output format is ipynb

--- a/src/core/jupyter/display-data.ts
+++ b/src/core/jupyter/display-data.ts
@@ -105,13 +105,24 @@ export function displayDataMimeType(
   return null;
 }
 
+export function displayDataLatexIsMath(latex: string[]) {
+  if (latex.length > 0) {
+    const first = latex[0];
+    const last = latex[latex.length - 1];
+    return (
+      // Inline or display math
+      (first.startsWith("$") && last.endsWith("$")) ||
+      // Latex environment
+      (first.startsWith("\\begin{") && last.includes("\\end{"))
+    );
+  }
+  return false;
+}
+
 export function displayDataWithMarkdownMath(output: JupyterOutputDisplayData) {
   if (Array.isArray(output.data[kTextLatex]) && !output.data[kTextMarkdown]) {
     const latex = output.data[kTextLatex] as string[];
-    if (
-      latex.length > 0 && latex[0].startsWith("$") &&
-      latex[latex.length - 1].endsWith("$")
-    ) {
+    if (displayDataLatexIsMath(latex)) {
       output = ld.cloneDeep(output);
       output.data[kTextMarkdown] = output.data[kTextLatex];
       return output;


### PR DESCRIPTION
## Description

Previously only math wrapped in `$...$` was allowed through, but other maths environments such as `\begin{align}...\end{align}` are also valid.

## Checklist

I have (if applicable):

- [X] filed a [contributor agreement](../CONTRIBUTING.md) -- emailed just now
- [ ] referenced the GitHub issue this PR closes
- [X] updated the appropriate changelog
