### PR TITLE
Parse and apply table classes given alongside caption text

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -19,6 +19,7 @@
 - Improve callout wrapping behavior for long strings with no word breaks.
 - Add overflow to tables generated from SQL code cells ([#3497](https://github.com/quarto-dev/quarto-cli/issues/3497)).
 - Fix support for parquet files in OJS code cells ([#3630](https://github.com/quarto-dev/quarto-cli/issues/3630)).
+- Forward bootstrap table classes from caption to table element ([#4036](https://github.com/quarto-dev/quarto-cli/issues/4036)).
 
 ## Article Layout
 

--- a/src/resources/filters/main.lua
+++ b/src/resources/filters/main.lua
@@ -139,6 +139,7 @@ import("./quarto-pre/resourcefiles.lua")
 import("./quarto-pre/results.lua")
 import("./quarto-pre/shortcodes-handlers.lua")
 import("./quarto-pre/shortcodes.lua")
+import("./quarto-pre/table-classes.lua")
 import("./quarto-pre/table-captions.lua")
 import("./quarto-pre/table-colwidth.lua")
 import("./quarto-pre/table-rawhtml.lua")
@@ -178,6 +179,7 @@ local quartoPre = {
   { name = "pre-tableRenderRawHtml", filter = tableRenderRawHtml() },
   { name = "pre-tableColwidthCell", filter = tableColwidthCell() },
   { name = "pre-tableColwidth", filter = tableColwidth() },
+  { name = "pre-tableClasses", filter = tableClasses() },
   { name = "pre-hidden", filter = hidden() },
   { name = "pre-contentHidden", filter = contentHidden() },
   { name = "pre-tableCaptions", filter = tableCaptions() },

--- a/src/resources/filters/quarto-pre/table-classes.lua
+++ b/src/resources/filters/quarto-pre/table-classes.lua
@@ -9,26 +9,6 @@ function contains(list, x)
 	return false
 end
 
--- propagate table classes to the table's <table> element
-function tableTableTag() 
-  return {
-    Table = function(el)
-      if tcontains(el.attr.classes) then
-        local tblColwidths = el.attr.attributes[kTblColwidths]
-        el.attr.attributes[kTblColwidths] = nil
-        if tblColwidths ~= nil then
-          return pandoc.walk_block(el, {
-            Table = function(tbl)
-              tbl.attr.attributes[kTblColwidths] = tblColwidths
-              return tbl
-            end
-          })
-        end
-      end
-    end,
-  }
-end
-
 -- handle classes to pass to `<table>` element
 function tableClasses()
 

--- a/src/resources/filters/quarto-pre/table-classes.lua
+++ b/src/resources/filters/quarto-pre/table-classes.lua
@@ -1,14 +1,6 @@
 -- table-classes.lua
 -- Copyright (C) 2020-2023 Posit Software, PBC
 
--- helper for checking whether a single value is present in a table
-function contains(list, x)
-	for _, v in pairs(list) do
-		if v == x then return true end
-	end
-	return false
-end
-
 -- handle classes to pass to `<table>` element
 function tableClasses()
 
@@ -21,22 +13,6 @@ function tableClasses()
         return tbl
       end
 
-      -- determine if we have any supplied classes, these should always begin with a `.` and
-      -- consist of alphanumeric characters
-      local caption =  tbl.caption.long[#tbl.caption.long]
-      local caption_str = pandoc.utils.stringify(caption)
-
-      local css_classes = {}
-
-      for css_class in string.gmatch(caption_str, "%.%-?[_a-zA-Z]+[_a-zA-Z0-9-]*") do
-        table.insert(css_classes, css_class)
-      end
-      
-      -- if table is empty then return the table unchanged
-      if #css_classes < 1 then
-        return tbl
-      end
-      
       -- generate a table containing recognized Bootstrap table classes
       local table_bootstrap_nm = {
         "primary", "secondary", "success", "danger", "warning", "info", "light", "dark",
@@ -44,22 +20,27 @@ function tableClasses()
         "responsive", "responsive-sm", "responsive-md", "responsive-lg", "responsive-xl", "responsive-xxl"
       }
 
-      -- strip off leading `.` chars from each class in `css_classes` and prefix each
-      -- item that is recognized as a Bootstrap class with `table-` 
-      for k, v in pairs(css_classes) do
-        css_classes[k] = string.sub(v, 2)
-        if contains(table_bootstrap_nm, css_classes[k]) then
-          css_classes[k] = "table-" .. css_classes[k]
+      -- determine if we have any supplied classes, these should always begin with a `.` and
+      -- consist of alphanumeric characters
+      local caption = tbl.caption.long[#tbl.caption.long]
+
+      local caption_parsed, attr = parseTableCaption(pandoc.utils.blocks_to_inlines({caption}))
+
+      local normalize_class = function(x)
+        if tcontains(table_bootstrap_nm, x) then
+          return "table-" .. x
+        else
+          return x
         end
       end
+      local normalized_classes = attr.classes:map(normalize_class)
 
-      -- insert the table classes
-      tbl.attr = pandoc.Attr("", css_classes)
-      empty_attr = pandoc.Attr("", {})
-      
-      -- regenerate the table caption by parsing only the caption part and placing that into the caption
-      local caption_parsed, attr = parseTableCaption(pandoc.utils.blocks_to_inlines({caption}))
-      tbl.caption.long = pandoc.Plain(createTableCaption(caption_parsed, empty_attr))
+      -- ensure that classes are appended (do not want to rewrite and wipe out any existing)
+      tbl.classes:extend(normalized_classes)
+
+      attr.classes = pandoc.List()
+
+      tbl.caption.long[#tbl.caption.long] = pandoc.Plain(createTableCaption(caption_parsed, attr))
 
       return tbl
     end

--- a/src/resources/filters/quarto-pre/table-classes.lua
+++ b/src/resources/filters/quarto-pre/table-classes.lua
@@ -75,9 +75,12 @@ function tableClasses()
 
       -- insert the table classes
       tbl.attr = pandoc.Attr("", css_classes)
+      empty_attr = pandoc.Attr("", {})
+      
+      -- regenerate the table caption by parsing only the caption part and placing that into the caption
+      local caption_parsed, attr = parseTableCaption(pandoc.utils.blocks_to_inlines({caption}))
+      tbl.caption.long = pandoc.Plain(createTableCaption(caption_parsed, empty_attr))
 
-      -- determine the index in which table caption begins
-     
       return tbl
     end
   }

--- a/src/resources/filters/quarto-pre/table-classes.lua
+++ b/src/resources/filters/quarto-pre/table-classes.lua
@@ -1,0 +1,85 @@
+-- table-classes.lua
+-- Copyright (C) 2020-2023 Posit Software, PBC
+
+-- helper for checking whether a single value is present in a table
+function contains(list, x)
+	for _, v in pairs(list) do
+		if v == x then return true end
+	end
+	return false
+end
+
+-- propagate table classes to the table's <table> element
+function tableTableTag() 
+  return {
+    Table = function(el)
+      if tcontains(el.attr.classes) then
+        local tblColwidths = el.attr.attributes[kTblColwidths]
+        el.attr.attributes[kTblColwidths] = nil
+        if tblColwidths ~= nil then
+          return pandoc.walk_block(el, {
+            Table = function(tbl)
+              tbl.attr.attributes[kTblColwidths] = tblColwidths
+              return tbl
+            end
+          })
+        end
+      end
+    end,
+  }
+end
+
+-- handle classes to pass to `<table>` element
+function tableClasses()
+
+  return {
+   
+    Table = function(tbl)
+      
+      -- if there is no caption then return tbl unchanged
+      if tbl.caption.long == nil or #tbl.caption.long < 1 then
+        return tbl
+      end
+
+      -- determine if we have any supplied classes, these should always begin with a `.` and
+      -- consist of alphanumeric characters
+      local caption =  tbl.caption.long[#tbl.caption.long]
+      local caption_str = pandoc.utils.stringify(caption)
+
+      local css_classes = {}
+
+      for css_class in string.gmatch(caption_str, "%.%-?[_a-zA-Z]+[_a-zA-Z0-9-]*") do
+        table.insert(css_classes, css_class)
+      end
+      
+      -- if table is empty then return the table unchanged
+      if #css_classes < 1 then
+        return tbl
+      end
+      
+      -- generate a table containing recognized Bootstrap table classes
+      local table_bootstrap_nm = {
+        "primary", "secondary", "success", "danger", "warning", "info", "light", "dark",
+        "striped", "hover", "active", "bordered", "borderless", "sm",
+        "responsive", "responsive-sm", "responsive-md", "responsive-lg", "responsive-xl", "responsive-xxl"
+      }
+
+      -- strip off leading `.` chars from each class in `css_classes` and prefix each
+      -- item that is recognized as a Bootstrap class with `table-` 
+      for k, v in pairs(css_classes) do
+        css_classes[k] = string.sub(v, 2)
+        if contains(table_bootstrap_nm, css_classes[k]) then
+          css_classes[k] = "table-" .. css_classes[k]
+        end
+      end
+
+      -- insert the table classes
+      tbl.attr = pandoc.Attr("", css_classes)
+
+      -- determine the index in which table caption begins
+     
+      return tbl
+    end
+  }
+
+end

--- a/tests/docs/smoke-all/2023/01/23/table-options.qmd
+++ b/tests/docs/smoke-all/2023/01/23/table-options.qmd
@@ -1,0 +1,23 @@
+---
+format: html
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - 
+          - "table.table-striped"
+          - "table.table-hover"
+          - "table.unknown"
+        - 
+          - "table.striped"
+          - "table.hover"
+          - "table.table-unknown"
+---
+
+| Default | Left | Right | Center |
+|---------|:-----|------:|:------:|
+| 12      | 12   |    12 |   12   |
+| 123     | 123  |   123 |  123   |
+| 1       | 1    |     1 |   1    |
+
+: This is a caption {#tbl-id .unknown .striped .hover .sm tbl-colwidths="[15, 15, 35, 35]"}


### PR DESCRIPTION
This allows for any table classes (should commonly be Bootstrap table classes) given as attributes next to a table caption to be parsed and inserted into the `<table>` element as classes. Any classes missing the necessary `table-` prefix will be handled so long as they are in the list of recognized Bootstrap 5 classes (those that apply to the entire table, not row, cell, or otherwise).

This is implemented as the `"pre-tableClasses"` Lua filter, placed in `"quartoPre"` *after* the `"pre-tableColwidth"` filter (which does parsing of the same attributes). The following Quarto document now produces a table with the Bootstrap classes applied:

````
---
format: html
---

| Default | Left | Right | Center |
|---------|:-----|------:|:------:|
| 12      | 12   |    12 |   12   |
| 123     | 123  |   123 |  123   |
| 1       | 1    |     1 |   1    |

: Here is the caption {.striped .hover .sm tbl-colwidths="[15, 15, 35, 35]"}
````

Here is the rendered document:

<img width="726" alt="table-classes" src="https://user-images.githubusercontent.com/5612024/214122402-72774de1-0e6d-435d-b60b-40847fd433f8.png">

Fixes: https://github.com/quarto-dev/quarto-cli/issues/4036
