### PR TITLE
code review: do not use nested, named function() declarations

### DIFF
--- a/src/resources/filters/ast/emulatedfilter.lua
+++ b/src/resources/filters/ast/emulatedfilter.lua
@@ -4,7 +4,7 @@
 -- Copyright (C) 2022 by RStudio, PBC
 
 local function plain_loader(handlers)
-  function wrapFilter(handler)
+  local function wrapFilter(handler)
     local wrappedFilter = {}
     wrappedFilter.scriptFile = handler.scriptFile
     for k, v in pairs(handler) do

--- a/src/resources/filters/ast/wrappedwriter.lua
+++ b/src/resources/filters/ast/wrappedwriter.lua
@@ -104,7 +104,7 @@ function wrapped_writer()
       end
     }
   
-    function handleBottomUpResult(v)
+    local function handleBottomUpResult(v)
       if type(v) == "string" then
         table.insert(resultingStrs, v)
       elseif type(v) == "userdata" then

--- a/src/resources/filters/common/meta.lua
+++ b/src/resources/filters/common/meta.lua
@@ -50,7 +50,7 @@ end
 
 function metaInjectLatex(meta, func)
   if _quarto.format.isLatexOutput() then
-    function inject(tex)
+    local function inject(tex)
       addInclude(meta, "tex", kHeaderIncludes, tex)
     end
     inject("\\makeatletter")
@@ -69,7 +69,7 @@ end
 
 function metaInjectRawLatex(meta, include, func)
   if _quarto.format.isLatexOutput() then
-    function inject(tex)
+    local function inject(tex)
       addInclude(meta, "tex", include, tex)
     end
     func(inject)
@@ -79,7 +79,7 @@ end
 
 function metaInjectHtml(meta, func)
   if _quarto.format.isHtmlOutput() then
-    function inject(html)
+    local function inject(html)
       addInclude(meta, "html", kHeaderIncludes, html)
     end
     func(inject)

--- a/src/resources/filters/common/refs.lua
+++ b/src/resources/filters/common/refs.lua
@@ -68,7 +68,7 @@ function hasSubRefs(divEl, type)
   if hasFigureOrTableRef(divEl) and not hasRefParent(divEl) then
     -- children w/ parent id
     local found = false
-    function checkForParent(el)
+    local function checkForParent(el)
       if not found then
         if hasRefParent(el) then
           if not type or (refType(el.attr.identifier) == type) then

--- a/src/resources/filters/common/timing.lua
+++ b/src/resources/filters/common/timing.lua
@@ -40,7 +40,7 @@ function capture_timings(filterList, trace)
       for key,func in pairs(v) do
         newFilter[key] = func
       end
-      function makeNewFilter(oldPandoc)
+      local function makeNewFilter(oldPandoc)
         return function (p)
           if oldPandoc ~= nil then
             local result = oldPandoc(p)

--- a/src/resources/filters/common/wrapped-filter.lua
+++ b/src/resources/filters/common/wrapped-filter.lua
@@ -113,7 +113,7 @@ function makeWrappedLuaFilter(scriptFile, filterHandler)
     local chunk, err = loadfile(scriptFile, "bt", env)
     local handlers = {}
   
-    function makeSingleHandler(handlerTable)
+    local function makeSingleHandler(handlerTable)
       local result = {}
       setmetatable(result, {
         __index = { scriptFile = scriptFile }

--- a/src/resources/filters/crossref/format.lua
+++ b/src/resources/filters/crossref/format.lua
@@ -129,7 +129,7 @@ function formatNumberOption(type, order, default)
   end
   
   -- return a pandoc.Str w/ chapter prefix (if any)
-  function resolve(num)
+  local function resolve(num)
     if section then
       local sectionIndex = section[1]
       if crossrefOption("chapters-alpha", false) then

--- a/src/resources/filters/crossref/tables.lua
+++ b/src/resources/filters/crossref/tables.lua
@@ -43,7 +43,7 @@ end
 
 function preprocessRawTableBlock(rawEl, parentId)
   
-  function divWrap(el, label, caption)
+  local function divWrap(el, label, caption)
     local div = pandoc.Div(el, pandoc.Attr(label))
     if parentId then
       div.attr.attributes[kRefParent] = parentId

--- a/src/resources/filters/layout/layout.lua
+++ b/src/resources/filters/layout/layout.lua
@@ -202,7 +202,7 @@ function layoutCells(divEl, cells)
     
     -- manage/perform next insertion into the layout
     local cellIndex = 1
-    function layoutNextCell(width)
+    local function layoutNextCell(width)
       -- check for a spacer width (negative percent)
       if isSpacerWidth(width) then
         local cell = pandoc.Div({

--- a/src/resources/filters/qmd-reader.lua
+++ b/src/resources/filters/qmd-reader.lua
@@ -37,7 +37,7 @@ function find_invalid_tags(str)
     "^[ \t\f\v]*(```+[ \t\f\v]*)(%{+[^.=\n\r]*%}+)", 
     "\n[ \t\f\v]*(```+[ \t\f\v]*)(%{+[^.=\n\r]+%}+)"
   }
-  function find_it(init)
+  local function find_it(init)
     for _, pattern in ipairs(patterns) do
       local range_start, range_end, ticks, tag = str:find(pattern, init)
       if range_start ~= nil then
@@ -119,7 +119,7 @@ function Reader (inputs, opts)
     format = "markdown",
     extensions = extensions,
   }
-  function restore_invalid_tags(tag)
+  local function restore_invalid_tags(tag)
     return tags[tag] or tag
   end
   local doc = pandoc.read(txt, flavor, opts):walk {

--- a/src/resources/filters/quarto-post/ojs.lua
+++ b/src/resources/filters/quarto-post/ojs.lua
@@ -6,12 +6,12 @@ function ojs()
   local uid = 0
   local cells = pandoc.List()
 
-  function uniqueId()
+  local function uniqueId()
     uid = uid + 1
     return "ojs-element-id-" .. uid
   end
 
-  function ojsInline(src)
+  local function ojsInline(src)
     local id = uniqueId()
     cells:insert({
         src = src,
@@ -21,21 +21,21 @@ function ojs()
     return pandoc.Span('', { id = id })
   end
 
-  function isInterpolationOpen(str)
+  local function isInterpolationOpen(str)
     if str.t ~= "Str" then
       return false
     end
     return str.text:find("${")
   end
 
-  function isInterpolationClose(str)
+  local function isInterpolationClose(str)
     if str.t ~= "Str" then
       return false
     end
     return str.text:find("}")
   end
 
-  function findArgIf(lst, fun, start)
+  local function findArgIf(lst, fun, start)
     if start == nil then
       start = 1
     end
@@ -48,18 +48,18 @@ function ojs()
     return nil
   end
 
-  function escapeSingle(str)
+  local function escapeSingle(str)
     local sub, _ = string.gsub(str, "'", "\\\\'")
     return sub
   end
 
-  function escapeDouble(str)
+  local function escapeDouble(str)
     local sub, _ = string.gsub(str, '"', '\\\\"')
     return sub
   end
 
-  function stringifyTokenInto(token, sequence)
-    function unknown()
+  local function stringifyTokenInto(token, sequence)
+    local function unknown()
       fail("Don't know how to handle token " .. token.t)
     end
     if     token.t == 'Cite' then
@@ -123,7 +123,7 @@ function ojs()
     end
   end
   
-  function stringifyTokens(sequence)
+  local function stringifyTokens(sequence)
     local result = pandoc.List()
     for i = 1, #sequence do
       stringifyTokenInto(sequence[i], result)
@@ -131,7 +131,7 @@ function ojs()
     return table.concat(result, "")
   end
 
-  function escape_quotes(str)
+  local function escape_quotes(str)
     local sub, _ = string.gsub(str, '\\', '\\\\')
     sub, _ = string.gsub(sub, '"', '\\"')
     sub, _ = string.gsub(sub, "'", "\\'")
@@ -139,7 +139,7 @@ function ojs()
     return sub
   end
   
-  function inlines_rec(inlines)
+  local function inlines_rec(inlines)
     -- FIXME I haven't tested this for nested interpolations
     local i = findArgIf(inlines, isInterpolationOpen)
     while i do

--- a/src/resources/filters/quarto-pre/panel-sidebar.lua
+++ b/src/resources/filters/quarto-pre/panel-sidebar.lua
@@ -7,25 +7,25 @@ function panelSidebar()
       if hasBootstrap() or _quarto.format.isRevealJsOutput() then
 
         -- functions to determine if an element has a layout class
-        function isSidebar(el)
+        local function isSidebar(el)
           return el ~= nil and el.t == "Div" and el.attr.classes:includes("panel-sidebar")
         end
-        function isContainer(el)
+        local function isContainer(el)
           return el ~= nil and
                  el.t == "Div" and 
                  (el.attr.classes:includes("panel-fill") or 
                   el.attr.classes:includes("panel-center") or
                   el.attr.classes:includes("panel-tabset"))
         end
-        function isHeader(el)
+        local function isHeader(el)
           return el ~= nil and el.t == "Header"
         end
-        function isQuartoHiddenDiv(el)
+        local function isQuartoHiddenDiv(el)
           return el ~= nil and el.t == "Div" and
                  string.find(el.attr.identifier, "^quarto%-") and
                  el.attr.classes:includes("hidden")
         end
-        function isNotQuartoHiddenDiv(el)
+        local function isNotQuartoHiddenDiv(el)
           return not isQuartoHiddenDiv(el)
         end
 

--- a/src/resources/filters/quarto-pre/shortcodes.lua
+++ b/src/resources/filters/quarto-pre/shortcodes.lua
@@ -186,7 +186,7 @@ function transformShortcodeInlines(inlines, noRawInlines)
   local shortcodeInlines = pandoc.List()
   local accum = outputInlines
 
-  function ensure_accum(i)
+  local function ensure_accum(i)
     if not transformed then
       transformed = true
       for j = 1,i - 1 do


### PR DESCRIPTION
Repeating what I shared on Slack:

Be very careful defining inner functions in Lua, and make sure they're locally scoped (`local function foo()` instead of `function foo()` )
If you do the latter, by accident, then the scope of that supposedly inner function is global, which means that all of the references that you thought would scope over the surrounding function are now global as well (this happens in particular for named parameters of the outer function).

I've done a full review of our codebase and replaced the named inner `function foo()` declarations with `local function foo()`.
