### PR TITLE
Fix no inspectable targets issue with Chrome Browser

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -200,6 +200,7 @@
 - Fix typo `thumnail-image` -> `thumbnail-image` in listing template ([#4602](//github.com/quarto-dev/quarto-cli/pull/4602)) (Thank you, @mattspence!).
 - Add support for targeting the `#refs` divs with citations when using `natbib` or `biblatex` to generate a bibliography.
 - Warn users about Chromium installation issues in WSL ([#4596](https://github.com/quarto-dev/quarto-cli/issues/4586)).
+- Fix issue with "No inspectable targets" with Chrome Browser ([#4653](https://github.com/quarto-dev/quarto-cli/issues/4653))
 - Add `title` attribute for callouts (can be used rather than heading for defining the title)
 
 ## Pandoc filter changes

--- a/src/core/cri/cri.ts
+++ b/src/core/cri/cri.ts
@@ -114,6 +114,7 @@ export async function criClient(appPath?: string, port?: number) {
       for (let i = 0; i < maxTries; ++i) {
         try {
           client = await cdp({ port });
+          break;
         } catch (e) {
           if (i === maxTries - 1) {
             throw e;


### PR DESCRIPTION
Fix #4653 

Issue is that somehow Chrome browser open in headless mode with no target available at `json/` endpoint. 

The logic to solve is to create a new tab if no target is already available. This way there will be a new target with websocket url to use. 

Another solution would be to default to `json/version` endpoint  (`devtools.Version(option)` from `devtools.js`)  to get the browser websocket url 

But it feels like the former is good enough and better as we prefer page type for the ws url, so I went with that. 

This PR will add to the `defaultTarget()` handler the creation of a new tab using `json/new` if no targets is to inspect. 
I wasn't sure where to put this here or not, we could also move it upper in the stack in `_fetchDebuggerURL()` directly, instead of only `defaultTarget()`. It would be more generic. 

This PR also fix an issue I found while working on it  - if `client` is created without error, no need to try `maxTries` (5) times 

Hope this is good. Not sure how to add tests for this quite specific fix. 

Tested locally and it works for me.
