### PR TITLE
Improve TinyTeX installation speed on Windows 

### DIFF
--- a/src/core/zip.ts
+++ b/src/core/zip.ts
@@ -14,11 +14,13 @@ export function unzip(file: string) {
   if (file.endsWith("zip")) {
     // It's a zip file
     if (Deno.build.os === "windows") {
-      const args = ["Expand-Archive", file, "-DestinationPath", dir];
-      const quoted = requireQuoting(args);
+      const args = [
+        "-Command",
+        `"& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('${file}', '${dir}'); }"`,
+      ];
       return safeWindowsExec(
         "powershell",
-        quoted.args,
+        args,
         (cmd: string[]) => {
           return execProcess(
             {


### PR DESCRIPTION
I change the windows method for unzip to match what we do in TinyTeX 
https://github.com/rstudio/tinytex/blob/main/tools/install-bin-windows.bat#L44

I changed only in `zip.ts` because we have `safeWindowsExec` which is required for correct handling. 


We have another version in `utils.ts` though
https://github.com/quarto-dev/quarto-cli/blob/b3c70af8c5d0d02e3334e1362abe9593d94f97cd/package/src/util/utils.ts#L34-L41

Another duplicated code that I cannot change here, because pass to `runCmd` directly, with no handling on windows for executing through a file. 

Anyway, I believe this does improve on Windows the speed of installing TinyTeX. We had no issue using that on Windows, with TinyTeX so I think it is safe. 


