### PR TITLE
Improve `include-after-body` documentation

### DIFF
--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -8531,12 +8531,13 @@ var require_yaml_intelligence_resources = __commonJS({
                                 {
                                   enum: [
                                     "always",
+                                    "whenSidebarOpen",
                                     "never"
                                   ]
                                 }
                               ],
                               default: "always",
-                              description: "Controls whether the in-document highlights are shown by default (`always` or `never`)"
+                              description: "Controls whether the in-document highlights are shown by default (`always`, `whenSidebarOpen` or `never`)"
                             },
                             theme: {
                               enum: [
@@ -13489,7 +13490,7 @@ var require_yaml_intelligence_resources = __commonJS({
               ]
             }
           },
-          description: 'Include contents at the beginning of the document body\n(e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command \nin LaTeX).\n\nA string value or an object with key "file" indicates a filename whose contents are to be included\n\nAn object with key "text" indicates textual content to be included\n'
+          description: 'Include contents at the beginning of the document body\n(e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command\nin LaTeX).\n\nA string value or an object with key "file" indicates a filename whose contents are to be included\n\nAn object with key "text" indicates textual content to be included\n'
         },
         {
           name: "include-after-body",
@@ -13508,7 +13509,7 @@ var require_yaml_intelligence_resources = __commonJS({
               ]
             }
           },
-          description: 'Include contents at the end of the document body (before\nthe `</body>` tag in HTML, or the `\\end{document}` command in LaTeX).\n\nA string value or an object with key "file" indicates a filename whose contents are to be included\n\nAn object with key "text" indicates textual content to be included\n'
+          description: 'Include content at the end of the document body immediately after the markdown content. While it will be included before the closing `</body>` tag in HTML and the `\\end{document}` command in LaTeX, this option refers to the end of the markdown content.\n\nA string value or an object with key "file" indicates a filename whose contents are to be included\n\nAn object with key "text" indicates textual content to be included\n'
         },
         {
           name: "include-in-header",
@@ -13527,7 +13528,7 @@ var require_yaml_intelligence_resources = __commonJS({
               ]
             }
           },
-          description: 'Include contents at the end of the header. This can\nbe used, for example, to include special CSS or JavaScript in HTML \ndocuments.\n\nA string value or an object with key "file" indicates a filename whose contents are to be included\n\nAn object with key "text" indicates textual content to be included\n'
+          description: 'Include contents at the end of the header. This can\nbe used, for example, to include special CSS or JavaScript in HTML\ndocuments.\n\nA string value or an object with key "file" indicates a filename whose contents are to be included\n\nAn object with key "text" indicates textual content to be included\n'
         },
         {
           name: "resources",
@@ -13553,7 +13554,7 @@ var require_yaml_intelligence_resources = __commonJS({
           },
           description: {
             short: "Text to be in a running header.",
-            long: "Text to be in a running header.\n\nProvide a single option or up to four options for different placements \n(odd page inner, odd page outer, even page innner, even page outer).\n"
+            long: "Text to be in a running header.\n\nProvide a single option or up to four options for different placements\n(odd page inner, odd page outer, even page innner, even page outer).\n"
           }
         },
         {
@@ -13568,7 +13569,7 @@ var require_yaml_intelligence_resources = __commonJS({
           },
           description: {
             short: "Text to be in a running footer.",
-            long: "Text to be in a running footer.\n\nProvide a single option or up to four options for different placements \n(odd page inner, odd page outer, even page innner, even page outer).\n\nSee [ConTeXt Headers and Footers](https://wiki.contextgarden.net/Headers_and_Footers) for more information.\n"
+            long: "Text to be in a running footer.\n\nProvide a single option or up to four options for different placements\n(odd page inner, odd page outer, even page innner, even page outer).\n\nSee [ConTeXt Headers and Footers](https://wiki.contextgarden.net/Headers_and_Footers) for more information.\n"
           }
         },
         {
@@ -13608,7 +13609,7 @@ var require_yaml_intelligence_resources = __commonJS({
           hidden: true,
           description: {
             short: "Include file with YAML metadata",
-            long: "Read metadata from the supplied YAML (or JSON) file. This\noption can be used with every input format, but string scalars\nin the YAML file will always be parsed as Markdown. Generally,\nthe input will be handled the same as in YAML metadata blocks.\nMetadata values specified inside the document, or by using `-M`, \noverwrite values specified with this option.\n"
+            long: "Read metadata from the supplied YAML (or JSON) file. This\noption can be used with every input format, but string scalars\nin the YAML file will always be parsed as Markdown. Generally,\nthe input will be handled the same as in YAML metadata blocks.\nMetadata values specified inside the document, or by using `-M`,\noverwrite values specified with this option.\n"
           }
         },
         {
@@ -13618,7 +13619,7 @@ var require_yaml_intelligence_resources = __commonJS({
           },
           description: {
             short: "Include files with YAML metadata",
-            long: "Read metadata from the supplied YAML (or JSON) files. This\noption can be used with every input format, but string scalars\nin the YAML file will always be parsed as Markdown. Generally,\nthe input will be handled the same as in YAML metadata blocks.\nValues in files specified later in the list will be preferred\nover those specified earlier. Metadata values specified inside \nthe document, or by using `-M`, overwrite values specified with\nthis option.\n"
+            long: "Read metadata from the supplied YAML (or JSON) files. This\noption can be used with every input format, but string scalars\nin the YAML file will always be parsed as Markdown. Generally,\nthe input will be handled the same as in YAML metadata blocks.\nValues in files specified later in the list will be preferred\nover those specified earlier. Metadata values specified inside\nthe document, or by using `-M`, overwrite values specified with\nthis option.\n"
           }
         }
       ],
@@ -18232,7 +18233,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "The giscus theme to use when displaying comments.",
         "The language that should be used when displaying the commenting\ninterface.",
         "Controls whether the sidebar opens automatically on startup.",
-        "Controls whether the in-document highlights are shown by default\n(<code>always</code> or <code>never</code>)",
+        "Controls whether the in-document highlights are shown by default\n(<code>always</code>, <code>whenSidebarOpen</code> or\n<code>never</code>)",
         "Controls the overall look of the sidebar (<code>classic</code> or\n<code>clean</code>)",
         "Controls whether the experimental New Note button should be shown in\nthe notes tab in the sidebar.",
         "Specify a URL to direct a user to, in a new tab. when they click on\nthe annotation author link in the header of an annotation.",
@@ -19843,7 +19844,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "Content to include at the beginning of the document body (e.g.&nbsp;after\nthe <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX).",
         "Content to include at the end of the document body (before the\n<code>&lt;/body&gt;</code> tag in HTML, or the\n<code>\\end{document}</code> command in LaTeX).",
         "Include contents at the beginning of the document body (e.g.&nbsp;after\nthe <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX).\nA string value or an object with key \u201Cfile\u201D indicates a filename\nwhose contents are to be included\nAn object with key \u201Ctext\u201D indicates textual content to be\nincluded",
-        "Include contents at the end of the document body (before the\n<code>&lt;/body&gt;</code> tag in HTML, or the\n<code>\\end{document}</code> command in LaTeX).\nA string value or an object with key \u201Cfile\u201D indicates a filename\nwhose contents are to be included\nAn object with key \u201Ctext\u201D indicates textual content to be\nincluded",
+        "Include content at the end of the document body, immediately after\nthe markdown content. While the content will be included before the\nclosing <code>&lt;/body&gt;</code> tag in HTML and the\n<code>\\end{document}</code> command in LaTeX, this option specifically\nrefers to the end of the content.\nA string value or an object with key \u201Cfile\u201D indicates a filename\nwhose contents are to be included\nAn object with key \u201Ctext\u201D indicates textual content to be\nincluded",
         "Include contents at the end of the header. This can be used, for\nexample, to include special CSS or JavaScript in HTML documents.\nA string value or an object with key \u201Cfile\u201D indicates a filename\nwhose contents are to be included\nAn object with key \u201Ctext\u201D indicates textual content to be\nincluded",
         "Path (or glob) to files to publish with this document.",
         {
@@ -21233,12 +21234,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 151733,
+        _internalId: 151732,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 151725,
+            _internalId: 151724,
             type: "enum",
             enum: [
               "png",
@@ -21254,7 +21255,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 151732,
+            _internalId: 151731,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -8532,12 +8532,13 @@ try {
                                   {
                                     enum: [
                                       "always",
+                                      "whenSidebarOpen",
                                       "never"
                                     ]
                                   }
                                 ],
                                 default: "always",
-                                description: "Controls whether the in-document highlights are shown by default (`always` or `never`)"
+                                description: "Controls whether the in-document highlights are shown by default (`always`, `whenSidebarOpen` or `never`)"
                               },
                               theme: {
                                 enum: [
@@ -13490,7 +13491,7 @@ try {
                 ]
               }
             },
-            description: 'Include contents at the beginning of the document body\n(e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command \nin LaTeX).\n\nA string value or an object with key "file" indicates a filename whose contents are to be included\n\nAn object with key "text" indicates textual content to be included\n'
+            description: 'Include contents at the beginning of the document body\n(e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command\nin LaTeX).\n\nA string value or an object with key "file" indicates a filename whose contents are to be included\n\nAn object with key "text" indicates textual content to be included\n'
           },
           {
             name: "include-after-body",
@@ -13509,7 +13510,7 @@ try {
                 ]
               }
             },
-            description: 'Include contents at the end of the document body (before\nthe `</body>` tag in HTML, or the `\\end{document}` command in LaTeX).\n\nA string value or an object with key "file" indicates a filename whose contents are to be included\n\nAn object with key "text" indicates textual content to be included\n'
+            description: 'Include content at the end of the document body immediately after the markdown content. While it will be included before the closing `</body>` tag in HTML and the `\\end{document}` command in LaTeX, this option refers to the end of the markdown content.\n\nA string value or an object with key "file" indicates a filename whose contents are to be included\n\nAn object with key "text" indicates textual content to be included\n'
           },
           {
             name: "include-in-header",
@@ -13528,7 +13529,7 @@ try {
                 ]
               }
             },
-            description: 'Include contents at the end of the header. This can\nbe used, for example, to include special CSS or JavaScript in HTML \ndocuments.\n\nA string value or an object with key "file" indicates a filename whose contents are to be included\n\nAn object with key "text" indicates textual content to be included\n'
+            description: 'Include contents at the end of the header. This can\nbe used, for example, to include special CSS or JavaScript in HTML\ndocuments.\n\nA string value or an object with key "file" indicates a filename whose contents are to be included\n\nAn object with key "text" indicates textual content to be included\n'
           },
           {
             name: "resources",
@@ -13554,7 +13555,7 @@ try {
             },
             description: {
               short: "Text to be in a running header.",
-              long: "Text to be in a running header.\n\nProvide a single option or up to four options for different placements \n(odd page inner, odd page outer, even page innner, even page outer).\n"
+              long: "Text to be in a running header.\n\nProvide a single option or up to four options for different placements\n(odd page inner, odd page outer, even page innner, even page outer).\n"
             }
           },
           {
@@ -13569,7 +13570,7 @@ try {
             },
             description: {
               short: "Text to be in a running footer.",
-              long: "Text to be in a running footer.\n\nProvide a single option or up to four options for different placements \n(odd page inner, odd page outer, even page innner, even page outer).\n\nSee [ConTeXt Headers and Footers](https://wiki.contextgarden.net/Headers_and_Footers) for more information.\n"
+              long: "Text to be in a running footer.\n\nProvide a single option or up to four options for different placements\n(odd page inner, odd page outer, even page innner, even page outer).\n\nSee [ConTeXt Headers and Footers](https://wiki.contextgarden.net/Headers_and_Footers) for more information.\n"
             }
           },
           {
@@ -13609,7 +13610,7 @@ try {
             hidden: true,
             description: {
               short: "Include file with YAML metadata",
-              long: "Read metadata from the supplied YAML (or JSON) file. This\noption can be used with every input format, but string scalars\nin the YAML file will always be parsed as Markdown. Generally,\nthe input will be handled the same as in YAML metadata blocks.\nMetadata values specified inside the document, or by using `-M`, \noverwrite values specified with this option.\n"
+              long: "Read metadata from the supplied YAML (or JSON) file. This\noption can be used with every input format, but string scalars\nin the YAML file will always be parsed as Markdown. Generally,\nthe input will be handled the same as in YAML metadata blocks.\nMetadata values specified inside the document, or by using `-M`,\noverwrite values specified with this option.\n"
             }
           },
           {
@@ -13619,7 +13620,7 @@ try {
             },
             description: {
               short: "Include files with YAML metadata",
-              long: "Read metadata from the supplied YAML (or JSON) files. This\noption can be used with every input format, but string scalars\nin the YAML file will always be parsed as Markdown. Generally,\nthe input will be handled the same as in YAML metadata blocks.\nValues in files specified later in the list will be preferred\nover those specified earlier. Metadata values specified inside \nthe document, or by using `-M`, overwrite values specified with\nthis option.\n"
+              long: "Read metadata from the supplied YAML (or JSON) files. This\noption can be used with every input format, but string scalars\nin the YAML file will always be parsed as Markdown. Generally,\nthe input will be handled the same as in YAML metadata blocks.\nValues in files specified later in the list will be preferred\nover those specified earlier. Metadata values specified inside\nthe document, or by using `-M`, overwrite values specified with\nthis option.\n"
             }
           }
         ],
@@ -18233,7 +18234,7 @@ try {
           "The giscus theme to use when displaying comments.",
           "The language that should be used when displaying the commenting\ninterface.",
           "Controls whether the sidebar opens automatically on startup.",
-          "Controls whether the in-document highlights are shown by default\n(<code>always</code> or <code>never</code>)",
+          "Controls whether the in-document highlights are shown by default\n(<code>always</code>, <code>whenSidebarOpen</code> or\n<code>never</code>)",
           "Controls the overall look of the sidebar (<code>classic</code> or\n<code>clean</code>)",
           "Controls whether the experimental New Note button should be shown in\nthe notes tab in the sidebar.",
           "Specify a URL to direct a user to, in a new tab. when they click on\nthe annotation author link in the header of an annotation.",
@@ -19844,7 +19845,7 @@ try {
           "Content to include at the beginning of the document body (e.g.&nbsp;after\nthe <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX).",
           "Content to include at the end of the document body (before the\n<code>&lt;/body&gt;</code> tag in HTML, or the\n<code>\\end{document}</code> command in LaTeX).",
           "Include contents at the beginning of the document body (e.g.&nbsp;after\nthe <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX).\nA string value or an object with key \u201Cfile\u201D indicates a filename\nwhose contents are to be included\nAn object with key \u201Ctext\u201D indicates textual content to be\nincluded",
-          "Include contents at the end of the document body (before the\n<code>&lt;/body&gt;</code> tag in HTML, or the\n<code>\\end{document}</code> command in LaTeX).\nA string value or an object with key \u201Cfile\u201D indicates a filename\nwhose contents are to be included\nAn object with key \u201Ctext\u201D indicates textual content to be\nincluded",
+          "Include content at the end of the document body, immediately after\nthe markdown content. While the content will be included before the\nclosing <code>&lt;/body&gt;</code> tag in HTML and the\n<code>\\end{document}</code> command in LaTeX, this option specifically\nrefers to the end of the content.\nA string value or an object with key \u201Cfile\u201D indicates a filename\nwhose contents are to be included\nAn object with key \u201Ctext\u201D indicates textual content to be\nincluded",
           "Include contents at the end of the header. This can be used, for\nexample, to include special CSS or JavaScript in HTML documents.\nA string value or an object with key \u201Cfile\u201D indicates a filename\nwhose contents are to be included\nAn object with key \u201Ctext\u201D indicates textual content to be\nincluded",
           "Path (or glob) to files to publish with this document.",
           {
@@ -21234,12 +21235,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 151733,
+          _internalId: 151732,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 151725,
+              _internalId: 151724,
               type: "enum",
               enum: [
                 "png",
@@ -21255,7 +21256,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 151732,
+              _internalId: 151731,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -1507,12 +1507,13 @@
                             {
                               "enum": [
                                 "always",
+                                "whenSidebarOpen",
                                 "never"
                               ]
                             }
                           ],
                           "default": "always",
-                          "description": "Controls whether the in-document highlights are shown by default (`always` or `never`)"
+                          "description": "Controls whether the in-document highlights are shown by default (`always`, `whenSidebarOpen` or `never`)"
                         },
                         "theme": {
                           "enum": [
@@ -6465,7 +6466,7 @@
           ]
         }
       },
-      "description": "Include contents at the beginning of the document body\n(e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command \nin LaTeX).\n\nA string value or an object with key \"file\" indicates a filename whose contents are to be included\n\nAn object with key \"text\" indicates textual content to be included\n"
+      "description": "Include contents at the beginning of the document body\n(e.g. after the `<body>` tag in HTML, or the `\\begin{document}` command\nin LaTeX).\n\nA string value or an object with key \"file\" indicates a filename whose contents are to be included\n\nAn object with key \"text\" indicates textual content to be included\n"
     },
     {
       "name": "include-after-body",
@@ -6484,7 +6485,7 @@
           ]
         }
       },
-      "description": "Include contents at the end of the document body (before\nthe `</body>` tag in HTML, or the `\\end{document}` command in LaTeX).\n\nA string value or an object with key \"file\" indicates a filename whose contents are to be included\n\nAn object with key \"text\" indicates textual content to be included\n"
+      "description": "Include content at the end of the document body immediately after the markdown content. While it will be included before the closing `</body>` tag in HTML and the `\\end{document}` command in LaTeX, this option refers to the end of the markdown content.\n\nA string value or an object with key \"file\" indicates a filename whose contents are to be included\n\nAn object with key \"text\" indicates textual content to be included\n"
     },
     {
       "name": "include-in-header",
@@ -6503,7 +6504,7 @@
           ]
         }
       },
-      "description": "Include contents at the end of the header. This can\nbe used, for example, to include special CSS or JavaScript in HTML \ndocuments.\n\nA string value or an object with key \"file\" indicates a filename whose contents are to be included\n\nAn object with key \"text\" indicates textual content to be included\n"
+      "description": "Include contents at the end of the header. This can\nbe used, for example, to include special CSS or JavaScript in HTML\ndocuments.\n\nA string value or an object with key \"file\" indicates a filename whose contents are to be included\n\nAn object with key \"text\" indicates textual content to be included\n"
     },
     {
       "name": "resources",
@@ -6529,7 +6530,7 @@
       },
       "description": {
         "short": "Text to be in a running header.",
-        "long": "Text to be in a running header.\n\nProvide a single option or up to four options for different placements \n(odd page inner, odd page outer, even page innner, even page outer).\n"
+        "long": "Text to be in a running header.\n\nProvide a single option or up to four options for different placements\n(odd page inner, odd page outer, even page innner, even page outer).\n"
       }
     },
     {
@@ -6544,7 +6545,7 @@
       },
       "description": {
         "short": "Text to be in a running footer.",
-        "long": "Text to be in a running footer.\n\nProvide a single option or up to four options for different placements \n(odd page inner, odd page outer, even page innner, even page outer).\n\nSee [ConTeXt Headers and Footers](https://wiki.contextgarden.net/Headers_and_Footers) for more information.\n"
+        "long": "Text to be in a running footer.\n\nProvide a single option or up to four options for different placements\n(odd page inner, odd page outer, even page innner, even page outer).\n\nSee [ConTeXt Headers and Footers](https://wiki.contextgarden.net/Headers_and_Footers) for more information.\n"
       }
     },
     {
@@ -6584,7 +6585,7 @@
       "hidden": true,
       "description": {
         "short": "Include file with YAML metadata",
-        "long": "Read metadata from the supplied YAML (or JSON) file. This\noption can be used with every input format, but string scalars\nin the YAML file will always be parsed as Markdown. Generally,\nthe input will be handled the same as in YAML metadata blocks.\nMetadata values specified inside the document, or by using `-M`, \noverwrite values specified with this option.\n"
+        "long": "Read metadata from the supplied YAML (or JSON) file. This\noption can be used with every input format, but string scalars\nin the YAML file will always be parsed as Markdown. Generally,\nthe input will be handled the same as in YAML metadata blocks.\nMetadata values specified inside the document, or by using `-M`,\noverwrite values specified with this option.\n"
       }
     },
     {
@@ -6594,7 +6595,7 @@
       },
       "description": {
         "short": "Include files with YAML metadata",
-        "long": "Read metadata from the supplied YAML (or JSON) files. This\noption can be used with every input format, but string scalars\nin the YAML file will always be parsed as Markdown. Generally,\nthe input will be handled the same as in YAML metadata blocks.\nValues in files specified later in the list will be preferred\nover those specified earlier. Metadata values specified inside \nthe document, or by using `-M`, overwrite values specified with\nthis option.\n"
+        "long": "Read metadata from the supplied YAML (or JSON) files. This\noption can be used with every input format, but string scalars\nin the YAML file will always be parsed as Markdown. Generally,\nthe input will be handled the same as in YAML metadata blocks.\nValues in files specified later in the list will be preferred\nover those specified earlier. Metadata values specified inside\nthe document, or by using `-M`, overwrite values specified with\nthis option.\n"
       }
     }
   ],
@@ -11208,7 +11209,7 @@
     "The giscus theme to use when displaying comments.",
     "The language that should be used when displaying the commenting\ninterface.",
     "Controls whether the sidebar opens automatically on startup.",
-    "Controls whether the in-document highlights are shown by default\n(<code>always</code> or <code>never</code>)",
+    "Controls whether the in-document highlights are shown by default\n(<code>always</code>, <code>whenSidebarOpen</code> or\n<code>never</code>)",
     "Controls the overall look of the sidebar (<code>classic</code> or\n<code>clean</code>)",
     "Controls whether the experimental New Note button should be shown in\nthe notes tab in the sidebar.",
     "Specify a URL to direct a user to, in a new tab. when they click on\nthe annotation author link in the header of an annotation.",
@@ -12819,7 +12820,7 @@
     "Content to include at the beginning of the document body (e.g.&nbsp;after\nthe <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX).",
     "Content to include at the end of the document body (before the\n<code>&lt;/body&gt;</code> tag in HTML, or the\n<code>\\end{document}</code> command in LaTeX).",
     "Include contents at the beginning of the document body (e.g.&nbsp;after\nthe <code>&lt;body&gt;</code> tag in HTML, or the\n<code>\\begin{document}</code> command in LaTeX).\nA string value or an object with key “file” indicates a filename\nwhose contents are to be included\nAn object with key “text” indicates textual content to be\nincluded",
-    "Include contents at the end of the document body (before the\n<code>&lt;/body&gt;</code> tag in HTML, or the\n<code>\\end{document}</code> command in LaTeX).\nA string value or an object with key “file” indicates a filename\nwhose contents are to be included\nAn object with key “text” indicates textual content to be\nincluded",
+    "Include content at the end of the document body, immediately after\nthe markdown content. While the content will be included before the\nclosing <code>&lt;/body&gt;</code> tag in HTML and the\n<code>\\end{document}</code> command in LaTeX, this option specifically\nrefers to the end of the content.\nA string value or an object with key “file” indicates a filename\nwhose contents are to be included\nAn object with key “text” indicates textual content to be\nincluded",
     "Include contents at the end of the header. This can be used, for\nexample, to include special CSS or JavaScript in HTML documents.\nA string value or an object with key “file” indicates a filename\nwhose contents are to be included\nAn object with key “text” indicates textual content to be\nincluded",
     "Path (or glob) to files to publish with this document.",
     {
@@ -14209,12 +14210,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 151733,
+    "_internalId": 151732,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 151725,
+        "_internalId": 151724,
         "type": "enum",
         "enum": [
           "png",
@@ -14230,7 +14231,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 151732,
+        "_internalId": 151731,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/schema/document-includes.yml
+++ b/src/resources/schema/document-includes.yml
@@ -28,7 +28,7 @@
         - ref: smart-include
   description: |
     Include contents at the beginning of the document body
-    (e.g. after the `<body>` tag in HTML, or the `\begin{document}` command 
+    (e.g. after the `<body>` tag in HTML, or the `\begin{document}` command
     in LaTeX).
 
     A string value or an object with key "file" indicates a filename whose contents are to be included
@@ -43,8 +43,7 @@
         - path
         - ref: smart-include
   description: |
-    Include contents at the end of the document body (before
-    the `</body>` tag in HTML, or the `\end{document}` command in LaTeX).
+    Include content at the end of the document body, immediately after the markdown content. While the content will be included before the closing `</body>` tag in HTML and the `\end{document}` command in LaTeX, this option specifically refers to the end of the content.
 
     A string value or an object with key "file" indicates a filename whose contents are to be included
 
@@ -59,7 +58,7 @@
         - ref: smart-include
   description: |
     Include contents at the end of the header. This can
-    be used, for example, to include special CSS or JavaScript in HTML 
+    be used, for example, to include special CSS or JavaScript in HTML
     documents.
 
     A string value or an object with key "file" indicates a filename whose contents are to be included
@@ -83,7 +82,7 @@
     long: |
       Text to be in a running header.
 
-      Provide a single option or up to four options for different placements 
+      Provide a single option or up to four options for different placements
       (odd page inner, odd page outer, even page innner, even page outer).
 
 - name: footertext
@@ -96,7 +95,7 @@
     long: |
       Text to be in a running footer.
 
-      Provide a single option or up to four options for different placements 
+      Provide a single option or up to four options for different placements
       (odd page inner, odd page outer, even page innner, even page outer).
 
       See [ConTeXt Headers and Footers](https://wiki.contextgarden.net/Headers_and_Footers) for more information.
@@ -130,7 +129,7 @@
       option can be used with every input format, but string scalars
       in the YAML file will always be parsed as Markdown. Generally,
       the input will be handled the same as in YAML metadata blocks.
-      Metadata values specified inside the document, or by using `-M`, 
+      Metadata values specified inside the document, or by using `-M`,
       overwrite values specified with this option.
 
 - name: metadata-files
@@ -144,6 +143,6 @@
       in the YAML file will always be parsed as Markdown. Generally,
       the input will be handled the same as in YAML metadata blocks.
       Values in files specified later in the list will be preferred
-      over those specified earlier. Metadata values specified inside 
+      over those specified earlier. Metadata values specified inside
       the document, or by using `-M`, overwrite values specified with
       this option.

--- a/src/resources/schema/document-includes.yml
+++ b/src/resources/schema/document-includes.yml
@@ -43,7 +43,7 @@
         - path
         - ref: smart-include
   description: |
-    Include content at the end of the document body, immediately after the markdown content. While the content will be included before the closing `</body>` tag in HTML and the `\end{document}` command in LaTeX, this option specifically refers to the end of the content.
+    Include content at the end of the document body immediately after the markdown content. While it will be included before the closing `</body>` tag in HTML and the `\end{document}` command in LaTeX, this option refers to the end of the markdown content.
 
     A string value or an object with key "file" indicates a filename whose contents are to be included
 

--- a/src/resources/types/schema-types.ts
+++ b/src/resources/types/schema-types.ts
@@ -171,8 +171,9 @@ should be shown in the notes tab in the sidebar. */;
       | boolean
       | (
         | "always"
+        | "whenSidebarOpen"
         | "never"
-      ) /* Controls whether the in-document highlights are shown by default (`always` or `never`) */;
+      ) /* Controls whether the in-document highlights are shown by default (`always`, `whenSidebarOpen` or `never`) */;
     services?: (
       {
         apiUrl: string /* The base URL of the service API. */;


### PR DESCRIPTION
## Description

This PR updates the documentation for `include-after-body` to better explain where this content will be placed. Closes #4631. See also #4628 for the motivation behind this change.

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog 

I didn't do the last. I assume you don't include doc changes to the changelog?
