### PR TITLE
report quarto version in most commands

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -167,6 +167,7 @@
 - Work around rare deno tempfile creation bug ([#4352](https://github.com/quarto-dev/quarto-cli/pull/4352)).
 - Only open "safe ports" for Chromium ([#4514](https://github.com/quarto-dev/quarto-cli/pull/4514)).
 - Detect potential bad argument ordering in `quarto render` ([#3581](https://github.com/quarto-dev/quarto-cli/pull/3581)).
+- Report version in most `quarto` commands ([#4567](https://github.com/quarto-dev/quarto-cli/pull/4567)).
 
 ## Pandoc filter changes
 

--- a/src/command/add/cmd.ts
+++ b/src/command/add/cmd.ts
@@ -10,6 +10,7 @@ import { createTempContext } from "../../core/temp.ts";
 import { installExtension } from "../../extension/install.ts";
 
 import { info } from "log/mod.ts";
+import { greet } from "../greet.ts";
 
 export const addCommand = new Command()
   .name("add")

--- a/src/command/add/cmd.ts
+++ b/src/command/add/cmd.ts
@@ -42,6 +42,7 @@ export const addCommand = new Command()
       options: { prompt?: boolean; embed?: string; updatePath?: boolean },
       extension: string,
     ) => {
+      greet();
       await initYamlIntelligenceResourcesFromFilesystem();
       const temp = createTempContext();
       try {

--- a/src/command/convert/cmd.ts
+++ b/src/command/convert/cmd.ts
@@ -17,6 +17,7 @@ import {
   markdownToJupyterNotebook,
 } from "./jupyter.ts";
 import { initYamlIntelligenceResourcesFromFilesystem } from "../../core/schema/utils.ts";
+import { greet } from "../greet.ts";
 
 const kNotebookFormat = "notebook";
 const kMarkdownFormat = "markdown";
@@ -49,6 +50,7 @@ export const convertCommand = new Command()
   )
   // deno-lint-ignore no-explicit-any
   .action(async (options: any, input: string) => {
+    greet();
     await initYamlIntelligenceResourcesFromFilesystem();
 
     if (!existsSync(input)) {

--- a/src/command/create-project/cmd.ts
+++ b/src/command/create-project/cmd.ts
@@ -19,6 +19,8 @@ import {
   projectTypes,
 } from "../../project/types/project-types.ts";
 import { kMarkdownEngine } from "../../execute/types.ts";
+import { info } from "log/mod.ts";
+import { quartoConfig } from "../../core/quarto.ts";
 
 // ensures project types are registered
 import "../../project/types/register.ts";
@@ -132,6 +134,8 @@ export const createProjectCommand = new Command()
   )
   // deno-lint-ignore no-explicit-any
   .action(async (options: any, dir?: string) => {
+    info(`This is quarto ${quartoConfig.version()}.`);
+
     if (dir === undefined || dir === ".") {
       dir = Deno.cwd();
     }

--- a/src/command/create/cmd.ts
+++ b/src/command/create/cmd.ts
@@ -24,6 +24,7 @@ import {
 } from "cliffy/prompt/mod.ts";
 import { readLines } from "io/mod.ts";
 import { info } from "log/mod.ts";
+import { greet } from "../greet.ts";
 
 export interface CreateContext {
   cwd: string;
@@ -102,6 +103,7 @@ export const createCommand = new Command()
       type?: string,
       ...commands: string[]
     ) => {
+      greet();
       if (options.json) {
         await createFromStdin();
       } else {

--- a/src/command/greet.ts
+++ b/src/command/greet.ts
@@ -1,0 +1,8 @@
+import { quartoConfig } from "../core/quarto.ts";
+import { info } from "log/mod.ts";
+
+export function greet() {
+  info(
+    `Quarto v${quartoConfig.version()}`,
+  );
+}

--- a/src/command/install/cmd.ts
+++ b/src/command/install/cmd.ts
@@ -17,6 +17,7 @@ import {
 } from "../../tools/tools-console.ts";
 import { installTool } from "../../tools/tools.ts";
 import { resolveCompatibleArgs } from "../remove/cmd.ts";
+import { greet } from "../greet.ts";
 
 export const installCommand = new Command()
   .name("install")
@@ -57,6 +58,7 @@ export const installCommand = new Command()
       options: { prompt?: boolean; embed?: string; updatePath?: boolean },
       ...target: string[]
     ) => {
+      greet();
       await initYamlIntelligenceResourcesFromFilesystem();
       const temp = createTempContext();
 

--- a/src/command/list/cmd.ts
+++ b/src/command/list/cmd.ts
@@ -18,6 +18,7 @@ import {
 } from "../../extension/extension-shared.ts";
 import { projectContext } from "../../project/project-context.ts";
 import { outputTools } from "../../tools/tools-console.ts";
+import { greet } from "../greet.ts";
 
 export const listCommand = new Command()
   .hidden()
@@ -36,6 +37,7 @@ export const listCommand = new Command()
   )
   .action(
     async (_options: unknown, type: string) => {
+      greet();
       await initYamlIntelligenceResourcesFromFilesystem();
       const temp = createTempContext();
       const extensionContext = createExtensionContext();

--- a/src/command/preview/cmd.ts
+++ b/src/command/preview/cmd.ts
@@ -42,6 +42,7 @@ import { renderProject } from "../render/project.ts";
 import { renderServices } from "../render/render-shared.ts";
 import { parseFormatString } from "../../core/pandoc/pandoc-formats.ts";
 import { normalizePath } from "../../core/path.ts";
+import { greet } from "../greet.ts";
 export const previewCommand = new Command()
   .name("preview")
   .stopEarly()
@@ -126,6 +127,8 @@ export const previewCommand = new Command()
   )
   // deno-lint-ignore no-explicit-any
   .action(async (options: any, file?: string, ...args: string[]) => {
+    greet();
+
     // one-time initialization of yaml validation modules
     setInitializer(initYamlIntelligenceResourcesFromFilesystem);
     await initState();

--- a/src/command/publish/cmd.ts
+++ b/src/command/publish/cmd.ts
@@ -44,6 +44,7 @@ import { ProjectContext } from "../../project/types.ts";
 import { openUrl } from "../../core/shell.ts";
 import { publishDocument, publishSite } from "../../publish/publish.ts";
 import { handleUnauthorized } from "../../publish/account.ts";
+import { greet } from "../greet.ts";
 
 export const publishCommand =
   // deno-lint-ignore no-explicit-any
@@ -133,6 +134,8 @@ export const publishCommand =
         provider?: string,
         path?: string,
       ) => {
+        greet();
+
         // if provider is a path and no path is specified then swap
         if (provider && !path && existsSync(provider)) {
           path = provider;

--- a/src/command/render/cmd.ts
+++ b/src/command/render/cmd.ts
@@ -16,6 +16,7 @@ import { renderResultFinalOutput } from "./render.ts";
 import { render, renderServices } from "./render-shared.ts";
 import { RenderResult } from "./types.ts";
 import { kCliffyImplicitCwd } from "../../config/constants.ts";
+import { greet } from "../greet.ts";
 
 export const renderCommand = new Command()
   .name("render")
@@ -124,6 +125,8 @@ export const renderCommand = new Command()
   )
   // deno-lint-ignore no-explicit-any
   .action(async (options: any, input?: string, ...args: string[]) => {
+    greet();
+
     // remove implicit clean argument (re-injected based on what the user
     // actually passes in flags.ts)
     if (options === undefined) {

--- a/src/command/serve/cmd.ts
+++ b/src/command/serve/cmd.ts
@@ -11,6 +11,7 @@ import * as colors from "fmt/colors.ts";
 import { error } from "log/mod.ts";
 import { initYamlIntelligenceResourcesFromFilesystem } from "../../core/schema/utils.ts";
 import { projectContext } from "../../project/project-context.ts";
+import { greet } from "../greet.ts";
 
 import { serve } from "./serve.ts";
 
@@ -43,6 +44,8 @@ export const serveCommand = new Command()
   )
   // deno-lint-ignore no-explicit-any
   .action(async (options: any, input?: string) => {
+    greet();
+
     await initYamlIntelligenceResourcesFromFilesystem();
     if (!input) {
       error(

--- a/src/command/update/cmd.ts
+++ b/src/command/update/cmd.ts
@@ -16,6 +16,7 @@ import {
   updateOrInstallTool,
 } from "../../tools/tools-console.ts";
 import { resolveCompatibleArgs } from "../remove/cmd.ts";
+import { greet } from "../greet.ts";
 
 export const updateCommand = new Command()
   .hidden()
@@ -49,10 +50,10 @@ export const updateCommand = new Command()
     "quarto update tool tinytex",
   )
   // temporarily disabled until we get things in order in 1.28.*
-  // .example(
-  //   "Update Chromium",
-  //   "quarto update tool chromium",
-  // )
+  .example(
+    "Update Chromium",
+    "quarto update tool chromium",
+  )
   .example(
     "Choose tool to update",
     "quarto update tool",
@@ -62,6 +63,7 @@ export const updateCommand = new Command()
       options: { prompt?: boolean; embed?: string },
       ...target: string[]
     ) => {
+      greet();
       await initYamlIntelligenceResourcesFromFilesystem();
       const temp = createTempContext();
       try {

--- a/src/command/use/cmd.ts
+++ b/src/command/use/cmd.ts
@@ -5,6 +5,7 @@
 *
 */
 import { Command, ValidationError } from "cliffy/command/mod.ts";
+import { greet } from "../greet.ts";
 
 import { useTemplateCommand } from "./commands/template.ts";
 
@@ -20,6 +21,7 @@ export const useCommand = new Command()
     "Automate document or project setup tasks.",
   )
   .action((_options, type, _target) => {
+    greet();
     if (type !== useTemplateCommand.getName()) {
       throw new ValidationError(
         `Unknown type '${type}'- did you mean 'template'?`,


### PR DESCRIPTION
Adds a minimal version prompt:

```
$ quarto render
Quarto v99.9.9
[1/3] issue-3579.qmd
[2/3] index.qmd
[3/3] about.qmd
```

This closes #4567.