### PR TITLE
Fix regression caused by listing warnings

### DIFF
--- a/src/project/types/website/listing/website-listing-read.ts
+++ b/src/project/types/website/listing/website-listing-read.ts
@@ -738,7 +738,10 @@ async function listItemFromFile(
     // This is a draft, don't include it in the listing
     return undefined;
   } else {
-    if (!docRawMetadata && extname(input) === ".qmd") {
+    if (
+      !docRawMetadata && extname(input) === ".qmd" ||
+      extname(input) === ".ipynb"
+    ) {
       warning(
         `File ${input} in the listing '${listing.id}' contains no metadata.`,
       );


### PR DESCRIPTION
This re-fixes #367

My implementation of warning regarding empty qmd files was way too aggressive, scale it back.

