### PR TITLE
Set explicitly R working directory expected by Quarto scripts

### DIFF
--- a/src/execute/rmd.ts
+++ b/src/execute/rmd.ts
@@ -195,9 +195,9 @@ async function callR<T>(
   outputFilter?: (output: string) => string,
   reportError = true,
 ): Promise<T> {
-  // establish cwd for execute (the current dir if there is an renv
+  // establish cwd for our R scripts (the current dir if there is an renv
   // otherwise the project dir if specified)
-  const cwd = withinActiveRenv() ? undefined : projectDir ?? Deno.cwd();
+  const cwd = withinActiveRenv() ? Deno.cwd() : projectDir ?? Deno.cwd();
 
   // create a temp file for writing the results
   const resultsFile = Deno.makeTempFileSync(

--- a/src/execute/rmd.ts
+++ b/src/execute/rmd.ts
@@ -197,7 +197,7 @@ async function callR<T>(
 ): Promise<T> {
   // establish cwd for execute (the current dir if there is an renv
   // otherwise the project dir if specified)
-  const cwd = withinActiveRenv() ? undefined : projectDir;
+  const cwd = withinActiveRenv() ? undefined : projectDir ?? Deno.cwd();
 
   // create a temp file for writing the results
   const resultsFile = Deno.makeTempFileSync(
@@ -208,6 +208,7 @@ async function callR<T>(
     action,
     params,
     results: resultsFile,
+    wd: cwd,
   });
 
   try {

--- a/src/resources/rmd/rmd.R
+++ b/src/resources/rmd/rmd.R
@@ -137,6 +137,11 @@
   request <- jsonlite::parse_json(input, simplifyVector = TRUE)
   params <- request$params
 
+  # Ensuring expected working dir for Quarto
+  # R process workding may be changed by some workflows (in  ~/.Rprofile)
+  # https://github.com/quarto-dev/quarto-cli/issues/2646
+  setwd(request$wd) # no need to reset it as R process is closed by R
+
   # source in helper functions if we have a resourceDir
   if (!is.null(params$resourceDir)) {
     res_dir <- file.path(params$resourceDir, "rmd")


### PR DESCRIPTION
Some unexpected workflows (like using `setwd()` in `~/.Rprofile`) may change the R working directory to be different that the R process `cwd` set with `Deno.run()`

Fix #2646

Opening this PR to illustrate the change mentioned in #2646 comments. Now looking at how to add tests for this... 

