### PR TITLE
reveal: add slide-title-fit-text option

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -47,6 +47,7 @@
 - Authors on the title slides now correctly object customization of the `$presentation-title-slide-text-align` scss variable ([#3843](https://github.com/quarto-dev/quarto-cli/issues/3843))
 - Properly support `show-notes: separate-page` [#3996](https://github.com/quarto-dev/quarto-cli/issues/3996)
 - Improve footnote / aside layout for centered slides. [#4297](https://github.com/quarto-dev/quarto-cli/issues/4297)
+- Add `slide-title-fit-text` option (enabled by default) which automatically fits slide title text onto a single line
 
 ## Dates
 

--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -46,8 +46,10 @@
 - Properly support scss imports for RevealJS extensions ([#3414](https://github.com/quarto-dev/quarto-cli/issues/3414))
 - Authors on the title slides now correctly object customization of the `$presentation-title-slide-text-align` scss variable ([#3843](https://github.com/quarto-dev/quarto-cli/issues/3843))
 - Properly support `show-notes: separate-page` [#3996](https://github.com/quarto-dev/quarto-cli/issues/3996)
-- Improve footnote / aside layout for centered slides. [#4297](https://github.com/quarto-dev/quarto-cli/issues/4297)
 - Add `slide-title-fit-text` option (enabled by default) which automatically fits slide title text onto a single line
+- Properly support `show-notes: separate-page` ([#3996](https://github.com/quarto-dev/quarto-cli/issues/3996)).
+- Improve footnote / aside layout for centered slides ([#4297](https://github.com/quarto-dev/quarto-cli/issues/4297)).
+- Add `slide-title-fit-text` option (enabled by default) which automatically fits slide title text onto a single line ([#4530](https://github.com/quarto-dev/quarto-cli/issues/4530)).
 
 ## Dates
 

--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -46,8 +46,6 @@
 - Properly support scss imports for RevealJS extensions ([#3414](https://github.com/quarto-dev/quarto-cli/issues/3414))
 - Authors on the title slides now correctly object customization of the `$presentation-title-slide-text-align` scss variable ([#3843](https://github.com/quarto-dev/quarto-cli/issues/3843))
 - Properly support `show-notes: separate-page` [#3996](https://github.com/quarto-dev/quarto-cli/issues/3996)
-- Add `slide-title-fit-text` option (enabled by default) which automatically fits slide title text onto a single line
-- Properly support `show-notes: separate-page` ([#3996](https://github.com/quarto-dev/quarto-cli/issues/3996)).
 - Improve footnote / aside layout for centered slides ([#4297](https://github.com/quarto-dev/quarto-cli/issues/4297)).
 - Add `slide-title-fit-text` option (enabled by default) which automatically fits slide title text onto a single line ([#4530](https://github.com/quarto-dev/quarto-cli/issues/4530)).
 

--- a/src/format/reveal/constants.ts
+++ b/src/format/reveal/constants.ts
@@ -15,6 +15,7 @@ export const kScrollable = "scrollable";
 export const kSmaller = "smaller";
 export const kCenter = "center";
 export const kCenterTitleSlide = "center-title-slide";
+export const kSlideTitleFitText = "slide-title-fit-text";
 export const kControlsAuto = "controlsAuto";
 export const kPreviewLinksAuto = "previewLinksAuto";
 export const kPdfSeparateFragments = "pdfSeparateFragments";

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -65,6 +65,7 @@ import {
   kScrollable,
   kSlideFooter,
   kSlideLogo,
+  kSlideTitleFitText,
   kSmaller,
 } from "./constants.ts";
 import { revealMetadataFilter } from "./metadata.ts";
@@ -131,10 +132,14 @@ export function revealjsFormat() {
           metadataOverride.previewLinks = false;
         }
 
+        // title fit text (default to true)
+        const slideTitleFitText = format.metadata[kSlideTitleFitText] ?? true;
+
         // additional options not supported by pandoc
         const extraConfig: Record<string, unknown> = {
           [kControlsAuto]: controlsAuto,
           [kPreviewLinksAuto]: previewLinksAuto,
+          [kSlideTitleFitText]: slideTitleFitText,
           [kSmaller]: !!format.metadata[kSmaller],
           [kPdfSeparateFragments]: !!format.metadata[kPdfSeparateFragments],
           [kAutoAnimateEasing]: format.metadata[kAutoAnimateEasing] || "ease",
@@ -478,6 +483,20 @@ function revealHtmlPostprocessor(
     slideHeadings.forEach((slideHeading) => {
       const slideHeadingEl = slideHeading as Element;
       if (slideHeadingTags.includes(slideHeadingEl.tagName)) {
+        // add span with r-fit-text if requested
+        if (extraConfig[kSlideTitleFitText]) {
+          // don't add if the user has already done so
+          if (!slideHeadingEl.getElementsByClassName("r-fit-text").length) {
+            const span = doc.createElement("span");
+            span.classList.add("r-fit-text");
+            for (const childEl of slideHeadingEl.childNodes) {
+              span.appendChild(childEl.cloneNode(true));
+            }
+            slideHeadingEl.innerHTML = "";
+            slideHeadingEl.appendChild(span);
+          }
+        }
+
         // remove attributes
         for (const attrib of slideHeadingEl.getAttributeNames()) {
           slideHeadingEl.removeAttribute(attrib);

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -16683,6 +16683,17 @@ var require_yaml_intelligence_resources = __commonJS({
           description: "Contexts in which the slide number appears (`all`, `print`, or `speaker`)"
         },
         {
+          name: "slide-title-fit-text",
+          tags: {
+            formats: [
+              "revealjs"
+            ]
+          },
+          schema: "boolean",
+          default: true,
+          description: "Automatically fit the slide title text into a single line."
+        },
+        {
           name: "title-slide-attributes",
           schema: {
             object: {
@@ -21005,7 +21016,8 @@ var require_yaml_intelligence_resources = __commonJS({
           long: "Title of the volume of the item or container holding the item.\nAlso use for titles of periodical special issues, special sections,\nand the like."
         },
         "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
-        "internal-schema-hack"
+        "internal-schema-hack",
+        "Automatically fit the slide title text into a single line."
       ],
       "schema/external-schemas.yml": [
         {
@@ -21230,12 +21242,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 151724,
+        _internalId: 151726,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 151716,
+            _internalId: 151718,
             type: "enum",
             enum: [
               "png",
@@ -21251,7 +21263,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 151723,
+            _internalId: 151725,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -16684,6 +16684,17 @@ try {
             description: "Contexts in which the slide number appears (`all`, `print`, or `speaker`)"
           },
           {
+            name: "slide-title-fit-text",
+            tags: {
+              formats: [
+                "revealjs"
+              ]
+            },
+            schema: "boolean",
+            default: true,
+            description: "Automatically fit the slide title text into a single line."
+          },
+          {
             name: "title-slide-attributes",
             schema: {
               object: {
@@ -21006,7 +21017,8 @@ try {
             long: "Title of the volume of the item or container holding the item.\nAlso use for titles of periodical special issues, special sections,\nand the like."
           },
           "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
-          "internal-schema-hack"
+          "internal-schema-hack",
+          "Automatically fit the slide title text into a single line."
         ],
         "schema/external-schemas.yml": [
           {
@@ -21231,12 +21243,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 151724,
+          _internalId: 151726,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 151716,
+              _internalId: 151718,
               type: "enum",
               enum: [
                 "png",
@@ -21252,7 +21264,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 151723,
+              _internalId: 151725,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -9659,6 +9659,17 @@
       "description": "Contexts in which the slide number appears (`all`, `print`, or `speaker`)"
     },
     {
+      "name": "slide-title-fit-text",
+      "tags": {
+        "formats": [
+          "revealjs"
+        ]
+      },
+      "schema": "boolean",
+      "default": true,
+      "description": "Automatically fit the slide title text into a single line."
+    },
+    {
       "name": "title-slide-attributes",
       "schema": {
         "object": {
@@ -13981,7 +13992,8 @@
       "long": "Title of the volume of the item or container holding the item.\nAlso use for titles of periodical special issues, special sections,\nand the like."
     },
     "Disambiguating year suffix in author-date styles (e.g.&nbsp;“a” in “Doe,\n1999a”).",
-    "internal-schema-hack"
+    "internal-schema-hack",
+    "Automatically fit the slide title text into a single line."
   ],
   "schema/external-schemas.yml": [
     {
@@ -14206,12 +14218,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 151724,
+    "_internalId": 151726,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 151716,
+        "_internalId": 151718,
         "type": "enum",
         "enum": [
           "png",
@@ -14227,7 +14239,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 151723,
+        "_internalId": 151725,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/schema/document-slides.yml
+++ b/src/resources/schema/document-slides.yml
@@ -59,6 +59,13 @@
   default: all
   description: "Contexts in which the slide number appears (`all`, `print`, or `speaker`)"
 
+- name: slide-title-fit-text
+  tags:
+    formats: [revealjs]
+  schema: boolean
+  default: true
+  description: "Automatically fit the slide title text into a single line."
+
 - name: title-slide-attributes
   schema:
     object:


### PR DESCRIPTION
As discussed in last week's team meeting, this option is enabled by default and automatically fits slide title text onto a single line using the `r-fit-text` class.


