### PR TITLE
Convert to forward slashes for csl and bib paths

### DIFF
--- a/src/project/types/book/book-bibliography.ts
+++ b/src/project/types/book/book-bibliography.ts
@@ -81,7 +81,7 @@ export async function bookBibliographyPostRender(
 
       // Fixes https://github.com/quarto-dev/quarto-cli/issues/2755
       if (csl) {
-        const cslAbsPath = join(firstFileDir, csl);
+        const cslAbsPath = pathWithForwardSlashes(join(firstFileDir, csl));
         if (safeExistsSync(cslAbsPath)) {
           csl = cslAbsPath;
         }
@@ -197,11 +197,13 @@ async function generateBibliographyHTML(
 
   // make the aggregated bibliography
   const yaml: Metadata = {
-    [kBibliography]: biblioPaths,
+    [kBibliography]: biblioPaths.map(pathWithForwardSlashes),
     [kNoCite]: ld.uniq(citeIds).map((id) => "@" + id).join(", "),
   };
   if (csl) {
-    yaml[kCsl] = isAbsolute(csl) ? relative(context.dir, csl) : csl;
+    yaml[kCsl] = isAbsolute(csl)
+      ? pathWithForwardSlashes(relative(context.dir, csl))
+      : csl;
   }
   const frontMatter = `---\n${stringify(yaml, { indent: 2 })}\n---\n`;
   const result = await execProcess({


### PR DESCRIPTION
This fixes #3944

# Context 

On Windows, Deno functions for paths like `join()` or `relative()` will use `\` to join paths. So even if our paths are forward slash in the first place they get converted. This is what happened in our code currently. 

* We make the CSL an absolute path (initially from https://github.com/quarto-dev/quarto-cli/commit/d78d4b22966df1a122d8e0bd13219ec7956a5005)
https://github.com/quarto-dev/quarto-cli/blob/1857dc4220cd079889f7d8b4ef1fdb0d73d4dd68/src/project/types/book/book-bibliography.ts#L83-L87

`join()` messes up the path

* We then make the CSL path relative (https://github.com/quarto-dev/quarto-cli/commit/a91bd59aa9a6eafe3e6d47873019bb31b4c3edac)
https://github.com/quarto-dev/quarto-cli/blob/a91bd59aa9a6eafe3e6d47873019bb31b4c3edac/src/project/types/book/book-bibliography.ts#L203-L205

`relative()` messes up also. 

I don't know why we make those two conversion which end up Relative -> Absolute -> Relative. 

Second commit above was to fix #2945 in the first place, but I believe this fix was the one to do. So maybe we should revert and use absolute ? 

It depends maybe if you remember why in d78d4b22966df1a122d8e0bd13219ec7956a5005 you commited 
> Don’t use relative path, it needs to be absolute

Anyway, this solves the issue with rendering the user's project in #3944. 

Not adding tests because we don't have on Windows yet