### PR TITLE
Add a missing space in output of `quarto preview --help`

### DIFF
--- a/src/command/preview/cmd.ts
+++ b/src/command/preview/cmd.ts
@@ -82,7 +82,7 @@ export const previewCommand = new Command()
   )
   .arguments("[file:string] [...args:string]")
   .description(
-    "Render and preview a document or website project.\n\nAutomatically reloads the browser when" +
+    "Render and preview a document or website project.\n\nAutomatically reloads the browser when " +
       "input files or document resources (e.g. CSS) change.\n\n" +
       "For website preview, the most recent execution results of computational documents are used to render\n" +
       "the site (this is to optimize startup time). If you want to perform a full render prior to\n" +
@@ -125,7 +125,7 @@ export const previewCommand = new Command()
   )
   // deno-lint-ignore no-explicit-any
   .action(async (options: any, file?: string, ...args: string[]) => {
-  // one-time initialization of yaml validation modules
+    // one-time initialization of yaml validation modules
     setInitializer(initYamlIntelligenceResourcesFromFilesystem);
     await initState();
 


### PR DESCRIPTION
This is a tiny minor fix for a missing space.