### PR TITLE
Do not add output_div on plot in knitr hook when output asis  

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -17,6 +17,7 @@
 
 - Help rmarkdown find pandoc binary bundled with Quarto if none is found ([#3688](https://github.com/quarto-dev/quarto-cli/issues/3688)).
 - Do not bind knitr engine when only inline `r` expressions are found ([#3908](https://github.com/quarto-dev/quarto-cli/issues/3908)).
+- Fix an issue with `output: asis` in chunks with plots ([#3683](https://github.com/quarto-dev/quarto-cli/issue3683)).
 
 ## Code Annotation
 

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -586,7 +586,9 @@ knitr_plot_hook <- function(format) {
         md <- sprintf("[%s](%s)", md, link)
       }
       
-      # enclose in output div
+      # result = "asis" specific
+      if (identical(options[["results"]], "asis")) return(md)
+      # enclose in output div 
       output_div(md, NULL, classes)
     }
 

--- a/tests/docs/smoke-all/2023/03/08/issue-3683.qmd
+++ b/tests/docs/smoke-all/2023/03/08/issue-3683.qmd
@@ -1,0 +1,17 @@
+---
+title: plots and output = "asis"
+_quarto:
+  tests:
+    markdown:
+      ensureFileRegexMatches:
+        - [] 
+        - ["::: \\{\\.cell-output-display\\}"]
+---
+
+```{r plot}
+#| echo: false
+#| output: asis
+cat("## Title\n")
+cat("\n")
+plot(mtcars)
+```

--- a/tests/docs/smoke-all/2023/03/08/issue-3683.qmd
+++ b/tests/docs/smoke-all/2023/03/08/issue-3683.qmd
@@ -5,10 +5,14 @@ _quarto:
     markdown:
       ensureFileRegexMatches:
         - [] 
-        - ["::: \\{\\.cell-output-display\\}"]
+        - ["::: cell-output-display"]
+    pptx: 
+      ensurePptxRegexMatches:
+        - ["figure-pptx/unnamed-chunk-1-1\\.png"]
+        - 2
 ---
 
-```{r plot}
+```{r}
 #| echo: false
 #| output: asis
 cat("## Title\n")

--- a/tests/new-smoke-all-test.ps1
+++ b/tests/new-smoke-all-test.ps1
@@ -45,6 +45,10 @@ _quarto:
       ensureDocxRegexMatches:
         - []
         - []
+    pptx:
+      ensurePptxRegexMatches:
+        - []
+        - []
     asciidoc: default
 ---
 "@

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -18,6 +18,7 @@ import { parse } from "encoding/yaml.ts";
 import { cleanoutput } from "./render/render.ts";
 import {
   ensureDocxRegexMatches,
+  ensurePptxRegexMatches,
   ensureFileRegexMatches,
   ensureHtmlElements,
   fileExists,
@@ -86,6 +87,7 @@ function resolveTestSpecs(
     ensureHtmlElements,
     ensureFileRegexMatches,
     ensureDocxRegexMatches,
+    ensurePptxRegexMatches,
   };
 
   for (const [format, testObj] of Object.entries(specs)) {


### PR DESCRIPTION
When output asis is set, don't add output div to plot

Fix #3683

`.cell` output div is already not included when output asis, but this need to be done for the plot hook also.
Regaring powerpoint non-support for output div, `output.lua` will handle unwrapping the div from the `.cell`

This PR also adds some tests for PPTX content, and add a verify function for this. Quite simple for now as it handles only one slide. 
