### PR TITLE
don't read all the website DOMs at once. Closes #4350.

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -207,6 +207,7 @@
 - Fix issue with "No inspectable targets" with Chrome Browser ([#4653](https://github.com/quarto-dev/quarto-cli/issues/4653))
 - Add `title` attribute for callouts (can be used rather than heading for defining the title)
 - Handle more varieties of raw HTML for Docusaurus output
+- Read and process DOM one-file-at-time in books and websites to reduce total memory usage ([#4350](https://github.com/quarto-dev/quarto-cli/issues/4350)).
 
 ## Pandoc filter changes
 

--- a/src/core/deno-dom.ts
+++ b/src/core/deno-dom.ts
@@ -25,6 +25,20 @@ export async function parseHtml(src: string): Promise<HTMLDocument> {
   return result;
 }
 
+export async function writeDomToHtmlFile(
+  doc: HTMLDocument,
+  path: string,
+  doctype?: string,
+) {
+  if (doc.documentElement === null) {
+    throw new Error("Document has no root element");
+  }
+  const output = doctype
+    ? doctype + "\n" + doc.documentElement.outerHTML
+    : doc.documentElement.outerHTML;
+  await Deno.writeTextFile(path, output);
+}
+
 // We are combining a number of scripts from
 // https://github.com/b-fuze/deno-dom/blob/master/deno-dom-native.ts
 // into this. If deno-dom fails, it's likely that this needs to be brought up to date.

--- a/src/project/types/book/book-bibliography.ts
+++ b/src/project/types/book/book-bibliography.ts
@@ -208,7 +208,7 @@ export async function bookBibliographyPostRender(
           "html",
           csl,
         );
-        const doc = await parseHtml(refsOutputFile.file);
+        const doc = await parseHtml(Deno.readTextFileSync(refsOutputFile.file));
         const newRefsDiv = doc.createElement("div");
         newRefsDiv.innerHTML = biblioHtml;
         const refsDiv = doc.getElementById("refs") as Element;

--- a/src/project/types/book/book-crossrefs.ts
+++ b/src/project/types/book/book-crossrefs.ts
@@ -60,7 +60,7 @@ export async function bookCrossrefsPostRender(
       const index = bookCrossrefIndexForOutputFile(fileRelative, indexes);
       if (index) {
         // resolve crossrefs
-        const doc = await parseHtml(outputFile.file);
+        const doc = await parseHtml(Deno.readTextFileSync(outputFile.file));
         resolveCrossrefs(
           context,
           fileRelative,

--- a/src/project/types/book/book-crossrefs.ts
+++ b/src/project/types/book/book-crossrefs.ts
@@ -9,7 +9,12 @@ import { warning } from "log/mod.ts";
 import { dirname, join, relative } from "path/mod.ts";
 import { existsSync } from "fs/mod.ts";
 
-import { Element, HTMLDocument } from "../../../core/deno-dom.ts";
+import {
+  Element,
+  HTMLDocument,
+  parseHtml,
+  writeDomToHtmlFile,
+} from "../../../core/deno-dom.ts";
 
 import { pathWithForwardSlashes } from "../../../core/path.ts";
 
@@ -55,13 +60,15 @@ export async function bookCrossrefsPostRender(
       const index = bookCrossrefIndexForOutputFile(fileRelative, indexes);
       if (index) {
         // resolve crossrefs
+        const doc = await parseHtml(outputFile.file);
         resolveCrossrefs(
           context,
           fileRelative,
           outputFile.format,
-          outputFile.doc,
+          doc,
           index,
         );
+        writeDomToHtmlFile(doc, outputFile.file, outputFile.doctype);
       }
     }
   }

--- a/src/project/types/book/book-render.ts
+++ b/src/project/types/book/book-render.ts
@@ -604,13 +604,13 @@ export async function bookPostRender(
     await bookBibliographyPostRender(context, incremental, websiteFiles);
     await bookCrossrefsPostRender(context, websiteFiles);
 
-    // write website files
-    websiteFiles.forEach((websiteFile) => {
-      const doctype = websiteFile.doctype;
-      const htmlOutput = (doctype ? doctype + "\n" : "") +
-        websiteFile.doc.documentElement?.outerHTML!;
-      Deno.writeTextFileSync(websiteFile.file, htmlOutput);
-    });
+    // website files are now already written on a per-file basis
+    // websiteFiles.forEach((websiteFile) => {
+    //   const doctype = websiteFile.doctype;
+    //   const htmlOutput = (doctype ? doctype + "\n" : "") +
+    //     websiteFile.doc.documentElement?.outerHTML!;
+    //   Deno.writeTextFileSync(websiteFile.file, htmlOutput);
+    // });
 
     // run standard website stuff (search, etc.)
     await websitePostRender(context, incremental, outputFiles);

--- a/src/project/types/website/website.ts
+++ b/src/project/types/website/website.ts
@@ -319,7 +319,7 @@ export const websiteProjectType: ProjectType = {
 };
 
 export interface WebsiteProjectOutputFile extends ProjectOutputFile {
-  doc: HTMLDocument;
+  // doc: HTMLDocument;
   doctype?: string;
 }
 
@@ -358,10 +358,10 @@ export function websiteOutputFiles(outputFiles: ProjectOutputFile[]) {
     .map((outputFile) => {
       const contents = Deno.readTextFileSync(outputFile.file);
       const doctypeMatch = contents.match(/^<!DOCTYPE.*?>/);
-      const doc = new DOMParser().parseFromString(contents, "text/html")!;
+      // const doc = new DOMParser().parseFromString(contents, "text/html")!;
       return {
         ...outputFile,
-        doc,
+        // doc,
         doctype: doctypeMatch ? doctypeMatch[0] : undefined,
       };
     });


### PR DESCRIPTION
Instead of keeping all of the DOM documents in memory, we now process them one at a time.

This requires writing the partial results to disk, which will potentially make things slightly slower. But it should significantly reduce our total memory usage when building large websites.