### PR TITLE
Fix typo for `column-screen-inset-right`

### DIFF
--- a/src/resources/editor/tools/attrs.yml
+++ b/src/resources/editor/tools/attrs.yml
@@ -100,7 +100,7 @@
       doc: Extend content to full width (with a small margin and shading)
     - value: ".column-screen-inset-left"
       doc: Extend content fully to the left (with a small margin)
-    - value: ".column-screen-inset-left"
+    - value: ".column-screen-inset-right"
       doc: Extend content fully to the right (with a small margin)
     - value: ".column-screen"
       doc: Extend content to full width


### PR DESCRIPTION
## Description

This fixes a typo in one of the VSCode autocomplete suggestions.

Fixes https://github.com/quarto-dev/quarto/issues/107