### PR TITLE
carry project config to kernelspec determination. Closes #2853

### DIFF
--- a/news/changelog-1.2.md
+++ b/news/changelog-1.2.md
@@ -8,6 +8,7 @@
 - Prevent overwrite of source .ipynb when output format is ipynb
 - Prefer kernel declared in YAML front matter when executing notebooks
 - Fix v1.1 regression in handling of cell display_data w/ Juptyer widgets
+- Allow jupyter kernel to be determined project-wide (#2853)
 
 ## Knitr
 

--- a/src/command/render/render-contexts.ts
+++ b/src/command/render/render-contexts.ts
@@ -203,6 +203,8 @@ export async function renderContexts(
   const { engine, target } = await fileExecutionEngineAndTarget(
     file.path,
     options.flags,
+    undefined,
+    project,
   );
 
   const engineClaimReason = fileEngineClaimReason(file.path);
@@ -269,6 +271,7 @@ export async function renderContexts(
           file.path,
           options.flags,
           markdown,
+          project,
         );
         context.engine = engine;
         context.target = target;

--- a/src/execute/engine.ts
+++ b/src/execute/engine.ts
@@ -27,6 +27,7 @@ import { languages as handlerLanguages } from "../core/handlers/base.ts";
 import { MappedString } from "../core/lib/text-types.ts";
 import { RenderFlags } from "../command/render/types.ts";
 import { mergeConfigs } from "../core/config.ts";
+import { ProjectContext } from "../project/types.ts";
 
 const kEngines: ExecutionEngine[] = [
   knitrEngine,
@@ -190,13 +191,14 @@ export async function fileExecutionEngineAndTarget(
   file: string,
   flags?: RenderFlags,
   markdown?: MappedString,
+  project?: ProjectContext,
 ) {
   const engine = fileExecutionEngine(file, flags, markdown);
   if (!engine) {
     throw new Error("Unable to render " + file);
   }
 
-  const target = await engine.target(file, flags?.quiet, markdown);
+  const target = await engine.target(file, flags?.quiet, markdown, project);
   if (!target) {
     throw new Error("Unable to render " + file);
   }

--- a/src/execute/jupyter/jupyter.ts
+++ b/src/execute/jupyter/jupyter.ts
@@ -86,6 +86,7 @@ import {
 import { asMappedString } from "../../core/lib/mapped-text.ts";
 import { MappedString, mappedStringFromFile } from "../../core/mapped-text.ts";
 import { breakQuartoMd } from "../../core/lib/break-quarto-md.ts";
+import { ProjectContext } from "../../project/types.ts";
 
 export const jupyterEngine: ExecutionEngine = {
   name: kJupyterEngine,
@@ -128,6 +129,7 @@ export const jupyterEngine: ExecutionEngine = {
     file: string,
     _quiet?: boolean,
     markdown?: MappedString,
+    project?: ProjectContext,
   ): Promise<ExecutionTarget | undefined> => {
     // at some point we'll resolve a full notebook/kernelspec
     let nb: JupyterNotebook | undefined;
@@ -157,8 +159,9 @@ export const jupyterEngine: ExecutionEngine = {
         metadata,
         data: { transient: true, kernelspec: {} },
       };
-      nb = await createNotebookforTarget(target);
+      nb = await createNotebookforTarget(target, project);
       target.data.kernelspec = nb.metadata.kernelspec;
+
       return target;
     } else if (isJupyterNotebook(file)) {
       return {
@@ -422,8 +425,11 @@ async function ensureYamlKernelspec(
   }
 }
 
-async function createNotebookforTarget(target: ExecutionTarget) {
-  const nb = await quartoMdToJupyter(target.markdown.value, true);
+async function createNotebookforTarget(
+  target: ExecutionTarget,
+  project?: ProjectContext,
+) {
+  const nb = await quartoMdToJupyter(target.markdown.value, true, project);
   Deno.writeTextFileSync(target.input, JSON.stringify(nb, null, 2));
   return nb;
 }

--- a/src/execute/types.ts
+++ b/src/execute/types.ts
@@ -15,6 +15,7 @@ import { PartitionedMarkdown } from "../core/pandoc/types.ts";
 import { RenderOptions } from "../command/render/types.ts";
 import { MappedString } from "../core/lib/text-types.ts";
 import { HandlerContextResults } from "../core/handlers/types.ts";
+import { ProjectContext } from "../project/types.ts";
 
 export const kQmdExtensions = [".qmd"];
 
@@ -34,6 +35,7 @@ export interface ExecutionEngine {
     file: string,
     quiet?: boolean,
     markdown?: MappedString,
+    project?: ProjectContext,
   ) => Promise<ExecutionTarget | undefined>;
   partitionedMarkdown: (
     file: string,


### PR DESCRIPTION
The determination of a kernelspec needs to know about project configuration, so we add that to `target`, etc.

This closes #2853.