### PR TITLE
Update outdated URL in man

### DIFF
--- a/src/command/run/run.ts
+++ b/src/command/run/run.ts
@@ -38,5 +38,5 @@ export const runCommand = new Command()
   .description(
     "Run a TypeScript, R, Python, or Lua script.\n\n" +
       "Run a utility script written in a variety of languages. For details, see:\n" +
-      "https://quarto.org/docs/projects/quarto-projects.html#periodic-scripts",
+      "https://quarto.org/docs/projects/scripts.html#periodic-scripts",
   );


### PR DESCRIPTION
## Description

Just updating an out of date URL in the docs for `quarto run`

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
