### PR TITLE
Add tests for Julia

### DIFF
--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -70,9 +70,9 @@ jobs:
           pushd tests
           source bin/activate
           python3 -m pip install --upgrade pip pip==21.3.1
-          python3 -m pip install wheel 
+          python3 -m pip install wheel
           python3 -m pip install --user virtualenv
-          python3 -m pip install -r requirements.txt          
+          python3 -m pip install -r requirements.txt
           popd
 
       - uses: ./.github/workflows/actions/quarto-dev
@@ -85,6 +85,15 @@ jobs:
 
       - name: Install Chrome
         uses: browser-actions/setup-chrome@latest
+
+      - name: Setup Julia
+        uses: julia-actions/setup-julia@v1
+
+      - name: Julia Packages
+        run: |
+          pushd tests
+          julia --project=. -e "import Pkg; Pkg.instantiate(); Pkg.build(\"IJulia\"); Pkg.precompile()"
+          popd
 
       - name: Smoke Test Commits
         if: github.event.before != ''

--- a/tests/Project.toml
+++ b/tests/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"

--- a/tests/Project.toml
+++ b/tests/Project.toml
@@ -1,4 +1,3 @@
 [deps]
-Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
+IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"

--- a/tests/docs/consistency-checks/julia-ref.qmd
+++ b/tests/docs/consistency-checks/julia-ref.qmd
@@ -4,7 +4,6 @@ format:
   html:
     keep-md: true
     code-background: true
-jupyter: julia-1.8
 ---
 
 I thought `output:false` would suppress the output, but no? `echo: false` does it.

--- a/tests/docs/consistency-checks/julia-ref.qmd
+++ b/tests/docs/consistency-checks/julia-ref.qmd
@@ -1,0 +1,81 @@
+---
+title: "Quarto Jupyter Cell Attribute Implementation Reference"
+format:
+  html:
+    keep-md: true
+    code-background: true
+jupyter: julia-1.8
+---
+
+I thought `output:false` would suppress the output, but no? `echo: false` does it.
+
+```{julia}
+#| echo: false
+using Plots
+```
+
+## `label`
+
+```{julia}
+#| label: julia-label-1
+
+plot([1,2,3,4])
+```
+
+
+```{julia}
+#| label: julia label 2
+
+plot([1,2,3,4])
+```
+
+### `fig-cap`
+
+```{julia}
+#| label: fig-caption-test
+#| fig-cap: A caption for the figure
+
+plot([1,2,3,4])
+```
+
+**(Styling Bug?) Centering of images appears inconsistent depending on whether they have captions?**
+
+### `fig-subcap`
+
+```{julia}
+#| label: fig-big-caption-test
+#| fig-cap: Big caption
+#| fig-subcap:
+#|   - Caption 1
+#|   - Caption 2
+plot([4,3,2,1]) |> display
+plot([1,2,3,4]) |> display
+```
+
+
+```{julia}
+#| label: fig-no-big-caption-test
+#| fig-subcap:
+#|   - Caption 1
+#|   - Caption 2
+plot([4,3,2,1]) |> display
+plot([1,2,3,4]) |> display
+```
+
+### `code-fold` and `code-summary`
+
+**(Inconsistency?) The R engine sets code-fold and code-summary for both the outer and inner div; The Julia engine ...**
+
+Fold:
+
+```{julia}
+#| code-fold: true
+plot([1,2,3,4])
+```
+
+Summary:
+
+```{julia}
+#| code-summary: "Some text"
+plot([1,2,3,4])
+```

--- a/tests/docs/crossrefs/julia-subfig.qmd
+++ b/tests/docs/crossrefs/julia-subfig.qmd
@@ -1,0 +1,21 @@
+---
+title: Julia Subfig Test
+---
+
+## Julia Crossref Figure
+
+```{julia}
+#| label: fig-plots
+#| fig-cap: "Plots"
+#| fig-subcap:
+#|   - "Plot 1"
+#|   - "Plot 2"
+#| layout-ncol: 2
+
+using Plots
+plot([1,23,2,4]) |> display
+
+plot([8,65,23,90]) |> display
+```
+
+See @fig-plots for examples. In particular, @fig-plots-2.

--- a/tests/docs/crossrefs/julia.qmd
+++ b/tests/docs/crossrefs/julia.qmd
@@ -1,0 +1,16 @@
+---
+title: Julia Crossref Test
+---
+
+## Julia Crossref Figure
+
+```{julia}
+#| label: fig-plot
+#| fig-cap: "Plot"
+
+using Plots
+Plots.gr(format="png")
+plot([1,23,2,4])
+```
+
+For example, see @fig-plot.

--- a/tests/docs/empty-frontmatter-julia.qmd
+++ b/tests/docs/empty-frontmatter-julia.qmd
@@ -1,0 +1,5 @@
+Some text
+
+```{julia}
+1 + 1
+```

--- a/tests/docs/markdown/commonmark-julia.qmd
+++ b/tests/docs/markdown/commonmark-julia.qmd
@@ -1,0 +1,8 @@
+---
+title: test
+format: commonmark
+---
+
+```{julia}
+1 + 1
+```

--- a/tests/smoke/convert/convert-empty-frontmatter.test.ts
+++ b/tests/smoke/convert/convert-empty-frontmatter.test.ts
@@ -8,3 +8,4 @@ import { docs } from "../../utils.ts";
 import { testConvert } from "./convert.ts";
 
 testConvert(docs("empty-frontmatter.qmd"));
+testConvert(docs("empty-frontmatter-julia.qmd"));

--- a/tests/smoke/crossref/figures.test.ts
+++ b/tests/smoke/crossref/figures.test.ts
@@ -83,7 +83,6 @@ if (Deno.build.os !== "windows") {
     ensureHtmlElements(juliaSubfigQmd.output.outputPath, [
       "section#julia-crossref-figure  div.quarto-layout-panel > figure > div.quarto-layout-row",
       "section#julia-crossref-figure  div.quarto-layout-panel > figure > figcaption.figure-caption",
-      "section#julia-crossref-figure  div.quarto-layout-panel > figure  svg"
     ]),
     ensureFileRegexMatches(juliaSubfigQmd.output.outputPath, [
       /Figure&nbsp;1: Plots/,

--- a/tests/smoke/crossref/figures.test.ts
+++ b/tests/smoke/crossref/figures.test.ts
@@ -63,6 +63,38 @@ if (Deno.build.os !== "windows") {
       /\?@fig-/,
     ]),
   ]);
+
+  const juliaQmd = crossref("julia.qmd", "html");
+  testRender(juliaQmd.input, "html", false, [
+    ensureHtmlElements(juliaQmd.output.outputPath, [
+      "section#julia-crossref-figure div#fig-plot > figure img.figure-img",
+      "section#julia-crossref-figure div#fig-plot > figure > figcaption",
+    ]),
+    ensureFileRegexMatches(juliaQmd.output.outputPath, [
+      /Figure&nbsp;1: Plot/,
+      /Figure&nbsp;1/,
+    ], [
+      /\?@fig-/,
+    ]),
+  ]);
+
+  const juliaSubfigQmd = crossref("julia-subfig.qmd", "html");
+  testRender(juliaSubfigQmd.input, "html", false, [
+    ensureHtmlElements(juliaSubfigQmd.output.outputPath, [
+      "section#julia-crossref-figure  div.quarto-layout-panel > figure > div.quarto-layout-row",
+      "section#julia-crossref-figure  div.quarto-layout-panel > figure > figcaption.figure-caption",
+      "section#julia-crossref-figure  div.quarto-layout-panel > figure  svg"
+    ]),
+    ensureFileRegexMatches(juliaSubfigQmd.output.outputPath, [
+      /Figure&nbsp;1: Plots/,
+      /Figure&nbsp;1/,
+      /Figure&nbsp;1 \(b\)/,
+      /\(a\) Plot 1/,
+      /\(b\) Plot 2/,
+    ], [
+      /\?@fig-/,
+    ]),
+  ]);
 }
 
 const knitrQmd = crossref("knitr.qmd", "html");

--- a/tests/smoke/render/render-commonmark.test.ts
+++ b/tests/smoke/render/render-commonmark.test.ts
@@ -13,6 +13,7 @@ const tests = [
   { file: "commonmark-plain.qmd", python: false },
   { file: "commonmark-r.qmd", python: false },
   { file: "commonmark-python.qmd", python: true },
+  { file: "commonmark-julia.qmd", python: false },
 ];
 tests.forEach((test) => {
   const input = docs(join("markdown", test.file));


### PR DESCRIPTION
Begin to address #3965

These are simple ports of the existing Python tests. I don't know enough typescript to add anything more novel. In particular, on my machine, the tests do not trigger #2539 , even though running `quarto render julia.qmd` from a shell fails unless the `--no-execute-daemon` option is added. 



- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
