### PR TITLE
Make `quarto.version` a Version object

### DIFF
--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -1691,8 +1691,14 @@ local function outputFile()
    end
 end
 
-local function version() 
-   return param('quarto-version', 'unknown')
+local function version()
+   local versionString = param('quarto-version', 'unknown')
+   local success, versionObject = pcall(pandoc.types.Version, versionString)
+   if success then
+      return versionObject
+   else
+      return versionString
+   end
 end
 
 local function projectProfiles()


### PR DESCRIPTION
## Description

This makes the `quarto.version` field behave like the `PANDOC_VERSION`
object. For example, this allows to do version checks with relational
operators as in `quarto.version >= '1.2.269'` or `quarto.version >= 1.2`.

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](../CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog