### PR TITLE
fix indentation for a11y highlight styles

### DIFF
--- a/src/resources/pandoc/highlight-styles/a11y-dark.theme
+++ b/src/resources/pandoc/highlight-styles/a11y-dark.theme
@@ -1,21 +1,21 @@
 {
     "text-color": null,
-        "background-color": "#2b2b2b",
-            "line-number-color": "#97947a",
-                "line-number-background-color": null,
-                    "_comments": [
-                        "Last update: Aug 24, 2022 (revision 1.1)",
-                        "This file has been adapted from: https://github.com/ericwbailey/a11y-syntax-highlighting#a11y-dark",
-                        "Also see: https://github.com/ericwbailey/a11y-syntax-highlighting/blob/main/dist/highlight/a11y-dark.css"
-                    ],
-                        "metadata": {
+    "background-color": "#2b2b2b",
+    "line-number-color": "#97947a",
+    "line-number-background-color": null,
+    "_comments": [
+        "Last update: Aug 24, 2022 (revision 1.1)",
+        "This file has been adapted from: https://github.com/ericwbailey/a11y-syntax-highlighting#a11y-dark",
+        "Also see: https://github.com/ericwbailey/a11y-syntax-highlighting/blob/main/dist/highlight/a11y-dark.css"
+    ],
+    "metadata": {
         "copyright": [
             "SPDX-FileCopyrightText: 2017 Eric W Bailey",
             "SPDX-FileCopyrightText: 2022 Mara Averick"
         ],
-            "license": "SPDX-License-Identifier: MIT",
-                "name": "a11y dark",
-                    "revision": 1
+        "license": "SPDX-License-Identifier: MIT",
+        "name": "a11y dark",
+        "revision": 1
     },
     "text-styles": {
         "Normal": {
@@ -23,206 +23,206 @@
         },
         "Other": {
             "text-color": "#ffa07a",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Attribute": {
             "text-color": "#ffd700",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "SpecialString": {
             "text-color": "#abe338",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Annotation": {
             "text-color": "#d4d0ab",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Function": {
             "text-color": "#ffd700",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "String": {
             "text-color": "#abe338",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "ControlFlow": {
             "text-color": "#ffa07a",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Operator": {
             "text-color": "#00e0e0",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Error": {
             "text-color": "#dcc6e0",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "BaseN": {
             "text-color": "#dcc6e0",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Alert": {
             "text-color": "#dcc6e0",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Variable": {
             "text-color": "#f5ab35",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "BuiltIn": {
             "text-color": "#f5ab35",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Extension": {
             "text-color": "#ffd700",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Preprocessor": {
             "text-color": "#dcc6e0",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Information": {
             "text-color": "#d4d0ab",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "VerbatimString": {
             "text-color": "#abe338",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Warning": {
             "text-color": "#d4d0ab",
-                "background-color": null,
-                    "bold": false,
-                        "italic": true,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": true,
+            "underline": false
         },
         "Documentation": {
             "text-color": "#d4d0ab",
-                "background-color": null,
-                    "bold": false,
-                        "italic": true,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": true,
+            "underline": false
         },
         "Import": {
             "text-color": "#f8f8f2",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Char": {
             "text-color": "#abe338",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "DataType": {
             "text-color": "#dcc6e0",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Float": {
             "text-color": "#f5ab35",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Comment": {
             "text-color": "#d4d0ab",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "CommentVar": {
             "text-color": "#d4d0ab",
-                "background-color": null,
-                    "bold": false,
-                        "italic": true,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": true,
+            "underline": false
         },
         "Constant": {
             "text-color": "#ffa07a",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "SpecialChar": {
             "text-color": "#00e0e0",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "DecVal": {
             "text-color": "#dcc6e0",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Keyword": {
             "text-color": "#ffa07a",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         }
     }
 }

--- a/src/resources/pandoc/highlight-styles/a11y-light.theme
+++ b/src/resources/pandoc/highlight-styles/a11y-light.theme
@@ -1,21 +1,21 @@
 {
     "text-color": null,
-        "background-color": "#fefefe",
-            "line-number-color": "#767676",
-                "line-number-background-color": null,
-                    "_comments": [
-                        "Last update: Aug 23, 2022 (revision 1.1)",
-                        "This file has been adapted from: https://github.com/ericwbailey/a11y-syntax-highlighting#a11y-light",
-                        "Also see: https://github.com/ericwbailey/a11y-syntax-highlighting/blob/main/dist/highlight/a11y-light.css"
-                    ],
-                        "metadata": {
+    "background-color": "#fefefe",
+    "line-number-color": "#767676",
+    "line-number-background-color": null,
+    "_comments": [
+        "Last update: Aug 23, 2022 (revision 1.1)",
+        "This file has been adapted from: https://github.com/ericwbailey/a11y-syntax-highlighting#a11y-light",
+        "Also see: https://github.com/ericwbailey/a11y-syntax-highlighting/blob/main/dist/highlight/a11y-light.css"
+    ],
+    "metadata": {
         "copyright": [
             "SPDX-FileCopyrightText: 2017 Eric W Bailey",
             "SPDX-FileCopyrightText: 2022 Mara Averick"
         ],
-            "license": "SPDX-License-Identifier: MIT",
-                "name": "a11y light",
-                    "revision": 1
+        "license": "SPDX-License-Identifier: MIT",
+        "name": "a11y light",
+        "revision": 1
     },
     "text-styles": {
         "Normal": {
@@ -23,206 +23,206 @@
         },
         "Other": {
             "text-color": "#d91e18",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Attribute": {
             "text-color": "#a55a00",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "SpecialString": {
             "text-color": "#008000",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Annotation": {
             "text-color": "#696969",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Function": {
             "text-color": "#06287e",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "String": {
             "text-color": "#008000",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "ControlFlow": {
             "text-color": "#d91e18",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Operator": {
             "text-color": "#00769e",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Error": {
             "text-color": "#7928a1",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "BaseN": {
             "text-color": "#7928a1",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Alert": {
             "text-color": "#7928a1",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Variable": {
             "text-color": "#a55a00",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "BuiltIn": {
             "text-color": null,
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Extension": {
             "text-color": null,
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Preprocessor": {
             "text-color": "#7928a1",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Information": {
             "text-color": "#696969",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "VerbatimString": {
             "text-color": "#008000",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Warning": {
             "text-color": "#696969",
-                "background-color": null,
-                    "bold": false,
-                        "italic": true,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": true,
+            "underline": false
         },
         "Documentation": {
             "text-color": "#696969",
-                "background-color": null,
-                    "bold": false,
-                        "italic": true,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": true,
+            "underline": false
         },
         "Import": {
             "text-color": null,
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Char": {
             "text-color": "#008000",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "DataType": {
             "text-color": "#7928a1",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Float": {
             "text-color": "#a55a00",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Comment": {
             "text-color": "#696969",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "CommentVar": {
             "text-color": "#696969",
-                "background-color": null,
-                    "bold": false,
-                        "italic": true,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": true,
+            "underline": false
         },
         "Constant": {
             "text-color": "#d91e18",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "SpecialChar": {
             "text-color": "#00769e",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "DecVal": {
             "text-color": "#7928a1",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         },
         "Keyword": {
             "text-color": "#d91e18",
-                "background-color": null,
-                    "bold": false,
-                        "italic": false,
-                            "underline": false
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
         }
     }
 }


### PR DESCRIPTION
## Description

The two included highlight styles `a11y-light.theme` and `a11y-dark.theme` had inconsistent indentation. This PR brings the indentation in line with the remaining `.theme` files.

## Checklist

I have (if applicable):

- [X] filed a [contributor agreement](../CONTRIBUTING.md). (not done since this is basically a typo PR)
- [X] referenced the GitHub issue this PR closes
- [X] updated the appropriate changelog
