### PR TITLE
Correctly handle revealjs title-slide when no id

### DIFF
--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -391,6 +391,8 @@ function revealHtmlPostprocessor(
       const titleSlide = doc.getElementById("title-slide");
       if (titleSlide) {
         titleSlide.removeAttribute("id");
+        // required for title-slide-style: pandoc
+        titleSlide.classList.add("quarto-title-block");
       }
     }
 
@@ -520,7 +522,9 @@ function revealHtmlPostprocessor(
     // doing this now the odds a user would want all of their
     // slides cnetered but NOT the title slide are close to zero
     if (format.metadata[kCenterTitleSlide] !== false) {
-      const titleSlide = doc.getElementById("title-slide") as Element;
+      const titleSlide = doc.getElementById("title-slide") as Element ??
+        // when hash-type: number, id are removed
+        doc.querySelector(".reveal .slides section.quarto-title-block");
       if (titleSlide) {
         titleSlide.classList.add("center");
       }

--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -203,12 +203,13 @@ section.has-dark-background {
   }
 }
 
-#title-slide {
+#title-slide,
+/* for when hash-type: number as identifier removed*/
+div.reveal div.slides section.quarto-title-block {
   text-align: $presentation-title-slide-text-align;
-}
-
-#title-slide .subtitle {
-  margin-bottom: 2.5rem;
+  .subtitle {
+    margin-bottom: 2.5rem;
+  }
 }
 
 .reveal .slides {

--- a/tests/docs/smoke-all/2023/03/08/revealjs-hash-number-pandoc-style.qmd
+++ b/tests/docs/smoke-all/2023/03/08/revealjs-hash-number-pandoc-style.qmd
@@ -1,0 +1,17 @@
+---
+title: Slide title
+format:
+  revealjs:
+    hash-type: number
+title-slide-style: pandoc
+_quarto:
+  tests:
+    revealjs:
+      ensureHtmlElements:
+        - ["div.reveal > div.slides > section.quarto-title-block" ]
+        - ["#title-slide"]
+---
+
+## slide 1
+
+Content

--- a/tests/docs/smoke-all/2023/03/08/revealjs-hash-number.qmd
+++ b/tests/docs/smoke-all/2023/03/08/revealjs-hash-number.qmd
@@ -1,0 +1,16 @@
+---
+title: Slide title
+format:
+  revealjs:
+    hash-type: number
+_quarto:
+  tests:
+    revealjs:
+      ensureHtmlElements:
+        - ["div.reveal > div.slides > section.quarto-title-block" ]
+        - ["#title-slide"]
+---
+
+## slide 1
+
+Content


### PR DESCRIPTION
Fix #4418

- when `hash-type: number`, `#title-slide` is removed, but our current rules targets the id only
- `.quarto-title-block` class is now target (which is added by new revealjs fancy title-slide)
- `title-slide-style: pandoc` will not add the class, so it is added when id is removed if not present

