### PR TITLE
multicore test suite

### DIFF
--- a/.github/workflows/performance-check.yml
+++ b/.github/workflows/performance-check.yml
@@ -31,6 +31,22 @@ jobs:
         run: |
           ./configure.sh
 
+      - name: Collect test suite timing
+        shell: bash
+        run: |
+          pushd tests
+          QUARTO_TEST_TIMING=timing.txt ./run-tests.sh
+          if [ "$?" == "0" ]; then          
+            git config --global user.name "GitHub Actions auto-commit"
+            git config --global user.email "username@users.noreply.github.com"
+            git add timing.txt
+            git commit -m "(auto) update timing"
+            git push origin main
+          else
+            echo "Test suite failed; skipping update of timing.txt"
+          fi
+          popd tests
+
       - name: Test Bundle
         id: create_bundle
         shell: bash
@@ -48,7 +64,7 @@ jobs:
 
           # move the TS file so quarto command will use bundled JS
           mv src/quarto.ts src/quarto1.ts
-          
+
           pushd package/pkg-working/bin
 
           # test a bare quarto command

--- a/tests/run-parallel-tests.sh
+++ b/tests/run-parallel-tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+quarto run run-parallel-tests.ts

--- a/tests/run-parallel-tests.ts
+++ b/tests/run-parallel-tests.ts
@@ -58,8 +58,8 @@ if (failed) {
 }
 
 const buckets: TestTiming[][] = [];
-const nBuckets = 8;
-const bucketSizes = (new Array(8)).fill(0);
+const nBuckets = navigator.hardwareConcurrency;
+const bucketSizes = (new Array(nBuckets)).fill(0);
 
 const argmin = (a: number[]): number => {
   let best = -1, bestValue = Infinity;
@@ -82,6 +82,15 @@ for (const timing of testTimings) {
   bucketSizes[ix] += timing.timing.real;
 }
 
+console.log(`Will run in ${nBuckets} cores`);
+console.log(
+  `Expected speedup: ${
+    (bucketSizes.reduce((a, b) => a + b, 0) / Math.max(...bucketSizes)).toFixed(
+      2,
+    )
+  }`,
+);
+
 Promise.all(buckets.map((bucket) => {
   const cmd: string[] = ["./run-tests.sh"];
   cmd.push(...bucket.map((tt) => tt.name));
@@ -89,8 +98,3 @@ Promise.all(buckets.map((bucket) => {
     cmd,
   }).status();
 }));
-
-// for (const bucket of buckets) {
-//   Deno.run();
-// }
-// console.log(bucketSizes);

--- a/tests/run-parallel-tests.ts
+++ b/tests/run-parallel-tests.ts
@@ -1,0 +1,96 @@
+import { expandGlobSync } from "https://deno.land/std/fs/expand_glob.ts";
+import { relative } from "https://deno.land/std/path/mod.ts";
+
+try {
+  Deno.readTextFileSync("timing.txt");
+} catch (e) {
+  console.log(e);
+  console.log("timing.txt missing. run ./tests.sh with QUARTO_TEST_TIMING=1");
+  Deno.exit(1);
+}
+
+const lines = Deno.readTextFileSync("timing.txt").trim().split("\n");
+const currentTests = new Set(
+  [...expandGlobSync("**/*.test.ts", { globstar: true })].map((entry) =>
+    `./${relative(Deno.cwd(), entry.path)}`
+  ),
+);
+const timedTests = new Set<string>();
+
+type Timing = {
+  real: number;
+  user: number;
+  sys: number;
+};
+type TestTiming = {
+  name: string;
+  timing: Timing;
+};
+
+const testTimings: TestTiming[] = [];
+
+for (let i = 0; i < lines.length; i += 2) {
+  const name = lines[i].trim();
+  const timingStrs = lines[i + 1].trim().replaceAll(/ +/g, " ").split(" ");
+  const timing = {
+    real: Number(timingStrs[0]),
+    user: Number(timingStrs[2]),
+    sys: Number(timingStrs[4]),
+  };
+  testTimings.push({ name, timing });
+  timedTests.add(name);
+}
+let failed = false;
+for (const timedTest of timedTests) {
+  if (!currentTests.has(timedTest)) {
+    console.log(`Missing test ${timedTest} in test suite`);
+    failed = true;
+  }
+}
+for (const currentTest of currentTests) {
+  if (!timedTests.has(currentTest)) {
+    console.log(`Missing test ${currentTest} in timing.txt`);
+    failed = true;
+  }
+}
+if (failed) {
+  Deno.exit(1);
+}
+
+const buckets: TestTiming[][] = [];
+const nBuckets = 8;
+const bucketSizes = (new Array(8)).fill(0);
+
+const argmin = (a: number[]): number => {
+  let best = -1, bestValue = Infinity;
+  for (let i = 0; i < a.length; ++i) {
+    if (a[i] < bestValue) {
+      best = i;
+      bestValue = a[i];
+    }
+  }
+  return best;
+};
+
+for (let i = 0; i < nBuckets; ++i) {
+  buckets.push([]);
+}
+
+for (const timing of testTimings) {
+  const ix = argmin(bucketSizes);
+  buckets[ix].push(timing);
+  bucketSizes[ix] += timing.timing.real;
+}
+
+Promise.all(buckets.map((bucket) => {
+  const cmd: string[] = ["./run-tests.sh"];
+  cmd.push(...bucket.map((tt) => tt.name));
+  return Deno.run({
+    cmd,
+  }).status();
+}));
+
+// for (const bucket of buckets) {
+//   Deno.run();
+// }
+// console.log(bucketSizes);

--- a/tests/run-parallel-tests.ts
+++ b/tests/run-parallel-tests.ts
@@ -5,7 +5,9 @@ try {
   Deno.readTextFileSync("timing.txt");
 } catch (e) {
   console.log(e);
-  console.log("timing.txt missing. run ./tests.sh with QUARTO_TEST_TIMING=1");
+  console.log(
+    "timing.txt missing. run ./tests.sh with QUARTO_TEST_TIMING=timing.txt",
+  );
   Deno.exit(1);
 }
 
@@ -56,6 +58,11 @@ for (const currentTest of currentTests) {
 if (failed) {
   Deno.exit(1);
 }
+// console.log(
+//   testTimings.map((a) => (a.timing.real)).reduce((a, b) => a + b, 0),
+// );
+// console.log(testTimings.sort((a, b) => a.timing.real - b.timing.real));
+// Deno.exit(0);
 
 const buckets: TestTiming[][] = [];
 const nBuckets = navigator.hardwareConcurrency;

--- a/tests/run-parallel-tests.ts
+++ b/tests/run-parallel-tests.ts
@@ -43,21 +43,7 @@ for (let i = 0; i < lines.length; i += 2) {
   timedTests.add(name);
 }
 let failed = false;
-for (const timedTest of timedTests) {
-  if (!currentTests.has(timedTest)) {
-    console.log(`Missing test ${timedTest} in test suite`);
-    failed = true;
-  }
-}
-for (const currentTest of currentTests) {
-  if (!timedTests.has(currentTest)) {
-    console.log(`Missing test ${currentTest} in timing.txt`);
-    failed = true;
-  }
-}
-if (failed) {
-  Deno.exit(1);
-}
+
 // console.log(
 //   testTimings.map((a) => (a.timing.real)).reduce((a, b) => a + b, 0),
 // );
@@ -89,14 +75,25 @@ for (const timing of testTimings) {
   bucketSizes[ix] += timing.timing.real;
 }
 
+for (const currentTest of currentTests) {
+  if (!timedTests.has(currentTest)) {
+    console.log(`Missing test ${currentTest} in timing.txt`);
+    failed = true;
+    bucketSizes[Math.floor(Math.random() * nBuckets)].push(currentTest);
+  }
+}
+
 console.log(`Will run in ${nBuckets} cores`);
-console.log(
-  `Expected speedup: ${
-    (bucketSizes.reduce((a, b) => a + b, 0) / Math.max(...bucketSizes)).toFixed(
-      2,
-    )
-  }`,
-);
+if (!failed) {
+  console.log(
+    `Expected speedup: ${
+      (bucketSizes.reduce((a, b) => a + b, 0) / Math.max(...bucketSizes))
+        .toFixed(
+          2,
+        )
+    }`,
+  );
+}
 
 Promise.all(buckets.map((bucket) => {
   const cmd: string[] = ["./run-tests.sh"];

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -39,7 +39,20 @@ fi
 # Ensure that tinytex is installed
 quarto install tinytex --no-prompt
 
-"${DENO_DIR}/tools/${DENO_ARCH_DIR}/deno" test ${QUARTO_DENO_OPTIONS} ${QUARTO_DENO_EXTRA_OPTIONS} "${QUARTO_IMPORT_ARGMAP}" $@
+if [ "$QUARTO_TEST_TIMING" != "" ]; then
+  QUARTO_DENO_OPTIONS="--config test-conf.json --unstable --allow-read --allow-write --allow-run --allow-env --allow-net --no-check"
+  rm -f timing.txt
+  FILES=$@
+  if [ "$FILES" == "" ]; then
+    FILES=`find . | grep \.test\.ts$`
+  fi
+  for i in $FILES; do
+    echo $i >> timing.txt
+    /usr/bin/time -a -o timing.txt "${DENO_DIR}/tools/${DENO_ARCH_DIR}/deno" test ${QUARTO_DENO_OPTIONS} ${QUARTO_DENO_EXTRA_OPTIONS} "${QUARTO_IMPORT_ARGMAP}" $i
+  done
+else
+  "${DENO_DIR}/tools/${DENO_ARCH_DIR}/deno" test ${QUARTO_DENO_OPTIONS} ${QUARTO_DENO_EXTRA_OPTIONS} "${QUARTO_IMPORT_ARGMAP}" $@
+fi
 
 SUCCESS=$?
 

--- a/tests/smoke/render/render-docx.test.ts
+++ b/tests/smoke/render/render-docx.test.ts
@@ -4,8 +4,10 @@
 * Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
-import { docs } from "../../utils.ts";
-import { testRender } from "./render.ts";
 
-testRender(docs("test.Rmd"), "html", false, []);
+import { docs } from "../../utils.ts";
+import { testRender, testSimpleIsolatedRender } from "./render.ts";
+
+//testRender(docs("test.Rmd"), "html", false, []);
+testSimpleIsolatedRender(docs("test.Rmd"), "html", false);
 testRender(docs("test.qmd"), "docx", true, []);

--- a/tests/smoke/render/render-r.test.ts
+++ b/tests/smoke/render/render-r.test.ts
@@ -5,27 +5,38 @@
 *
 */
 
-import { docs, fileLoader } from "../../utils.ts";
+import { docs, fileLoader, inTempDirectory } from "../../utils.ts";
+import { join } from "path/mod.ts";
 import { ensureHtmlSelectorSatisfies, fileExists } from "../../verify.ts";
 import { testRender } from "./render.ts";
 
-const plotPath = "docs/test_files/figure-html";
+inTempDirectory((dir) => {
+  const tempInput = join(dir, "test.Rmd");
+  Deno.copyFileSync(docs("test.Rmd"), tempInput);
+  const thisPlotPath = join(dir, "test_files/figure-html");
 
-testRender(docs("test.Rmd"), "html", false, [
-  fileExists(plotPath),
-], {
-  teardown: () => {
-    return Deno.remove(plotPath, { recursive: true });
-  },
+  testRender(tempInput, "html", false, [
+    fileExists(thisPlotPath),
+  ], {
+    teardown: () => {
+      return Deno.remove(dir, { recursive: true });
+    },
+  });
 });
 
-testRender(docs("test.Rmd"), "html", false, [
-  fileExists(plotPath),
-], {
-  teardown: () => {
-    return Deno.remove(plotPath, { recursive: true });
-  },
-}, ["--execute-params", "docs/params.yml"]);
+inTempDirectory((dir) => {
+  const tempInput = join(dir, "test.Rmd");
+  Deno.copyFileSync(docs("test.Rmd"), tempInput);
+
+  const thisPlotPath = join(dir, "test_files/figure-html");
+  testRender(tempInput, "html", false, [
+    fileExists(thisPlotPath),
+  ], {
+    teardown: () => {
+      return Deno.remove(dir, { recursive: true });
+    },
+  }, ["--execute-params", "docs/params.yml"]);
+});
 
 const knitrOptions = fileLoader()("test-knitr-options.qmd", "html");
 testRender(knitrOptions.input, "html", false, [

--- a/tests/smoke/render/render.ts
+++ b/tests/smoke/render/render.ts
@@ -5,6 +5,7 @@
 *
 */
 import { existsSync } from "fs/mod.ts";
+import { basename, join } from "path/mod.ts";
 
 import { outputForInput } from "../../utils.ts";
 import { TestContext, testQuartoCmd, Verify } from "../../test.ts";
@@ -14,6 +15,21 @@ import {
   noSupportingFiles,
   outputCreated,
 } from "../../verify.ts";
+
+export function testSimpleIsolatedRender(
+  file: string,
+  to: string,
+  noSupporting: boolean,
+) {
+  const dir = Deno.makeTempDirSync();
+  const tempInput = join(dir, basename(file));
+  Deno.copyFileSync(file, tempInput);
+  testRender(tempInput, to, noSupporting, [], {
+    teardown: () => {
+      return Deno.remove(dir, { recursive: true });
+    },
+  });
+}
 
 export function testRender(
   input: string,

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -166,7 +166,7 @@ export function test(test: TestDescriptor) {
         };
 
         // Capture the output
-        const log = Deno.makeTempFileSync({ dir: wd, suffix: ".json" });
+        const log = Deno.makeTempFileSync({ suffix: ".json" });
         await initializeLogger({
           log: log,
           level: "INFO",

--- a/tests/timing.txt
+++ b/tests/timing.txt
@@ -1,0 +1,196 @@
+./smoke/directives/include-fixups.test.ts
+        0.01 real         0.01 user         0.00 sys
+./smoke/filters/filters.test.ts
+        2.04 real         1.77 user         0.38 sys
+./smoke/smoke-all.test.ts
+       99.84 real        84.48 user        20.23 sys
+./smoke/authors/author-name.test.ts
+        2.92 real         2.76 user         0.64 sys
+./smoke/yaml-intelligence/yaml-intelligence.test.ts
+        0.73 real         1.14 user         0.13 sys
+./smoke/yaml-intelligence/yaml-intelligence-folded-block-strings.test.ts
+        0.68 real         0.94 user         0.11 sys
+./smoke/render/render-code-highlighting.test.ts
+        1.68 real         1.88 user         0.28 sys
+./smoke/render/render-bibio.test.ts
+        1.24 real         1.39 user         0.24 sys
+./smoke/render/render-docx.test.ts
+        1.86 real         2.02 user         0.33 sys
+./smoke/render/render-commonmark.test.ts
+       15.78 real        11.92 user         4.36 sys
+./smoke/render/render-latex-output.test.ts
+        2.11 real         2.15 user         0.37 sys
+./smoke/render/render-plain.test.ts
+        1.42 real         1.65 user         0.30 sys
+./smoke/render/render-templates.test.ts
+       15.50 real        14.28 user         1.87 sys
+./smoke/render/render-page-layout.test.ts
+       10.52 real         9.48 user         1.01 sys
+./smoke/render/render-date.test.ts
+        1.75 real         1.86 user         0.38 sys
+./smoke/render/render-pdf.test.ts
+       85.27 real        60.00 user        10.74 sys
+./smoke/render/render-minimal.test.ts
+        0.91 real         1.14 user         0.18 sys
+./smoke/render/render-title-block.test.ts
+        2.38 real         2.33 user         0.51 sys
+./smoke/render/render-format-extension.test.ts
+       22.96 real        20.38 user         2.72 sys
+./smoke/render/render-ojs.test.ts
+        1.11 real         1.42 user         0.17 sys
+./smoke/render/render-jupyter.test.ts
+        3.83 real         3.81 user         0.50 sys
+./smoke/render/render-code-tools.test.ts
+        3.26 real         3.15 user         0.59 sys
+./smoke/render/render-reveal.test.ts
+        7.15 real         5.68 user         1.06 sys
+./smoke/render/render-freeze.test.ts
+        5.25 real         4.69 user         0.98 sys
+./smoke/render/render-r.test.ts
+        5.09 real         4.69 user         0.86 sys
+./smoke/render/render-callout.test.ts
+        1.70 real         1.81 user         0.31 sys
+./smoke/ojs/dependency-traversal.test.ts
+        1.09 real         1.39 user         0.17 sys
+./smoke/ojs/complex-layout.test.ts
+        1.95 real         2.23 user         0.28 sys
+./smoke/crossref/sections.test.ts
+        0.86 real         1.13 user         0.17 sys
+./smoke/crossref/thereoms.test.ts
+        1.13 real         1.38 user         0.20 sys
+./smoke/crossref/tables.test.ts
+        2.69 real         2.71 user         0.46 sys
+./smoke/crossref/figures.test.ts
+       36.89 real        32.53 user         7.13 sys
+./smoke/crossref/listings.test.ts
+        0.90 real         1.20 user         0.16 sys
+./smoke/crossref/unresolved.test.ts
+        0.85 real         1.13 user         0.17 sys
+./smoke/crossref/chapters.test.ts
+        0.90 real         1.21 user         0.16 sys
+./smoke/crossref/options.test.ts
+        1.09 real         1.33 user         0.22 sys
+./smoke/crossref/latex.test.ts
+        0.86 real         1.13 user         0.16 sys
+./smoke/crossref/syntax.test.ts
+        1.32 real         1.56 user         0.25 sys
+./smoke/crossref/docx.test.ts
+        0.93 real         1.15 user         0.16 sys
+./smoke/crossref/equations.test.ts
+        0.82 real         1.13 user         0.16 sys
+./smoke/shortcodes/shortcodes-core.test.ts
+        2.07 real         2.16 user         0.42 sys
+./smoke/extensions/extension-render-reveal.test.ts
+        1.68 real         1.75 user         0.41 sys
+./smoke/extensions/extension-render-doc.test.ts
+        3.09 real         3.12 user         0.53 sys
+./smoke/extensions/install.test.ts
+       16.32 real         3.07 user         1.15 sys
+./smoke/extensions/extension-render-journals.test.ts
+       47.02 real        35.51 user         4.38 sys
+./smoke/extensions/extension-render-project.test.ts
+        1.34 real         1.67 user         0.27 sys
+./smoke/env/check.test.ts
+        5.58 real         5.47 user         2.03 sys
+./smoke/env/install.test.ts
+        0.89 real         0.30 user         0.08 sys
+./smoke/project/project-simple.test.ts
+        1.14 real         1.38 user         0.23 sys
+./smoke/project/project-book.test.ts
+        5.61 real         5.38 user         0.83 sys
+./smoke/project/project-website.test.ts
+        1.43 real         1.66 user         0.28 sys
+./smoke/project/project-stdout.test.ts
+        1.16 real         1.44 user         0.22 sys
+./smoke/schema/load-yaml-schema-schema.test.ts
+        0.02 real         0.01 user         0.00 sys
+./smoke/book/render-book.test.ts
+       28.00 real        27.17 user         2.12 sys
+./smoke/site/render-navigation.test.ts
+        1.68 real         1.94 user         0.33 sys
+./smoke/site/render-site.test.ts
+       31.69 real        26.20 user         5.88 sys
+./smoke/site/render-blog.test.ts
+        2.18 real         2.31 user         0.41 sys
+./smoke/site/render-listings.test.ts
+        4.59 real         4.45 user         0.78 sys
+./smoke/site/render-shortcode-navbar.test.ts
+        1.22 real         1.45 user         0.23 sys
+./smoke/yaml/core-yaml-dashes.test.ts
+        0.98 real         1.24 user         0.19 sys
+./smoke/run/stdlib-run-version.test.ts
+        0.65 real         0.49 user         0.17 sys
+./smoke/create/create.test.ts
+       23.65 real        24.22 user         4.37 sys
+./smoke/engine/include-engine-detection.test.ts
+        1.54 real         1.72 user         0.28 sys
+./smoke/scholar/render-scholar.test.ts
+        2.09 real         2.13 user         0.44 sys
+./smoke/convert/convert-empty-frontmatter.test.ts
+        1.21 real         1.29 user         0.24 sys
+./unit/yaml.test.ts
+        0.75 real         1.03 user         0.14 sys
+./unit/path.test.ts
+        0.33 real         0.28 user         0.07 sys
+./unit/pandoc-partition.test.ts
+        0.31 real         0.25 user         0.07 sys
+./unit/confluence.test.ts
+        0.37 real         0.30 user         0.09 sys
+./unit/yaml-intelligence/hover-info.test.ts
+        0.69 real         0.97 user         0.13 sys
+./unit/yaml-intelligence/annotated-yaml.test.ts
+        0.74 real         1.03 user         0.13 sys
+./unit/yaml-intelligence/error-colon-no-space.test.ts
+        0.74 real         1.00 user         0.13 sys
+./unit/mapped-strings/mapped-text.test.ts
+        0.31 real         0.27 user         0.07 sys
+./unit/mapped-strings/multiple-source.test.ts
+        0.31 real         0.25 user         0.06 sys
+./unit/pandoc.test.ts
+        0.31 real         0.25 user         0.07 sys
+./unit/paths/qualified-path.test.ts
+        0.30 real         0.25 user         0.06 sys
+./unit/text.test.ts
+        0.31 real         0.25 user         0.06 sys
+./unit/guess-chunk-options-format.test.ts
+        0.31 real         0.25 user         0.06 sys
+./unit/environment.test.ts
+        0.30 real         0.25 user         0.07 sys
+./unit/binary-search.test.ts
+        0.31 real         0.26 user         0.07 sys
+./unit/partition-cell-options.test.ts
+        0.64 real         0.91 user         0.10 sys
+./unit/pandoc-formats.test.ts
+        0.31 real         0.26 user         0.06 sys
+./unit/break-quarto-md/break-quarto-md.test.ts
+        0.67 real         1.00 user         0.11 sys
+./unit/filter-paths.test.ts
+        0.30 real         0.25 user         0.06 sys
+./unit/schema-validation/format-aliases.test.ts
+        0.68 real         0.97 user         0.13 sys
+./unit/schema-validation/hello-world.test.ts
+        0.73 real         1.02 user         0.13 sys
+./unit/schema-validation/format-pandoc-from-file-simple-tests.test.ts
+        0.69 real         0.99 user         0.13 sys
+./unit/schema-validation/error-narrowing.test.ts
+        0.68 real         0.97 user         0.13 sys
+./unit/schema-validation/simple.test.ts
+        0.68 real         0.98 user         0.13 sys
+./unit/schema-validation/format-execute.test.ts
+        0.01 real         0.01 user         0.00 sys
+./unit/schema-validation/error-location.test.ts
+        0.30 real         0.25 user         0.06 sys
+./unit/schema-validation/schema-schema.test.ts
+        1.78 real         2.30 user         0.23 sys
+./unit/schema-validation/schema-files.test.ts
+        0.77 real         1.06 user         0.13 sys
+./unit/schema-validation/schema-completions.test.ts
+        0.64 real         0.97 user         0.10 sys
+./unit/schema-validation/object-super.test.ts
+        0.68 real         0.98 user         0.13 sys
+./integration/playwright-tests.test.ts
+       31.64 real        45.80 user         8.75 sys
+./integration/guess-chunk-options-format-document.test.ts
+        1.31 real         1.52 user         0.25 sys
+./integration/mermaid/github-issue-1340.test.ts
+        2.95 real         1.86 user         0.30 sys

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -8,6 +8,12 @@
 import { basename, dirname, extname, join } from "path/mod.ts";
 import { parseFormatString } from "../src/core/pandoc/pandoc-formats.ts";
 
+// caller is responsible for cleanup!
+export function inTempDirectory(fn: (dir: string) => unknown): unknown {
+  const dir = Deno.makeTempDirSync();
+  return fn(dir);
+}
+
 // Gets output that should be created for this input file and target format
 export function outputForInput(input: string, to: string) {
   // TODO: Consider improving this (e.g. for cases like Beamer)


### PR DESCRIPTION
## tl;dr

```
$ ./run-parallel-tests.sh
Will run in 10 cores
Expected speedup: 5.89
* The library is already synchronized with the lockfile.
```

A parallel test suite should be as simple as `deno test --parallel`, but our test suite is somehow still not working great in that scenario, so this approach takes a bit of extra work. Every time a new test is added (or every time we want to update the timing file because we think the relative runtimes have significantly changed), we need to collect a full slow run.

That's done by `QUARTO_TEST_TIMING=1 ./run-tests.sh`, which will recreate the `tests/timing.txt` file.

With that file in place, `./run-parallel-tests.sh` uses a simple scheduler to run our test suite across a large number of parallelized individual `./run-tests.sh` call.

The report is also a little uglier, but it's functional enough: there's a global "test failed" output if any of the tests fail, and then you have to scroll up to find the test.

A 6x speedup seems worth the effort, though. There's still a largeish improvement to be done by splitting `smoke/smoke-all.test.ts` as a special case, but this will get us going.