### PR TITLE
jupyter fixups: don't add newlines where they don't belong

### DIFF
--- a/src/core/jupyter/jupyter-fixups.ts
+++ b/src/core/jupyter/jupyter-fixups.ts
@@ -114,7 +114,7 @@ export function fixupFrontMatter(nb: JupyterNotebook): JupyterNotebook {
 
   // helper to create nb lines (w/ newline after)
   const nbLines = (lns: string[]) => {
-    return lns.map((line) => `${line}\n`);
+    return lns.map((line) => line.endsWith("\n") ? line : `${line}\n`);
   };
 
   // look for the first raw block that has a yaml object
@@ -137,7 +137,7 @@ export function fixupFrontMatter(nb: JupyterNotebook): JupyterNotebook {
   for (const cell of nb.cells) {
     if (cell.cell_type === "markdown") {
       const { lines, headingText } = markdownWithExtractedHeading(
-        cell.source.join("\n"),
+        nbLines(cell.source).join(""),
       );
       if (headingText) {
         title = headingText;


### PR DESCRIPTION
This closes #4750.

The repro case in the linked issue is useful, but the breakage being reported is much worse. Consider this:

````
---
keep-md: true
---

# header 1

Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod 
tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim 
veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex 
ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate 
velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id 
est laborum.

- item1
- item2
- item3a

```{python}
1 + 1
```
````

On main, we produce the following:


````
---
keep-md: true
title: header 1
---








Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod

tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim

veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex

ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate

velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat

cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id

est laborum.



- item1

- item2

- item3a


::: {.cell execution_count=1}
``` {.python .cell-code}
1 + 1
```

::: {.cell-output .cell-output-display execution_count=6}
```
2
```
:::
:::
````