### PR TITLE
Add check for R package version requirement

### DIFF
--- a/src/command/check/check.ts
+++ b/src/command/check/check.ts
@@ -231,7 +231,7 @@ async function checkKnitrInstallation(services: RenderServices) {
     completeMessage(kMessage + "OK");
     info(knitrCapabilitiesMessage(caps, kIndent));
     info("");
-    if (caps.rmarkdown) {
+    if (caps.packages.rmarkdown && caps.packages.knitrVersOk) {
       const kKnitrMessage = "Checking Knitr engine render......";
       await withSpinner({
         message: kKnitrMessage,
@@ -240,7 +240,15 @@ async function checkKnitrInstallation(services: RenderServices) {
         await checkKnitrRender(services);
       });
     } else {
-      info(knitrInstallationMessage(kIndent));
+      info(
+        knitrInstallationMessage(
+          kIndent,
+          caps.packages.knitr && !caps.packages.knitrVersOk
+            ? "knitr"
+            : "rmarkdown",
+          !!caps.packages.knitr && !caps.packages.knitrVersOk,
+        ),
+      );
       info("");
     }
   } else {

--- a/src/execute/rmd.ts
+++ b/src/execute/rmd.ts
@@ -272,17 +272,30 @@ function withinActiveRenv() {
 
 async function printCallRDiagnostics() {
   const caps = await knitrCapabilities();
-  if (caps && !caps.rmarkdown) {
-    info("");
-    info("R installation:");
-    info(knitrCapabilitiesMessage(caps, "  "));
-    info("");
-    info(knitrInstallationMessage());
-    info("");
-  } else if (!caps) {
+  if (!caps) {
     info("");
     info(rInstallationMessage());
     info("");
+  } else {
+    if (
+      !caps?.packages.rmarkdown || !caps?.packages.knitr ||
+      !caps?.packages.knitrVersOk
+    ) {
+      info("");
+      info("R installation:");
+      info(knitrCapabilitiesMessage(caps, "  "));
+      info("");
+      info(
+        knitrInstallationMessage(
+          "",
+          caps.packages.knitr && !caps?.packages.knitrVersOk
+            ? "knitr"
+            : "rmarkdown",
+          !!caps.packages.knitr && !caps.packages.knitrVersOk,
+        ),
+      );
+      info("");
+    }
   }
 }
 

--- a/src/resources/capabilities/knitr.R
+++ b/src/resources/capabilities/knitr.R
@@ -4,9 +4,18 @@ cat("versionMinor:", version$minor, "\n")
 cat("versionPatch:", version$patch, "\n")
 cat("home:", R.home(), "\n")
 cat("libPaths:\n")
-for (lib in .libPaths())
+for (lib in .libPaths()) {
   cat(paste0('  - ', shQuote(lib)), "\n")
-cat("rmarkdown: ")
+}
+cat("packages:\n")
+cat("  knitr: ")
+if (requireNamespace("knitr", quietly = TRUE)) {
+  cat(paste0('\"', as.character(utils::packageVersion("knitr")), '\"'))
+} else {
+  cat("null")
+}
+cat("\n")
+cat("  rmarkdown: ")
 if (requireNamespace("rmarkdown", quietly = TRUE)) {
   cat(paste0('\"', as.character(utils::packageVersion("rmarkdown")), '\"'))
 } else {

--- a/src/resources/rmd/rmd.R
+++ b/src/resources/rmd/rmd.R
@@ -217,7 +217,7 @@ if (!rmarkdown::pandoc_available(error = FALSE)) {
   # Checking env var to be safe, but should always set by Quarto
   if (!is.na(quarto_bin_path)) {
     pandoc_dir <- normalizePath(file.path(quarto_bin_path, "tools"))
-    rmarkdown::find_pandoc(dir = pandoc_dir)
+    invisible(rmarkdown::find_pandoc(dir = pandoc_dir))
   }
 }
 


### PR DESCRIPTION
This closes #2336

Not sure how to test that really but here is the output in local installation 

* No knitr (which means rmarkdown failure too) 

````
> quarto check knitr                                                                                                                                                                                                                                                                                                                                                                                                  (/) Checking R installation...........++ Activating rlang global_entrace

++ Setting QUARTO_PYTHON

[>] Checking R installation...........OK
      Version: 4.2.2
      Path: C:/PROGRA~1/R/R-42~1.2
      LibPaths:
        - C:/Users/chris/AppData/Local/R/win-library/4.2
        - C:/Program Files/R/R-4.2.2/library
      knitr: (None)
      rmarkdown: (None)

      The rmarkdown package is not available in this R installation.
      Install with install.packages("rmarkdown")
````

same when rendering a Rmd / qmd file with R 

````                                                                                                                                                                                                                 
Error in `loadNamespace()`:
! there is no package called 'rmarkdown'
Backtrace:
    ▆
 1. └─base::loadNamespace(x)
 2.   └─base::withRestarts(stop(cond), retry_loadNamespace = function() NULL)
 3.     └─base (local) withOneRestart(expr, restarts[[1L]])
 4.       └─base (local) doWithOneRestart(return(expr), restart)
Execution halted

R installation:
  Version: 4.2.2
  Path: C:/PROGRA~1/R/R-42~1.2
  LibPaths:
    - C:/Users/chris/AppData/Local/R/win-library/4.2
    - C:/Program Files/R/R-4.2.2/library
  knitr: (None)
  rmarkdown: (None)

The rmarkdown package is not available in this R installation.
Install with install.packages("rmarkdown")
````

* Knitr is not in the minimum required version 

````
> quarto check knitr                                                                                                                                                                                                                                                                                                                                                                                                  
(\) Checking R installation...........

[>] Checking R installation...........OK
      Version: 4.2.2
      Path: C:/PROGRA~1/R/R-42~1.2
      LibPaths:
        - C:/Users/chris/AppData/Local/R/win-library/4.2
        - C:/Program Files/R/R-4.2.2/library
      knitr: 1.28
      NOTE: knitr version 1.28 is too old. Please upgrade to 1.30 or later.
      rmarkdown: 2.20

      The knitr package is outdated in this R installation.
      Update with update.packages("knitr")
````

and `quarto render`

```
Error:
! 'hooks_markdown' is not an exported object from 'namespace:knitr'
Backtrace:
    ▆
 1. └─global .main()
 2.   └─execute(...)
 3.     └─knitr_options(format, resourceDir, handledLanguages)
 4.       └─knitr_hooks(format, resourceDir, handledLanguages)
Execution halted

R installation:
  Version: 4.2.2
  Path: C:/PROGRA~1/R/R-42~1.2
  LibPaths:
    - C:/Users/chris/AppData/Local/R/win-library/4.2
    - C:/Program Files/R/R-4.2.2/library
  knitr: 1.28
  NOTE: knitr version 1.28 is too old. Please upgrade to 1.30 or later.
  rmarkdown: 2.20

The knitr package is outdated in this R installation.
Update with update.packages("knitr")
````

* knitr and rmarkdown are ok 
````
> quarto check knitr                                                                                                                                                                                                                                                                                                                                                                                                  
(-) Checking R installation...........++ Activating rlang global_entrace

++ Setting QUARTO_PYTHON

[>] Checking R installation...........OK
      Version: 4.2.2
      Path: C:/PROGRA~1/R/R-42~1.2
      LibPaths:
        - C:/Users/chris/AppData/Local/R/win-library/4.2
        - C:/Program Files/R/R-4.2.2/library
      knitr: 1.42
      rmarkdown: 2.20

[>] Checking Knitr engine render......OK
````

Hopefully this is the right place and message are clear. 

If we have other requirement we can refactor more I think. 
