### PR TITLE
Add PRQL's comment character

### DIFF
--- a/src/core/lib/partition-cell-options.ts
+++ b/src/core/lib/partition-cell-options.ts
@@ -306,6 +306,7 @@ export const kLangCommentChars: Record<string, string | [string, string]> = {
   groovy: "//",
   sed: "#",
   perl: "#",
+  prql: "#",
   ruby: "#",
   tikz: "%",
   js: "//",

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -21033,6 +21033,7 @@ var require_yaml_intelligence_resources = __commonJS({
         groovy: "//",
         sed: "#",
         perl: "#",
+        prql: "#",
         ruby: "#",
         tikz: "%",
         js: "//",
@@ -21049,12 +21050,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 146893,
+        _internalId: 146895,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 146885,
+            _internalId: 146887,
             type: "enum",
             enum: [
               "png",
@@ -21070,7 +21071,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 146892,
+            _internalId: 146894,
             type: "anyOf",
             anyOf: [
               {
@@ -30129,6 +30130,7 @@ var kLangCommentChars = {
   groovy: "//",
   sed: "#",
   perl: "#",
+  prql: "#",
   ruby: "#",
   tikz: "%",
   js: "//",

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -21034,6 +21034,7 @@ try {
           groovy: "//",
           sed: "#",
           perl: "#",
+          prql: "#",
           ruby: "#",
           tikz: "%",
           js: "//",
@@ -21050,12 +21051,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 146893,
+          _internalId: 146895,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 146885,
+              _internalId: 146887,
               type: "enum",
               enum: [
                 "png",
@@ -21071,7 +21072,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 146892,
+              _internalId: 146894,
               type: "anyOf",
               anyOf: [
                 {
@@ -30143,6 +30144,7 @@ ${tidyverseInfo(
     groovy: "//",
     sed: "#",
     perl: "#",
+    prql: "#",
     ruby: "#",
     tikz: "%",
     js: "//",

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -14009,6 +14009,7 @@
     "groovy": "//",
     "sed": "#",
     "perl": "#",
+    "prql": "#",
     "ruby": "#",
     "tikz": "%",
     "js": "//",
@@ -14025,12 +14026,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 146893,
+    "_internalId": 146895,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 146885,
+        "_internalId": 146887,
         "type": "enum",
         "enum": [
           "png",
@@ -14046,7 +14047,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 146892,
+        "_internalId": 146894,
         "type": "anyOf",
         "anyOf": [
           {


### PR DESCRIPTION
## Description

Suggested by https://github.com/quarto-dev/quarto-cli/discussions/4092#discussioncomment-4780616

Add [PRQL](https://prql-lang.org/)'s comment character.

The development version of [prqlr](https://eitsupi.r-universe.dev/prqlr) R package allows the use of prql executable code blocks. (by knitr engine)

````md
```{prql}
#| engine-opts:
#|   dialect: mssql
#|   signature_comment: false

from a
take 5
```
````

The code block above is converted as follows.
(Since PRQL syntax highlighting is not available in pandoc, prql executable code blocks are converted by default to Elm code blocks that provide the appropriate syntax highlighting for PRQL.)

````md
```elm
from a
take 5
```

```sql
SELECT
  TOP (5) *
FROM
  a
```
````

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
