### PR TITLE
Fix `embed` and `verbatim` knitr's engine for revealjs 

### DIFF
--- a/src/core/handlers/base.ts
+++ b/src/core/handlers/base.ts
@@ -279,8 +279,15 @@ function makeHandlerContext(
   return { context, results };
 }
 
+// return cell language handler only
 export function languages(): string[] {
-  return Object.keys(handlers);
+  const cellLanguage = [];
+  for (const [k, v] of Object.entries(handlers)) {
+    if (v.type === "cell") {
+      cellLanguage.push(k);
+    }
+  }
+  return cellLanguage;
 }
 
 export async function languageSchema(

--- a/src/resources/rmd/execute.R
+++ b/src/resources/rmd/execute.R
@@ -52,11 +52,6 @@ execute <- function(input, format, tempDir, libDir, dependencies, cwd, params, r
   })
 
   # pass through all languages handled by cell handlers in quarto
-  # but filter out those which should not replaced R knitr engines
-  ignoredHandlers <- c(
-    "embed" # only supported within Jupyter
-  )
-  handledLanguages <- setdiff(handledLanguages, ignoredHandlers)
   langs = lapply(
     setNames(handledLanguages, handledLanguages),
     function(lang) {
@@ -78,7 +73,7 @@ execute <- function(input, format, tempDir, libDir, dependencies, cwd, params, r
     do.call(options, r_options)
   }
 
-  # get knitr options
+  # get kntir options
   knitr <- knitr_options(format, resourceDir, handledLanguages)
 
   # fixup options for cache

--- a/src/resources/rmd/execute.R
+++ b/src/resources/rmd/execute.R
@@ -52,6 +52,11 @@ execute <- function(input, format, tempDir, libDir, dependencies, cwd, params, r
   })
 
   # pass through all languages handled by cell handlers in quarto
+  # but filter out those which should not replaced R knitr engines
+  ignoredHandlers <- c(
+    "embed" # only supported within Jupyter
+  )
+  handledLanguages <- setdiff(handledLanguages, ignoredHandlers)
   langs = lapply(
     setNames(handledLanguages, handledLanguages),
     function(lang) {
@@ -73,7 +78,7 @@ execute <- function(input, format, tempDir, libDir, dependencies, cwd, params, r
     do.call(options, r_options)
   }
 
-  # get kntir options
+  # get knitr options
   knitr <- knitr_options(format, resourceDir, handledLanguages)
 
   # fixup options for cache

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -44,6 +44,15 @@ knitr_hooks <- function(format, resourceDir, handledLanguages) {
         options[["results"]] <- "hold"
       }
     }
+    # handle specifically format which sets echo: false like revealjs
+    if (knitr::pandoc_to("revealjs", exact = TRUE)) {
+      # to adapt to true for engine that have no output
+      if (identical(options[["echo"]], FALSE) && 
+          options[["engine"]] %in% c("embed", "verbatim")
+      ) {
+        options[["echo"]] <- TRUE
+      }
+    }
     options
   }
 

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -171,9 +171,8 @@ knitr_hooks <- function(format, resourceDir, handledLanguages) {
       return(x)
     }
 
-    # verbatim and comment should do nothing
-    if (identical(options[["engine"]], "verbatim") ||
-        identical(options[["engine"]], "comment")) {
+    # verbatim-like and comment knitr's engine should do nothing
+    if (options[["engine"]] %in% c("verbatim", "embed", "comment")) {
       return(x)
     }
 

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -47,7 +47,7 @@ knitr_hooks <- function(format, resourceDir, handledLanguages) {
     # handle specifically format which sets echo: false like revealjs
     if (knitr::pandoc_to("revealjs", exact = TRUE)) {
       # to adapt to true for engine that have no output
-      if (identical(options[["echo"]], FALSE) && 
+      if (identical(options[["echo"]], FALSE) &&
           options[["engine"]] %in% c("embed", "verbatim")
       ) {
         options[["echo"]] <- TRUE

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -44,15 +44,11 @@ knitr_hooks <- function(format, resourceDir, handledLanguages) {
         options[["results"]] <- "hold"
       }
     }
-    # handle specifically format which sets echo: false like revealjs
-    if (knitr::pandoc_to("revealjs", exact = TRUE)) {
-      # to adapt to true for engine that have no output
-      if (identical(options[["echo"]], FALSE) &&
-          options[["engine"]] %in% c("embed", "verbatim")
-      ) {
-        options[["echo"]] <- TRUE
-      }
+    # for source-only engine, always set `echo: TRUE`
+    if (options[["engine"]] %in% c("embed", "verbatim")) {
+      options[["echo"]] <- TRUE
     }
+
     options
   }
 

--- a/tests/docs/smoke-all/2023/03/09/code.R
+++ b/tests/docs/smoke-all/2023/03/09/code.R
@@ -1,0 +1,1 @@
+cat("this is code.R\n")

--- a/tests/docs/smoke-all/2023/03/09/revealjs-knitr-embed-verbatim.qmd
+++ b/tests/docs/smoke-all/2023/03/09/revealjs-knitr-embed-verbatim.qmd
@@ -1,0 +1,28 @@
+---
+format: 
+  revealjs: default
+engine: knitr
+_quarto:
+  tests:
+    revealjs:
+      ensureHtmlElements:
+        - ["#verbatim div.sourceCode pre code", "#embed div.sourceCode pre code"]
+        - ["#verbatim div.cell", "#embed div.cell"]
+      ensureFileRegexMatches:
+        - ["this is code\\.R"]
+        - []
+---
+
+From issue : https://github.com/quarto-dev/quarto-cli/issues/4712
+
+## Verbatim {#verbatim}
+
+````{verbatim}
+Some content
+````
+
+## Embed {#embed}
+
+````{embed, file = "code.R"}
+````
+


### PR DESCRIPTION
General fix : With new `embed` feature in 1.3 for Jupyter, we need to make sure this does not override `embed` Knitr engine (cc @dragonstyle  as discussed)

Specific to revealjs: Set echo = TRUE for `embed` and `verbatim` engine when `revealjs` because those engine expect `echo` to be TRUE to be shown, but `revealjs` default to `FALSE`

This fix #4712

Note: our extension to include external file works fine - but it feels like those engines should still work correctly

By working on these R files, I think we can improve the handling of chunk hook, especially to treat those two engines as others (if we want to support `echo: fenced` for example. At first I did it in this PR, but then as this is some R refactoring more generic, I'll do it in another PR (#4735). We can then postpone to 1.4 if we think this is two much. 

