### PR TITLE
Remove from_simple_table from table_captions.lua

### DIFF
--- a/src/resources/filters/quarto-pre/table-captions.lua
+++ b/src/resources/filters/quarto-pre/table-captions.lua
@@ -132,22 +132,18 @@ function applyTableCaptions(el, tblCaptions, tblLabels)
   return pandoc.walk_block(el, {
     Table = function(el)
       if idx <= #tblLabels then
-        local table = pandoc.utils.to_simple_table(el)
+        local cap = pandoc.Inlines({})
         if #tblCaptions[idx] > 0 then
-          table.caption = pandoc.List()
-          tappend(table.caption, tblCaptions[idx])
-          table.caption:insert(pandoc.Space())
-        end
-        if table.caption == nil then
-          table.caption = pandoc.List()
+          print(tblCaptions[idx])
+          cap:extend(tblCaptions[idx])
+          cap:insert(pandoc.Space())
         end
         if #tblLabels[idx] > 0 then
-          tappend(table.caption, {
-            pandoc.Str("{#" .. tblLabels[idx] .. "}")
-          })
+          cap:insert(pandoc.Str("{#" .. tblLabels[idx] .. "}"))
         end
         idx = idx + 1
-        return pandoc.utils.from_simple_table(table)
+        el.caption.long = pandoc.Plain(cap)
+        return el
       end
     end,
     RawBlock = function(raw)

--- a/tests/docs/smoke-all/2023/02/25/issue-4316.qmd
+++ b/tests/docs/smoke-all/2023/02/25/issue-4316.qmd
@@ -1,0 +1,34 @@
+---
+format: html
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ["th[colspan=\"2\"]"]
+        - []
+---
+
+```{r}
+#| include: false
+library(gt)
+```
+
+```{r}
+#| echo: false
+#| tbl-cap: "Caption"
+#| label: tbl-test
+dat <- data.frame(
+  a = c("A", "B"),
+  x = c(1, 2), 
+  y = c(12, 9), 
+  z = c(13, 11))
+
+dat %>%
+  gt() %>%
+  tab_spanner(
+	label = "Subheader",
+	columns = c(x, y)
+  )
+```
+
+@tbl-test


### PR DESCRIPTION
(Re-) closes #4316.

We can no longer use a round-trip to SimpleTable because Quarto now processes tables with complex layouts (ColSpans, etc), and those are not supported in SimpleTable.