### PR TITLE
Only use "safe" ports for preview, etc

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -1,4 +1,5 @@
 ## Confluence Publishing
+
 - Add support for publishing both documents and projects to Atlassian Confluence spaces and as children to Confluence pages.
 
 ## Jupyter Notebooks
@@ -159,6 +160,7 @@
 - use correct language code for Korean ([#4187](https://github.com/quarto-dev/quarto-cli/discussions/4187)).
 - resolve YAML options correctly for comments with open+close syntax ([#3901](https://github.com/quarto-dev/quarto-cli/issues/3901)).
 - Work around rare deno tempfile creation bug ([#4352](https://github.com/quarto-dev/quarto-cli/pull/4352)).
+- Only open "safe ports" for Chromium ([#4514](https://github.com/quarto-dev/quarto-cli/pull/4514)).
 
 ## Pandoc filter changes
 

--- a/src/core/port.ts
+++ b/src/core/port.ts
@@ -180,12 +180,35 @@ export function getAvailablePortSync(
  */
 function getRandomPortSync(options: IOptions): number {
   const randomPort = random(0, 65535);
+
+  const restrictedPorts = [
+    // from https://chromium.googlesource.com/chromium/src.git/+/refs/heads/master/net/base/port_util.cc
+    // as of 2023-02-23.
+    1719, // h323gatestat
+    1720, // h323hostcall
+    1723, // pptp
+    2049, // nfs
+    3659, // apple-sasl / PasswordServer
+    4045, // lockd
+    5060, // sip
+    5061, // sips
+    6000, // X11
+    6566, // sane-port
+    6665, // Alternate IRC [Apple addition]
+    6666, // Alternate IRC [Apple addition]
+    6667, // Standard IRC [Apple addition]
+    6668, // Alternate IRC [Apple addition]
+    6669, // Alternate IRC [Apple addition]
+    6697, // IRC + TLS
+    10080, // Amanda
+  ];
+
   if (
     isPortAvailableSync({
       port: randomPort,
       ...(options.hostname ? { hostname: options.hostname } : {}),
       ...(options.transport ? { transport: options.transport } : {}),
-    })
+    }) && !(restrictedPorts.includes(randomPort)) // https://github.com/quarto-dev/quarto-cli/issues/4514
   ) {
     return randomPort;
   } else {


### PR DESCRIPTION
This closes #4514 by using a list of "restricted" ports from [Chromium's source code](https://chromium.googlesource.com/chromium/src.git/+/refs/heads/master/net/base/port_util.cc).