### PR TITLE
Help rmarkdown find quarto bundled pandoc binary if none is found

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -11,6 +11,10 @@
 - Don't install SIGCHLD signal handler since it interferes with IJulia in Julia 1.8.4 and greater ([#2539](https://github.com/quarto-dev/quarto-cli/issues/2539)).
 - Resolve full path to QUARTO_PYTHON binary
 
+## Knitr engine
+
+- Help rmarkdown find pandoc binary bundled with Quarto if none is found ([#3688](https://github.com/quarto-dev/quarto-cli/issues/3688)).
+
 ## Code Annotation
 
 - Add support for annotation of code cells (executable or non-executable). You can read more about code annotation at [https://www.quarto.org/docs/prerelease/1.3.html](https://www.quarto.org/docs/prerelease/1.3.html).

--- a/src/resources/rmd/rmd.R
+++ b/src/resources/rmd/rmd.R
@@ -210,6 +210,17 @@ has_annotations <- function(input)  {
   hasAnnotations
 }
 
+if (!rmarkdown::pandoc_available(error = FALSE)) {
+  # When FALSE, this means no Pandoc is found by rmarkdown, not even on PATH
+  # In that case we configure rmarkdown to use Quarto bundled version
+  quarto_bin_path <- Sys.getenv("QUARTO_BIN_PATH", NA_character_)
+  # Checking env var to be safe, but should always set by Quarto
+  if (!is.na(quarto_bin_path)) {
+    pandoc_dir <- normalizePath(file.path(quarto_bin_path, "tools"))
+    rmarkdown::find_pandoc(dir = pandoc_dir)
+  }
+}
+
 # run main
 .main()
 


### PR DESCRIPTION
This should fix #3688

As a reminder the issue is: 

* Quarto has Pandoc bundled to use internally
* Some R code in `.qmd` may use **rmarkdown** to use Pandoc by checking `pandoc_available()` before using `pandoc_convert()` or else. This is the case of **htmlwidgets** in the #3688 issue. 
* RStudio IDE will do some configuration to tell **rmarkdown** to use the Quarto Pandoc binary. But outside of RStudio, running `quarto render` on the same `.qmd` won't work because there is no other Pandoc on the system, and **rmarkdown** doesn't know about Quarto one. 
  **rmarkdown** expect other tools  to set `RSTUDIO_PANDOC` env var to add to its search paths, or specify `dir = ` argument in `find_pandoc()` to cache a version to use for a session. 

## Current solution

This is a first proposal to make things work for as soon as 1.3 and target specifically **rmarkdown** setup as we use it directly. 

* It relies on using `QUARTO_BIN_PATH` which is exposed as `tools/` folder is not. 
* It uses directly the caching mechanism of **rmarkdown** to avoid setting `RSTUDIO_PANDOC` and add to env var of the users.

This should solve #3688 as this example now works (as Pandoc is found)

````markdown

---
title: Pandoc for rmarkdown
---

```{r}
rmarkdown::find_pandoc()
```
````

Not this will only works in `quarto render` and not for `quarto run my_script.R`. 

This was the quick solution I had in mind but it seems during our discussions that a more generic solution, possibly external to Quarto itself could be desired. 

## Other solutions

However, as discussed with @cscheid, the issue could be more generic, especially if we think of the python ecosystem. 

* Quarto has Pandoc but do not expose a path to it yet
* Some system may not have pandoc on PATH, so it would be clever to use the Quarto Pandoc from within a `.qmd` file...
* ... as `.qmd` can compute with code that would require Pandoc  (e.g [pypandoc]() which can be configure to use Pandoc specified at `PYPANDOC_PANDOC` if none is found on PATH). 

This means we could 
* either expose a new env var `QUARTO_TOOLS_PANDOC=$QUARTO_BIN_PATH/tools/pandoc.exe` so that other tools can access the information to configure their usage or search. 
* or simply document that a tool can use Pandoc in Quarto by retrieving `QUARTO_BIN_PATH` and  looking for `pandoc.exe` in `tools` subfolder. 


For the first case, I believe exposing such environment variable is done in the `quarto` command itselfs. Here is the place I identified based on other env var and would like confirmation 

* https://github.com/quarto-dev/quarto-cli/blob/main/package/scripts/common/quarto for running Quarto on Linux and Mac
* https://github.com/quarto-dev/quarto-cli/blob/main/package/launcher/src/main.rs so that the launcher quarto.exe exposes the env var
* https://github.com/quarto-dev/quarto-cli/blob/main/package/scripts/windows/quarto.cmd so that it works with dev Pandoc to on windows 


For the second case, this means we have nothing to do in Quarto itself but instead adapting **rmarkdown** and release a new version

Hopefully this helps make the right choice. 

cc @jjallaire @cscheid @dragonstyle 