### PR TITLE
Correctly handles htmlwidgets passed in inline R code 

### DIFF
--- a/src/resources/rmd/patch.R
+++ b/src/resources/rmd/patch.R
@@ -133,7 +133,14 @@ if (utils::packageVersion("knitr") >= "1.32.8") {
     } else if (inherits(x, "knit_asis")) {
       # delegate
       is_html_widget <- inherits(x, "knit_asis_htmlwidget")
-      x <- knitr:::sew.knit_asis(x, options, ...)
+      # knit_asis method checks on missing options which 
+      # it gets in knitr because UseMethod() is called in generic
+      # but here we pass our default empty list options
+      x <- if (missing(options)) {
+        knitr:::sew.knit_asis(x, ...)
+      } else {
+        knitr:::sew.knit_asis(x, options, ...)
+      }
 
       # if it's an html widget then it was already wrapped
       # by add_html_caption

--- a/tests/docs/smoke-all/2023/03/02/issue-4402.qmd
+++ b/tests/docs/smoke-all/2023/03/02/issue-4402.qmd
@@ -1,0 +1,28 @@
+---
+format: html
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ["#in-chunk div.datatables", "#inline div.datatables"]
+        - []
+---
+
+## In-chunk {#in-chunk}
+
+htmlwidgets should work in chunk 
+
+```{r dt}
+#| echo: false
+#| message: false
+carsDT <- DT::datatable(cars)
+carsDT
+```
+
+## Inline {#inline}
+
+and inline 
+
+`r carsDT`
+
+

--- a/tests/new-smoke-all-test.ps1
+++ b/tests/new-smoke-all-test.ps1
@@ -10,7 +10,7 @@ cd $smokeAllFolder
 
 function CheckCreateAndEnter([string]$folder) {
   If (-Not (Test-Path -Path $folder)) {
-    mkdir $folder
+    $null = mkdir $folder
   }
   cd $folder
 }

--- a/tests/renv.lock
+++ b/tests/renv.lock
@@ -702,9 +702,9 @@
       "RemoteUsername": "yihui",
       "RemoteRepo": "knitr",
       "RemoteRef": "master",
-      "RemoteSha": "78f1db5c32e59c85e06f9704ab7b22a459c2b945",
+      "RemoteSha": "db4eafb3e05939c6d8e558cf66665a4669ee0bbc",
       "RemoteHost": "api.github.com",
-      "Hash": "f83defa969149ac30ff836162d56e894",
+      "Hash": "9acfef646b3349e9853fdfb1181707ec",
       "Requirements": [
         "evaluate",
         "highr",


### PR DESCRIPTION
fix `sew.knit_asis()` behavior for inline R code

In Quarto we are not calling a generic with `UseMethod()`. We are replacing all functions in **knitr** and calling some methods directly as usual function. 

This creates a side effect with `knitr::sew.knit_asis()` which contains some checks on `missing(options)` (which corresponds to inline code I believe). This PR correctly call the function with missing options, if they are indeed missing. 

Also 

- Add tests
- require a dev version of knitr for our tests to pass (for yihui/knitr#2237)
- small tweaks in helper file


This fix #4402