### PR TITLE
Do not add trailing slash to code-server proxy uri

### DIFF
--- a/news/changelog-1.2.md
+++ b/news/changelog-1.2.md
@@ -152,6 +152,7 @@
 - Restart Jupyter kernel daemon if preview server is restarted.
 - Enable use of external preview servers for serving project output
 - Add `--no-serve` command line parameter to prevent serving altogether
+- Do not add trailing slash to VSCODE_PROXY_URI set by code-server
 
 ## Publishing
 

--- a/src/command/render/render-shared.ts
+++ b/src/command/render/render-shared.ts
@@ -179,7 +179,7 @@ export async function printBrowsePreviewMessage(
     info(`\nBrowse at ${url}`, { format: colors.green });
   } else if (isVSCodeTerminal() && isVSCodeServer()) {
     const browseUrl = vsCodeServerProxyUri()!.replace("{{port}}", `${port}`) +
-      "/" + path;
+      path;
     info(`\nBrowse at ${browseUrl}`, { format: colors.green });
   } else if (isJupyterHubServer()) {
     const httpReferrer = `${


### PR DESCRIPTION
## Description

It is already added since code-server v4.8.0: https://github.com/coder/code-server/issues/5711

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](../CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [x] updated the appropriate changelog
