### PR TITLE
Do a deep clone of pandoc options when creating the default file 

### DIFF
--- a/src/command/render/defaults.ts
+++ b/src/command/render/defaults.ts
@@ -8,6 +8,8 @@
 import { extname } from "path/mod.ts";
 import { stringify } from "encoding/yaml.ts";
 
+import * as ld from "../../core/lodash.ts";
+
 import { FormatPandoc, QuartoFilter } from "../../config/types.ts";
 import { isLatexOutput } from "../../config/format.ts";
 
@@ -38,7 +40,9 @@ export async function generateDefaults(
   let allDefaults: FormatPandoc | undefined;
 
   if (options.format.pandoc) {
-    allDefaults = options.format.pandoc || {};
+    allDefaults = (options.format.pandoc
+      ? ld.cloneDeep(options.format.pandoc)
+      : {}) as FormatPandoc;
 
     // resolve filters
     const resolvedFilters = await resolveFilters(

--- a/src/command/render/pandoc.ts
+++ b/src/command/render/pandoc.ts
@@ -451,6 +451,9 @@ export async function runPandoc(
       if (extras.pandoc[kHighlightStyle]) {
         delete printAllDefaults[kHighlightStyle];
         allDefaults[kHighlightStyle] = extras.pandoc[kHighlightStyle];
+      } else {
+        delete printAllDefaults[kHighlightStyle];
+        delete allDefaults[kHighlightStyle];
       }
     }
 
@@ -1305,7 +1308,6 @@ function resolveTextHighlightStyle(
 
   if (highlightTheme === "none") {
     // Clear the highlighting
-    pandoc[kHighlightStyle] = null;
     if (extras.pandoc) {
       delete extras.pandoc[kHighlightStyle];
     }
@@ -1331,7 +1333,6 @@ function resolveTextHighlightStyle(
       break;
     case "none":
       // Clear the highlighting
-      delete pandoc[kHighlightStyle];
       if (extras.pandoc) {
         delete extras.pandoc[kHighlightStyle];
       }


### PR DESCRIPTION
Do a deep clone of pandoc options when creating the default file  Pandoc

Without it there was some undesired before during post processing due to modified configuration like to format.

Should fix #4260 as discussed with @dragonstyle 