### PR TITLE
Add Dropbox to video providers

### DIFF
--- a/src/resources/extensions/quarto/video/video.lua
+++ b/src/resources/extensions/quarto/video/video.lua
@@ -26,7 +26,8 @@ local VIDEO_TYPES = {
   YOUTUBE = "YOUTUBE",
   BRIGHTCOVE = "BRIGHTCOVE",
   VIMEO = "VIMEO",
-  VIDEOJS = "VIDEOJS"
+  VIDEOJS = "VIDEOJS",
+  DROPBOX = "DROPBOX"
 }
 
 local ASPECT_RATIOS = {
@@ -152,12 +153,32 @@ local videoJSBuilder = function(params)
   result.id = id
   return result
 end
+
+local dropboxBuilder = function(params)
+  if not (params and params.src) then return nil end
+  local src = params.src
+  local isDropbox = function()
+    return string.find(src, 'https://www.dropbox.com') and checkEndMatch(src, '?raw=1')
+  end
+
+  if not isDropbox() then return nil end
+
+  local result = {}
+
+  local SNIPPET = [[<iframe data-external="1" src="{src}"{width}{height} allowfullscreen="" title="{title}" allow="encrypted-media"></iframe>]]
+  result.snippet = replaceCommonAttributes(SNIPPET, params)
+  result.type = VIDEO_TYPES.DROPBOX
+  result.src = params.src
+  return result
+end
+
 local getSnippetFromBuilders = function(src, height, width, title, start)
   local builderList = {
     youTubeBuilder,
     brightcoveBuilder,
     vimeoBuilder,
-    videoJSBuilder}
+    videoJSBuilder,
+    dropboxBuilder}
 
   local params = { src = src, height = height, width = width, title = title, start = start }
 
@@ -174,6 +195,7 @@ local helpers = {
   ["brightcoveBuilder"] = brightcoveBuilder,
   ["vimeoBuilder"] = vimeoBuilder,
   ["videoJSBuilder"] = videoJSBuilder,
+  ["dropboxBuilder"] = dropboxBuilder,
   ["wrapWithDiv"] = wrapWithDiv,
   ["VIDEO_TYPES"] = VIDEO_TYPES,
   ["VIDEO_SHORTCODE_NUM_VIDEOJS"] = VIDEO_SHORTCODE_NUM_VIDEOJS,


### PR DESCRIPTION
Welcome to the quarto GitHub repo!

We are always happy to hear feedback from our users.

To file a _pull request_, please follow these instructions carefully: <https://yihui.org/issue/#bug-reports>

If you're a collaborator from outside `quarto-dev` making changes larger than a typo, please make sure you have filed an [individual](https://rstudioblog.files.wordpress.com/2017/05/rstudio_individual_contributor_agreement.pdf) or [corporate](https://rstudioblog.files.wordpress.com/2017/05/rstudio_corporate_contributor_agreement.pdf) contributor agreement. You can send the signed copy to jj@rstudio.com.

Also, please complete and keep the checklist below.

## Description

Addresses issue #4153.

To embed a video saved on dropbox.com, use Dropbox to get a shareable link to the file. Then paste that link into a video shortcode, e. g., 

```
{{< video https://www.dropbox.com/s/f7kzi3u0hvnkldr/5_16_08_19.mp4?raw=1 >}}
```
**Note:** The link as pasted from Dropbox will end in `?dl=0`, which must be replaced with `?raw=1` as in the above example.


## Checklist

I have (if applicable):

- [ x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ x] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
