### PR TITLE
Simplify to vector when parsing json message for R

### DIFF
--- a/src/resources/rmd/rmd.R
+++ b/src/resources/rmd/rmd.R
@@ -129,7 +129,7 @@
   close(stdin)
 
   # parse request and params
-  request <- jsonlite::parse_json(input)
+  request <- jsonlite::parse_json(input, simplifyVector = TRUE)
   params <- request$params
 
   # source in helper functions if we have a resourceDir

--- a/tests/docs/smoke-all/2023/01/12/knitr-options-yaml.qmd
+++ b/tests/docs/smoke-all/2023/01/12/knitr-options-yaml.qmd
@@ -1,0 +1,22 @@
+---
+title: "Define knitr options in YAML"
+knitr:
+  opts_chunk:
+    dev:
+      - png
+      - pdf
+      - svg
+---
+
+Issue [#3909](https://github.com/quarto-dev/quarto-cli/issues/3909) for details 
+
+```{r}
+knitr::opts_chunk$get("dev")
+```
+
+```{r}
+#| dev:
+#|   - png
+#|   - svg
+knitr::opts_current$get("dev")
+```


### PR DESCRIPTION
So that we get vector instead of unnamed list as e.g some knitr options expect vector. This closes #3909

## Context 

Setting multiple for `dev` was not working 
````markdown
---
title: "Document"
format: 
  html:
    embed-resources: false
knitr:
  opts_chunk:
    dev:
      - png
      - pdf
      - svg
---

```{r}
library(ggplot2)
ggplot() + ggtitle("this is a title")
```
````

because Quarto parses the YAML then pass it to the R process using JSON message that is parsed with **jsonlite** but `knitr$opts_chunk$dev` is seen as a unamed list and not coerced to a vector. 

This creates issue within **knitr** which expect a vector for some options and currently does not handle or coerce list to vector itself. 

I believe that YAML parsing does correctly see this as a vector, so it seems ok to simplify when parsing the JSON. 
This will also convert to Matrix and Dataframe in some case - if we want to prevent that we could do 
````
request <- jsonlite::parse_json(input, simplifyVector = TRUE, simplifyDataFrame = FALSE, simplifyMatrix = FALSE)
````
but seems too much. 

If this is too broad fix anyway, We could simplify only the `knitr` fields in the message.;

BTW I tried to add a test using the new smoke-all folder - Hopefully adding a file is enough for it to be run. 

