### PR TITLE
`publish gh-pages` renders into clean directory

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -69,7 +69,7 @@
 
 - Fix issue assigning specific sidebar to a specific page using `sidebar:` (#3389)
 - Change behavior of `publish gh-pages` to always render into a clean directory.
-  Previous behavior was to add to existing contents of `gh-pages` branch. ([dicsussion #3189](https://github.com/quarto-dev/quarto-cli/discussions/3199), @ijlyttle)
+  Previous behavior was to add to existing contents of `gh-pages` branch. ([#3199](https://github.com/quarto-dev/quarto-cli/discussions/3199), @ijlyttle)
 
 ## Books
 

--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -68,6 +68,8 @@
 ## Websites
 
 - Fix issue assigning specific sidebar to a specific page using `sidebar:` (#3389)
+- Change behavior of `publish gh-pages` to always render into a clean directory.
+  Previous behavior was to add to existing contents of `gh-pages` branch. ([dicsussion #3189](https://github.com/quarto-dev/quarto-cli/discussions/3199), @ijlyttle)
 
 ## Books
 

--- a/src/publish/gh-pages/gh-pages.ts
+++ b/src/publish/gh-pages/gh-pages.ts
@@ -338,6 +338,12 @@ async function withWorktree(
     cwd: dir,
   });
 
+  // remove files in existing site, i.e. start clean
+  await execProcess({
+    cmd: ["git", "rm", "-r", "--quiet", "."],
+    cwd: join(dir, siteDir),
+  })
+
   try {
     await f();
   } finally {


### PR DESCRIPTION
## Description

Fix #3199

I found that I needed to make the cleaning in a different place. I made the smallest change that I could, but I have a suspicion that the end result could be cleaner.

I see that you went to some trouble to pull `gh-pages` into a worktree, instead of creating an orphan branch. My guess is that, at one point, you wanted to add to `gh-pages`, perhaps along the lines of what pkgdown does to facilitate the `dev` directory to be added to an existing site.

Not my place to suggest what the "right" behavior is, but I thought I'd point out that this fix may leave in place some unnecessary infrastructure. That said, using the worktree *does* let you track changes in the branch.

I figured I should point it out, and give you all a chance to ask for further changes (or no further changes). 

Otherwise, I tested this on one of my repos; in this case, it works as advertised.

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](../CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [x] updated the appropriate changelog
