### PR TITLE
Correctly use pptx as extension for Powerpoint format

### DIFF
--- a/src/format/formats.ts
+++ b/src/format/formats.ts
@@ -270,7 +270,7 @@ export function defaultWriterFormat(to: string): Format {
 }
 
 function powerpointFormat(): Format {
-  return createFormat("pptx", "Powerpoint", {
+  return createFormat("Powerpoint", "pptx", {
     render: {
       [kPageWidth]: 10,
       [kOutputDivs]: false,


### PR DESCRIPTION
Fix an issue following #3429

@dragonstyle I believe this should be the right order. Currently, building with `format: pptx` will create a `.Powerpoint` file. 

I found that by chance as I tried to use quarto for pptx and it gave me this weird results. I looked and found this. 

I think this should have been tested somehow (correctly generate a `.pptx` file),  but I did not check or add test. This is because I think the test suites as evolved and I am not up to date yet on where add such test. Feel free to add some if you know. 

I quickly looked at other calls, and it seems this is the only one where there was an inversion. Not 100% sure though. 