### PR TITLE
Update Company name where feasible

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,5 +1,5 @@
 Quarto
-Copyright (C) 2020-2021 RStudio, PBC
+Copyright (C) 2020-2022 Posit Software, PBC
 
 With the exceptions noted below, this code is released under the 
 [GPL](http://www.gnu.org/copyleft/gpl.html), version 2 or later:
@@ -23,4 +23,3 @@ the source distribution.  On Debian systems, the complete text of the
 GPL can be found in `/usr/share/common-licenses/GPL`.
 
 Quarto's source code is at https://github.com/quarto-dev/quarto-cli
-

--- a/package/src/bld.ts
+++ b/package/src/bld.ts
@@ -1,7 +1,7 @@
 /*
 * package.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { Command } from "cliffy/command/mod.ts";

--- a/package/src/cmd/pkg-cmd.ts
+++ b/package/src/cmd/pkg-cmd.ts
@@ -1,7 +1,7 @@
 /*
 * pkg-cmd.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { Command } from "cliffy/command/mod.ts";

--- a/package/src/common/archive-binary-dependencies.ts
+++ b/package/src/common/archive-binary-dependencies.ts
@@ -1,7 +1,7 @@
 /*
 * archive-binary-dependencies.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { join } from "path/mod.ts";

--- a/package/src/common/compile-quarto-latexmk.ts
+++ b/package/src/common/compile-quarto-latexmk.ts
@@ -1,7 +1,7 @@
 /*
 * compile-quarto-latexmk.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { Command } from "cliffy/command/mod.ts";

--- a/package/src/common/config.ts
+++ b/package/src/common/config.ts
@@ -1,7 +1,7 @@
 /*
 * config.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 
@@ -42,8 +42,10 @@ export function readConfiguration(
   const out = join(pkg, getEnv("QUARTO_OUT_DIR") || "out");
 
   const dist = getEnv("QUARTO_DIST_PATH") || "dist";
-  const share = getEnv("QUARTO_SHARE_PATH") || join(dist, getEnv("QUARTO_SHARE_DIR") || "share");
-  const bin = getEnv("QUARTO_BIN_PATH") || join(dist, getEnv("QUARTO_BIN_DIR") || "bin");
+  const share = getEnv("QUARTO_SHARE_PATH") ||
+    join(dist, getEnv("QUARTO_SHARE_DIR") || "share");
+  const bin = getEnv("QUARTO_BIN_PATH") ||
+    join(dist, getEnv("QUARTO_BIN_DIR") || "bin");
   const directoryInfo = {
     root,
     pkg,

--- a/package/src/common/configure.ts
+++ b/package/src/common/configure.ts
@@ -1,7 +1,7 @@
 /*
 * dependencies.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { dirname, join, SEP } from "path/mod.ts";

--- a/package/src/common/create-dev-import-map.ts
+++ b/package/src/common/create-dev-import-map.ts
@@ -1,7 +1,7 @@
 /*
 * create-dev-import-map.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 
@@ -12,7 +12,9 @@ const QUARTO_SRC_PATH = Deno.env.get("QUARTO_SRC_PATH") || ".";
 
 const importMapSpecs = [
   {
-    importMap: JSON.parse(Deno.readTextFileSync(join(QUARTO_SRC_PATH, "import_map.json"))),
+    importMap: JSON.parse(
+      Deno.readTextFileSync(join(QUARTO_SRC_PATH, "import_map.json")),
+    ),
     prefix: "",
   },
   {

--- a/package/src/common/create-schema-types.ts
+++ b/package/src/common/create-schema-types.ts
@@ -1,7 +1,7 @@
 /*
 * create-schema-types.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/package/src/common/cyclic-dependencies.ts
+++ b/package/src/common/cyclic-dependencies.ts
@@ -1,7 +1,7 @@
 /*
 * cyclic-dependencies.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { basename, isAbsolute, join } from "path/mod.ts";
@@ -140,8 +140,8 @@ function parseSwcBundlerLog(
 }
 async function loadModules(config: Configuration) {
   info("Reading modules");
-  const denoExecPath = Deno.env.get("QUARTO_DENO")
-  if (! denoExecPath) {
+  const denoExecPath = Deno.env.get("QUARTO_DENO");
+  if (!denoExecPath) {
     throw Error("QUARTO_DENO is not defined");
   }
   const result = await runCmd(

--- a/package/src/common/dependencies/dartsass.ts
+++ b/package/src/common/dependencies/dartsass.ts
@@ -1,7 +1,7 @@
 /*
 * dartsass.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { existsSync } from "fs/mod.ts";
@@ -19,7 +19,6 @@ export function dartSass(version: string): Dependency {
       url:
         `https://github.com/sass/dart-sass/releases/download/${version}/${filename}`,
       configure: async (path: string) => {
-
         const vendor = Deno.env.get("QUARTO_VENDOR_BINARIES");
         if (vendor === undefined || vendor === "true") {
           // Remove existing dart-sass dir

--- a/package/src/common/dependencies/deno_dom.ts
+++ b/package/src/common/dependencies/deno_dom.ts
@@ -1,7 +1,7 @@
 /*
 * deno_dom.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/package/src/common/dependencies/dependencies.ts
+++ b/package/src/common/dependencies/dependencies.ts
@@ -1,7 +1,7 @@
 /*
 * dependencies.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/package/src/common/dependencies/esbuild.ts
+++ b/package/src/common/dependencies/esbuild.ts
@@ -1,7 +1,7 @@
 /*
 * esbuild.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { existsSync } from "fs/mod.ts";
@@ -21,11 +21,9 @@ export function esBuild(version: string): Dependency {
       url:
         `https://registry.npmjs.org/esbuild-${platformstr}/-/esbuild-${platformstr}-${version}.tgz`,
       configure: async (path: string) => {
-
         const file = Deno.build.os === "windows" ? "esbuild.exe" : "esbuild";
         const vendor = Deno.env.get("QUARTO_VENDOR_BINARIES");
         if (vendor === undefined || vendor === "true") {
-
           // Remove existing dir
           const dir = dirname(path);
 

--- a/package/src/common/dependencies/pandoc.ts
+++ b/package/src/common/dependencies/pandoc.ts
@@ -1,7 +1,7 @@
 /*
 * pandoc.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { existsSync } from "fs/mod.ts";
@@ -28,7 +28,7 @@ export function pandoc(version: string): Dependency {
         const pandocSubdir = join(dir, `pandoc-${version}`);
         const vendor = Deno.env.get("QUARTO_VENDOR_BINARIES");
         if (vendor === undefined || vendor === "true") {
-         // Clean pandoc interim dir
+          // Clean pandoc interim dir
           if (existsSync(pandocSubdir)) {
             Deno.removeSync(pandocSubdir, { recursive: true });
           }

--- a/package/src/common/import-report/deno-info.ts
+++ b/package/src/common/import-report/deno-info.ts
@@ -3,7 +3,7 @@
 *
 * functions and interfaces for processing data from `deno info --json`
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/package/src/common/package-filters.ts
+++ b/package/src/common/package-filters.ts
@@ -1,7 +1,7 @@
 /*
 * package-filters.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { dirname, join } from "path/mod.ts";

--- a/package/src/common/prepare-dist.ts
+++ b/package/src/common/prepare-dist.ts
@@ -1,7 +1,7 @@
 /*
 * prepare-dist.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/package/src/common/update-html-dependencies.ts
+++ b/package/src/common/update-html-dependencies.ts
@@ -1,7 +1,7 @@
 /*
 * bootstrap.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { ensureDir, ensureDirSync, existsSync } from "fs/mod.ts";

--- a/package/src/common/update-pandoc.ts
+++ b/package/src/common/update-pandoc.ts
@@ -1,7 +1,7 @@
 /*
 * update-pandoc.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { Command } from "cliffy/command/mod.ts";

--- a/package/src/linux/installer.ts
+++ b/package/src/linux/installer.ts
@@ -1,7 +1,7 @@
 /*
 * installer.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { join } from "path/mod.ts";
@@ -82,7 +82,8 @@ export async function makeInstallerDeb(
   control = control + val("Installed-Size", `${Math.round(size / 1024)}`);
   control = control + val("Section", "user/text");
   control = control + val("Priority", "optional");
-  control = control + val("Maintainer", "RStudio, PBC <quarto@rstudio.org>");
+  control = control +
+    val("Maintainer", "Posit Software, PBC <quarto@rstudio.org>");
   control = control + val("Homepage", url);
   control = control +
     val(
@@ -108,7 +109,7 @@ export async function makeInstallerDeb(
   copyrightLines.push(`Source: ${url}`);
   copyrightLines.push("");
   copyrightLines.push("Files: *");
-  copyrightLines.push("Copyright: RStudio, PBC.");
+  copyrightLines.push("Copyright: Posit Software, PBC.");
   copyrightLines.push("License: GPL-2+");
   const copyrightText = copyrightLines.join("\n");
   Deno.writeTextFileSync(join(debianDir, "copyright"), copyrightText);

--- a/package/src/macos/installer.ts
+++ b/package/src/macos/installer.ts
@@ -1,7 +1,7 @@
 /*
 * installer.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/package/src/util/cmd.ts
+++ b/package/src/util/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/package/src/util/deno.ts
+++ b/package/src/util/deno.ts
@@ -1,7 +1,7 @@
 /*
 * deno.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { info } from "log/mod.ts";
@@ -14,8 +14,8 @@ export async function bundle(
 ) {
   // Bundle source code
   const denoBundleCmd: string[] = [];
-  const denoExecPath = Deno.env.get("QUARTO_DENO")
-  if (! denoExecPath) {
+  const denoExecPath = Deno.env.get("QUARTO_DENO");
+  if (!denoExecPath) {
     throw Error("QUARTO_DENO is not defined");
   }
   denoBundleCmd.push(denoExecPath);
@@ -48,8 +48,8 @@ export async function compile(
   configuration: Configuration,
 ) {
   const denoBundleCmd: string[] = [];
-  const denoExecPath = Deno.env.get("QUARTO_DENO")
-  if (! denoExecPath) {
+  const denoExecPath = Deno.env.get("QUARTO_DENO");
+  if (!denoExecPath) {
     throw Error("QUARTO_DENO is not defined");
   }
   denoBundleCmd.push(denoExecPath);
@@ -79,8 +79,8 @@ export async function install(
   configuration: Configuration,
 ) {
   const denoBundleCmd: string[] = [];
-  const denoExecPath = Deno.env.get("QUARTO_DENO")
-  if (! denoExecPath) {
+  const denoExecPath = Deno.env.get("QUARTO_DENO");
+  if (!denoExecPath) {
     throw Error("QUARTO_DENO is not defined");
   }
   denoBundleCmd.push(denoExecPath);
@@ -124,8 +124,8 @@ export function updateDenoPath(installPath: string, config: Configuration) {
   if (installPath) {
     info("Updating install script deno path");
     const installTxt = Deno.readTextFileSync(installPath);
-    const denoExecPath = Deno.env.get("QUARTO_DENO")
-    if (! denoExecPath) {
+    const denoExecPath = Deno.env.get("QUARTO_DENO");
+    if (!denoExecPath) {
       throw Error("QUARTO_DENO is not defined");
     }
     const finalTxt = Deno.build.os === "windows"

--- a/package/src/util/github.ts
+++ b/package/src/util/github.ts
@@ -1,7 +1,7 @@
 /*
 * github.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { join } from "path/mod.ts";

--- a/package/src/util/tar.ts
+++ b/package/src/util/tar.ts
@@ -1,7 +1,7 @@
 /*
 * tar.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/package/src/windows/quarto.wxs
+++ b/package/src/windows/quarto.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Name="Quarto" Language="1033" Manufacturer="Rstudio, PBC" Version="$(env.QUARTO_INSTALLER_VERSION)" UpgradeCode="$(env.QUARTO_MSI_UPGRADE_CODE)">
+  <Product Id="*" Name="Quarto" Language="1033" Manufacturer="Posit Software, PBC" Version="$(env.QUARTO_INSTALLER_VERSION)" UpgradeCode="$(env.QUARTO_MSI_UPGRADE_CODE)">
 
     <Package InstallerVersion="300" Compressed="yes" InstallScope="perMachine" />
 

--- a/src/command/add/cmd.ts
+++ b/src/command/add/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 import { Command } from "cliffy/command/mod.ts";

--- a/src/command/build-js/cmd.ts
+++ b/src/command/build-js/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/capabilities/capabilities.ts
+++ b/src/command/capabilities/capabilities.ts
@@ -1,7 +1,7 @@
 /*
 * capabilities.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/capabilities/cmd.ts
+++ b/src/command/capabilities/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/check/check.ts
+++ b/src/command/check/check.ts
@@ -1,7 +1,7 @@
 /*
 * check.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/check/cmd.ts
+++ b/src/command/check/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/command.ts
+++ b/src/command/command.ts
@@ -1,7 +1,7 @@
 /*
 * command.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/convert/cmd.ts
+++ b/src/command/convert/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/convert/jupyter.ts
+++ b/src/command/convert/jupyter.ts
@@ -1,7 +1,7 @@
 /*
 * jupyter.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/create-project/cmd.ts
+++ b/src/command/create-project/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/create/artifacts/artifact-shared.ts
+++ b/src/command/create/artifacts/artifact-shared.ts
@@ -1,7 +1,7 @@
 /*
 * artifact-shared.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/create/artifacts/document.ts
+++ b/src/command/create/artifacts/document.ts
@@ -1,7 +1,7 @@
 /*
 * document.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/create/artifacts/extension.ts
+++ b/src/command/create/artifacts/extension.ts
@@ -1,7 +1,7 @@
 /*
 * extension.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/create/artifacts/project.ts
+++ b/src/command/create/artifacts/project.ts
@@ -1,7 +1,7 @@
 /*
 * project.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/create/cmd.ts
+++ b/src/command/create/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/create/editor.ts
+++ b/src/command/create/editor.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/inspect/cmd.ts
+++ b/src/command/inspect/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/install/cmd.ts
+++ b/src/command/install/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 import { Command } from "cliffy/command/mod.ts";

--- a/src/command/list/cmd.ts
+++ b/src/command/list/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 import { Command } from "cliffy/command/mod.ts";

--- a/src/command/pandoc/cmd.ts
+++ b/src/command/pandoc/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * pandoc.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/preview/cmd.ts
+++ b/src/command/preview/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 
@@ -125,7 +125,7 @@ export const previewCommand = new Command()
   )
   // deno-lint-ignore no-explicit-any
   .action(async (options: any, file?: string, ...args: string[]) => {
-  // one-time initialization of yaml validation modules
+    // one-time initialization of yaml validation modules
     setInitializer(initYamlIntelligenceResourcesFromFilesystem);
     await initState();
 

--- a/src/command/preview/preview.ts
+++ b/src/command/preview/preview.ts
@@ -1,7 +1,7 @@
 /*
 * preview.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/publish/account.ts
+++ b/src/command/publish/account.ts
@@ -1,7 +1,7 @@
 /*
 * account.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/publish/cmd.ts
+++ b/src/command/publish/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 
@@ -53,7 +53,7 @@ export const publishCommand =
       "Publish a document or project. Available providers include:\n\n" +
         " - Quarto Pub (quarto-pub)\n" +
         " - GitHub Pages (gh-pages)\n" +
-        " - RStudio Connect (connect)\n" +
+        " - Posit Connect (connect)\n" +
         " - Netlify (netlify)\n\n" +
         "Accounts are configured interactively during publishing.\n" +
         "Manage/remove accounts with: quarto publish accounts",
@@ -104,7 +104,7 @@ export const publishCommand =
       "quarto publish gh-pages",
     )
     .example(
-      "Publish project to RStudio Connect",
+      "Publish project to Posit Connect",
       "quarto publish connect",
     )
     .example(

--- a/src/command/publish/deployment.ts
+++ b/src/command/publish/deployment.ts
@@ -1,7 +1,7 @@
 /*
 * deployment.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/publish/options.ts
+++ b/src/command/publish/options.ts
@@ -1,7 +1,7 @@
 /*
 * options.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/remove/cmd.ts
+++ b/src/command/remove/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/authors.ts
+++ b/src/command/render/authors.ts
@@ -1,7 +1,7 @@
 /*
 * authors.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/cleanup.ts
+++ b/src/command/render/cleanup.ts
@@ -1,7 +1,7 @@
 /*
 * renderCleanup.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/cmd.ts
+++ b/src/command/render/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/codetools.ts
+++ b/src/command/render/codetools.ts
@@ -1,7 +1,7 @@
 /*
 * codetools.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/constants.ts
+++ b/src/command/render/constants.ts
@@ -1,7 +1,7 @@
 /*
 * constants.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/crossref.ts
+++ b/src/command/render/crossref.ts
@@ -1,7 +1,7 @@
 /*
 * crossref.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/defaults.ts
+++ b/src/command/render/defaults.ts
@@ -1,7 +1,7 @@
 /*
 * defaults.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/filters.ts
+++ b/src/command/render/filters.ts
@@ -1,7 +1,7 @@
 /*
 * filters.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/flags.ts
+++ b/src/command/render/flags.ts
@@ -1,7 +1,7 @@
 /*
 * flags.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { existsSync } from "fs/mod.ts";

--- a/src/command/render/freeze.ts
+++ b/src/command/render/freeze.ts
@@ -1,7 +1,7 @@
 /*
 * freeze.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 
@@ -20,7 +20,11 @@ import { cloneDeep } from "../../core/lodash.ts";
 import { inputFilesDir } from "../../core/render.ts";
 import { TempContext } from "../../core/temp.ts";
 import { md5Hash } from "../../core/hash.ts";
-import { removeIfEmptyDir, removeIfExists, safeRemoveIfExists } from "../../core/path.ts";
+import {
+  removeIfEmptyDir,
+  removeIfExists,
+  safeRemoveIfExists,
+} from "../../core/path.ts";
 
 import {
   kIncludeAfterBody,

--- a/src/command/render/latexmk/latex.ts
+++ b/src/command/render/latexmk/latex.ts
@@ -1,7 +1,7 @@
 /*
  * latex.ts
  *
- * Copyright (C) 2020 by RStudio, PBC
+ * Copyright (C) 2020-2022 Posit Software, PBC
  *
  */
 

--- a/src/command/render/latexmk/latexmk.ts
+++ b/src/command/render/latexmk/latexmk.ts
@@ -1,7 +1,7 @@
 /*
  * latexmk.ts
  *
- * Copyright (C) 2020 by RStudio, PBC
+ * Copyright (C) 2020-2022 Posit Software, PBC
  *
  */
 

--- a/src/command/render/latexmk/parse-error.ts
+++ b/src/command/render/latexmk/parse-error.ts
@@ -1,7 +1,7 @@
 /*
  * log.ts
  *
- * Copyright (C) 2020 by RStudio, PBC
+ * Copyright (C) 2020-2022 Posit Software, PBC
  *
  */
 

--- a/src/command/render/latexmk/pdf.ts
+++ b/src/command/render/latexmk/pdf.ts
@@ -1,7 +1,7 @@
 /*
  * pdf.ts
  *
- * Copyright (C) 2020 by RStudio, PBC
+ * Copyright (C) 2020-2022 Posit Software, PBC
  *
  */
 

--- a/src/command/render/latexmk/pkgmgr.ts
+++ b/src/command/render/latexmk/pkgmgr.ts
@@ -1,7 +1,7 @@
 /*
  * pkgmgr.ts
  *
- * Copyright (C) 2020 by RStudio, PBC
+ * Copyright (C) 2020-2022 Posit Software, PBC
  *
  */
 

--- a/src/command/render/latexmk/texlive.ts
+++ b/src/command/render/latexmk/texlive.ts
@@ -1,7 +1,7 @@
 /*
  * texlive.ts
  *
- * Copyright (C) 2020 by RStudio, PBC
+ * Copyright (C) 2020-2022 Posit Software, PBC
  *
  */
 import { info } from "log/mod.ts";

--- a/src/command/render/latexmk/types.ts
+++ b/src/command/render/latexmk/types.ts
@@ -1,7 +1,7 @@
 /*
 * types.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { PdfEngine } from "../../../config/types.ts";

--- a/src/command/render/layout.ts
+++ b/src/command/render/layout.ts
@@ -1,7 +1,7 @@
 /*
 * layout.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/output-tex.ts
+++ b/src/command/render/output-tex.ts
@@ -1,7 +1,7 @@
 /*
 * output-tex.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/output.ts
+++ b/src/command/render/output.ts
@@ -1,7 +1,7 @@
 /*
 * output.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/pandoc-dependencies-html.ts
+++ b/src/command/render/pandoc-dependencies-html.ts
@@ -1,7 +1,7 @@
 /*
 * pandoc-dependencies-html.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/pandoc-dependencies-resources.ts
+++ b/src/command/render/pandoc-dependencies-resources.ts
@@ -1,7 +1,7 @@
 /*
 * pandoc-dependencies-resources.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/pandoc-dependencies.ts
+++ b/src/command/render/pandoc-dependencies.ts
@@ -1,7 +1,7 @@
 /*
 * pandoc-dependencies.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/pandoc-html.ts
+++ b/src/command/render/pandoc-html.ts
@@ -1,7 +1,7 @@
 /*
 * pandoc-html.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/pandoc.ts
+++ b/src/command/render/pandoc.ts
@@ -1,7 +1,7 @@
 /*
 * pandoc.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/project.ts
+++ b/src/command/render/project.ts
@@ -1,7 +1,7 @@
 /*
 * project.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/render-contexts.ts
+++ b/src/command/render/render-contexts.ts
@@ -1,7 +1,7 @@
 /*
 * render-info.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/render-files.ts
+++ b/src/command/render/render-files.ts
@@ -1,7 +1,7 @@
 /*
 * render-files.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/render-info.ts
+++ b/src/command/render/render-info.ts
@@ -1,7 +1,7 @@
 /*
 * render-info.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/render-paths.ts
+++ b/src/command/render/render-paths.ts
@@ -1,7 +1,7 @@
 /*
 * render-paths.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/render-shared.ts
+++ b/src/command/render/render-shared.ts
@@ -1,7 +1,7 @@
 /*
 * render-shared.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/render.ts
+++ b/src/command/render/render.ts
@@ -1,7 +1,7 @@
 /*
 * render.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/resources.ts
+++ b/src/command/render/resources.ts
@@ -1,7 +1,7 @@
 /*
 * resources.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/render/template.ts
+++ b/src/command/render/template.ts
@@ -1,7 +1,7 @@
 /*
 * template.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { basename, isAbsolute, join } from "path/mod.ts";

--- a/src/command/render/types.ts
+++ b/src/command/render/types.ts
@@ -1,7 +1,7 @@
 /*
 * types.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/run/run.ts
+++ b/src/command/run/run.ts
@@ -1,7 +1,7 @@
 /*
 * run.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/serve/cmd.ts
+++ b/src/command/serve/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/serve/serve.ts
+++ b/src/command/serve/serve.ts
@@ -1,7 +1,7 @@
 /*
 * run.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/tools/cmd.ts
+++ b/src/command/tools/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/uninstall/cmd.ts
+++ b/src/command/uninstall/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/command/update/cmd.ts
+++ b/src/command/update/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 import { Command } from "cliffy/command/mod.ts";

--- a/src/command/use/cmd.ts
+++ b/src/command/use/cmd.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 import { Command, ValidationError } from "cliffy/command/mod.ts";

--- a/src/command/use/commands/template.ts
+++ b/src/command/use/commands/template.ts
@@ -1,7 +1,7 @@
 /*
 * template.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,7 +1,7 @@
 /*
 * constants.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/config/format.ts
+++ b/src/config/format.ts
@@ -1,7 +1,7 @@
 /*
 * format.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/config/localization.ts
+++ b/src/config/localization.ts
@@ -1,7 +1,7 @@
 /*
 * localization.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/config/metadata.ts
+++ b/src/config/metadata.ts
@@ -1,7 +1,7 @@
 /*
 * config.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/config/pdf.ts
+++ b/src/config/pdf.ts
@@ -1,7 +1,7 @@
 /*
 * pdf.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/config/toc.ts
+++ b/src/config/toc.ts
@@ -1,7 +1,7 @@
 /*
 * toc.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,7 +1,7 @@
 /*
 * types.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { Document } from "../core/deno-dom.ts";

--- a/src/core/ansi-colors.ts
+++ b/src/core/ansi-colors.ts
@@ -1,7 +1,7 @@
 /*
 * ansi-colors.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/appdirs.ts
+++ b/src/core/appdirs.ts
@@ -1,7 +1,7 @@
 /*
 * appdirs.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/array.ts
+++ b/src/core/array.ts
@@ -1,7 +1,7 @@
 /*
 * array.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/async.ts
+++ b/src/core/async.ts
@@ -1,7 +1,7 @@
 /*
 * async.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/author.ts
+++ b/src/core/author.ts
@@ -1,7 +1,7 @@
 /*
 * author.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/bibliography.ts
+++ b/src/core/bibliography.ts
@@ -1,7 +1,7 @@
 /*
 * bibliography.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 * Copyright (c) 2016-2021 Thomas Watson Steen
 *
 * Adapted from: https://github.com/watson/ci-info

--- a/src/core/cast.ts
+++ b/src/core/cast.ts
@@ -1,7 +1,7 @@
 /*
 * cast.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 */
 
 export function asNumber(x?: unknown, defaultValue = 0) {

--- a/src/core/ci-info.ts
+++ b/src/core/ci-info.ts
@@ -1,7 +1,7 @@
 /*
 * ci-info.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 * Copyright (c) 2016-2021 Thomas Watson Steen
 *
 * Adapted from: https://github.com/watson/ci-info

--- a/src/core/cleanup.ts
+++ b/src/core/cleanup.ts
@@ -1,7 +1,7 @@
 /*
 * cleanup.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,7 +1,7 @@
 /*
 * config.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/console.ts
+++ b/src/core/console.ts
@@ -1,7 +1,7 @@
 /*
 * console.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/copy.ts
+++ b/src/core/copy.ts
@@ -1,7 +1,7 @@
 /*
 * copy.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/cri/cri.ts
+++ b/src/core/cri/cri.ts
@@ -3,7 +3,7 @@
  *
  * Chrome Remote Interface
  *
- * Copyright (c) 2022 by RStudio, PBC.
+ * Copyright (c) 2022 Posit Software, PBC
  */
 
 import { decode } from "encoding/base64.ts";

--- a/src/core/cri/deno-cri/api.js
+++ b/src/core/cri/deno-cri/api.js
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2021 Andrea Cardaci <cyrus.and@gmail.com>
  *
- * Deno port Copyright (C) 2022 by RStudio, PBC
+ * Deno port Copyright (C) 2022 Posit Software, PBC
  */
 
 function arrayToObject(parameters) {

--- a/src/core/cri/deno-cri/chrome.js
+++ b/src/core/cri/deno-cri/chrome.js
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2021 Andrea Cardaci <cyrus.and@gmail.com>
  *
- * Deno port Copyright (C) 2022 by RStudio, PBC
+ * Deno port Copyright (C) Posit Software, PBC
  */
 
 import EventEmitter from "events/mod.ts";

--- a/src/core/cri/deno-cri/defaults.js
+++ b/src/core/cri/deno-cri/defaults.js
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2021 Andrea Cardaci <cyrus.and@gmail.com>
  *
- * Deno port Copyright (C) 2022 by RStudio, PBC
+ * Deno port Copyright (C) 2022 Posit Software, PBC
  */
 
 export const HOST = "localhost";

--- a/src/core/cri/deno-cri/devtools.js
+++ b/src/core/cri/deno-cri/devtools.js
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2021 Andrea Cardaci <cyrus.and@gmail.com>
  *
- * Deno port Copyright (C) 2022 by RStudio, PBC
+ * Deno port Copyright (C) 2022 Posit Software, PBC
  */
 
 import * as defaults from "./defaults.js";

--- a/src/core/cri/deno-cri/external-request.js
+++ b/src/core/cri/deno-cri/external-request.js
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2021 Andrea Cardaci <cyrus.and@gmail.com>
  *
- * Deno port Copyright (C) 2022 by RStudio, PBC
+ * Deno port Copyright (C) 2022 Posit Software, PBC
  */
 
 export default async function externalRequest(options) {

--- a/src/core/cri/deno-cri/index.js
+++ b/src/core/cri/deno-cri/index.js
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2021 Andrea Cardaci <cyrus.and@gmail.com>
  *
- * Deno port Copyright (C) 2022 by RStudio, PBC
+ * Deno port Copyright (C) 2022 Posit Software, PBC
  */
 
 import EventEmitter from "events/mod.ts";

--- a/src/core/cri/deno-cri/websocket-wrapper.js
+++ b/src/core/cri/deno-cri/websocket-wrapper.js
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2021 Andrea Cardaci <cyrus.and@gmail.com>
  *
- * Deno port Copyright (C) 2022 by RStudio, PBC
+ * Deno port Copyright (C) 2022 Posit Software, PBC
  */
 
 import EventEmitter from "events/mod.ts";

--- a/src/core/csl.ts
+++ b/src/core/csl.ts
@@ -1,7 +1,7 @@
 /*
 * csl.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/css.ts
+++ b/src/core/css.ts
@@ -1,7 +1,7 @@
 /*
 * css.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/dart-sass.ts
+++ b/src/core/dart-sass.ts
@@ -1,7 +1,7 @@
 /*
 * dart-sass.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { join } from "path/mod.ts";

--- a/src/core/date.ts
+++ b/src/core/date.ts
@@ -1,7 +1,7 @@
 /*
 * date.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import momentGuess from "moment-guess";

--- a/src/core/deno-dom.ts
+++ b/src/core/deno-dom.ts
@@ -1,7 +1,7 @@
 /*
 * deno-dom.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/deno/import-maps.ts
+++ b/src/core/deno/import-maps.ts
@@ -1,7 +1,7 @@
 /*
 * import-maps.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/deno/monkey-patch.ts
+++ b/src/core/deno/monkey-patch.ts
@@ -1,7 +1,7 @@
 /*
 * monkey-patch.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/devconfig.ts
+++ b/src/core/devconfig.ts
@@ -1,7 +1,7 @@
 /*
 * devconfig.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 
@@ -36,7 +36,8 @@ export function createDevConfig(
   scriptDir: string,
 ): DevConfig {
   const scriptPath = join(scriptDir, "quarto" + (isWindows() ? ".cmd" : ""));
-  const srcDir = Deno.env.get("QUARTO_SRC_PATH") || join(quartoConfig.sharePath(), "../../src");
+  const srcDir = Deno.env.get("QUARTO_SRC_PATH") ||
+    join(quartoConfig.sharePath(), "../../src");
   return {
     deno,
     deno_dom,
@@ -77,8 +78,8 @@ export function readInstalledDevConfig(): DevConfig | null {
 }
 
 export function readSourceDevConfig(): DevConfig {
-
-  const rootDir = Deno.env.get("QUARTO_ROOT") || join(quartoConfig.sharePath(), "../../src");
+  const rootDir = Deno.env.get("QUARTO_ROOT") ||
+    join(quartoConfig.sharePath(), "../../src");
   const configurationScript = join(
     rootDir,
     "configuration",
@@ -119,9 +120,7 @@ export async function reconfigureQuarto(
   installed: DevConfig | null,
   source: DevConfig,
 ) {
-  const configureScript = isWindows()
-    ? ".\\configure.cmd"
-    : "./configure.sh";
+  const configureScript = isWindows() ? ".\\configure.cmd" : "./configure.sh";
 
   const quartoDir = Deno.realPathSync(
     join(quartoConfig.sharePath(), "..", ".."),

--- a/src/core/download.ts
+++ b/src/core/download.ts
@@ -1,7 +1,7 @@
 /*
 * download.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/ejs.ts
+++ b/src/core/ejs.ts
@@ -1,7 +1,7 @@
 /*
 * ejs.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/encode-metadata.ts
+++ b/src/core/encode-metadata.ts
@@ -1,7 +1,7 @@
 /*
 * encode-metadata.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 import { encode as base64Encode } from "encoding/base64.ts";

--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -1,7 +1,7 @@
 /*
 * env.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/esbuild.ts
+++ b/src/core/esbuild.ts
@@ -1,7 +1,7 @@
 /*
 * esbuild.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 
@@ -20,7 +20,7 @@ export async function esbuildCompile(
     `--format=${format}`,
     ...(args || []),
   ];
-  
+
   return await esbuildCommand(fullArgs, input, workingDir);
 }
 

--- a/src/core/file.ts
+++ b/src/core/file.ts
@@ -1,7 +1,7 @@
 /*
 * file.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/giscus.ts
+++ b/src/core/giscus.ts
@@ -1,7 +1,7 @@
 /*
 * giscus.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/handlers/base.ts
+++ b/src/core/handlers/base.ts
@@ -1,7 +1,7 @@
 /*
 * base.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/handlers/dot.ts
+++ b/src/core/handlers/dot.ts
@@ -1,7 +1,7 @@
 /*
 * graphviz.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/handlers/handlers.ts
+++ b/src/core/handlers/handlers.ts
@@ -1,7 +1,7 @@
 /*
 * handlers.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/handlers/include.ts
+++ b/src/core/handlers/include.ts
@@ -1,7 +1,7 @@
 /*
 * include.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/handlers/mermaid.ts
+++ b/src/core/handlers/mermaid.ts
@@ -1,7 +1,7 @@
 /*
 * mermaid.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/hash.ts
+++ b/src/core/hash.ts
@@ -1,7 +1,7 @@
 /*
 * hash.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/html.ts
+++ b/src/core/html.ts
@@ -1,7 +1,7 @@
 /*
 * html.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/http-devserver.ts
+++ b/src/core/http-devserver.ts
@@ -1,7 +1,7 @@
 /*
 * http-devserver.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/http-server.ts
+++ b/src/core/http-server.ts
@@ -1,7 +1,7 @@
 /*
 * http-server.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -1,7 +1,7 @@
 /*
 * http.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/image.ts
+++ b/src/core/image.ts
@@ -1,7 +1,7 @@
 /*
 * image.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/jupyter/capabilities.ts
+++ b/src/core/jupyter/capabilities.ts
@@ -1,7 +1,7 @@
 /*
 * capabilities.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 
@@ -24,7 +24,6 @@ export async function jupyterCapabilities(kernelspec?: JupyterKernelspec) {
   const language = kernelspec?.language || kNoLanguage;
 
   if (!jupyterCapsCache.has(language)) {
-
     // if we are targeting julia then prefer the julia installed miniconda
     const juliaCaps = await getVerifiedJuliaCondaJupyterCapabilities();
     if (language === "julia" && juliaCaps) {
@@ -81,7 +80,7 @@ async function getVerifiedJuliaCondaJupyterCapabilities() {
       ".julia",
       "conda",
       "3",
-      isWindows() ? "python.exe" : join("bin", "python3")
+      isWindows() ? "python.exe" : join("bin", "python3"),
     );
     if (existsSync(juliaPython)) {
       const caps = await getJupyterCapabilities([juliaPython]);

--- a/src/core/jupyter/display-data.ts
+++ b/src/core/jupyter/display-data.ts
@@ -1,7 +1,7 @@
 /*
 * display-data.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/jupyter/exec.ts
+++ b/src/core/jupyter/exec.ts
@@ -1,7 +1,7 @@
 /*
 * exec.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/jupyter/filtered-notebook-cache.ts
+++ b/src/core/jupyter/filtered-notebook-cache.ts
@@ -1,7 +1,7 @@
 /*
 * filtered-notebook-cache.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/jupyter/jupyter-filters.ts
+++ b/src/core/jupyter/jupyter-filters.ts
@@ -1,7 +1,7 @@
 /*
 * jupyter-filters.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/jupyter/jupyter-shared.ts
+++ b/src/core/jupyter/jupyter-shared.ts
@@ -1,7 +1,7 @@
 /*
 * jupyter-shared.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { join } from "path/mod.ts";

--- a/src/core/jupyter/jupyter.ts
+++ b/src/core/jupyter/jupyter.ts
@@ -1,7 +1,7 @@
 /*
 * jupyter.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/jupyter/kernels.ts
+++ b/src/core/jupyter/kernels.ts
@@ -1,7 +1,7 @@
 /*
 * kerenels.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/jupyter/labels.ts
+++ b/src/core/jupyter/labels.ts
@@ -1,7 +1,7 @@
 /*
 * labels.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/jupyter/preserve.ts
+++ b/src/core/jupyter/preserve.ts
@@ -1,7 +1,7 @@
 /*
 * preserve.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/jupyter/tags.ts
+++ b/src/core/jupyter/tags.ts
@@ -1,7 +1,7 @@
 /*
 * tags.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/jupyter/types.ts
+++ b/src/core/jupyter/types.ts
@@ -1,7 +1,7 @@
 /*
 * types.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/jupyter/venv.ts
+++ b/src/core/jupyter/venv.ts
@@ -1,7 +1,7 @@
 /*
 * venv.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/jupyter/widgets.ts
+++ b/src/core/jupyter/widgets.ts
@@ -1,7 +1,7 @@
 /*
 * widgets.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/knitr.ts
+++ b/src/core/knitr.ts
@@ -1,7 +1,7 @@
 /*
 * knitr.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/language.ts
+++ b/src/core/language.ts
@@ -1,7 +1,7 @@
 /*
 * language.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/binary-search.ts
+++ b/src/core/lib/binary-search.ts
@@ -1,7 +1,7 @@
 /*
 * binary-search.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/break-quarto-md-types.ts
+++ b/src/core/lib/break-quarto-md-types.ts
@@ -3,7 +3,7 @@
 *
 * types for break-quarto-md.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/break-quarto-md.ts
+++ b/src/core/lib/break-quarto-md.ts
@@ -4,7 +4,7 @@
 * Breaks up a qmd file into a list of chunks of related text: YAML
 * front matter, "pure" markdown, triple-backtick sections, and so on.
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/error.ts
+++ b/src/core/lib/error.ts
@@ -2,7 +2,7 @@
 /*
 * error.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/errors.ts
+++ b/src/core/lib/errors.ts
@@ -3,7 +3,7 @@
 *
 * functions that help format errors consistently
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 
@@ -134,7 +134,7 @@ function errorKey(err: TidyverseError): string {
 }
 
 export function reportOnce(
-  reporter: ((err: TidyverseError) => unknown),
+  reporter: (err: TidyverseError) => unknown,
   reportSet?: Set<string>,
 ): (err: TidyverseError) => unknown {
   const errorsReported = reportSet || new Set();

--- a/src/core/lib/guess-chunk-options-format.ts
+++ b/src/core/lib/guess-chunk-options-format.ts
@@ -9,7 +9,7 @@
 * styles are being used, so we don't attempt to validate or parse
 * something that really isn't YAML.
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/mapped-text.ts
+++ b/src/core/lib/mapped-text.ts
@@ -1,7 +1,7 @@
 /**
  * mapped-text.ts
  *
- * Copyright (C) 2021 by RStudio, PBC
+ * Copyright (C) 2021-2022 Posit Software, PBC
  */
 
 import { glb } from "./binary-search.ts";

--- a/src/core/lib/memoize.ts
+++ b/src/core/lib/memoize.ts
@@ -3,7 +3,7 @@
 *
 * Utilities to memoize functions
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 
@@ -15,11 +15,11 @@ export function memoize(
   // deno-lint-ignore no-explicit-any
   keyMemoizer: (...args: any) => string,
   // deno-lint-ignore no-explicit-any
-): ((...args: any[]) => any) {
+): (...args: any[]) => any {
   // deno-lint-ignore no-explicit-any
   const memo: Record<string, any> = {};
   // deno-lint-ignore no-explicit-any
-  const inner: ((...args: any[]) => any) = (...args: any[]) => {
+  const inner: (...args: any[]) => any = (...args: any[]) => {
     const key = keyMemoizer(...args);
     const v = memo[key];
     if (v !== undefined) {

--- a/src/core/lib/parse-shortcode.ts
+++ b/src/core/lib/parse-shortcode.ts
@@ -3,7 +3,7 @@
 *
 * Recognizes and parses shortcodes.
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/partition-cell-options.ts
+++ b/src/core/lib/partition-cell-options.ts
@@ -3,7 +3,7 @@
 *
 * Splits code cell into metadata+options
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/polyfills.ts
+++ b/src/core/lib/polyfills.ts
@@ -3,7 +3,7 @@
 *
 * some polyfills we can't depend on in older execution environments.
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 * (Note that code here is derived from other open-source libraries. We include a link and respective copyright notice)
 *

--- a/src/core/lib/promise.ts
+++ b/src/core/lib/promise.ts
@@ -1,7 +1,7 @@
 /*
 * promise.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/ranged-text.ts
+++ b/src/core/lib/ranged-text.ts
@@ -1,7 +1,7 @@
 /*
 * ranged-text.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/regexp.js
+++ b/src/core/lib/regexp.js
@@ -3,7 +3,7 @@
  *
  * Routines to manipulate regular expressions.
  *
- * Copyright (C) 2021 by RStudio, PBC
+ * Copyright (C) 2021-2022 Posit Software, PBC
  *
  */
 

--- a/src/core/lib/semaphore.ts
+++ b/src/core/lib/semaphore.ts
@@ -1,7 +1,7 @@
 /*
 * semaphore.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/text-types.ts
+++ b/src/core/lib/text-types.ts
@@ -1,7 +1,7 @@
 /*
 * text-types.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/text.ts
+++ b/src/core/lib/text.ts
@@ -1,7 +1,7 @@
 /*
 * text.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-intelligence/annotated-yaml.ts
+++ b/src/core/lib/yaml-intelligence/annotated-yaml.ts
@@ -1,7 +1,7 @@
 /*
 * annotated-yaml.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-intelligence/descriptions.ts
+++ b/src/core/lib/yaml-intelligence/descriptions.ts
@@ -3,7 +3,7 @@
 *
 * utility functions to help with schema descriptions
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 */
 
 import { Schema } from "../yaml-schema/types.ts";

--- a/src/core/lib/yaml-intelligence/hover.ts
+++ b/src/core/lib/yaml-intelligence/hover.ts
@@ -1,7 +1,7 @@
 /*
 * hover.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-intelligence/js-yaml-schema.ts
+++ b/src/core/lib/yaml-intelligence/js-yaml-schema.ts
@@ -1,7 +1,7 @@
 /*
 * js-yaml-schema.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-intelligence/parsing.ts
+++ b/src/core/lib/yaml-intelligence/parsing.ts
@@ -1,7 +1,7 @@
 /*
 * parsing.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-intelligence/paths.ts
+++ b/src/core/lib/yaml-intelligence/paths.ts
@@ -1,7 +1,7 @@
 /*
 * paths.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-intelligence/resources.ts
+++ b/src/core/lib/yaml-intelligence/resources.ts
@@ -3,7 +3,7 @@
 *
 * Manages all resources needed to create/validate YAML schema, including schemas themselves
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-intelligence/types.ts
+++ b/src/core/lib/yaml-intelligence/types.ts
@@ -1,7 +1,7 @@
 /*
 * types.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-intelligence/vs-code.ts
+++ b/src/core/lib/yaml-intelligence/vs-code.ts
@@ -1,7 +1,7 @@
 /*
 * web-worker.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-intelligence/web-worker-manager.ts
+++ b/src/core/lib/yaml-intelligence/web-worker-manager.ts
@@ -3,7 +3,7 @@
 *
 * enables RPC-style for web workers
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-intelligence/web-worker.ts
+++ b/src/core/lib/yaml-intelligence/web-worker.ts
@@ -1,7 +1,7 @@
 /*
 * web-worker.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-intelligence/yaml-intelligence.ts
+++ b/src/core/lib/yaml-intelligence/yaml-intelligence.ts
@@ -1,7 +1,7 @@
 /*
 * yaml-intelligence.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-schema/chunk-metadata.ts
+++ b/src/core/lib/yaml-schema/chunk-metadata.ts
@@ -3,7 +3,7 @@
 *
 * JSON Schema for Quarto's YAML chunk metadata
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-schema/common.ts
+++ b/src/core/lib/yaml-schema/common.ts
@@ -8,7 +8,7 @@
 * `normalizeSchema()` call that takes a schema produced here and
 * returns a valid JSON Schema object.
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-schema/constants.ts
+++ b/src/core/lib/yaml-schema/constants.ts
@@ -3,7 +3,7 @@
 *
 * Constants for the YAML validator
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-schema/definitions.ts
+++ b/src/core/lib/yaml-schema/definitions.ts
@@ -1,7 +1,7 @@
 /*
 * definitions.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 
@@ -28,7 +28,7 @@ export function defineCached(
     { schema: ConcreteSchema; errorHandlers: ValidatorErrorHandlerFunction[] }
   >,
   schemaId: string,
-): (() => Promise<ConcreteSchema>) {
+): () => Promise<ConcreteSchema> {
   let schema: ConcreteSchema;
 
   return async () => {

--- a/src/core/lib/yaml-schema/execute.ts
+++ b/src/core/lib/yaml-schema/execute.ts
@@ -4,7 +4,7 @@
 * Functions to compile and create the schemas for the `execute` field
 * in project and frontmatter
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-schema/format-aliases.ts
+++ b/src/core/lib/yaml-schema/format-aliases.ts
@@ -3,7 +3,7 @@
 *
 * handles format alias names
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-schema/format-schemas.ts
+++ b/src/core/lib/yaml-schema/format-schemas.ts
@@ -3,7 +3,7 @@
 *
 * Functions to define JSON Schemas for quarto formats
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-schema/from-yaml.ts
+++ b/src/core/lib/yaml-schema/from-yaml.ts
@@ -3,7 +3,7 @@
 *
 * Functions to convert YAML to JSON Schema
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-schema/front-matter.ts
+++ b/src/core/lib/yaml-schema/front-matter.ts
@@ -3,7 +3,7 @@
 *
 * JSON Schema for Quarto's YAML frontmatter
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-schema/project-config.ts
+++ b/src/core/lib/yaml-schema/project-config.ts
@@ -3,7 +3,7 @@
 *
 * JSON Schema for _quarto.yml, Quarto's project configuration YAML
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-schema/types.ts
+++ b/src/core/lib/yaml-schema/types.ts
@@ -3,7 +3,7 @@
 *
 * Types for the YAML validator
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-schema/validated-yaml.ts
+++ b/src/core/lib/yaml-schema/validated-yaml.ts
@@ -3,7 +3,7 @@
 *
 * lib-safe helper functions for reading and validating YAML
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-validation/errors.ts
+++ b/src/core/lib/yaml-validation/errors.ts
@@ -3,7 +3,7 @@
 *
 * Functions for creating/setting yaml validation errors
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-validation/resolve.ts
+++ b/src/core/lib/yaml-validation/resolve.ts
@@ -1,7 +1,7 @@
 /*
 * resolve.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-validation/schema-navigation.ts
+++ b/src/core/lib/yaml-validation/schema-navigation.ts
@@ -4,7 +4,7 @@
 *
 * functions to navigate schema
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 
@@ -54,8 +54,8 @@ export function navigateSchemaByInstancePath(
       const patternPropMatch = matchPatternProperties(
         subSchema,
         key,
-        allowPartialMatches !== undefined && 
-        allowPartialMatches &&
+        allowPartialMatches !== undefined &&
+          allowPartialMatches &&
           index === path.length - 1, // allow prefix matches only if it's the last entry
       );
       if (patternPropMatch) {
@@ -111,8 +111,8 @@ export function navigateSchemaBySchemaPathSingle(
   // deno-lint-ignore no-explicit-any
 ): any {
   const ensurePathFragment = (
-    fragment: (number | string),
-    expected: (number | string),
+    fragment: number | string,
+    expected: number | string,
   ) => {
     if (fragment !== expected) {
       throw new Error(

--- a/src/core/lib/yaml-validation/schema-utils.ts
+++ b/src/core/lib/yaml-validation/schema-utils.ts
@@ -1,7 +1,7 @@
 /*
 * schema-utils.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 
@@ -205,7 +205,7 @@ function getObjectCompletions(s: ConcreteSchema): Completion[] {
         if (hidden) {
           continue;
         }
-        let description: (string | { $ref: string }) = "";
+        let description: string | { $ref: string } = "";
         for (const md of maybeDescriptions) {
           if (md !== undefined) {
             description = md;

--- a/src/core/lib/yaml-validation/schema.ts
+++ b/src/core/lib/yaml-validation/schema.ts
@@ -3,7 +3,7 @@
 *
 * JSON Schema core definitions
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-validation/state.ts
+++ b/src/core/lib/yaml-validation/state.ts
@@ -4,7 +4,7 @@
 * Helpers to manage the global state required by the yaml intelligence
 * code
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-validation/types.ts
+++ b/src/core/lib/yaml-validation/types.ts
@@ -1,7 +1,7 @@
 /*
 * types.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 
@@ -28,7 +28,7 @@ export type ValidatorErrorHandlerFunction = (
    * error.violatingObject (a subobject of parse.result).
    */
   schema: Schema,
-) => (LocalizedError | null);
+) => LocalizedError | null;
 
 export interface YAMLSchemaT {
   schema: Schema;

--- a/src/core/lib/yaml-validation/validator-queue.ts
+++ b/src/core/lib/yaml-validation/validator-queue.ts
@@ -1,7 +1,7 @@
 /*
 * validator-queue.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-validation/validator.ts
+++ b/src/core/lib/yaml-validation/validator.ts
@@ -3,7 +3,7 @@
 *
 * main validator class.
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lib/yaml-validation/yaml-schema.ts
+++ b/src/core/lib/yaml-validation/yaml-schema.ts
@@ -4,7 +4,7 @@
 * A class to manage YAML Schema validation and associated tasks like
 * error localization
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lifetimes.ts
+++ b/src/core/lifetimes.ts
@@ -1,7 +1,7 @@
 /*
 * lifetimes.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/lodash.ts
+++ b/src/core/lodash.ts
@@ -3,7 +3,7 @@
 *
 * piecemeal exports of lodash to make the tree-shaker happier
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -1,7 +1,7 @@
 /*
 * log.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -3,7 +3,7 @@
 *
 * Utilities for main() functions (setup, cleanup, etc)
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 
@@ -25,7 +25,7 @@ import { cleanupSessionTempDir } from "./temp.ts";
 // }
 
 export async function mainRunner(
-  runner: (() => Promise<unknown>),
+  runner: () => Promise<unknown>,
 ): Promise<unknown> {
   try {
     // install termination signal handlers

--- a/src/core/mapped-text.ts
+++ b/src/core/mapped-text.ts
@@ -1,7 +1,7 @@
 /**
  * mapped-text.ts
  *
- * Copyright (C) 2021 by RStudio, PBC
+ * Copyright (C) 2021-2022 Posit Software, PBC
  */
 
 import { diffLines } from "./lib/external/diff.js";

--- a/src/core/mime.ts
+++ b/src/core/mime.ts
@@ -1,7 +1,7 @@
 /*
 * mime.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/pandoc/codegen.ts
+++ b/src/core/pandoc/codegen.ts
@@ -3,7 +3,7 @@
 *
 * A minimal API to build pandoc markdown text.
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/pandoc/pandoc-attr.ts
+++ b/src/core/pandoc/pandoc-attr.ts
@@ -1,7 +1,7 @@
 /*
 * pandoc-attr.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/pandoc/pandoc-formats.ts
+++ b/src/core/pandoc/pandoc-formats.ts
@@ -1,7 +1,7 @@
 /*
  * pandoc-formats.ts
  *
- * Copyright (C) 2020 by RStudio, PBC
+ * Copyright (C) 2020-2022 Posit Software, PBC
  *
  */
 import { extname } from "path/mod.ts";

--- a/src/core/pandoc/pandoc-id.ts
+++ b/src/core/pandoc/pandoc-id.ts
@@ -1,7 +1,7 @@
 /*
  * pandoc-id.ts
  *
- * Copyright (C) 2020 by RStudio, PBC
+ * Copyright (C) 2020-2022 Posit Software, PBC
  *
  */
 

--- a/src/core/pandoc/pandoc-partition.ts
+++ b/src/core/pandoc/pandoc-partition.ts
@@ -1,7 +1,7 @@
 /*
 * markdown.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { PandocAttr, PartitionedMarkdown } from "./types.ts";

--- a/src/core/pandoc/types.ts
+++ b/src/core/pandoc/types.ts
@@ -1,7 +1,7 @@
 /*
 * types.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -1,7 +1,7 @@
 /*
 * path.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/pdfjs.ts
+++ b/src/core/pdfjs.ts
@@ -1,7 +1,7 @@
 /*
 * pdfjs.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/performance.ts
+++ b/src/core/performance.ts
@@ -1,7 +1,7 @@
 /*
 * performance.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -1,7 +1,7 @@
 /*
 * platform.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/png.ts
+++ b/src/core/png.ts
@@ -1,7 +1,7 @@
 /*
 * png.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 * Copyright (C) 2020 by mel-mouk@achiev (ISC license):
 *   https://github.com/achiev-open/png-decoder-intro
 * Copyright (C) 2017 by Michael Wang (ISC license):

--- a/src/core/port.ts
+++ b/src/core/port.ts
@@ -1,7 +1,7 @@
 /*
 * port.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/process.ts
+++ b/src/core/process.ts
@@ -1,7 +1,7 @@
 /*
 * process.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/progress.ts
+++ b/src/core/progress.ts
@@ -1,7 +1,7 @@
 /*
 * progress.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/promise.ts
+++ b/src/core/promise.ts
@@ -1,7 +1,7 @@
 /*
 * promise.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/puppeteer.ts
+++ b/src/core/puppeteer.ts
@@ -1,7 +1,7 @@
 /*
 * puppeteer.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/qualified-path.ts
+++ b/src/core/qualified-path.ts
@@ -3,7 +3,7 @@
 *
 * Path objects that hold additional information about their status
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/quarto.ts
+++ b/src/core/quarto.ts
@@ -1,7 +1,7 @@
 /*
 * env.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { existsSync } from "fs/exists.ts";

--- a/src/core/random.ts
+++ b/src/core/random.ts
@@ -1,7 +1,7 @@
 /*
 * random.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/ranged-text.ts
+++ b/src/core/ranged-text.ts
@@ -1,7 +1,7 @@
 /*
 * ranged-text.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -1,7 +1,7 @@
 /*
 * registry.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/render.ts
+++ b/src/core/render.ts
@@ -1,7 +1,7 @@
 /*
 * render.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/resources.ts
+++ b/src/core/resources.ts
@@ -1,7 +1,7 @@
 /*
 * resources.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/retry.ts
+++ b/src/core/retry.ts
@@ -1,7 +1,7 @@
 /*
 * retry.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/run/deno.ts
+++ b/src/core/run/deno.ts
@@ -1,7 +1,7 @@
 /*
 * deno.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/run/lua.ts
+++ b/src/core/run/lua.ts
@@ -1,7 +1,7 @@
 /*
 * lua.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/run/python.ts
+++ b/src/core/run/python.ts
@@ -1,7 +1,7 @@
 /*
 * python.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/run/r.ts
+++ b/src/core/run/r.ts
@@ -1,7 +1,7 @@
 /*
 * r.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/run/run.ts
+++ b/src/core/run/run.ts
@@ -1,7 +1,7 @@
 /*
 * run.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/run/shell.ts
+++ b/src/core/run/shell.ts
@@ -1,7 +1,7 @@
 /*
 * shell.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/run/types.ts
+++ b/src/core/run/types.ts
@@ -1,7 +1,7 @@
 /*
 * types.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/sass.ts
+++ b/src/core/sass.ts
@@ -1,7 +1,7 @@
 /*
 * sass.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/schema/annotated-yaml.ts
+++ b/src/core/schema/annotated-yaml.ts
@@ -4,7 +4,7 @@
 * Parses YAML and returns an annotated parse with location information
 * to enable good error messages on validation
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/schema/build-schema-file.ts
+++ b/src/core/schema/build-schema-file.ts
@@ -4,7 +4,7 @@
 * Collects the existing schemas and builds a single JSON file with
 * their description
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/schema/deno-init-tree-sitter.ts
+++ b/src/core/schema/deno-init-tree-sitter.ts
@@ -3,7 +3,7 @@
 *
 * code to initialize tree sitter on deno.
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/schema/types-from-schema.ts
+++ b/src/core/schema/types-from-schema.ts
@@ -3,7 +3,7 @@
 *
 * generates a typescript file with type definitions from our yaml schema definitions.
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/schema/utils.ts
+++ b/src/core/schema/utils.ts
@@ -1,7 +1,7 @@
 /*
 * utils.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/schema/validate-document.ts
+++ b/src/core/schema/validate-document.ts
@@ -1,7 +1,7 @@
 /*
 * validate-document.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/schema/validated-yaml.ts
+++ b/src/core/schema/validated-yaml.ts
@@ -3,7 +3,7 @@
 *
 * helper functions for reading and validating YAML
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/schema/yaml-schema.ts
+++ b/src/core/schema/yaml-schema.ts
@@ -1,7 +1,7 @@
 /*
 * yaml-schema.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/shell.ts
+++ b/src/core/shell.ts
@@ -1,7 +1,7 @@
 /*
 * shell.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/svg.ts
+++ b/src/core/svg.ts
@@ -1,7 +1,7 @@
 /*
 * svg.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/temp-types.ts
+++ b/src/core/temp-types.ts
@@ -1,7 +1,7 @@
 /*
 * temp-types.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/temp.ts
+++ b/src/core/temp.ts
@@ -1,7 +1,7 @@
 /*
 * temp.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/tex.ts
+++ b/src/core/tex.ts
@@ -1,7 +1,7 @@
 /*
 * tex.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/text.ts
+++ b/src/core/text.ts
@@ -1,7 +1,7 @@
 /*
 * text.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/timing.ts
+++ b/src/core/timing.ts
@@ -1,7 +1,7 @@
 /*
 * timing.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/units.ts
+++ b/src/core/units.ts
@@ -1,7 +1,7 @@
 /*
 * units.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -1,7 +1,7 @@
 /*
 * url.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/uuid.ts
+++ b/src/core/uuid.ts
@@ -1,7 +1,7 @@
 /*
 * uuid.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/wait.ts
+++ b/src/core/wait.ts
@@ -1,7 +1,7 @@
 /*
 * wait.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/watch.ts
+++ b/src/core/watch.ts
@@ -1,7 +1,7 @@
 /*
 * watch.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/windows.ts
+++ b/src/core/windows.ts
@@ -1,7 +1,7 @@
 /*
 * windows.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { existsSync } from "fs/mod.ts";

--- a/src/core/yaml.ts
+++ b/src/core/yaml.ts
@@ -1,7 +1,7 @@
 /*
 * yaml.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/core/zip.ts
+++ b/src/core/zip.ts
@@ -1,7 +1,7 @@
 /*
 * zip.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { dirname } from "path/mod.ts";

--- a/src/execute/engine-info.ts
+++ b/src/execute/engine-info.ts
@@ -1,7 +1,7 @@
 /*
 * engine-info.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/execute/engine-shared.ts
+++ b/src/execute/engine-shared.ts
@@ -1,7 +1,7 @@
 /*
 * engine-shared.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/execute/engine.ts
+++ b/src/execute/engine.ts
@@ -1,7 +1,7 @@
 /*
 * engine.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/execute/jupyter/jupyter-kernel.ts
+++ b/src/execute/jupyter/jupyter-kernel.ts
@@ -1,7 +1,7 @@
 /*
 * jupyter-kernel.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/execute/jupyter/jupyter.ts
+++ b/src/execute/jupyter/jupyter.ts
@@ -1,7 +1,7 @@
 /*
 * jupyter.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/execute/markdown.ts
+++ b/src/execute/markdown.ts
@@ -1,7 +1,7 @@
 /*
 * markdown.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/execute/ojs/annotate-source.ts
+++ b/src/execute/ojs/annotate-source.ts
@@ -1,7 +1,7 @@
 /*
 * annotate-source.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/execute/ojs/compile.ts
+++ b/src/execute/ojs/compile.ts
@@ -1,7 +1,7 @@
 /*
 * compile.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/execute/ojs/errors.ts
+++ b/src/execute/ojs/errors.ts
@@ -1,7 +1,7 @@
 /*
 * errors.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/execute/ojs/extract-resources.ts
+++ b/src/execute/ojs/extract-resources.ts
@@ -1,7 +1,7 @@
 /*
 * extract-resources.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/execute/ojs/ojs-tools.ts
+++ b/src/execute/ojs/ojs-tools.ts
@@ -2,7 +2,7 @@
 *
 * ojs-tools.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/execute/rmd.ts
+++ b/src/execute/rmd.ts
@@ -1,7 +1,7 @@
 /*
 * rmd.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/execute/types.ts
+++ b/src/execute/types.ts
@@ -1,7 +1,7 @@
 /*
 * types.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import {

--- a/src/extension/extension-host.ts
+++ b/src/extension/extension-host.ts
@@ -1,7 +1,7 @@
 /*
 * extension-host.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/extension/extension-shared.ts
+++ b/src/extension/extension-shared.ts
@@ -1,7 +1,7 @@
 /*
 * extension-shared.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import SemVer, { Range } from "semver/mod.ts";

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -1,7 +1,7 @@
 /*
 * extension.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/extension/install.ts
+++ b/src/extension/install.ts
@@ -1,7 +1,7 @@
 /*
 * install.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/extension/remove.ts
+++ b/src/extension/remove.ts
@@ -1,7 +1,7 @@
 /*
 * remove.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { basename, dirname } from "path/mod.ts";

--- a/src/extension/template.ts
+++ b/src/extension/template.ts
@@ -1,7 +1,7 @@
 /*
 * template.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/format/docx/format-docx.ts
+++ b/src/format/docx/format-docx.ts
@@ -1,7 +1,7 @@
 /*
 * format-docx.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/format/epub/format-epub.ts
+++ b/src/format/epub/format-epub.ts
@@ -1,7 +1,7 @@
 /*
 * format-epub.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/format/formats-shared.ts
+++ b/src/format/formats-shared.ts
@@ -1,7 +1,7 @@
 /*
 * formats-shared.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/format/formats.ts
+++ b/src/format/formats.ts
@@ -1,7 +1,7 @@
 /*
 * formats.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/format/html/format-html-appendix.ts
+++ b/src/format/html/format-html-appendix.ts
@@ -1,7 +1,7 @@
 /*
 * format-html-appendix.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/format/html/format-html-bootstrap.ts
+++ b/src/format/html/format-html-bootstrap.ts
@@ -1,7 +1,7 @@
 /*
 * format-html-bootstrap.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/format/html/format-html-info.ts
+++ b/src/format/html/format-html-info.ts
@@ -3,7 +3,7 @@
 *
 * functions to obtain information about qmd files in HTML format
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/format/html/format-html-math.ts
+++ b/src/format/html/format-html-math.ts
@@ -1,7 +1,7 @@
 /*
 * format-html-math.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/format/html/format-html-meta.ts
+++ b/src/format/html/format-html-meta.ts
@@ -1,7 +1,7 @@
 /*
 * format-html-meta.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/format/html/format-html-scss.ts
+++ b/src/format/html/format-html-scss.ts
@@ -1,7 +1,7 @@
 /*
 * format-html-scss.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/format/html/format-html-shared.ts
+++ b/src/format/html/format-html-shared.ts
@@ -1,7 +1,7 @@
 /*
 * format-html-shared.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { dirname, join, relative } from "path/mod.ts";

--- a/src/format/html/format-html-title.ts
+++ b/src/format/html/format-html-title.ts
@@ -1,7 +1,7 @@
 /*
 * format-html-title.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/format/html/format-html.ts
+++ b/src/format/html/format-html.ts
@@ -1,7 +1,7 @@
 /*
 * format-html.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { join } from "path/mod.ts";

--- a/src/format/ipynb/format-ipynb.ts
+++ b/src/format/ipynb/format-ipynb.ts
@@ -1,7 +1,7 @@
 /*
 * format-ipynb.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/format/markdown/format-markdown.ts
+++ b/src/format/markdown/format-markdown.ts
@@ -1,7 +1,7 @@
 /*
 * format-markdown.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/format/pdf/format-pdf.ts
+++ b/src/format/pdf/format-pdf.ts
@@ -1,7 +1,7 @@
 /*
 * format-pdf.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/format/reveal/constants.ts
+++ b/src/format/reveal/constants.ts
@@ -1,7 +1,7 @@
 /*
 * constants.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/format/reveal/format-reveal-multiplex.ts
+++ b/src/format/reveal/format-reveal-multiplex.ts
@@ -1,7 +1,7 @@
 /*
 * format-reveal-multiplex.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/format/reveal/format-reveal-plugin.ts
+++ b/src/format/reveal/format-reveal-plugin.ts
@@ -1,7 +1,7 @@
 /*
 * format-reveal-plugin.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/format/reveal/format-reveal-theme.ts
+++ b/src/format/reveal/format-reveal-theme.ts
@@ -1,7 +1,7 @@
 /*
 * format-reveal-theme.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -1,7 +1,7 @@
 /*
 * format-reveal.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { join } from "path/mod.ts";

--- a/src/format/reveal/metadata.ts
+++ b/src/format/reveal/metadata.ts
@@ -1,7 +1,7 @@
 /*
 * metadata.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/format/reveal/schemas.ts
+++ b/src/format/reveal/schemas.ts
@@ -1,7 +1,7 @@
 /*
 * schemas.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/project/project-config.ts
+++ b/src/project/project-config.ts
@@ -1,7 +1,7 @@
 /*
 * project-config.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/project-context.ts
+++ b/src/project/project-context.ts
@@ -1,7 +1,7 @@
 /*
 * project-context.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/project-create.ts
+++ b/src/project/project-create.ts
@@ -1,7 +1,7 @@
 /*
 * project-create.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/project-crossrefs.ts
+++ b/src/project/project-crossrefs.ts
@@ -1,7 +1,7 @@
 /*
 * project-crossrefs.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/project-gitignore.ts
+++ b/src/project/project-gitignore.ts
@@ -1,7 +1,7 @@
 /*
 * project-gitignore.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/project-index.ts
+++ b/src/project/project-index.ts
@@ -1,7 +1,7 @@
 /*
 * project-index.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/project-profile.ts
+++ b/src/project/project-profile.ts
@@ -1,7 +1,7 @@
 /*
 * profile.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/project/project-resources.ts
+++ b/src/project/project-resources.ts
@@ -1,7 +1,7 @@
 /*
 * project-resources.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/project-scratch.ts
+++ b/src/project/project-scratch.ts
@@ -1,7 +1,7 @@
 /*
 * project-scratch.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/project-shared.ts
+++ b/src/project/project-shared.ts
@@ -1,7 +1,7 @@
 /*
 * project-shared.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/serve/serve.ts
+++ b/src/project/serve/serve.ts
@@ -1,7 +1,7 @@
 /*
 * serve.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/serve/types.ts
+++ b/src/project/serve/types.ts
@@ -1,7 +1,7 @@
 /*
 * types.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/serve/watch.ts
+++ b/src/project/serve/watch.ts
@@ -1,7 +1,7 @@
 /*
 * watch.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types.ts
+++ b/src/project/types.ts
@@ -1,7 +1,7 @@
 /*
 * types.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/book/book-bibliography.ts
+++ b/src/project/types/book/book-bibliography.ts
@@ -1,7 +1,7 @@
 /*
 * book-bibliography.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/book/book-config.ts
+++ b/src/project/types/book/book-config.ts
@@ -1,7 +1,7 @@
 /*
 * book-config.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/book/book-crossrefs.ts
+++ b/src/project/types/book/book-crossrefs.ts
@@ -1,7 +1,7 @@
 /*
 * book-crossrefs.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/book/book-extension.ts
+++ b/src/project/types/book/book-extension.ts
@@ -1,7 +1,7 @@
 /*
 * book-extension.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/book/book-render.ts
+++ b/src/project/types/book/book-render.ts
@@ -1,7 +1,7 @@
 /*
 * book-render.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/book/book-shared.ts
+++ b/src/project/types/book/book-shared.ts
@@ -1,7 +1,7 @@
 /*
 * book-shared.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/book/book.ts
+++ b/src/project/types/book/book.ts
@@ -1,7 +1,7 @@
 /*
 * book.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/project-default.ts
+++ b/src/project/types/project-default.ts
@@ -1,7 +1,7 @@
 /*
 * proejct-default.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 
@@ -17,14 +17,13 @@ export const kDefaultProjectFileContents = "{ project: { type: 'default' } }";
 export const defaultProjectType: ProjectType = {
   type: "default",
 
-  formatLibDirs:
-    () => [
-      "bootstrap",
-      "quarto-html",
-      "quarto-ojs",
-      "quarto-diagram",
-      "quarto-contrib",
-    ],
+  formatLibDirs: () => [
+    "bootstrap",
+    "quarto-html",
+    "quarto-ojs",
+    "quarto-diagram",
+    "quarto-contrib",
+  ],
 
   create: (title: string): ProjectCreate => {
     const resourceDir = resourcePath(join("projects", "default"));

--- a/src/project/types/project-types.ts
+++ b/src/project/types/project-types.ts
@@ -1,7 +1,7 @@
 /*
 * project-types.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { ProjectType } from "./types.ts";

--- a/src/project/types/register.ts
+++ b/src/project/types/register.ts
@@ -3,7 +3,7 @@
 *
 * registers available project types for use in quarto.
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/types.ts
+++ b/src/project/types/types.ts
@@ -1,7 +1,7 @@
 /*
 * types.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/website/about/website-about.ts
+++ b/src/project/types/website/about/website-about.ts
@@ -1,7 +1,7 @@
 /*
 * website-about.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { Document, Element } from "deno_dom/deno-dom-wasm-noinit.ts";

--- a/src/project/types/website/listing/website-listing-categories.ts
+++ b/src/project/types/website/listing/website-listing-categories.ts
@@ -1,7 +1,7 @@
 /*
 * website-listing-categories.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { Document } from "deno_dom/deno-dom-wasm-noinit.ts";

--- a/src/project/types/website/listing/website-listing-feed.ts
+++ b/src/project/types/website/listing/website-listing-feed.ts
@@ -1,7 +1,7 @@
 /*
 * website-listing-feed.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/website/listing/website-listing-index.ts
+++ b/src/project/types/website/listing/website-listing-index.ts
@@ -1,7 +1,7 @@
 /*
 * website-listing-index.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/website/listing/website-listing-project.ts
+++ b/src/project/types/website/listing/website-listing-project.ts
@@ -1,7 +1,7 @@
 /*
 * website-listing-project.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/website/listing/website-listing-read.ts
+++ b/src/project/types/website/listing/website-listing-read.ts
@@ -2,7 +2,7 @@
 * website-listing-resolve.ts
 .ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { debug, warning } from "log/mod.ts";

--- a/src/project/types/website/listing/website-listing-shared.ts
+++ b/src/project/types/website/listing/website-listing-shared.ts
@@ -2,7 +2,7 @@
 * website-listing-shared
 .ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { dirname, join, relative } from "path/mod.ts";

--- a/src/project/types/website/listing/website-listing-template.ts
+++ b/src/project/types/website/listing/website-listing-template.ts
@@ -2,7 +2,7 @@
 * website-listing-template
 .ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { Document, Element } from "deno_dom/deno-dom-wasm-noinit.ts";

--- a/src/project/types/website/listing/website-listing.ts
+++ b/src/project/types/website/listing/website-listing.ts
@@ -2,7 +2,7 @@
 * website-listing
 .ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/website/util/discover-meta.ts
+++ b/src/project/types/website/util/discover-meta.ts
@@ -1,7 +1,7 @@
 /*
 * discover-meta.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/website/website-aliases.ts
+++ b/src/project/types/website/website-aliases.ts
@@ -1,7 +1,7 @@
 /*
 * website-aliases.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { ensureDirSync, existsSync } from "fs/mod.ts";

--- a/src/project/types/website/website-analytics.ts
+++ b/src/project/types/website/website-analytics.ts
@@ -1,7 +1,7 @@
 /*
 * website-analytics.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { Document } from "../../../core/deno-dom.ts";

--- a/src/project/types/website/website-config.ts
+++ b/src/project/types/website/website-config.ts
@@ -1,7 +1,7 @@
 /*
 * website-config.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/website/website-constants.ts
+++ b/src/project/types/website/website-constants.ts
@@ -1,7 +1,7 @@
 /*
 * website-constants.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/website/website-giscus.ts
+++ b/src/project/types/website/website-giscus.ts
@@ -1,7 +1,7 @@
 /*
 * website-giscus.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/website/website-meta.ts
+++ b/src/project/types/website/website-meta.ts
@@ -1,7 +1,7 @@
 /*
 * website-meta.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/website/website-navigation-md.ts
+++ b/src/project/types/website/website-navigation-md.ts
@@ -1,7 +1,7 @@
 /*
 * website-navigation-md.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { dirname, extname, isAbsolute, join } from "path/mod.ts";

--- a/src/project/types/website/website-navigation.ts
+++ b/src/project/types/website/website-navigation.ts
@@ -1,7 +1,7 @@
 /*
 * website-navigation.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/website/website-pipeline-md.ts
+++ b/src/project/types/website/website-pipeline-md.ts
@@ -1,7 +1,7 @@
 /*
 * website-pipeline-md.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { Document, Element, Node } from "../../../core/deno-dom.ts";

--- a/src/project/types/website/website-resources.ts
+++ b/src/project/types/website/website-resources.ts
@@ -1,7 +1,7 @@
 /*
 * website-resources.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/website/website-search.ts
+++ b/src/project/types/website/website-search.ts
@@ -1,7 +1,7 @@
 /*
 * website-search.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/website/website-shared.ts
+++ b/src/project/types/website/website-shared.ts
@@ -1,7 +1,7 @@
 /*
 * website-shared.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/website/website-sidebar-auto.ts
+++ b/src/project/types/website/website-sidebar-auto.ts
@@ -1,7 +1,7 @@
 /*
 * website-sidebar-auto.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/website/website-sitemap.ts
+++ b/src/project/types/website/website-sitemap.ts
@@ -1,7 +1,7 @@
 /*
 * website-sitemap.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/website/website-types.ts
+++ b/src/project/types/website/website-types.ts
@@ -1,7 +1,7 @@
 /*
 * website-types.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/website/website-utils.ts
+++ b/src/project/types/website/website-utils.ts
@@ -1,7 +1,7 @@
 /*
 * website-utils.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/project/types/website/website.ts
+++ b/src/project/types/website/website.ts
@@ -1,7 +1,7 @@
 /*
 * website.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/publish/account.ts
+++ b/src/publish/account.ts
@@ -1,7 +1,7 @@
 /*
 * account.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/publish/common/account.ts
+++ b/src/publish/common/account.ts
@@ -1,7 +1,7 @@
 /*
 * account.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/publish/common/data.ts
+++ b/src/publish/common/data.ts
@@ -1,7 +1,7 @@
 /*
 * data.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/publish/common/publish.ts
+++ b/src/publish/common/publish.ts
@@ -1,7 +1,7 @@
 /*
 * publish.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/publish/config.ts
+++ b/src/publish/config.ts
@@ -1,7 +1,7 @@
 /*
 * config.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/publish/gh-pages/gh-pages.ts
+++ b/src/publish/gh-pages/gh-pages.ts
@@ -1,7 +1,7 @@
 /*
 * ghpages.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/publish/netlify/netlify.ts
+++ b/src/publish/netlify/netlify.ts
@@ -1,7 +1,7 @@
 /*
 * netlify.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/publish/provider.ts
+++ b/src/publish/provider.ts
@@ -1,7 +1,7 @@
 /*
 * provider.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/publish/publish.ts
+++ b/src/publish/publish.ts
@@ -1,7 +1,7 @@
 /*
 * publish.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/publish/quarto-pub/api/index.ts
+++ b/src/publish/quarto-pub/api/index.ts
@@ -1,7 +1,7 @@
 /*
 * index.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/publish/quarto-pub/api/types.ts
+++ b/src/publish/quarto-pub/api/types.ts
@@ -1,7 +1,7 @@
 /*
 * types.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/publish/quarto-pub/quarto-pub.ts
+++ b/src/publish/quarto-pub/quarto-pub.ts
@@ -1,7 +1,7 @@
 /*
 * quarto-pub.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/publish/rsconnect/api/index.ts
+++ b/src/publish/rsconnect/api/index.ts
@@ -1,7 +1,7 @@
 /*
 * index.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/publish/rsconnect/api/types.ts
+++ b/src/publish/rsconnect/api/types.ts
@@ -1,7 +1,7 @@
 /*
 * types.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/publish/rsconnect/bundle.ts
+++ b/src/publish/rsconnect/bundle.ts
@@ -1,7 +1,7 @@
 /*
 * bundle.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/publish/rsconnect/rsconnect.ts
+++ b/src/publish/rsconnect/rsconnect.ts
@@ -1,7 +1,7 @@
 /*
 * rsconnect.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { info } from "log/mod.ts";

--- a/src/publish/types.ts
+++ b/src/publish/types.ts
@@ -1,7 +1,7 @@
 /*
 * types.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/quarto-core/attribution/document.ts
+++ b/src/quarto-core/attribution/document.ts
@@ -1,7 +1,7 @@
 /*
 * document.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/quarto-core/dotenv.ts
+++ b/src/quarto-core/dotenv.ts
@@ -1,7 +1,7 @@
 /*
 * dotenv.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/quarto-core/inspect.ts
+++ b/src/quarto-core/inspect.ts
@@ -1,7 +1,7 @@
 /*
 * inspect.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/quarto-core/profile.ts
+++ b/src/quarto-core/profile.ts
@@ -1,7 +1,7 @@
 /*
 * profile.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/quarto-core/text-highlighting.ts
+++ b/src/quarto-core/text-highlighting.ts
@@ -1,7 +1,7 @@
 /*
 * text-highlighting.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { join } from "path/mod.ts";

--- a/src/quarto.ts
+++ b/src/quarto.ts
@@ -1,7 +1,7 @@
 /*
 * quarto.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/tools/github.ts
+++ b/src/tools/github.ts
@@ -1,7 +1,7 @@
 /*
 * github.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/tools/impl/chromium.ts
+++ b/src/tools/impl/chromium.ts
@@ -1,7 +1,7 @@
 /*
  * chromium.ts
  *
- * Copyright (C) 2020 by RStudio, PBC
+ * Copyright (C) 2020-2022 Posit Software, PBC
  *
  */
 
@@ -76,7 +76,7 @@ async function preparePackage(_ctx: InstallContext): Promise<PackageInfo> {
     `Downloading Chromium ${revision}`,
   );
   //  const spin = spinner("Installing");
-  let spinnerStatus: ((() => void) | undefined);
+  let spinnerStatus: (() => void) | undefined;
   const fetcherObj = await fetcher();
   const revisionInfo = await fetcherObj.download(
     revision,

--- a/src/tools/impl/tinytex-info.ts
+++ b/src/tools/impl/tinytex-info.ts
@@ -1,7 +1,7 @@
 /*
 * tools-info.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/src/tools/impl/tinytex.ts
+++ b/src/tools/impl/tinytex.ts
@@ -1,7 +1,7 @@
 /*
  * tinytex.ts
  *
- * Copyright (C) 2020 by RStudio, PBC
+ * Copyright (C) 2020-2022 Posit Software, PBC
  *
  */
 import { warning } from "log/mod.ts";

--- a/src/tools/tools-console.ts
+++ b/src/tools/tools-console.ts
@@ -1,7 +1,7 @@
 /*
 * cmd.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 import * as colors from "fmt/colors.ts";

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -1,7 +1,7 @@
 /*
 * install.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,7 +1,7 @@
 /*
 * types.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/docs/extensions/basic/_extensions/quarto-ext/lightbox/_extension.yml
+++ b/tests/docs/extensions/basic/_extensions/quarto-ext/lightbox/_extension.yml
@@ -1,5 +1,5 @@
 name: Lightbox
-author: RStudio, PBC
+author: "Posit Software, PBC"
 version: 0.0.1
 contributes:
   filters:

--- a/tests/docs/extensions/basic/_extensions/quarto-journals/jss/_extensions/quarto-ext/fancy-text/_extension.yml
+++ b/tests/docs/extensions/basic/_extensions/quarto-journals/jss/_extensions/quarto-ext/fancy-text/_extension.yml
@@ -1,5 +1,5 @@
 title: Fancy Text
-author: "RStudio, PBC"
+author: "Posit Software, PBC"
 version: 0.0.1
 contributes:
   shortcodes:

--- a/tests/docs/extensions/basic/_extensions/quarto-journals/jss/_extensions/quarto-ext/latex-environment/_extension.yml
+++ b/tests/docs/extensions/basic/_extensions/quarto-journals/jss/_extensions/quarto-ext/latex-environment/_extension.yml
@@ -1,5 +1,5 @@
 title: LaTeX Environment
-author: RStudio, PBC
+author: "Posit Software, PBC"
 version: 0.1.0
 contributes:
   filters:

--- a/tests/docs/extensions/basic/_extensions/quarto-journals/jss/_extensions/quarto-ext/latex-environment/latex-environment.lua
+++ b/tests/docs/extensions/basic/_extensions/quarto-journals/jss/_extensions/quarto-ext/latex-environment/latex-environment.lua
@@ -1,5 +1,5 @@
 -- environment.lua
--- Copyright (C) 2020 by RStudio, PBC
+-- Copyright (C) 2020-2022 Posit Software, PBC
 
 local classEnvironments = pandoc.MetaMap({})
 

--- a/tests/docs/extensions/project/_extensions/quarto-ext/lightbox/_extension.yml
+++ b/tests/docs/extensions/project/_extensions/quarto-ext/lightbox/_extension.yml
@@ -1,5 +1,5 @@
 name: Lightbox
-author: RStudio, PBC
+author: "Posit Software, PBC"
 version: 0.0.1
 contributes:
   filters:

--- a/tests/docs/extensions/project/_extensions/quarto-journals/jss/_extensions/quarto-ext/fancy-text/_extension.yml
+++ b/tests/docs/extensions/project/_extensions/quarto-journals/jss/_extensions/quarto-ext/fancy-text/_extension.yml
@@ -1,5 +1,5 @@
 title: Fancy Text
-author: "RStudio, PBC"
+author: "Posit Software, PBC"
 version: 0.0.1
 contributes:
   shortcodes:

--- a/tests/integration/formats/html/ojs-echo-false-codetools.test.ts
+++ b/tests/integration/formats/html/ojs-echo-false-codetools.test.ts
@@ -3,7 +3,7 @@
 *
 * tests that `echo: false` in an ojs cell doesn't break the codetools dropdown
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/tests/integration/formats/html/ojs-es-imports.test.ts
+++ b/tests/integration/formats/html/ojs-es-imports.test.ts
@@ -3,7 +3,7 @@
 *
 * test that ojs initializes and produces output
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/tests/integration/formats/html/ojs-runs.test.ts
+++ b/tests/integration/formats/html/ojs-runs.test.ts
@@ -3,7 +3,7 @@
 *
 * test that ojs initializes and produces output
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/tests/integration/formats/html/ojs-static-data.test.ts
+++ b/tests/integration/formats/html/ojs-static-data.test.ts
@@ -4,7 +4,7 @@
 * test that we're adding OJS code to OJS projects, and not adding OJS
 * code to projects without OJS.
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/tests/integration/formats/html/ojs-test-inline-spans.test.ts
+++ b/tests/integration/formats/html/ojs-test-inline-spans.test.ts
@@ -3,7 +3,7 @@
 *
 * test that ojs initializes and produces output
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/tests/integration/formats/html/ojs-test-presence.ts
+++ b/tests/integration/formats/html/ojs-test-presence.ts
@@ -4,7 +4,7 @@
 * test that we're adding OJS code to OJS projects, and not adding OJS
 * code to projects without OJS.
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/tests/integration/formats/html/ojs-utils.ts
+++ b/tests/integration/formats/html/ojs-utils.ts
@@ -3,7 +3,7 @@
 *
 * utilities for testing ojs code
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/tests/integration/guess-chunk-options-format-document.test.ts
+++ b/tests/integration/guess-chunk-options-format-document.test.ts
@@ -4,15 +4,11 @@
 * test that guess-chunk-options-format correctly controls YAML
 * validation in knitr chunks
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 
 import { testRender } from "../smoke/render/render.ts";
 
-
 const computesKnitr = "docs/yaml/guess-chunk-options-format-knitr.qmd";
-testRender(computesKnitr, "html", false, [
-  
-]);
-
+testRender(computesKnitr, "html", false, []);

--- a/tests/integration/mermaid/github-issue-1340.test.ts
+++ b/tests/integration/mermaid/github-issue-1340.test.ts
@@ -1,7 +1,7 @@
 /*
 * github-issue-1340.test.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/tests/puppeteer.ts
+++ b/tests/puppeteer.ts
@@ -3,7 +3,7 @@
 *
 * puppeteer testing utils
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/authors/author-name.test.ts
+++ b/tests/smoke/authors/author-name.test.ts
@@ -1,7 +1,7 @@
 /*
 * authors-name.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/convert/convert-empty-frontmatter.test.ts
+++ b/tests/smoke/convert/convert-empty-frontmatter.test.ts
@@ -1,7 +1,7 @@
 /*
 * convert-empty-frontmatter.test.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 import { docs } from "../../utils.ts";

--- a/tests/smoke/convert/convert.ts
+++ b/tests/smoke/convert/convert.ts
@@ -1,7 +1,7 @@
 /*
 * convert.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { existsSync } from "fs/mod.ts";

--- a/tests/smoke/create/create.test.ts
+++ b/tests/smoke/create/create.test.ts
@@ -1,7 +1,7 @@
 /*
 * create.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/crossref/chapters.test.ts
+++ b/tests/smoke/crossref/chapters.test.ts
@@ -1,7 +1,7 @@
 /*
 * chapters.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/crossref/docx.test.ts
+++ b/tests/smoke/crossref/docx.test.ts
@@ -1,7 +1,7 @@
 /*
 * latex.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/crossref/equations.test.ts
+++ b/tests/smoke/crossref/equations.test.ts
@@ -1,7 +1,7 @@
 /*
 * equations.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/crossref/figures.test.ts
+++ b/tests/smoke/crossref/figures.test.ts
@@ -1,7 +1,7 @@
 /*
 * figures.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/crossref/latex.test.ts
+++ b/tests/smoke/crossref/latex.test.ts
@@ -1,7 +1,7 @@
 /*
 * latex.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/crossref/listings.test.ts
+++ b/tests/smoke/crossref/listings.test.ts
@@ -1,7 +1,7 @@
 /*
 * listings.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/crossref/options.test.ts
+++ b/tests/smoke/crossref/options.test.ts
@@ -1,7 +1,7 @@
 /*
 * options.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/crossref/sections.test.ts
+++ b/tests/smoke/crossref/sections.test.ts
@@ -1,7 +1,7 @@
 /*
 * sections.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/crossref/syntax.test.ts
+++ b/tests/smoke/crossref/syntax.test.ts
@@ -1,7 +1,7 @@
 /*
 * syntax.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/crossref/tables.test.ts
+++ b/tests/smoke/crossref/tables.test.ts
@@ -1,7 +1,7 @@
 /*
 * tables.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/crossref/thereoms.test.ts
+++ b/tests/smoke/crossref/thereoms.test.ts
@@ -1,7 +1,7 @@
 /*
 * theorems.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/crossref/unresolved.test.ts
+++ b/tests/smoke/crossref/unresolved.test.ts
@@ -1,7 +1,7 @@
 /*
 * unresolved.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { ensureFileRegexMatches } from "../../verify.ts";

--- a/tests/smoke/crossref/utils.ts
+++ b/tests/smoke/crossref/utils.ts
@@ -1,7 +1,7 @@
 /*
 * utils.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/directives/include-fixups.test.ts
+++ b/tests/smoke/directives/include-fixups.test.ts
@@ -1,7 +1,7 @@
 /*
 * include-fixups.test.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/engine/include-engine-detection.test.ts
+++ b/tests/smoke/engine/include-engine-detection.test.ts
@@ -1,7 +1,7 @@
 /*
 * include-engine-detection.test.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/env/check.test.ts
+++ b/tests/smoke/env/check.test.ts
@@ -1,7 +1,7 @@
 /*
 * check.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { testQuartoCmd } from "../../test.ts";

--- a/tests/smoke/env/install.test.ts
+++ b/tests/smoke/env/install.test.ts
@@ -1,7 +1,7 @@
 /*
 * install-tools.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { testQuartoCmd } from "../../test.ts";

--- a/tests/smoke/extensions/extension-render-doc.test.ts
+++ b/tests/smoke/extensions/extension-render-doc.test.ts
@@ -1,7 +1,7 @@
 /*
 * extension-render-doc.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/extensions/extension-render-project.test.ts
+++ b/tests/smoke/extensions/extension-render-project.test.ts
@@ -1,7 +1,7 @@
 /*
 * extension-render-project.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/extensions/extension-render-reveal.test.ts
+++ b/tests/smoke/extensions/extension-render-reveal.test.ts
@@ -1,7 +1,7 @@
 /*
 * extension-render-reveal.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/ojs/complex-layout.test.ts
+++ b/tests/smoke/ojs/complex-layout.test.ts
@@ -1,7 +1,7 @@
 /*
 * complex-layout.test.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 import { testRender } from "../render/render.ts";

--- a/tests/smoke/ojs/dependency-traversal.test.ts
+++ b/tests/smoke/ojs/dependency-traversal.test.ts
@@ -1,7 +1,7 @@
 /*
 * dependency-traversal.test.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 import { testRender } from "../render/render.ts";

--- a/tests/smoke/project/common.ts
+++ b/tests/smoke/project/common.ts
@@ -1,7 +1,7 @@
 /*
 * common.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { existsSync } from "fs/mod.ts";

--- a/tests/smoke/project/project-book.test.ts
+++ b/tests/smoke/project/project-book.test.ts
@@ -1,7 +1,7 @@
 /*
 * project-render.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { exists, existsSync } from "fs/mod.ts";
@@ -33,7 +33,7 @@ testQuartoCmd(
     fileExists(join(kProjectWorkingDir, "references.bib")),
     verifyYamlFile(
       kQuartoProjectFile,
-      ((yaml: unknown) => {
+      (yaml: unknown) => {
         // Make sure there is a project yaml section
         const metadata = yaml as Metadata;
         if (
@@ -44,7 +44,7 @@ testQuartoCmd(
         } else {
           return false;
         }
-      }),
+      },
     ),
   ],
   {

--- a/tests/smoke/project/project-simple.test.ts
+++ b/tests/smoke/project/project-simple.test.ts
@@ -1,7 +1,7 @@
 /*
 * project-render.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { existsSync } from "fs/mod.ts";
@@ -32,11 +32,11 @@ testQuartoCmd(
     fileExists(kQuartoProjectFile),
     verifyYamlFile(
       kQuartoProjectFile,
-      ((yaml: unknown) => {
+      (yaml: unknown) => {
         // Make sure there is a project yaml section
         const metadata = yaml as Metadata;
         return metadata.project !== undefined;
-      }),
+      },
     ),
   ],
   {

--- a/tests/smoke/project/project-website.test.ts
+++ b/tests/smoke/project/project-website.test.ts
@@ -1,7 +1,7 @@
 /*
 * project-website.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { existsSync } from "fs/mod.ts";
@@ -32,7 +32,7 @@ testQuartoCmd(
     fileExists(join(kProjectWorkingDir, "index.qmd")),
     verifyYamlFile(
       kQuartoProjectFile,
-      ((yaml: unknown) => {
+      (yaml: unknown) => {
         // Make sure there is a project yaml section
         const metadata = yaml as Metadata;
         if (
@@ -43,7 +43,7 @@ testQuartoCmd(
         } else {
           return false;
         }
-      }),
+      },
     ),
   ],
   {

--- a/tests/smoke/render/render-bibio.test.ts
+++ b/tests/smoke/render/render-bibio.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-biblio.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { docs, outputForInput } from "../../utils.ts";

--- a/tests/smoke/render/render-callout.test.ts
+++ b/tests/smoke/render/render-callout.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-callout.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/render/render-code-highlighting.test.ts
+++ b/tests/smoke/render/render-code-highlighting.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-r.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/render/render-code-tools.test.ts
+++ b/tests/smoke/render/render-code-tools.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-r.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/render/render-commonmark.test.ts
+++ b/tests/smoke/render/render-commonmark.test.ts
@@ -1,7 +1,7 @@
 /*
 * render.jupyter.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { join } from "path/mod.ts";

--- a/tests/smoke/render/render-date.test.ts
+++ b/tests/smoke/render/render-date.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-date.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { docs, outputForInput } from "../../utils.ts";

--- a/tests/smoke/render/render-docx.test.ts
+++ b/tests/smoke/render/render-docx.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-docx.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { docs } from "../../utils.ts";

--- a/tests/smoke/render/render-format-extension.test.ts
+++ b/tests/smoke/render/render-format-extension.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-format-extension.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/render/render-freeze.test.ts
+++ b/tests/smoke/render/render-freeze.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-freeze.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { stringify } from "encoding/yaml.ts";

--- a/tests/smoke/render/render-jupyter.test.ts
+++ b/tests/smoke/render/render-jupyter.test.ts
@@ -1,7 +1,7 @@
 /*
 * render.jupyter.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { docs } from "../../utils.ts";

--- a/tests/smoke/render/render-latex-output.test.ts
+++ b/tests/smoke/render/render-latex-output.test.ts
@@ -1,7 +1,7 @@
 /*
 * render.latex-output.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/render/render-minimal.test.ts
+++ b/tests/smoke/render/render-minimal.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-callout.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/render/render-ojs.test.ts
+++ b/tests/smoke/render/render-ojs.test.ts
@@ -1,7 +1,7 @@
 /*
 * render.observable.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { testRender } from "./render.ts";

--- a/tests/smoke/render/render-page-layout.test.ts
+++ b/tests/smoke/render/render-page-layout.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-page-layout.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { docs } from "../../utils.ts";

--- a/tests/smoke/render/render-pdf-chunks.ts
+++ b/tests/smoke/render/render-pdf-chunks.ts
@@ -1,7 +1,7 @@
 /*
 * render-pdf-chunks.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { docs } from "../../utils.ts";

--- a/tests/smoke/render/render-pdf.test.ts
+++ b/tests/smoke/render/render-pdf.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-pdf.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/render/render-plain.test.ts
+++ b/tests/smoke/render/render-plain.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-plain.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { docs } from "../../utils.ts";

--- a/tests/smoke/render/render-r.test.ts
+++ b/tests/smoke/render/render-r.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-r.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/render/render-reveal.test.ts
+++ b/tests/smoke/render/render-reveal.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-reveal.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/render/render-templates.test.ts
+++ b/tests/smoke/render/render-templates.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-pdf.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/render/render-text-highlighting.ts
+++ b/tests/smoke/render/render-text-highlighting.ts
@@ -1,7 +1,7 @@
 /*
 * render-text-highlighting.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { docs, outputForInput } from "../../utils.ts";

--- a/tests/smoke/render/render-title-block.test.ts
+++ b/tests/smoke/render/render-title-block.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-title-block.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/render/render.ts
+++ b/tests/smoke/render/render.ts
@@ -1,7 +1,7 @@
 /*
 * render.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { existsSync } from "fs/mod.ts";

--- a/tests/smoke/schema/load-yaml-schema-schema.test.ts
+++ b/tests/smoke/schema/load-yaml-schema-schema.test.ts
@@ -1,7 +1,7 @@
 /*
 * load-yaml-schema-schema.test.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/scholar/render-scholar.test.ts
+++ b/tests/smoke/scholar/render-scholar.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-scholar.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { docs, outputForInput } from "../../utils.ts";

--- a/tests/smoke/site/render-blog.test.ts
+++ b/tests/smoke/site/render-blog.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-blog.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { docs } from "../../utils.ts";

--- a/tests/smoke/site/render-listings.test.ts
+++ b/tests/smoke/site/render-listings.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-listings.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { dirname, join } from "path/mod.ts";

--- a/tests/smoke/site/render-navigation.test.ts
+++ b/tests/smoke/site/render-navigation.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-navigation.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { docs } from "../../utils.ts";

--- a/tests/smoke/site/render-site.test.ts
+++ b/tests/smoke/site/render-site.test.ts
@@ -1,7 +1,7 @@
 /*
 * render-site.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/smoke/site/site.ts
+++ b/tests/smoke/site/site.ts
@@ -1,7 +1,7 @@
 /*
 * site.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { exists } from "fs/exists.ts";

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -1,7 +1,7 @@
 /*
  * smoke-all.test.ts
  *
- * Copyright (C) 2022 by RStudio, PBC
+ * Copyright (C) 2022 Posit Software, PBC
  *
  */
 

--- a/tests/smoke/yaml-intelligence/yaml-intelligence-folded-block-strings.test.ts
+++ b/tests/smoke/yaml-intelligence/yaml-intelligence-folded-block-strings.test.ts
@@ -1,7 +1,7 @@
 /*
  * yaml-intelligence-embedded-html.test.ts
  *
- * Copyright (C) 2022 by RStudio, PBC
+ * Copyright (C) 2022 Posit Software, PBC
  *
  */
 

--- a/tests/smoke/yaml-intelligence/yaml-intelligence.test.ts
+++ b/tests/smoke/yaml-intelligence/yaml-intelligence.test.ts
@@ -1,7 +1,7 @@
 /*
  * yaml-intelligence.test.ts
  *
- * Copyright (C) 2022 by RStudio, PBC
+ * Copyright (C) 2022 Posit Software, PBC
  *
  */
 

--- a/tests/smoke/yaml/core-yaml-dashes.test.ts
+++ b/tests/smoke/yaml/core-yaml-dashes.test.ts
@@ -1,7 +1,7 @@
 /*
 * core-yaml-dashes.test.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,7 +1,7 @@
 /*
 * test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { existsSync } from "fs/mod.ts";

--- a/tests/unit/binary-search.test.ts
+++ b/tests/unit/binary-search.test.ts
@@ -1,7 +1,7 @@
 /*
 * binary-search.test.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/tests/unit/break-quarto-md/break-quarto-md.test.ts
+++ b/tests/unit/break-quarto-md/break-quarto-md.test.ts
@@ -1,7 +1,7 @@
 /*
 * break-quarto-md.test.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/tests/unit/environment.test.ts
+++ b/tests/unit/environment.test.ts
@@ -1,7 +1,7 @@
 /*
 * environment.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { assert, assertEquals } from "testing/asserts.ts";

--- a/tests/unit/filter-paths.test.ts
+++ b/tests/unit/filter-paths.test.ts
@@ -1,7 +1,7 @@
 /*
 * glob.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { assert } from "testing/asserts.ts";

--- a/tests/unit/guess-chunk-options-format.test.ts
+++ b/tests/unit/guess-chunk-options-format.test.ts
@@ -1,7 +1,7 @@
 /*
 * guess-chunk-option-format.test.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/tests/unit/mapped-strings/mapped-text.test.ts
+++ b/tests/unit/mapped-strings/mapped-text.test.ts
@@ -1,7 +1,7 @@
 /*
 * mapped-text.test.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 import { unitTest } from "../../test.ts";

--- a/tests/unit/mapped-strings/multiple-source.test.ts
+++ b/tests/unit/mapped-strings/multiple-source.test.ts
@@ -1,7 +1,7 @@
 /*
 * multiple-source.test.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/tests/unit/pandoc-partition.test.ts
+++ b/tests/unit/pandoc-partition.test.ts
@@ -1,7 +1,7 @@
 /*
 * pandoc-partition.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { assert } from "testing/asserts.ts";

--- a/tests/unit/pandoc.test.ts
+++ b/tests/unit/pandoc.test.ts
@@ -1,7 +1,7 @@
 /*
 * pandoc.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { assert, assertEquals } from "testing/asserts.ts";

--- a/tests/unit/path.test.ts
+++ b/tests/unit/path.test.ts
@@ -1,7 +1,7 @@
 /*
 * path.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/unit/paths/qualified-path.test.ts
+++ b/tests/unit/paths/qualified-path.test.ts
@@ -1,7 +1,7 @@
 /*
 * qualified-path.test.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/tests/unit/schema-validation/error-location.test.ts
+++ b/tests/unit/schema-validation/error-location.test.ts
@@ -1,7 +1,7 @@
 /*
 * error-location.test.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/tests/unit/schema-validation/error-narrowing.test.ts
+++ b/tests/unit/schema-validation/error-narrowing.test.ts
@@ -3,7 +3,7 @@
 *
 * Unit tests regarding the YAML validation error narrowing heuristics
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/tests/unit/schema-validation/object-super.test.ts
+++ b/tests/unit/schema-validation/object-super.test.ts
@@ -1,7 +1,7 @@
 /*
 * object-super.test.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/tests/unit/schema-validation/schema-completions.test.ts
+++ b/tests/unit/schema-validation/schema-completions.test.ts
@@ -1,7 +1,7 @@
 /*
  * yaml-intelligence.test.ts
  *
- * Copyright (C) 2022 by RStudio, PBC
+ * Copyright (C) 2022 Posit Software, PBC
  *
  */
 

--- a/tests/unit/schema-validation/schema-schema.test.ts
+++ b/tests/unit/schema-validation/schema-schema.test.ts
@@ -1,7 +1,7 @@
 /*
  * schema-schema.test.ts
  *
- * Copyright (C) 2022 by RStudio, PBC
+ * Copyright (C) 2022 Posit Software, PBC
  *
  */
 

--- a/tests/unit/schema-validation/simple.test.ts
+++ b/tests/unit/schema-validation/simple.test.ts
@@ -1,7 +1,7 @@
 /*
  * simple.test.ts
  *
- * Copyright (C) 2022 by RStudio, PBC
+ * Copyright (C) 2022 Posit Software, PBC
  *
  */
 

--- a/tests/unit/schema-validation/utils.ts
+++ b/tests/unit/schema-validation/utils.ts
@@ -1,7 +1,7 @@
 /*
 * utils.ts
 *
-* Copyright (C) 2021 by RStudio, PBC
+* Copyright (C) 2021-2022 Posit Software, PBC
 *
 */
 

--- a/tests/unit/text.test.ts
+++ b/tests/unit/text.test.ts
@@ -1,7 +1,7 @@
 /*
 * lines.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { unitTest } from "../test.ts";

--- a/tests/unit/yaml-intelligence/annotated-yaml.test.ts
+++ b/tests/unit/yaml-intelligence/annotated-yaml.test.ts
@@ -1,7 +1,7 @@
 /*
 * annotated-yaml.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { assert } from "testing/asserts.ts";

--- a/tests/unit/yaml-intelligence/error-colon-no-space.test.ts
+++ b/tests/unit/yaml-intelligence/error-colon-no-space.test.ts
@@ -1,7 +1,7 @@
 /*
 * error-colon-no-space.test.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 

--- a/tests/unit/yaml-intelligence/hover-info.test.ts
+++ b/tests/unit/yaml-intelligence/hover-info.test.ts
@@ -1,7 +1,7 @@
 /*
 * hover-info.test.ts
 *
-* Copyright (C) 2022 by RStudio, PBC
+* Copyright (C) 2022 Posit Software, PBC
 *
 */
 import { assert } from "testing/asserts.ts";
@@ -52,8 +52,7 @@ yamlValidationUnitTest("hover-info - simple()", async () => {
   const hoverInfo = `**code-fold**\n\n${
     // deno-lint-ignore no-explicit-any
     (getYamlIntelligenceResource("schema/cell-codeoutput.yml") as any)[2]
-      .description.long
-  }`;
+      .description.long}`;
   assert(
     result !== null &&
       result.content === hoverInfo,

--- a/tests/unit/yaml.test.ts
+++ b/tests/unit/yaml.test.ts
@@ -1,7 +1,7 @@
 /*
 * yaml.test.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 import { unitTest } from "../test.ts";

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,7 +1,7 @@
 /*
 * utils.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 

--- a/tests/verify.ts
+++ b/tests/verify.ts
@@ -1,7 +1,7 @@
 /*
 * verify.ts
 *
-* Copyright (C) 2020 by RStudio, PBC
+* Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
 


### PR DESCRIPTION
This PR updates the Company name (RStudio, PBC -> Posit Software, PBC) where it's safe to do so. Year ranges were added wherever necessary in copyright statements. Deno formatting occurred with every re-saved file (except for `COPYRIGHT` where formatting was suppressed to conserve indentation).

Fixes: https://github.com/quarto-dev/quarto-cli/issues/3329