### PR TITLE
Fix preview of docusaurus project on Windows

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -145,3 +145,4 @@
 ## Project
 
 - fix rendering of individual project files to stdout ([#4052](https://github.com/quarto-dev/quarto-cli/issues/4052)).
+- fix previewing docusaurus project on Windows ([#4312](https://github.com/quarto-dev/quarto-cli/issues/4312)).

--- a/src/project/serve/serve.ts
+++ b/src/project/serve/serve.ts
@@ -378,8 +378,10 @@ function externalPreviewServer(
   }
 
   // parse command line args and interpolate host and port
-  const cmd = serve.cmd.split(/[\t ]/).map((arg) => {
-    if (arg === "{host}") {
+  const cmd = serve.cmd.split(/[\t ]/).map((arg, index) => {
+    if (Deno.build.os === "windows" && index === 0 && arg === "npm") {
+      return "npm.cmd";
+    } else if (arg === "{host}") {
       return options.host || kLocalhost;
     } else if (arg === "{port}") {
       return String(options.port);


### PR DESCRIPTION
`Deno.run` won't find `npm` but will find `npm.cmd`. 

This is really scoped to fix #4312 by a "patch" after a discussion with @dragonstyle. 

Other possible fix would be what we have done for several `execProcess()` call having Windows issues: 

* `requireQuoting()` to be sure no problem with argument
* Wrap in  call to `Deno.run()` in a Promise and then in `safeWindowsExec()`

We decided to no go that far for now, and see other possible issue we can have with current serve. Patching command to add extension on Windows can be a valid long term fix maybe. 

### About the issue

Issue here in #4312 is that `npm` is not found by `Deno.run` whereas `npm.cmd`. Program in PATH and extension being required on Windows is something common, but it is hard to find a pattern of when or which tool will have this issue. For example, npm is on of them, but hugo isn't in my test (`hugo` is found, but extension is `exe` in `hugo.exe`)
