### PR TITLE
download extension as zip file from github when on Windows

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -216,7 +216,8 @@
 
 ## Other
 
-- fix error when running the command `quarto render -h` to receive help ([#3202](https://github.com/quarto-dev/quarto-cli/issues/3202)).
+- Fix error when running the command `quarto render -h` to receive help ([#3202](https://github.com/quarto-dev/quarto-cli/issues/3202)).
 - Fix error when rendering a document with an extension which provides a directory as `format-resources` ([#4377](https://github.com/quarto-dev/quarto-cli/issues/4377)).
 - Fix incorrect copying of resource files during rendering ([#4544](https://github.com/quarto-dev/quarto-cli/issues/4544))
 - Extension authors may now force files to be included in their template by writing the file / file path in the `.quartoignore` file prefixed with a `!`. For example `!README.md` ([#4061](https://github.com/quarto-dev/quarto-cli/issues/4061)).
+- Fix issue when installing extensions on older Windows ([#4203](https://github.com/quarto-dev/quarto-cli/issues/4203)).

--- a/src/command/use/commands/template.ts
+++ b/src/command/use/commands/template.ts
@@ -134,7 +134,7 @@ async function stageTemplate(
     // The filename
     const filename = (typeof (source.resolvedTarget) === "string"
       ? source.resolvedTarget
-      : source.resolvedTarget.url).split("/").pop() || "extension.zip";
+      : source.resolvedFile) || "extension.zip";
 
     // The tarball path
     const toFile = join(archiveDir, filename);

--- a/src/core/zip.ts
+++ b/src/core/zip.ts
@@ -5,6 +5,7 @@
 *
 */
 import { dirname } from "path/mod.ts";
+import { isWindows } from "./platform.ts";
 import { execProcess } from "./process.ts";
 import { safeWindowsExec } from "./windows.ts";
 
@@ -13,7 +14,7 @@ export function unzip(file: string) {
 
   if (file.endsWith("zip")) {
     // It's a zip file
-    if (Deno.build.os === "windows") {
+    if (isWindows()) {
       const args = [
         "-Command",
         `"& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('${file}', '${dir}'); }"`,

--- a/src/extension/extension-host.ts
+++ b/src/extension/extension-host.ts
@@ -12,6 +12,9 @@ export interface ResolvedExtensionInfo {
   // The url to the resolved extension
   url: string;
 
+  // The file part of the url resolved
+  urlFile?: string;
+
   // The Fetch Response from fetching that URL
   response: Promise<Response>;
 
@@ -30,6 +33,7 @@ export interface ExtensionSource {
   type: "remote" | "local";
   owner?: string;
   resolvedTarget: Response | string;
+  resolvedFile?: string;
   targetSubdir?: string;
   learnMoreUrl?: string;
 }
@@ -51,6 +55,7 @@ export async function extensionSource(
       return {
         type: "remote",
         resolvedTarget: response,
+        resolvedFile: resolved?.urlFile,
         owner: resolved?.owner,
         targetSubdir: resolved?.subdirectory,
         learnMoreUrl: resolved?.learnMoreUrl,
@@ -228,6 +233,7 @@ function makeResolvers(
       if (url) {
         return {
           url,
+          urlFile: url.split("/").pop(),
           response: fetch(url),
           owner: host.organization,
           subdirectory: urlProvider.archiveSubdir(host),

--- a/src/extension/extension-host.ts
+++ b/src/extension/extension-host.ts
@@ -6,6 +6,7 @@
 */
 
 import { existsSync } from "fs/mod.ts";
+import { isWindows } from "../core/platform.ts";
 
 export interface ResolvedExtensionInfo {
   // The url to the resolved extension
@@ -91,10 +92,12 @@ interface ExtensionUrlProvider {
   learnMoreUrl: (host: ExtensionHost) => string | undefined;
 }
 
+const archiveExt = isWindows() ? ".zip" : ".tar.gz";
+
 const githubLatestUrlProvider = {
   extensionUrl: (host: ExtensionHost) => {
     if (host.modifier === undefined || host.modifier === "latest") {
-      return `https://github.com/${host.organization}/${host.repo}/archive/refs/heads/main.tar.gz`;
+      return `https://github.com/${host.organization}/${host.repo}/archive/refs/heads/main${archiveExt}`;
     }
   },
   archiveSubdir: (host: ExtensionHost) => {
@@ -113,7 +116,7 @@ const githubLatestUrlProvider = {
 const githubTagUrlProvider = {
   extensionUrl: (host: ExtensionHost) => {
     if (host.modifier) {
-      return `https://github.com/${host.organization}/${host.repo}/archive/refs/tags/${host.modifier}.tar.gz`;
+      return `https://github.com/${host.organization}/${host.repo}/archive/refs/tags/${host.modifier}${archiveExt}`;
     }
   },
   archiveSubdir: (host: ExtensionHost) => {
@@ -132,7 +135,7 @@ const githubTagUrlProvider = {
 const githubBranchUrlProvider = {
   extensionUrl: (host: ExtensionHost) => {
     if (host.modifier) {
-      return `https://github.com/${host.organization}/${host.repo}/archive/refs/heads/${host.modifier}.tar.gz`;
+      return `https://github.com/${host.organization}/${host.repo}/archive/refs/heads/${host.modifier}${archiveExt}`;
     }
   },
   archiveSubdir: (host: ExtensionHost) => {

--- a/src/extension/install.ts
+++ b/src/extension/install.ts
@@ -178,7 +178,7 @@ async function stageExtension(
     // The filename
     const filename = (typeof (source.resolvedTarget) === "string"
       ? source.resolvedTarget
-      : source.resolvedTarget.url).split("/").pop() || "extension.zip";
+      : source.resolvedFile) || "extension.zip";
 
     // The tarball path
     const toFile = join(archiveDir, filename);


### PR DESCRIPTION
Fix #4203

Installing extension currently does not work on some windows system, because we are defaulting to `tar.gz` and the using `tar` to uncompress. If `tar.exe` can be found on some windows, it is not always the case, and some are only compatible with `zip` file. 

This PR 

* Download the zip version of archive from Github
* Add extension information to download filename because Github links resolved to one with extension and our `unzip()` mechanism rely on matching `.zip` to the file

````
> $res=Invoke-WebRequest -Method Get -Uri "https://github.com/quarto-ext/latex-environment/archive/refs/heads/main.zip" -MaximumRedirection 0 -ErrorAction SilentlyContinue -SkipHttpErrorCheck
> $res.Headers.Location
https://codeload.github.com/quarto-ext/latex-environment/zip/refs/heads/main
````

I tried to do it a more generic way in `makeResolver` to try guess extension based on `Content-Type` we can get from resolved response, but at the end, it was probably simpler like this PR. 

Feel free to suggest a more refactored way