### PR TITLE
do not install signal handler for subprocess. Closes #2539

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -4,6 +4,7 @@
 - Only attempt to postprocess `text/plain` output if it's nonempty ([#3896](https://github.com/quarto-dev/quarto-cli/issues/3896)).
 - Fix output of bokeh plots so the right number of cells is generated ([#2107](https://github.com/quarto-dev/quarto-cli/issues/2107)).
 - Fix output of code cells that contain triple backticks (or more) ([#3179](https://github.com/quarto-dev/quarto-cli/issues/3179)).
+- Don't install SIGCHLD signal handler since it interferes with IJulia in Julia 1.8.4 and greater ([#2539](https://github.com/quarto-dev/quarto-cli/issues/2539)).
 
 ## Code Annotation
 

--- a/src/resources/jupyter/jupyter.py
+++ b/src/resources/jupyter/jupyter.py
@@ -204,8 +204,6 @@ def run_server_subprocess(options, status):
       flags |= 0x00000200  # CREATE_NEW_PROCESS_GROUP
       flags |= 0x08000000  # CREATE_NO_WINDOW
       flags |= 0x01000000  # CREATE_BREAKAWAY_FROM_JOB
-   else:
-      signal.signal(signal.SIGCHLD, signal.SIG_IGN)
 
    # forward options via env vars
    os.environ["QUARTO_JUPYTER_OPTIONS"] = json.dumps(options)


### PR DESCRIPTION
In unix environments, we currently install a SIG_IGN handler on SIGCHLD.

That turns out to be a cause for for #2539.

We shouldn't need to ignore SIGCHLD signals to prevent zombie processes because we also set `start_new_session = True`, which presumably calls the `setsid` syscall.