### PR TITLE
added algorithm environment to theorems.lua

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -87,3 +87,4 @@
 - Add new `kbd` shortcode, to describe keyboard keys ([#3384](https://github.com/quarto-dev/quarto-cli/issues/3384)). See the [pre-release documentation](https://quarto.org/docs/prerelease/1.3.html) for details.
 - Replace default style for date picker component in OJS ([#2863](https://github.com/quarto-dev/quarto-cli/issues/2863)).
 - `quarto check` now supports `quarto check versions` for checking binary dependency versions in the case of custom binaries ([#3602](https://github.com/quarto-dev/quarto-cli/issues/3602)).
+- Add 'algorithm' as a theorem type. ([#3605](https://github.com/quarto-dev/quarto-cli/discussions/3605)).

--- a/src/resources/filters/common/theorems.lua
+++ b/src/resources/filters/common/theorems.lua
@@ -41,7 +41,12 @@ theoremTypes = {
   exr  = {
     env = "exercise",
     style = "definition",
-    title = "Exercise"
+    title = "Exercise",
+  },
+  alg = {
+    env = "algorithm",
+    style = "plain",
+    title = "Algorithm",
   }
 }
 


### PR DESCRIPTION


## Description
 
Please describe your PR here.


I have added an **algorithm** environment to the list of theorem-like environments in ```theorems.lua```.
This responds to my suggestion in #3605.
```lua
  alg = {
    env = "algorithm",
    style = "plain",
    title = "Algorithm",
  }
```


## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](../CONTRIBUTING.md).
- [x]  referenced the GitHub issue this PR closes
- [x] updated the appropriate changelog
