### PR TITLE
Fixed typo -- "thumnail" now "thumbnail"

### DIFF
--- a/src/resources/projects/website/listing/item-default.ejs.md
+++ b/src/resources/projects/website/listing/item-default.ejs.md
@@ -27,7 +27,7 @@ print(`<div class="metadata-value listing-${field}">${listing.utilities.outputLi
 <div class="thumbnail">
 <a href="<%- item.path %>">
 <% if (item.image) { %>
-<%= listing.utilities.img(itemNumber, item.image, "thumnail-image", item['image-alt']) %>
+<%= listing.utilities.img(itemNumber, item.image, "thumbnail-image", item['image-alt']) %>
 <% } else { %>
 <%= listing.utilities.imgPlaceholder(itemNumber, item.outputHref) %>
 <% } %>


### PR DESCRIPTION
## Description

This is a quick fix of a typo. "thumnail-image" is now "thumbnail-image" 