### PR TITLE
Remove `docx` format from `code_line_numbers` schema

### DIFF
--- a/src/resources/schema/cell-codeoutput.yml
+++ b/src/resources/schema/cell-codeoutput.yml
@@ -78,7 +78,7 @@
 - name: code-line-numbers
   tags:
     contexts: [document-code]
-    formats: [$html-all, docx, ms, $pdf-all]
+    formats: [$html-all, ms, $pdf-all]
   schema:
     anyOf:
       - boolean


### PR DESCRIPTION
## Description

Update to schema to remove the docx format from the `code_line_numbers`.

Part of fix for https://github.com/quarto-dev/quarto-web/issues/608