### PR TITLE
Update _language-it.yml

### DIFF
--- a/src/resources/language/_language-it.yml
+++ b/src/resources/language/_language-it.yml
@@ -11,7 +11,7 @@ section-title-citation: "Citazione"
 appendix-attribution-bibtex: "BibTeX"
 appendix-attribution-cite-as: "Per favore citare questo lavoro come:"
 
-title-block-author-single: "Autore/a"
+title-block-author-single: "Autore/Autrice"
 title-block-author-plural: "Autori"
 title-block-affiliation-single: "Affiliazione"
 title-block-affiliation-plural: "Affiliazioni"


### PR DESCRIPTION
Author in Italia (male) is "Autore", and "Autrice" for female. Than it's not "Autore/a". It could be "Autore/trice", but I think it's better the full version "Autore/Autrice"

Welcome to the quarto GitHub repo!

We are always happy to hear feedback from our users.

To file a _pull request_, please follow these instructions carefully: <https://yihui.org/issue/#bug-reports>

If you're a collaborator from outside `quarto-dev` making changes larger than a typo, please make sure you have filed an [individual](https://rstudioblog.files.wordpress.com/2017/05/rstudio_individual_contributor_agreement.pdf) or [corporate](https://rstudioblog.files.wordpress.com/2017/05/rstudio_corporate_contributor_agreement.pdf) contributor agreement. You can send the signed copy to jj@rstudio.com.

Also, please complete and keep the checklist below.

## Description

Please describe your PR here.

````md
```py
print("An Italian localization correction proposal")
```
````

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](../CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
