### PR TITLE
respect QUARTO_PANDOC in update-pandoc

### DIFF
--- a/news/changelog-1.2.md
+++ b/news/changelog-1.2.md
@@ -1,6 +1,9 @@
 ## New In This Patch Release
 
 - Fixes an issue using Quarto with the most recent version of jupyter_client (version 8.0.0 and later)
+- Fix QUARTO_PANDOC variable not being respected in update-pandoc process. This
+  would cause errors where pandoc is not bundled with Quarto, such as in the
+conda package.
 
 ## Fixed In Previous Patch Releases
 

--- a/package/src/common/update-pandoc.ts
+++ b/package/src/common/update-pandoc.ts
@@ -102,8 +102,10 @@ async function writePandocTemplates(config: Configuration) {
 }
 
 async function readTemplate(format: string, bin: string): Promise<string> {
+  const pandoc = Deno.env.get("QUARTO_PANDOC") ||
+    join(bin, "tools", "pandoc");
   const result = await execProcess({
-    cmd: [join(bin, "tools", "pandoc"), "--print-default-template", format],
+    cmd: [pandoc, "--print-default-template", format],
     stdout: "piped",
     stderr: "piped",
   });


### PR DESCRIPTION
## Description

This is a patch from the conda package. This particular code block does not respect QUARTO_PANDOC, and thus can fail when using pandoc other than the standard distribution. I am submitting this against 1.2.x because that's what the conda package builds right now. If you'd prefer it to be only on newer work, let me know. It's fine to remain a patch on the conda package for as long as needed.

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
