### PR TITLE
Support privacy-enhanced youtube url (-nocookie version) for video shortcode 

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -115,6 +115,7 @@
 - ensure proof titles are appended to paragraph nodes ([#3772](https://github.com/quarto-dev/quarto-cli/issues/3772)).
 - Support parsing markdown in table captions in LaTeX and HTML tables ([#2573](https://github.com/quarto-dev/quarto-cli/issues/2573)).
 - Improve parsing of include shortcodes ([#3159](https://github.com/quarto-dev/quarto-cli/issues/3159)).
+- Add support for Youtube privacy-enhanced urls in `video` shortcodes ([#4060](https://github.com/quarto-dev/quarto-cli/issues/4060)).
 
 ## Pandoc filter changes
 

--- a/src/resources/extensions/quarto/video/video.lua
+++ b/src/resources/extensions/quarto/video/video.lua
@@ -68,6 +68,7 @@ local youTubeBuilder = function(params)
   if not (params and params.src) then return nil end
   local src = params.src
   match = checkEndMatch(src, 'https://www.youtube.com/embed/')
+  match = match or checkEndMatch(src, 'https://www.youtube%-nocookie.com/embed/')
   match = match or checkEndMatch(src, 'https://youtu.be/')
   match = match or string.match(src, '%?v=(.-)&')
   match = match or string.match(src, '%?v=(.-)$')


### PR DESCRIPTION
Fix #4060 

This will now work 

````markdown
---
format: html
---

## Test

{{< video https://www.youtube-nocookie.com/embed/wo9vZccmqwc >}}
````

@allenmanning you're the author to the video extensions initially; this was easy enough to fix so I opened the PR, however the rest of the extension is not clear to me:

- Is [`video-filter.lua`](https://github.com/quarto-dev/quarto-cli/blob/main/src/resources/extensions/quarto/video/video-filter.lua) still something that can be used ? It feels like a leftover of the external extension. 
- Are tests still leaving in [`test-suite.lua`](https://github.com/quarto-dev/quarto-cli/blob/main/src/resources/extensions/quarto/video/_tests/test-suite.lua) ? Are they run part of our tests suite ? 

Thanks