### PR TITLE
Confluence:  Add support for tilda in front of space name

### DIFF
--- a/src/publish/confluence/confluence-helper.ts
+++ b/src/publish/confluence/confluence-helper.ts
@@ -112,7 +112,7 @@ export const tokenFilterOut = (
 
 export const confluenceParentFromString = (url: string): ConfluenceParent => {
   const match = url.match(
-    /^https.*?wiki\/spaces\/(?:(\w+)|(\w+)\/overview|.(\w+)\/pages\/(\d+).*)$/
+    /^https.*?wiki\/spaces\/(?:(\w+)|(\w+)\/overview|~?(\w+)\/pages\/(\d+).*)$/
   );
   if (match) {
     return {

--- a/src/publish/confluence/confluence-helper.ts
+++ b/src/publish/confluence/confluence-helper.ts
@@ -112,7 +112,7 @@ export const tokenFilterOut = (
 
 export const confluenceParentFromString = (url: string): ConfluenceParent => {
   const match = url.match(
-    /^https.*?wiki\/spaces\/(?:(\w+)|(\w+)\/overview|(\w+)\/pages\/(\d+).*)$/
+    /^https.*?wiki\/spaces\/(?:(\w+)|(\w+)\/overview|.(\w+)\/pages\/(\d+).*)$/
   );
   if (match) {
     return {

--- a/src/publish/confluence/confluence-helper.ts
+++ b/src/publish/confluence/confluence-helper.ts
@@ -112,7 +112,7 @@ export const tokenFilterOut = (
 
 export const confluenceParentFromString = (url: string): ConfluenceParent => {
   const match = url.match(
-    /^https.*?wiki\/spaces\/(?:(\w+)|(\w+)\/overview|~?(\w+)\/pages\/(\d+).*)$/
+    /^https.*?wiki\/spaces\/(?:(\w+)|(\w+)\/overview|(~?\w+)\/pages\/(\d+).*)$/
   );
   if (match) {
     return {

--- a/tests/unit/confluence.test.ts
+++ b/tests/unit/confluence.test.ts
@@ -260,6 +260,18 @@ unitTest("confluenceParentFromString_valid", async () => {
   assertEquals(expected, result);
 });
 
+unitTest("confluenceParentFromString_valid", async () => {
+  const url =
+    "https://allenmanning.atlassian.net/wiki/spaces/~QUARTOCONF/pages/8781825/Markdown+Basics1";
+  const result = confluenceParentFromString(url);
+  const expected: ConfluenceParent = {
+    space: "QUARTOCONF",
+    parent: "8781825",
+  };
+  assertEquals(expected, result);
+});
+
+
 unitTest("confluenceParentFromString_valid_noParent", async () => {
   const url = "https://allenmanning.atlassian.net/wiki/spaces/QUARTOCONF";
   const result = confluenceParentFromString(url);

--- a/tests/unit/confluence.test.ts
+++ b/tests/unit/confluence.test.ts
@@ -265,7 +265,7 @@ unitTest("confluenceParentFromString_valid", async () => {
     "https://allenmanning.atlassian.net/wiki/spaces/~QUARTOCONF/pages/8781825/Markdown+Basics1";
   const result = confluenceParentFromString(url);
   const expected: ConfluenceParent = {
-    space: "QUARTOCONF",
+    space: "~QUARTOCONF",
     parent: "8781825",
   };
   assertEquals(expected, result);


### PR DESCRIPTION
## Description

- Addresses https://github.com/quarto-dev/quarto-cli/issues/3720
- In the Atlassian wiki I wish to publish to, Personal spaces are not named, they are of the form `/~<long-numeric-id>/`
- the current regex for parent capturing will only find spaces of form`(\w+)`
- this updates the regex and adds a test.
- ~~However, I cannot fully confirm this is the correct route as my attempt to publish now yields a `404`.  Is there small, simple page that is recommended for testing uploads? I am currently testing with a vanilla `quarto create` project.~~




## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](../CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
