### PR TITLE
Fix Pdf Export mode menu button and keyboard shortcut

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+src/resources/formats/revealjs/plugins/line-highlight/line-highlight.js
+src/resources/formats/revealjs/plugins/menu/menu.js
+src/resources/formats/revealjs/plugins/menu/quarto-menu.js
+src/resources/formats/revealjs/plugins/multiplex/multiplex.js
+src/resources/formats/revealjs/plugins/multiplex/socket.io.js
+src/resources/formats/revealjs/plugins/pdfexport/pdfexport.js
+src/resources/formats/revealjs/plugins/support/support.js
+src/resources/formats/revealjs/plugins/tone/tone.js

--- a/configuration
+++ b/configuration
@@ -27,7 +27,7 @@ export CLIPBOARD_JS=2.0.11
 export TIPPY_JS=6.3.7
 export PDF_JS=2.8.335
 # Using commit to fix https://github.com/quarto-dev/quarto-cli/issues/2430 - revert to using a release tag when included
-export REVEAL_JS=e281b3234e7991283ce4dcca705dd9a6a9ebe5d2 
+export REVEAL_JS=e281b3234e7991283ce4dcca705dd9a6a9ebe5d2
 export REVEAL_JS_MENU=2.1.0
 export REVEAL_JS_CHALKBOARD=a88c134e2cf3c7780448db003e7329c3cbd8cfb4
 export REVEAL_JS_PDFEXPORT=2.0.1

--- a/package/src/bld.ts
+++ b/package/src/bld.ts
@@ -10,7 +10,7 @@ import { configure } from "./common/configure.ts";
 import { mainRunner } from "../../src/core/main.ts";
 
 import { prepareDist } from "./common/prepare-dist.ts";
-import { updateHtmlDepedencies } from "./common/update-html-dependencies.ts";
+import { updateHtmlDependencies } from "./common/update-html-dependencies.ts";
 import { makeInstallerDeb } from "./linux/installer.ts";
 import { makeInstallerMac } from "./macos/installer.ts";
 import {
@@ -64,7 +64,7 @@ function getCommands() {
       ),
   );
   commands.push(
-    packageCommand(updateHtmlDepedencies)
+    packageCommand(updateHtmlDependencies)
       .name("update-html-dependencies")
       .description(
         "Updates Bootstrap, themes, and JS/CSS dependencies based upon the version in configuration",

--- a/package/src/common/patches/0001-Patch-PdfExport-RevealJS-plugin-to-export-toggle-fun.patch
+++ b/package/src/common/patches/0001-Patch-PdfExport-RevealJS-plugin-to-export-toggle-fun.patch
@@ -1,0 +1,27 @@
+From cdf668f9b164dca04eece54c88eaed4541211335 Mon Sep 17 00:00:00 2001
+From: Christophe Dervieux <christophe.dervieux@gmail.com>
+Date: Tue, 7 Mar 2023 16:12:53 +0100
+Subject: [PATCH] Patch PdfExport RevealJS plugin to export toggle function
+
+This will enable toggling PDF export mode using API
+---
+ src/resources/formats/revealjs/plugins/pdfexport/pdfexport.js | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/resources/formats/revealjs/plugins/pdfexport/pdfexport.js b/src/resources/formats/revealjs/plugins/pdfexport/pdfexport.js
+index c399fa9de..bf9104c8e 100644
+--- a/src/resources/formats/revealjs/plugins/pdfexport/pdfexport.js
++++ b/src/resources/formats/revealjs/plugins/pdfexport/pdfexport.js
+@@ -101,6 +101,9 @@ var PdfExport = ( function( _Reveal ){
+ 			Reveal = _Reveal;
+ 			install();
+ 		};
++		Plugin.togglePdfExport = function () {
++      togglePdfExport();
++    };
+ 	}
+ 
+ 	return Plugin;
+-- 
+2.39.2.windows.1
+

--- a/package/src/common/update-html-dependencies.ts
+++ b/package/src/common/update-html-dependencies.ts
@@ -806,7 +806,7 @@ async function updateGithubSourceCodeDependency(
   patches?: string[]
 ) {
   info(`Updating ${name}...`);
-  const version = Deno.env.get(versionEnvVar);
+  const version = Deno.env.get(versionEnvVar)?.trim();
   if (version) {
     const fileName = `${name}.zip`;
     const distUrl = join(

--- a/package/src/util/git.ts
+++ b/package/src/util/git.ts
@@ -1,5 +1,6 @@
 import { join } from "path/mod.ts";
 import { info } from "log/mod.ts";
+import * as colors from "fmt/colors.ts";
 
 export interface Repo {
   dir: string;
@@ -86,4 +87,27 @@ async function clone(workingDir: string, url: string) {
   } else {
     throw Error("No output from git clone");
   }
+}
+
+
+export async function applyGitPatches(patches: string[]) {
+  if (!patches) return undefined
+  info(`Applying Git patches...`);
+  Promise.all(
+    patches.map( async (patch) => {
+      info(`  - patch ${colors.blue(patch)}`)
+      const gitCmd: string[] = [];
+      gitCmd.push("git");
+      gitCmd.push("apply");
+      gitCmd.push(patch);
+      const p = Deno.run({
+        cmd: gitCmd,
+        stderr: "piped",
+      });
+      const status = await p.status();
+      if (status.code !== 0) {
+        throw Error("Failed to apply patch");
+      }
+    })
+  )
 }

--- a/src/format/reveal/format-reveal-plugin.ts
+++ b/src/format/reveal/format-reveal-plugin.ts
@@ -437,7 +437,7 @@ function revealMenuTools(format: Format) {
     {
       title: "PDF Export Mode",
       key: "e",
-      handler: "overview",
+      handler: "togglePdfExport",
     },
   ];
   if (format.metadata[kRevealChalkboard]) {

--- a/src/resources/formats/revealjs/plugins/menu/quarto-menu.js
+++ b/src/resources/formats/revealjs/plugins/menu/quarto-menu.js
@@ -37,4 +37,7 @@ window.RevealMenuToolHandlers = {
   downloadDrawings: revealMenuToolHandler(function () {
     RevealChalkboard.download();
   }),
+  togglePdfExport: revealMenuToolHandler(function () {
+    PdfExport.togglePdfExport();
+  }),
 };

--- a/src/resources/formats/revealjs/plugins/pdfexport/pdfexport.js
+++ b/src/resources/formats/revealjs/plugins/pdfexport/pdfexport.js
@@ -101,6 +101,9 @@ var PdfExport = ( function( _Reveal ){
 			Reveal = _Reveal;
 			install();
 		};
+		Plugin.togglePdfExport = function () {
+      togglePdfExport();
+    };
 	}
 
 	return Plugin;


### PR DESCRIPTION
This fix #2988

We patch RevealJS plugin PdfExport so that the toggle function is exported. This allow us to assign it as handler to our menu logic and keyboard shortcut. 

To make things clean, the patching of external library is done using a Git Patch, so I added support for that in update-html-dependencies logic. 

This PR also adds a prettier configuration file for ignoring some file from the VSCODE auto formatting as we don't want to touch those in our commit tree since they are external. 

A mixed PR but all related to the bug fix.