### PR TITLE
[chores] Add id to invalidate cache easily in smoke test

### DIFF
--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -48,9 +48,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.RENV_PATHS_ROOT }}
-          key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
+          key: ${{ runner.os }}-1-renv-${{ hashFiles('**/renv.lock') }}
           restore-keys: |
-            ${{ runner.os }}-renv-
+            ${{ runner.os }}-1-renv-
 
       - name: Restore packages
         run: |


### PR DESCRIPTION
This add an id to invalidate the cache easily. We just need to increase the id when needed. 

We could also add a the OS version info into the cache key, but this would be one more step in the workflow to compute the information, and then use it in the key. If we want to do that, then this action can be useful (https://github.com/marketplace/actions/github-actions-runner-os-system-information) to use or for inspiration on how to retrieve. 

