### PR TITLE
Fix table top border rendering for html

### DIFF
--- a/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
@@ -1060,11 +1060,9 @@ div.hanging-indent {
   word-break: break-word;
 }
 
-.table {
-  border-top: 1px solid $table-border-color;
-}
-
 .table > thead {
+  border-top-width: 1px;
+  border-top-color: $table-border-color;
   border-bottom: 1px solid $table-group-separator-color;
 }
 

--- a/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
@@ -1060,17 +1060,12 @@ div.hanging-indent {
   word-break: break-word;
 }
 
-.table > :not(:first-child) {
-  border-top-width: 1px;
-  border-top-color: $table-border-color;
+.table {
+  border-top: 1px solid $table-border-color;
 }
 
 .table > thead {
   border-bottom: 1px solid $table-group-separator-color;
-}
-
-.table > tbody {
-  border-top: 1px solid $table-border-color;
 }
 
 @if $code-block-border-left {


### PR DESCRIPTION
As explained in issue #3084, the top border of tables does not always render correctly in html because of the way the html is generated by Pandoc and the css rules defined for tables. This pull request fixes #3084 and simplifies the border rules.

I don't know if this bug fix is large enough to require a signed contributor agreement. Please let me know if I have to file one!