### PR TITLE
performance: index mismatched formats correctly

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -134,6 +134,7 @@
 - Render `page-footer` even when a Navbar isn't present ([#4053](https://github.com/quarto-dev/quarto-cli/issues/4053))
 - Don't treat links with no `href` as external when `link-external-icon` is enabled ([#3645](https://github.com/quarto-dev/quarto-cli/issues/3645))
 - Escape HTML from code cells that appears inline in search results ([#4404](https://github.com/quarto-dev/quarto-cli/issues/4404))
+- Use input last modified timestamp when updating sitemap ([#3251](https://github.com/quarto-dev/quarto-cli/issues/3251))
 - Add support for overriding the url used to report an issue with a website using `issue-url` (which can be provided even if there is no repo provided for the website).
 - Properly localize search button title and various toggle aria-labels ([#4559](https://github.com/quarto-dev/quarto-cli/issues/4559))
 - Support `navbar: true` to turn on a top navbar even if there are no contents

--- a/src/project/project-config.ts
+++ b/src/project/project-config.ts
@@ -99,7 +99,7 @@ export async function partitionedMarkdownForInput(
   input: string,
 ) {
   // first see if we can get the partioned markdown out of the index
-  const index = readInputTargetIndex(projectDir, input);
+  const { index } = readInputTargetIndex(projectDir, input);
   if (index) {
     return index.markdown;
     // otherwise fall back to calling the engine to do the partition

--- a/src/project/project-index.ts
+++ b/src/project/project-index.ts
@@ -236,10 +236,23 @@ export async function inputTargetIndexForOutputFile(
   project: ProjectContext,
   outputRelative: string,
 ) {
+  if (!project.inputTargetIndexCache) {
+    project.inputTargetIndexCache = new Map();
+  }
+  if (project.inputTargetIndexCache.has(outputRelative)) {
+    return project.inputTargetIndexCache.get(outputRelative);
+  }
+
   const input = await inputFileForOutputFile(project, outputRelative);
   if (input) {
-    return await inputTargetIndex(project, relative(project.dir, input));
+    const result = await inputTargetIndex(
+      project,
+      relative(project.dir, input),
+    );
+    project.inputTargetIndexCache.set(outputRelative, result);
+    return result;
   } else {
+    project.inputTargetIndexCache.set(outputRelative, undefined);
     return undefined;
   }
 }

--- a/src/project/types.ts
+++ b/src/project/types.ts
@@ -19,6 +19,7 @@ import {
   ProjectConfig as ProjectConfig_Project,
   ProjectPreview,
 } from "../resources/types/schema-types.ts";
+import { InputTargetIndex } from "./project-index.ts";
 export {
   type NavigationItem as NavItem,
   type NavigationItemObject,
@@ -44,6 +45,7 @@ export interface ProjectContext {
   engines: string[];
   files: ProjectFiles;
   config?: ProjectConfig;
+  inputTargetIndexCache?: Map<string, InputTargetIndex | undefined>;
   formatExtras?: (
     project: ProjectContext,
     source: string,

--- a/src/project/types.ts
+++ b/src/project/types.ts
@@ -45,7 +45,6 @@ export interface ProjectContext {
   engines: string[];
   files: ProjectFiles;
   config?: ProjectConfig;
-  inputTargetIndexCache?: Map<string, InputTargetIndex | undefined>;
   formatExtras?: (
     project: ProjectContext,
     source: string,


### PR DESCRIPTION
When resolving InputTargetIndex entries, we currently never cache entries whose formats fail to match the project formats.

In conjunction with the fact that we walk every entry in the project to resolve an input file name (a different perf fix for the future), means that we had a very bad perf situation in `inputFileForOutputFile`. This PR fixes the problem.

This cuts the rendering time of `quarto-web` by just under half on my machine, from 5:51 to 3:18.

This closes #4643.