### PR TITLE
Check first for http(s) protocol before testing local

### DIFF
--- a/src/extension/extension-host.ts
+++ b/src/extension/extension-host.ts
@@ -36,7 +36,7 @@ export interface ExtensionSource {
 export async function extensionSource(
   target: string,
 ): Promise<ExtensionSource | undefined> {
-  if (existsSync(target)) {
+  if (!target.match(/^https?:\/\/.*$/) && existsSync(target)) {
     return { type: "local", resolvedTarget: target };
   }
 

--- a/src/extension/extension-host.ts
+++ b/src/extension/extension-host.ts
@@ -36,22 +36,10 @@ export interface ExtensionSource {
 export async function extensionSource(
   target: string,
 ): Promise<ExtensionSource | undefined> {
-  let targetUrl;
-  try {
-    // is this a remote extension with full URL ?
-    targetUrl = new URL(target);
-    if (!/^http(s)?/.test(targetUrl.protocol)) {
-      throw new Error("Only http(s) remote extensions can be installed.");
-    }
-  } catch {
-    // is this a local extension ?
-    if (existsSync(target)) {
-      // local extensions on file system
-      return { type: "local", resolvedTarget: target };
-    }
+  if (!target.match(/^https?:\/\/.*$/) && existsSync(target)) {
+    return { type: "local", resolvedTarget: target };
   }
 
-  // resolve remote extension shortener (e.g quarto-ext/lightbox)
   for (const resolver of extensionHostResolvers) {
     const resolved = resolver(target);
     if (!resolved) {

--- a/src/extension/extension-host.ts
+++ b/src/extension/extension-host.ts
@@ -36,10 +36,22 @@ export interface ExtensionSource {
 export async function extensionSource(
   target: string,
 ): Promise<ExtensionSource | undefined> {
-  if (!target.match(/^https?:\/\/.*$/) && existsSync(target)) {
-    return { type: "local", resolvedTarget: target };
+  let targetUrl;
+  try {
+    // is this a remote extension with full URL ?
+    targetUrl = new URL(target);
+    if (!/^http(s)?/.test(targetUrl.protocol)) {
+      throw new Error("Only http(s) remote extensions can be installed.");
+    }
+  } catch {
+    // is this a local extension ?
+    if (existsSync(target)) {
+      // local extensions on file system
+      return { type: "local", resolvedTarget: target };
+    }
   }
 
+  // resolve remote extension shortener (e.g quarto-ext/lightbox)
   for (const resolver of extensionHostResolvers) {
     const resolved = resolver(target);
     if (!resolved) {

--- a/tests/smoke/extensions/install.test.ts
+++ b/tests/smoke/extensions/install.test.ts
@@ -120,6 +120,7 @@ testQuartoCmd(
       return templateDir;
     },
     teardown: () => {
+      Deno.chdir("..");
       Deno.removeSync(templateDir, { recursive: true });
       return Promise.resolve();
     },


### PR DESCRIPTION
On Window, `existsSync()` on a URL path does not work as it does on Linux. So filtering those urls

fix #4124 - Installing extension from url fails on WindowsWelcome to the quarto GitHub repo!

**THIS PR IS ON MY WINDOWS BRANCH AND NOT ON MAIN - THIS IS EXPECTED**

@dragonstyle just to check with you that fix is ok. It should resolve test but you mentioned `new URL` solution. Did not work for me.

