### PR TITLE
change back underlining regions to work with js-yaml annotations

### DIFF
--- a/news/changelog-1.2.md
+++ b/news/changelog-1.2.md
@@ -212,3 +212,4 @@
 - Don't use tree-sitter outside of interactive IDE contexts (#2502)
 - Support custom Lua writers in YAML front matter (#2687)
 - Better error message with inadvertent `!` in YAML strings (#2808)
+- More precise underlining of YAML validation errors (#2681)

--- a/src/core/lib/yaml-validation/errors.ts
+++ b/src/core/lib/yaml-validation/errors.ts
@@ -953,8 +953,8 @@ export function createSourceContext(
         const endColumn = (lineNumber < end.line ? rawLine.length : end.column);
         contextLines.push(content);
         contextLines.push(
-          " ".repeat(prefixWidth + startColumn) +
-            "~".repeat(endColumn - startColumn),
+          " ".repeat(prefixWidth + startColumn - 1) +
+            "~".repeat(endColumn - startColumn + 1),
         );
       }
     }


### PR DESCRIPTION
Closes #2681.

(Context: we switched away from tree-sitter-yaml as the preferred yaml parser. tree-sitter emits regions whose offsets are one character off from js-yaml. This fixes that.)