### PR TITLE
Support passing a github token when fetching api info for tinytex

### DIFF
--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -78,6 +78,8 @@ jobs:
       - uses: ./.github/workflows/actions/quarto-dev
 
       - name: Install Tinytex
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           quarto install tinytex
 

--- a/src/tools/github.ts
+++ b/src/tools/github.ts
@@ -14,7 +14,10 @@ import { GitHubRelease } from "./types.ts";
 // Look up the latest release for a Github Repo
 export async function getLatestRelease(repo: string): Promise<GitHubRelease> {
   const url = `https://api.github.com/repos/${repo}/releases/latest`;
-  const response = await fetch(url);
+  const headers = Deno.env.get("GH_TOKEN")
+    ? { headers: { Authorization: "Bearer " + Deno.env.get("GH_TOKEN") } }
+    : undefined;
+  const response = await fetch(url, headers);
   if (response.status !== 200) {
     throw new Error(
       `Unable to determine latest release for ${repo}\n${response.status} - ${response.statusText}`,


### PR DESCRIPTION
This should prevent api rate limitation in our CI for example as encounter today 

![image](https://user-images.githubusercontent.com/6791940/210813599-5cb30035-d009-4f78-b4bc-b5cac189aa4d.png)

https://github.com/quarto-dev/quarto-cli/actions/runs/3846727481/jobs/6552360460#step:12:21

https://github.com/quarto-dev/quarto-cli/actions/runs/3845829204/jobs/6550433968#step:12:21

