### PR TITLE
Lua: ensure we're using Custom-aware walkers everywhere

### DIFF
--- a/src/resources/filters/ast/customnodes.lua
+++ b/src/resources/filters/ast/customnodes.lua
@@ -17,7 +17,7 @@ function resolve_custom_node(node)
   end
 end
 
-function run_emulated_filter(doc, filter)
+function run_emulated_filter(doc, filter, top_level)
   local wrapped_filter = {}
   for k, v in pairs(filter) do
     wrapped_filter[k] = v
@@ -132,7 +132,7 @@ function run_emulated_filter(doc, filter)
   end
 
   local result = doc:walk(wrapped_filter)
-  if filter._filter_name ~= nil then
+  if top_level and filter._filter_name ~= nil then
     add_trace(result, filter._filter_name)
   end
   return result

--- a/src/resources/filters/ast/runemulation.lua
+++ b/src/resources/filters/ast/runemulation.lua
@@ -8,7 +8,7 @@ local function run_emulated_filter_chain(doc, filters, afterFilterPass)
   if tisarray(filters) then
     for i, v in ipairs(filters) do
       local function callback()
-        doc = run_emulated_filter(doc, v)
+        doc = run_emulated_filter(doc, v, true)
       end
       if v.scriptFile then
         _quarto.withScriptFile(v.scriptFile, callback)
@@ -20,7 +20,7 @@ local function run_emulated_filter_chain(doc, filters, afterFilterPass)
       end
     end
   elseif type(filters) == "table" then
-    doc = run_emulated_filter(doc, filters)
+    doc = run_emulated_filter(doc, filters, true)
     if afterFilterPass then
       afterFilterPass()
     end

--- a/src/resources/filters/common/refs.lua
+++ b/src/resources/filters/common/refs.lua
@@ -78,7 +78,7 @@ function hasSubRefs(divEl, type)
 
       end
     end
-    pandoc.walk_block(divEl, {
+    _quarto.ast.walk(divEl, {
       Div = checkForParent,
       Image = checkForParent
     })

--- a/src/resources/filters/common/tables.lua
+++ b/src/resources/filters/common/tables.lua
@@ -115,7 +115,7 @@ end
 
 function countTables(div)
   local tables = 0
-  pandoc.walk_block(div, {
+  _quarto.ast.walk(div, {
     Table = function(table)
       tables = tables + 1
     end,

--- a/src/resources/filters/common/wrapped-filter.lua
+++ b/src/resources/filters/common/wrapped-filter.lua
@@ -195,7 +195,7 @@ function filterSeq(filters)
         if filter.filter ~= nil then
           filter = filter.filter
         end
-        local r = run_emulated_filter(doc, filter)
+        local r = run_emulated_filter(doc, filter, true)
         if r ~= nil then
           doc = r
           result = r

--- a/src/resources/filters/crossref/format.lua
+++ b/src/resources/filters/crossref/format.lua
@@ -61,7 +61,7 @@ function refPrefix(type, upper)
   if upper then
     local el = pandoc.Plain(prefix)
     local firstStr = true
-    el = pandoc.walk_block(el, {
+    el = _quarto.ast.walk(el, {
       Str = function(str)
         if firstStr then
           local strText = pandoc.text.upper(pandoc.text.sub(str.text, 1, 1)) .. pandoc.text.sub(str.text, 2, -1)

--- a/src/resources/filters/crossref/preprocess.lua
+++ b/src/resources/filters/crossref/preprocess.lua
@@ -37,7 +37,7 @@ function crossrefPreprocess()
                 if isTableRef(el.attr.identifier) then
                   el.attr.classes:insert("tbl-parent")
                 end
-                el = pandoc.walk_block(el, walkRefs(el.attr.identifier))
+                el = _quarto.ast.walk(el, walkRefs(el.attr.identifier))
               end
             end
             return el
@@ -100,7 +100,7 @@ function crossrefPreprocess()
               el.content:insert(err)
             end
           end
-          doc.blocks[i] = pandoc.walk_block(el, walkRefs(parentId))
+          doc.blocks[i] = _quarto.ast.walk(el, walkRefs(parentId))
         end
       end
 

--- a/src/resources/filters/crossref/theorems.lua
+++ b/src/resources/filters/crossref/theorems.lua
@@ -8,7 +8,7 @@ function crossrefPreprocessTheorems()
     Div = function(el)
       local type = refType(el.attr.identifier)
       if types[type] ~= nil or proofType(el) ~= nil then
-        return pandoc.walk_block(el, {
+        return _quarto.ast.walk(el, {
           Header = function(el)
             el.classes:insert("unnumbered")
             return el

--- a/src/resources/filters/layout/cites.lua
+++ b/src/resources/filters/layout/cites.lua
@@ -7,7 +7,7 @@ function citesPreprocess()
     
     Note = function(note) 
       if _quarto.format.isLatexOutput() and marginCitations() then
-        return pandoc.walk_inline(note, {
+        return _quarto.ast.walk(note, {
           Inlines = walkUnresolvedCitations(function(citation, appendInline, appendAtEnd)
             appendAtEnd(citePlaceholderInline(citation))
           end)
@@ -21,7 +21,7 @@ function citesPreprocess()
         if hasMarginColumn(figure) or hasMarginCaption(figure) then
           -- This is a figure in the margin itself, we need to append citations at the end of the caption
           -- without any floating
-          para.content[1] = pandoc.walk_inline(figure, {
+          para.content[1] = _quarto.ast.walk(figure, {
               Inlines = walkUnresolvedCitations(function(citation, appendInline, appendAtEnd)
                 appendAtEnd(citePlaceholderInlineWithProtection(citation))
               end)
@@ -30,7 +30,7 @@ function citesPreprocess()
         elseif marginCitations() then
           -- This is a figure is in the body, but the citation should be in the margin. Use 
           -- protection to shift any citations over
-          para.content[1] = pandoc.walk_inline(figure, {
+          para.content[1] = _quarto.ast.walk(figure, {
             Inlines = walkUnresolvedCitations(function(citation, appendInline, appendAtEnd)
               appendInline(marginCitePlaceholderWithProtection(citation))
             end)
@@ -56,7 +56,7 @@ function citesPreprocess()
             end
           end  
         else
-          return pandoc.walk_block(div, {
+          return _quarto.ast.walk(div, {
             Inlines = walkUnresolvedCitations(function(citation, appendInline, appendAtEnd)
               if hasMarginColumn(div) then
                 appendAtEnd(citePlaceholderInline(citation))

--- a/src/resources/filters/layout/jats.lua
+++ b/src/resources/filters/layout/jats.lua
@@ -5,7 +5,7 @@
 function jatsDivFigure(divEl)
 
   -- ensure that only valid elements are permitted
-  local filteredEl = pandoc.walk_block(divEl, {
+  local filteredEl = _quarto.ast.walk(divEl, {
     Header = function(el)
       return pandoc.Strong(el.content)
     end

--- a/src/resources/filters/layout/latex.lua
+++ b/src/resources/filters/layout/latex.lua
@@ -462,7 +462,7 @@ function latexCell(cell, vAlign, endOfRow, endOfTable)
   -- ensure that pandoc doesn't write any nested figures
   for i,block in ipairs(content) do
     latexHandsoffFigure(block)
-    content[i] = pandoc.walk_block(block, {
+    content[i] = _quarto.ast.walk(block, {
       Para = latexHandsoffFigure
     })
   end
@@ -565,7 +565,7 @@ function latexHandsoffFigure(el)
 end
 
 function latexRemoveTableDelims(el)
-  return pandoc.walk_block(el, {
+  return _quarto.ast.walk(el, {
     RawBlock = function(el)
       if _quarto.format.isRawLatex(el) then
         el.text = el.text:gsub("\\begin{table}[^\n]*\n", "")

--- a/src/resources/filters/normalize/pandoc3.lua
+++ b/src/resources/filters/normalize/pandoc3.lua
@@ -5,7 +5,7 @@ function parse_pandoc3_figures()
   local walk_recurse
   walk_recurse = function(constructor)
     local drop_figure_treatment = function(el)
-      return el:walk(walk_recurse(pandoc.Plain))
+      return _quarto.ast.walk(el, walk_recurse(pandoc.Plain))
     end
     return {
       traverse = "topdown",
@@ -46,7 +46,7 @@ function parse_pandoc3_figures()
 
   return {
     Pandoc = function(doc)
-      local result = doc:walk(walk_recurse(pandoc.Para))
+      local result = _quarto.ast.walk(doc, walk_recurse(pandoc.Para))
       return result
     end
   }

--- a/src/resources/filters/normalize/parsehtml.lua
+++ b/src/resources/filters/normalize/parsehtml.lua
@@ -55,7 +55,7 @@ function parse_html_tables()
           tableHtml = preprocess_table_text(tableHtml)
           local tableDoc = pandoc.read(tableHtml, "html")
           local skip = false
-          tableDoc:walk({
+          _quarto.ast.walk(tableDoc, {
             Table = function(table)
               if table.attributes[kDisableProcessing] ~= nil then
                 skip = true
@@ -72,7 +72,7 @@ function parse_html_tables()
             -- need it. We keep it here for symmetry with
             -- the after_table clause.
             local block = pandoc.RawBlock(el.format, before_table)
-            local result = block:walk(filter)
+            local result = _quarto.ast.walk(block, filter)
             if type(result) == "table" then
               blocks:extend(result)
             else
@@ -82,7 +82,7 @@ function parse_html_tables()
           blocks:extend(tableDoc.blocks)
           if after_table ~= "" then
             local block = pandoc.RawBlock(el.format, after_table)
-            local result = block:walk(filter)
+            local result = _quarto.ast.walk(block, filter)
             if type(result) == "table" then
               blocks:extend(result)
             else

--- a/src/resources/filters/quarto-post/book.lua
+++ b/src/resources/filters/quarto-post/book.lua
@@ -3,6 +3,8 @@
 
 --- Removes notes and links
 local function clean (inlines)
+  -- this is in post, so it's after render, so we don't need to worry about
+  -- custom ast nodes
   return inlines:walk {
     Note = function (_) return {} end,
     Link = function (link) return link.content end,

--- a/src/resources/filters/quarto-post/delink.lua
+++ b/src/resources/filters/quarto-post/delink.lua
@@ -17,6 +17,8 @@ function delink()
         end
 
         -- find links and transform them to spans
+        -- this is in post, so it's after render, so we don't need to worry about
+        -- custom ast nodes
         return pandoc.walk_block(div, {
           Link = function(link)
             return pandoc.Span(link.content)

--- a/src/resources/filters/quarto-pre/callout.lua
+++ b/src/resources/filters/quarto-pre/callout.lua
@@ -214,10 +214,10 @@ end
 -- whose output is a table
 function isCodeCellTable(el) 
   local isTable = false
-  pandoc.walk_block(el, {
+  _quarto.ast.walk(el, {
     Div = function(div)
       if div.attr.classes:find_if(isCodeCellDisplay) then
-        pandoc.walk_block(div, {
+        _quarto.ast.walk(div, {
           Table = function(tbl)
             isTable = true
           end
@@ -230,7 +230,7 @@ end
 
 function isCodeCellFigure(el)
   local isFigure = false
-  pandoc.walk_block(el, {
+  _quarto.ast.walk(el, {
     Div = function(div)
       if div.attr.classes:find_if(isCodeCellDisplay) then
         if (isFigureDiv(div)) then

--- a/src/resources/filters/quarto-pre/table-captions.lua
+++ b/src/resources/filters/quarto-pre/table-captions.lua
@@ -40,7 +40,7 @@ function tableCaptions()
               -- special case: knitr::kable will generate a \begin{tablular} without
               -- a \begin{table} wrapper -- put the wrapper in here if need be
               if _quarto.format.isLatexOutput() then
-                el = pandoc.walk_block(el, {
+                el = _quarto.ast.walk(el, {
                   RawBlock = function(raw)
                     if _quarto.format.isRawLatex(raw) then
                       if raw.text:match(_quarto.patterns.latexTabularPattern) and not raw.text:match(_quarto.patterns.latexTablePattern) then
@@ -144,7 +144,7 @@ end
 
 function applyTableCaptions(el, tblCaptions, tblLabels)
   local idx = 1
-  return pandoc.walk_block(el, {
+  return _quarto.ast.walk(el, {
     Table = function(el)
       if idx <= #tblLabels then
         local cap = pandoc.Inlines({})

--- a/src/resources/filters/quarto-pre/table-colwidth.lua
+++ b/src/resources/filters/quarto-pre/table-colwidth.lua
@@ -26,7 +26,7 @@ local function tblColwidthValues(tbl, tblColwidths)
   -- take appropriate action
   if tblColwidths == "auto" then
     local foundLink = false
-    pandoc.walk_block(tbl, {
+    _quarto.ast.walk(tbl, {
       Link = function(el)
         foundLink = true
       end
@@ -89,7 +89,7 @@ function tableColwidthCell()
         local tblColwidths = el.attr.attributes[kTblColwidths]
         el.attr.attributes[kTblColwidths] = nil
         if tblColwidths ~= nil then
-          return pandoc.walk_block(el, {
+          return _quarto.ast.walk(el, {
             Table = function(tbl)
               tbl.attr.attributes[kTblColwidths] = tblColwidths
               return tbl

--- a/tests/docs/smoke-all/2023/03/03/issue-4621.qmd
+++ b/tests/docs/smoke-all/2023/03/03/issue-4621.qmd
@@ -1,0 +1,22 @@
+---
+title: "Crossref bug"
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - ["Figure\\&nbsp;1"]
+---
+
+:::{.callout-note}
+
+```{r}
+#| label: fig-div-plot
+#| fig-cap: my plot!
+plot(1:10, 1:10)
+```
+
+Check out @fig-div-plot
+
+:::
+
+Check out @fig-div-plot


### PR DESCRIPTION
In our code we should make sure to use `_quarto.ast.walk` instead of `pandoc.walk_block`, etc. The former will "reach into" Custom AST nodes and process them correctly; the latter stops at `RawInline` blocks. This is unfortunate but an unavoidable consequence of our custom AST node design.

This PR replaces all `:walk()`, `walk_block`, etc. calls in the quarto-pre chain (where custom AST nodes appear) with `_quarto.ast.walk`, and fixes code that breaks because of that change.

This closes #4621.

We should probably add a warning to walk_block etc in our Lua-types declarations to avoid future problems. They're not exactly deprecated, but they are likely to be the wrong call...