### PR TITLE
fix: improve YouTube watch url parser

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -100,6 +100,7 @@
 - Add new `kbd` shortcode, to describe keyboard keys ([#3384](https://github.com/quarto-dev/quarto-cli/issues/3384)). See the [pre-release documentation](https://quarto.org/docs/prerelease/1.3.html) for details.
 - Replace default style for date picker component in OJS ([#2863](https://github.com/quarto-dev/quarto-cli/issues/2863)).
 - `quarto check` now supports `quarto check versions` for checking binary dependency versions in the case of custom binaries ([#3602](https://github.com/quarto-dev/quarto-cli/issues/3602)).
+- fix video shortcode for `https://www.youtube.com/watch?v=` URLs ([#3781](https://github.com/quarto-dev/quarto-cli/discussions/3781)).
 
 ## Pandoc filter changes
 

--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -100,7 +100,6 @@
 - Add new `kbd` shortcode, to describe keyboard keys ([#3384](https://github.com/quarto-dev/quarto-cli/issues/3384)). See the [pre-release documentation](https://quarto.org/docs/prerelease/1.3.html) for details.
 - Replace default style for date picker component in OJS ([#2863](https://github.com/quarto-dev/quarto-cli/issues/2863)).
 - `quarto check` now supports `quarto check versions` for checking binary dependency versions in the case of custom binaries ([#3602](https://github.com/quarto-dev/quarto-cli/issues/3602)).
-- fix video shortcode for `https://www.youtube.com/watch?v=` URLs ([#3781](https://github.com/quarto-dev/quarto-cli/discussions/3781)).
 
 ## Pandoc filter changes
 

--- a/src/resources/extensions/quarto/video/_tests/test-suite.lua
+++ b/src/resources/extensions/quarto/video/_tests/test-suite.lua
@@ -65,9 +65,9 @@ function TestYouTubeBuilder:testShareURL()
   checkYouTubeBuilder(params, expected)
 end
 
-function TestYouTubeBuilder:testShareURL()
+function TestYouTubeBuilder:testWebRawURL()
   local params = {
-    src = 'https://youtu.be/wo9vZccmqwc'
+    src = 'https://www.youtube.com/watch?v=wo9vZccmqwc'
   }
   local expected = SIMPLE_YOUTUBE_EXPECTED
   checkYouTubeBuilder(params, expected)

--- a/src/resources/extensions/quarto/video/video.lua
+++ b/src/resources/extensions/quarto/video/video.lua
@@ -69,8 +69,7 @@ local youTubeBuilder = function(params)
   local src = params.src
   match = checkEndMatch(src, 'https://www.youtube.com/embed/')
   match = match or checkEndMatch(src, 'https://youtu.be/')
-  match = match or string.match(src, '%?v=(.-)&')
-  match = match or string.match(src, '%?v=(.-)$')
+  match = match or string.match(src, '%?v=([%w-_]+)')
 
   if not match then return nil end
 


### PR DESCRIPTION
## Description

This PR:
- improve the matching pattern for URL like `https://www.youtube.com/watch?v=wo9vZccmqwc` (see #3781).
- remove a duplicated test.
  https://github.com/quarto-dev/quarto-cli/blob/80548e60915e7c77ee39e049aa1a0eee1704730d/src/resources/extensions/quarto/video/_tests/test-suite.lua#L60-L75
- add a test for `https://www.youtube.com/watch?v=wo9vZccmqwc` with no additional arguments in the URL.

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](../CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
