### PR TITLE
use plain table for theorem types

### DIFF
--- a/src/resources/filters/common/theorems.lua
+++ b/src/resources/filters/common/theorems.lua
@@ -2,7 +2,7 @@
 -- Copyright (C) 2020 by RStudio, PBC
 
 -- available theorem types
-theoremTypes = pandoc.List({
+theoremTypes = {
   thm = {
     env = "theorem",
     style = "plain",
@@ -43,7 +43,7 @@ theoremTypes = pandoc.List({
     style = "definition",
     title = "Exercise"
   }
-})
+}
 
 function hasTheoremRef(el)
   local type = refType(el.attr.identifier)


### PR DESCRIPTION
Bug originally reported by @andrie

MRE is any div with a three letter prefix that doesn't match one of the theorem or proof types, e.g.

```markdown
::: {#new-platforms}
:::
```

Will result in this error:

```bash
Error running filter C:/Users/apdev/AppData/Local/Programs/Quarto/share/filters/crossref/crossref.lua:
...ocal/Programs/Quarto/share/filters/crossref/crossref.lua:2096: attempt to index a function value (local 'theoremType')
stack traceback:
	...ocal/Programs/Quarto/share/filters/crossref/crossref.lua:1239: in function <...ocal/Programs/Quarto/share/filters/crossref/crossref.lua:1233>
```

Error traced to the fact that our lookup table for theorem types uses `pandoc.List`, which returns a function for a missed key lookup with brackets (in this case `theoremTypes["new"]`) which passes our `nil` check.

This change turns it into an ordinary Lua table, which matches the semantics of all of its uses (it is basically indexed using `[]` and `tkeys()` is called on it.

