### PR TITLE
clear filemetadata between runs

### DIFF
--- a/src/resources/filters/ast/runemulation.lua
+++ b/src/resources/filters/ast/runemulation.lua
@@ -3,7 +3,7 @@
 --
 -- Copyright (C) 2022 by RStudio, PBC
 
-local function run_emulated_filter_chain(doc, filters)
+local function run_emulated_filter_chain(doc, filters, afterFilterPass)
   init_trace(doc)
   if tisarray(filters) then
     for i, v in ipairs(filters) do
@@ -15,9 +15,15 @@ local function run_emulated_filter_chain(doc, filters)
       else
         callback()
       end
+      if afterFilterPass then
+        afterFilterPass()
+      end
     end
   elseif type(filters) == "table" then
     doc = run_emulated_filter(doc, filters)
+    if afterFilterPass then
+      afterFilterPass()
+    end
   else
     error("Internal Error: run_emulated_filter_chain expected a table or array instead of " .. type(filters))
     crash_with_stack_trace()
@@ -26,7 +32,7 @@ local function run_emulated_filter_chain(doc, filters)
   return doc
 end
 
-local function emulate_pandoc_filter(filters)
+local function emulate_pandoc_filter(filters, afterFilterPass)
   return {
     traverse = 'topdown',
     Pandoc = function(doc)
@@ -36,7 +42,7 @@ local function emulate_pandoc_filter(filters)
         local profiler = require('profiler')
         profiler.start()
         -- doc = to_emulated(doc)
-        doc = run_emulated_filter_chain(doc, filters)
+        doc = run_emulated_filter_chain(doc, filters, afterFilterPass)
         -- doc = from_emulated(doc)
 
         -- the installation happens in main.lua ahead of loaders
@@ -48,7 +54,7 @@ local function emulate_pandoc_filter(filters)
         profiler.report("profiler.txt")
         crash_with_stack_trace() -- run a single file for now.
       end
-      return run_emulated_filter_chain(doc, filters), false
+      return run_emulated_filter_chain(doc, filters, afterFilterPass), false
     end
   }
 end
@@ -61,7 +67,7 @@ function run_as_extended_ast(specTable)
     end
   end
 
-  table.insert(pandocFilterList, emulate_pandoc_filter(specTable.filters))
+  table.insert(pandocFilterList, emulate_pandoc_filter(specTable.filters, specTable.afterFilterPass))
   if specTable.post then
     for _, v in ipairs(specTable.post) do
       table.insert(pandocFilterList, v)

--- a/src/resources/filters/common/filemetadata.lua
+++ b/src/resources/filters/common/filemetadata.lua
@@ -12,10 +12,7 @@ fileMetadataState = {
 function fileMetadata() 
   return {
     RawInline = parseFileMetadata,
-    RawBlock = parseFileMetadata,
-    Pandoc = function(_el) 
-      resetFileMetadata()
-    end,
+    RawBlock = parseFileMetadata      
   }
 end
 

--- a/src/resources/filters/common/filemetadata.lua
+++ b/src/resources/filters/common/filemetadata.lua
@@ -12,7 +12,10 @@ fileMetadataState = {
 function fileMetadata() 
   return {
     RawInline = parseFileMetadata,
-    RawBlock = parseFileMetadata
+    RawBlock = parseFileMetadata,
+    Pandoc = function(_el) 
+      resetFileMetadata()
+    end,
   }
 end
 
@@ -44,3 +47,13 @@ function currentFileMetadataState()
   return fileMetadataState
 end
 
+
+function resetFileMetadata()  
+  fileMetadataState = {
+    file = nil,
+    appendix = false,
+    include_directory = nil,
+  }
+end
+
+  

--- a/src/resources/filters/main.lua
+++ b/src/resources/filters/main.lua
@@ -303,6 +303,11 @@ local result = run_as_extended_ast({
   pre = {
     initOptions()
   },
+  afterFilterPass = function() 
+    -- After filter pass is called after each pass through a filter group
+    -- allowing state or other items to be handled
+    resetFileMetadata()
+  end,
   filters = capture_timings(filterList),
 })
 


### PR DESCRIPTION
We need to reset the state of individual files between filter passes.

The issue causing this is similar to what we discussed yesterday - the state of whether we have 'entered the appendix' is being set by an early filter pass and then not reset for subsequent filter passes. I confirmed this change fixes the issue, but am curious if you've encountered this before and if so is there a better solution (this feels slightly indirect to me).

Fixes #4145

