### PR TITLE
pre- and post- process HTML tables around Pandoc

### DIFF
--- a/src/format/html/format-html.ts
+++ b/src/format/html/format-html.ts
@@ -700,6 +700,44 @@ function htmlFormatPostprocessor(
     // Process code annotations that may appear in this document
     processCodeAnnotations(format, doc);
 
+    // Process tables to restore th-vs-td markers
+    const tables = doc.querySelectorAll(
+      "table",
+    );
+
+    for (let i = 0; i < tables.length; ++i) {
+      const table = (tables[i] as Element);
+      if (table.getAttribute("data-quarto-disable-processing")) {
+        continue;
+      }
+      console.log("table before postprocess", table.outerHTML);
+      table.removeAttribute("data-quarto-postprocess-tables");
+      table.querySelectorAll("tr").forEach((tr) => {
+        const { children } = (tr as Element);
+        for (let j = 0; j < children.length; ++j) {
+          const child = children[j] as Element;
+          if (child.tagName === "TH" || child.tagName === "TD") {
+            const isTH =
+              child.getAttribute("data-quarto-table-cell-role") === "th";
+            // create a new element with the correct tag and move all children and attributes to
+            // new element
+            const newElement = doc.createElement(isTH ? "th" : "td");
+            while (child.firstChild) {
+              newElement.appendChild(child.firstChild);
+            }
+            for (let k = 0; k < child.attributes.length; ++k) {
+              const attr = child.attributes[k];
+              newElement.setAttribute(attr.name, attr.value);
+            }
+
+            // replace the old element with the new one
+            child.parentNode?.replaceChild(newElement, child);
+          }
+        }
+      });
+      console.log("table after postprocess", table.outerHTML);
+    }
+
     // no resource refs
     return Promise.resolve(kHtmlEmptyPostProcessResult);
   };

--- a/src/resources/filters/normalize/parsehtml.lua
+++ b/src/resources/filters/normalize/parsehtml.lua
@@ -3,6 +3,25 @@
 
 local kDisableProcessing = "quarto-disable-processing"
 
+local function preprocess_table_text(src)
+  -- html manipulation with regex is fraught, but those specific
+  -- changes are safe assuming that no one is using quarto- as
+  -- a prefix for dataset attributes in the tables.
+  -- See
+  -- * https://www.w3.org/html/wg/spec/syntax.html#start-tags
+  -- * https://www.w3.org/html/wg/spec/syntax.html#end-tags
+
+  print(src)
+
+  src = src:gsub("<th([%s>])", "<td data-quarto-table-cell-role=\"th\"%1")
+  src = src:gsub("</th([%s>])", "</td%1")
+  src = src:gsub("<table([%s>])", "<table data-quarto-postprocess=\"true\"%1")
+
+  print(src)
+
+  return src
+end
+
 function parse_html_tables()
   return {
     RawBlock = function(el)
@@ -20,6 +39,23 @@ function parse_html_tables()
           local before_table = string.sub(el.text, 1, i - 1)
           local after_table = string.sub(el.text, j + 1)
           local tableHtml = tableBegin .. "\n" .. tableBody .. "\n" .. tableEnd
+          -- Pandoc's HTML-table -> AST-table processing does not faithfully respect
+          -- `th` vs `td` elements. This causes some complex tables to be parsed incorrectly,
+          -- and changes which elements are `th` and which are `td`.
+          --
+          -- For quarto, this change is not acceptable because `td` and `th` have
+          -- accessibility impacts (see https://github.com/rstudio/gt/issues/678 for a concrete
+          -- request from a screen-reader user).
+          --
+          -- To preserve td and th, we replace `th` elements in the input with 
+          -- `td data-quarto-table-cell-role="th"`. 
+          -- 
+          -- Then, in our HTML postprocessor,
+          -- we replace th elements with td (since pandoc chooses to set some of its table
+          -- elements as th, even if the original table requested not to), and replace those 
+          -- annotated td elements with th elements.
+
+          tableHtml = preprocess_table_text(tableHtml)
           local tableDoc = pandoc.read(tableHtml, "html")
           local skip = false
           tableDoc:walk({


### PR DESCRIPTION
This PR closes #4316.

In quarto 1.3, we process HTML tables into Pandoc AST nodes by default. Currently, this allows us to extract captions and process markdown where requested, as well as have user Lua filters process tables uniformly, independently of whether they're HTML or Pandoc, and further functionality is likely to be added over time.

The problem is that in the process of parsing HTML tables, Pandoc is opinionated about what counts as a `th` and a `td` and where. This ultimately causes it to miss some attributes including `colspan` and `rowspan` in some instances of `th`, which causes breakage on complex tables like the ones `gt` is capable of producing.

Additionally, precise preservation of `td` and `th` are important for quarto in the context of accessibility. So in our use case, we take the distinction between `td` and `th` elements in well-formed HTML tables to be important, and a requirement.

## Approach

We normalize table input before Pandoc sees it, and preserver the information through dataset attributes that are handled in a postprocessor. Specifically, we convert every `th` element to a `td data-quarto-cell-role="th"`.

## References

- Upstream [Pandoc issue](https://github.com/jgm/pandoc/issues/8647) explaining why Pandoc won't change its behavior.