### PR TITLE
Set correct permissions when replacing the intermediate tex file

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -50,6 +50,7 @@
 - Fix temporary `.tex` filenames in the presence of multiple variants ([#3762](https://github.com/quarto-dev/quarto-cli/issues/3762)).
   - Note that this fix changes the filenames used for PDF files with variants. In quarto 1.3, the automatic output names for PDF files include format variants and modifiers.
 - Correctly download online image on Windows ([#3982](https://github.com/quarto-dev/quarto-cli/issues/3982)).
+- Permissions of `.tex` file are now correct when `keep-tex: true` ([#4380](https://github.com/quarto-dev/quarto-cli/issues/4380)).
 
 ## Beamer Format
 

--- a/src/format/pdf/format-pdf.ts
+++ b/src/format/pdf/format-pdf.ts
@@ -390,6 +390,14 @@ async function processLines(
   // The temp file we generate into
   const outputFile = temp.createFile({ suffix: ".tex" });
   const file = await Deno.open(inputFile);
+  // Preserve the existing permissions as we'll replace
+  let mode;
+  if (Deno.build.os !== "windows") {
+    const stat = Deno.statSync(inputFile);
+    if (stat.mode !== null) {
+      mode = stat.mode;
+    }
+  }
   try {
     for await (const line of readLines(file)) {
       let processedLine: string | undefined = line;
@@ -404,6 +412,7 @@ async function processLines(
       if (processedLine !== undefined) {
         Deno.writeTextFileSync(outputFile, processedLine + "\n", {
           append: true,
+          mode,
         });
       }
     }


### PR DESCRIPTION
This fix #4380

We need to be sure of the permissions when we replace a file

Same pattern as in 
https://github.com/quarto-dev/quarto-cli/blob/b01c1dfaa69ccfe7beb053da94861071a4ca15e0/src/command/render/pandoc-html.ts#L444-L461