### PR TITLE
Allow to set `comments.hypothesis.showHighlights = "whenSidebarOpen"`

### DIFF
--- a/src/resources/schema/definitions.yml
+++ b/src/resources/schema/definitions.yml
@@ -283,9 +283,9 @@
                     showHighlights:
                       anyOf:
                         - boolean
-                        - enum: ["always", "never"]
+                        - enum: ["always", "whenSidebarOpen", "never"]
                       default: "always"
-                      description: Controls whether the in-document highlights are shown by default (`always` or `never`)
+                      description: Controls whether the in-document highlights are shown by default (`always`, `whenSidebarOpen` or `never`)
                     theme:
                       enum: ["classic", "clean"]
                       default: classic


### PR DESCRIPTION
From hypothesis [official documentation](https://h.readthedocs.io/projects/client/en/latest/publishers/config.html#cmdoption-arg-showHighlights):

> `"whenSidebarOpen"` - Highlights are only shown when the sidebar is open.

I hereby release this contribution under public domain ([CC0](https://creativecommons.org/publicdomain/zero/1.0/)) (so I don't have to send you a CLA).

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md). 
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
