### PR TITLE
fix typo of knitr option's name

### DIFF
--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -720,7 +720,7 @@ normalize_options <- function(options) {
                     "fig-subcap",
                     "fig-ncol",
                     "fig-sep",
-                    "fig.process",
+                    "fig-process",
                     "fig-showtext",
                     # Animation
                     "animation-hook",


### PR DESCRIPTION
## Description

Fix typo of option's name. (I think it has not worked so far because of the typo.)

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
