### PR TITLE
fix alignment of mermaid HTML figures. Closes #3294

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -38,6 +38,7 @@
 - Allow `%%| label` mermaid cell option that control the `id` of the resulting SVG, to facilitate CSS overrides.
 - Use `htmlLabels: false` in mermaid flowcharts.
 - Remove support for tooltips, which appear to not be working in mermaid 9.2.2.
+- Add support for `fig-align` in mermaid diagrams in HTML format ([#3294](https://github.com/quarto-dev/quarto-cli/issues/3294))
 
 ## Dates
 

--- a/src/core/handlers/base.ts
+++ b/src/core/handlers/base.ts
@@ -58,6 +58,7 @@ import {
   kCodeOverflow,
   kCodeSummary,
   kEcho,
+  kFigAlign,
   kFigCapLoc,
   kLayout,
   kLayoutNcol,
@@ -618,7 +619,6 @@ export const baseHandler: LanguageHandler = {
       }
     }
 
-    const paraBlock = pandocHtmlBlock("p");
     const divBlock = pandocBlock(":::");
 
     // PandocNodes ignore self-pushes (n.push(n))
@@ -638,7 +638,7 @@ export const baseHandler: LanguageHandler = {
       };
     }
     const figureLike = unrolledOutput ? cellBlock : divBlock(figureLikeOptions);
-    const cellOutput = unrolledOutput ? cellBlock : paraBlock();
+    const cellOutput = unrolledOutput ? cellBlock : divBlock();
 
     figureLike.push(cellOutput);
     cellOutputDiv.push(figureLike);
@@ -723,6 +723,9 @@ export function getDivAttributes(
   const classStr = (options?.classes as (string | undefined)) || "";
 
   const classes = classStr === "" ? [] : classStr.trim().split(" ");
+  if (typeof options?.[kFigAlign] === "string") {
+    attrs.push(`layout-align="${options?.[kFigAlign]}"`);
+  }
   if (typeof options?.panel === "string") {
     classes.push(`panel-${options?.panel}`);
   }

--- a/src/core/pandoc/codegen.ts
+++ b/src/core/pandoc/codegen.ts
@@ -131,14 +131,14 @@ export function pandocList(opts: {
 
 export function pandocBlock(delimiter: string) {
   return function (
-    opts: {
+    opts?: {
       language?: string;
       id?: string;
       classes?: string[];
       attrs?: string[];
       skipFirstLineBreak?: boolean;
       contents?: PandocNode[];
-    } | undefined,
+    },
   ): PandocNode {
     let { id, classes, attrs, language, skipFirstLineBreak, contents } = opts ||
       {};

--- a/src/resources/formats/html/_quarto-rules.scss
+++ b/src/resources/formats/html/_quarto-rules.scss
@@ -94,13 +94,16 @@ figure .quarto-layout-row figure figcaption {
   width: 100%;
   margin-bottom: 0;
 }
-.quarto-figure-left > figure > p {
+.quarto-figure-left > figure > p,
+.quarto-figure-left > figure > div /* for mermaid and dot diagrams */ {
   text-align: left;
 }
-.quarto-figure-center > figure > p {
+.quarto-figure-center > figure > p,
+.quarto-figure-center > figure > div /* for mermaid and dot diagrams */ {
   text-align: center;
 }
-.quarto-figure-right > figure > p {
+.quarto-figure-right > figure > p,
+.quarto-figure-right > figure > div /* for mermaid and dot diagrams */ {
   text-align: right;
 }
 figure > p:empty {

--- a/src/resources/formats/html/mermaid/mermaid-init.js
+++ b/src/resources/formats/html/mermaid/mermaid-init.js
@@ -211,6 +211,17 @@ const _quartoMermaid = {
     if (options["reveal"]) {
       this.fixupAlignment(svg, options["figAlign"] || "center");
     }
+
+    // forward align attributes to the correct parent dif
+    // so that the svg figure is aligned correctly
+    const div = svg.parentElement.parentElement.parentElement;
+    const align = div.parentElement.parentElement.dataset.layoutAlign;
+    if (align) {
+      div.classList.remove("quarto-figure-left");
+      div.classList.remove("quarto-figure-center");
+      div.classList.remove("quarto-figure-right");
+      div.classList.add(`quarto-figure-${align}`);
+    }
   },
 };
 
@@ -219,6 +230,7 @@ window.addEventListener(
   "load",
   function () {
     let i = 0;
+    // we need pre because of whitespace preservation
     for (const el of Array.from(document.querySelectorAll("pre.mermaid-js"))) {
       // &nbsp; doesn't appear to be treated as whitespace by mermaid
       // so we replace it with a space.
@@ -241,9 +253,15 @@ window.addEventListener(
         svg.id = el.dataset.label;
         delete el.dataset.label;
       }
+
+      const svg = el.querySelector("svg");
+      const parent = el.parentElement;
+      parent.removeChild(el);
+      parent.appendChild(svg);
+      svg.classList.add("mermaid-js");
     }
     for (const svgEl of Array.from(
-      document.querySelectorAll("pre.mermaid-js svg")
+      document.querySelectorAll("svg.mermaid-js")
     )) {
       _quartoMermaid.postProcess(svgEl);
     }


### PR DESCRIPTION
The generation of raw HTML in base handlers was broken. We fix #3294 by using pandoc markdown instead of raw html and changing some of the JS postprocessing to match.