### PR TITLE
Fix embeding notebook when external href is provided

### DIFF
--- a/src/format/html/format-html-notebook.ts
+++ b/src/format/html/format-html-notebook.ts
@@ -34,7 +34,7 @@ import { ProjectContext } from "../../project/types.ts";
 interface NotebookView {
   title: string;
   href: string;
-  supporting: boolean;
+  supporting?: string;
 }
 
 interface NotebookViewOptions {
@@ -157,9 +157,7 @@ export async function processNotebookEmbeds(
             return {
               title: htmlPreview.title,
               href: htmlPreview.href,
-              supporting: htmlPreview.supporting
-                ? join(inputDir, htmlPreview.href)
-                : undefined,
+              supporting: htmlPreview.supporting,
             };
           } else {
             return {
@@ -378,14 +376,12 @@ async function renderHtmlView(
       title: options.title,
       href: join(dirname(href), nbPreviewFile),
       // notebbok to be included as supporting file
-      supporting: true,
+      supporting: join(inputDir, dirname(href), nbPreviewFile),
     };
   } else {
     return {
       title: options.title,
       href: options.href,
-      // no supporting file as external href is used
-      supporting: false,
     };
   }
 }

--- a/src/format/html/format-html-notebook.ts
+++ b/src/format/html/format-html-notebook.ts
@@ -34,6 +34,7 @@ import { ProjectContext } from "../../project/types.ts";
 interface NotebookView {
   title: string;
   href: string;
+  supporting: boolean;
 }
 
 interface NotebookViewOptions {
@@ -156,7 +157,9 @@ export async function processNotebookEmbeds(
             return {
               title: htmlPreview.title,
               href: htmlPreview.href,
-              supporting: join(inputDir, htmlPreview.href),
+              supporting: htmlPreview.supporting
+                ? join(inputDir, htmlPreview.href)
+                : undefined,
             };
           } else {
             return {
@@ -374,11 +377,15 @@ async function renderHtmlView(
     return {
       title: options.title,
       href: join(dirname(href), nbPreviewFile),
+      // notebbok to be included as supporting file
+      supporting: true,
     };
   } else {
     return {
       title: options.title,
       href: options.href,
+      // no supporting file as external href is used
+      supporting: false,
     };
   }
 }


### PR DESCRIPTION
When  embedding notebook and an external href is provided in option, no supporting file should be added and included.

Follow up on e5eec41f1b8cdba9dbaee94beba9c769448b95e9 to fix #4337

This is a suggestion as I don't know well the codebase here. What do you think ? 

With this, no supporting file is added, so no issue when creating the resources file and Windows tests are passing. 


