### PR TITLE
Update CSS for date picker in OJS

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -72,4 +72,5 @@
 - Add optional `rel` attribute to navigation links ([#3212](https://github.com/quarto-dev/quarto-cli/issues/3212))
 - Use the right port when CRI is initialized multiple times ([#3066](https://github.com/quarto-dev/quarto-cli/issues/3066))
 - Allow custom themes for giscus ([#3105](https://github.com/quarto-dev/quarto-cli/issues/3105))
-- new `kbd` shortcode, to describe keyboard keys ([#3384](https://github.com/quarto-dev/quarto-cli/issues/3384)). See the [pre-release documentation](https://quarto.org/docs/prerelease/1.3.html) for details.
+- Add new `kbd` shortcode, to describe keyboard keys ([#3384](https://github.com/quarto-dev/quarto-cli/issues/3384)). See the [pre-release documentation](https://quarto.org/docs/prerelease/1.3.html) for details.
+- Replace default style for date picker component in OJS ([#2863](https://github.com/quarto-dev/quarto-cli/issues/2863)).

--- a/src/resources/formats/html/ojs/quarto-ojs.css
+++ b/src/resources/formats/html/ojs/quarto-ojs.css
@@ -155,3 +155,9 @@ code span.quarto-ojs-error-pinpoint {
 .quarto-ojs-table-fixup {
   padding-left: 14px;
 }
+
+div.observablehq input[type="date"] {
+  border-style: solid;
+  padding: 0.8em 0.5em 0.8em 0.5em;
+  border-color: rgba(220, 220, 220, 0.3);
+}


### PR DESCRIPTION
This just changes the CSS for the date picker in OJS outputs.

Fixes: https://github.com/quarto-dev/quarto-cli/issues/2863