### PR TITLE
Properly set id attribute to ensure re-use

### DIFF
--- a/src/resources/projects/website/navigation/quarto-nav.js
+++ b/src/resources/projects/website/navigation/quarto-nav.js
@@ -88,6 +88,7 @@ window.document.addEventListener("DOMContentLoaded", function () {
     let linkStyle = window.document.querySelector("#quarto-target-style");
     if (!linkStyle) {
       linkStyle = window.document.createElement("style");
+      linkStyle.setAttribute("id", "quarto-target-style");
       window.document.head.appendChild(linkStyle);
     }
     while (linkStyle.firstChild) {

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -47,7 +47,7 @@ Pygments==2.9.0
 pyparsing==3.0.9
 pyrsistent==0.17.3
 python-dateutil==2.8.1
-pyzmq==22.1.0
+pyzmq==24.0.1
 qtconsole==5.1.0
 QtPy==1.9.0
 Send2Trash==1.7.1


### PR DESCRIPTION
We are attempting to reuse the same style tag, but since the id attribute is not properly set, we miss the existing style tag and append a new one.

Fixes #3172

