### PR TITLE
Add support for `content-mode` in the grid system

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -513,6 +513,13 @@ export const kCrossrefChaptersAppendix = "chapters-appendix";
 export const kCrossrefChaptersAlpha = "chapters-alpha";
 export const kCrossrefChapterId = "chapter-id";
 
+export const kGrid = "grid";
+export const kContentMode = "content-mode";
+export const kAuto = "auto";
+export const kStandardContent = "standard";
+export const kFullContent = "full";
+export const kSlimContent = "slim";
+
 export const kFigResponsive = "fig-responsive";
 export const kOutputLocation = "output-location";
 

--- a/src/format/html/format-html-scss.ts
+++ b/src/format/html/format-html-scss.ts
@@ -22,7 +22,7 @@ import { outputVariable, SassVariable, sassVariable } from "../../core/sass.ts";
 
 import { Format, SassBundle, SassLayer } from "../../config/types.ts";
 import { Metadata } from "../../config/types.ts";
-import { kTheme } from "../../config/constants.ts";
+import { kGrid, kTheme } from "../../config/constants.ts";
 
 import {
   kPageFooter,
@@ -456,7 +456,7 @@ function pandocVariablesToThemeDefaults(
   });
 
   // Resolve any grid variables
-  const gridObj = metadata["grid"] as Metadata;
+  const gridObj = metadata[kGrid] as Metadata;
   if (gridObj) {
     add(explicitVars, "grid-sidebar-width", gridObj["sidebar-width"]);
     add(explicitVars, "grid-margin-width", gridObj["margin-width"]);

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -13917,6 +13917,15 @@ try {
               object: {
                 closed: true,
                 properties: {
+                  "content-mode": {
+                    enum: [
+                      "auto",
+                      "standard",
+                      "full",
+                      "slim"
+                    ],
+                    description: "Defines whether to use the standard, slim, or full content grid or to automatically select the most appropriate content grid."
+                  },
                   "sidebar-width": {
                     string: {
                       description: "The base width of the sidebar (left) column in an HTML page."
@@ -19260,10 +19269,6 @@ try {
           "Default profile to apply if QUARTO_PROFILE is not defined.",
           "Define a profile group for which at least one profile is always\nactive.",
           {
-            short: "Location of output relative to the code that generated it\n(<code>default</code>, <code>fragment</code>, <code>slide</code>,\n<code>column</code>, or <code>column-location</code>)",
-            long: "Location of output relative to the code that generated it. The\npossible values are as follows:"
-          },
-          {
             short: "Unique label for code cell",
             long: "Unique label for code cell. Used when other code needs to refer to\nthe cell (e.g.&nbsp;for cross references <code>fig-samples</code> or\n<code>tbl-summary</code>)"
           },
@@ -19415,6 +19420,10 @@ try {
           "Include errors in the output (note that this implies that errors\nexecuting code will not halt processing of the document).",
           "Catch all for preventing any output (code or results) from being\nincluded in output.",
           "Panel type for cell output (<code>tabset</code>, <code>input</code>,\n<code>sidebar</code>, <code>fill</code>, <code>center</code>)",
+          {
+            short: "Location of output relative to the code that generated it\n(<code>default</code>, <code>fragment</code>, <code>slide</code>,\n<code>column</code>, or <code>column-location</code>)",
+            long: "Location of output relative to the code that generated it. The\npossible values are as follows:"
+          },
           "Include messages in rendered output.",
           {
             short: "How to display text results",
@@ -19931,6 +19940,7 @@ try {
             short: "Properties of the grid system used to layout Quarto HTML pages.",
             long: ""
           },
+          "Defines whether to use the standard, slim, or full content grid or to\nautomatically select the most appropriate content grid.",
           "The base width of the sidebar (left) column in an HTML page.",
           "The base width of the margin (right) column in an HTML page.",
           "The base width of the body (center) column in an HTML page.",
@@ -20233,6 +20243,10 @@ try {
           {
             short: "Use a smaller default font for slide content",
             long: "<code>true</code> to use a smaller default font for slide content.\nThis can also be set per-slide by including the <code>.smaller</code>\nclass on the slide title."
+          },
+          {
+            short: "Location of output relative to the code that generated it\n(<code>default</code>, <code>fragment</code>, <code>slide</code>,\n<code>column</code>, or <code>column-location</code>)",
+            long: "Location of output relative to the code that generated it. The\npossible values are as follows:"
           },
           "Flags if the presentation is running in an embedded mode",
           "The display mode that will be used to show slides",
@@ -21256,12 +21270,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 151940,
+          _internalId: 152136,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 151932,
+              _internalId: 152128,
               type: "enum",
               enum: [
                 "png",
@@ -21277,7 +21291,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 151939,
+              _internalId: 152135,
               type: "anyOf",
               anyOf: [
                 {
@@ -30391,36 +30405,44 @@ ${tidyverseInfo(
     const rawParams = [];
     const name = nameMatch[0];
     let paramStr = capture.slice(name.length).trim();
-    const paramName = "([a-zA-Z0-9_-]+)";
-    const paramValue1 = `([^"'\\s]+)`;
-    const paramValue2 = `"([^"]*)"`;
-    const paramValue3 = `'([^']*)'`;
-    const paramValue = `(?:${paramValue1})|(?:${paramValue2})|(?:${paramValue3})`;
-    const paramNameAndValue = `(?:${paramName}\\s*=\\s*${paramValue1})|(?:${paramName}\\s*=\\s*${paramValue2})|(?:${paramName}\\s*=\\s*${paramValue3})`;
-    const paramRe = new RegExp(`(?:${paramValue}|${paramNameAndValue})`);
     while (paramStr.length) {
-      const paramMatch = paramStr.match(paramRe);
+      let paramMatch;
+      paramMatch = paramStr.match(/^[a-zA-Z0-9_-]+="[^"]*"/);
       if (!paramMatch) {
-        throw new Error("invalid shortcode: " + capture);
+        paramMatch = paramStr.match(/^[a-zA-Z0-9_-]+='[^']*'/);
       }
-      const captures = paramMatch.slice(1).filter((x) => x !== void 0);
-      if (captures.length === 1) {
-        params.push(captures[0]);
-        rawParams.push({
-          value: captures[0]
-        });
-      } else if (captures.length === 2) {
-        namedParams[captures[0]] = captures[1];
-        rawParams.push({
-          name: captures[0],
-          value: captures[1]
-        });
-      } else {
-        throw new Error(
-          "Internal Error, could not determine correct shortcode capture for " + capture
-        );
+      if (!paramMatch) {
+        paramMatch = paramStr.match(/^[a-zA-Z0-9_-]+=[^"'\s]+/);
       }
-      paramStr = paramStr.slice(paramMatch[0].length).trim();
+      if (paramMatch) {
+        const [name2, value] = paramMatch[0].split("=");
+        namedParams[name2] = value;
+        rawParams.push({
+          name: name2,
+          value
+        });
+        paramStr = paramStr.slice(paramMatch[0].length).trim();
+        continue;
+      }
+      paramMatch = paramStr.match(/^[^"'\s]+/);
+      if (paramMatch) {
+        params.push(paramMatch[0]);
+        rawParams.push({
+          value: paramMatch[0]
+        });
+        paramStr = paramStr.slice(paramMatch[0].length).trim();
+        continue;
+      }
+      paramMatch = paramStr.match(/^"[^"]*"/) || paramStr.match(/^'[^']*'/);
+      if (paramMatch) {
+        params.push(paramMatch[0].slice(1, -1));
+        rawParams.push({
+          value: paramMatch[0].slice(1, -1)
+        });
+        paramStr = paramStr.slice(paramMatch[0].length).trim();
+        continue;
+      }
+      throw new Error("invalid shortcode: " + capture);
     }
     return { name, params, namedParams, rawParams };
   }

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -6892,6 +6892,15 @@
         "object": {
           "closed": true,
           "properties": {
+            "content-mode": {
+              "enum": [
+                "auto",
+                "standard",
+                "full",
+                "slim"
+              ],
+              "description": "Defines whether to use the standard, slim, or full content grid or to automatically select the most appropriate content grid."
+            },
             "sidebar-width": {
               "string": {
                 "description": "The base width of the sidebar (left) column in an HTML page."
@@ -12235,10 +12244,6 @@
     "Default profile to apply if QUARTO_PROFILE is not defined.",
     "Define a profile group for which at least one profile is always\nactive.",
     {
-      "short": "Location of output relative to the code that generated it\n(<code>default</code>, <code>fragment</code>, <code>slide</code>,\n<code>column</code>, or <code>column-location</code>)",
-      "long": "Location of output relative to the code that generated it. The\npossible values are as follows:"
-    },
-    {
       "short": "Unique label for code cell",
       "long": "Unique label for code cell. Used when other code needs to refer to\nthe cell (e.g.&nbsp;for cross references <code>fig-samples</code> or\n<code>tbl-summary</code>)"
     },
@@ -12390,6 +12395,10 @@
     "Include errors in the output (note that this implies that errors\nexecuting code will not halt processing of the document).",
     "Catch all for preventing any output (code or results) from being\nincluded in output.",
     "Panel type for cell output (<code>tabset</code>, <code>input</code>,\n<code>sidebar</code>, <code>fill</code>, <code>center</code>)",
+    {
+      "short": "Location of output relative to the code that generated it\n(<code>default</code>, <code>fragment</code>, <code>slide</code>,\n<code>column</code>, or <code>column-location</code>)",
+      "long": "Location of output relative to the code that generated it. The\npossible values are as follows:"
+    },
     "Include messages in rendered output.",
     {
       "short": "How to display text results",
@@ -12906,6 +12915,7 @@
       "short": "Properties of the grid system used to layout Quarto HTML pages.",
       "long": ""
     },
+    "Defines whether to use the standard, slim, or full content grid or to\nautomatically select the most appropriate content grid.",
     "The base width of the sidebar (left) column in an HTML page.",
     "The base width of the margin (right) column in an HTML page.",
     "The base width of the body (center) column in an HTML page.",
@@ -13208,6 +13218,10 @@
     {
       "short": "Use a smaller default font for slide content",
       "long": "<code>true</code> to use a smaller default font for slide content.\nThis can also be set per-slide by including the <code>.smaller</code>\nclass on the slide title."
+    },
+    {
+      "short": "Location of output relative to the code that generated it\n(<code>default</code>, <code>fragment</code>, <code>slide</code>,\n<code>column</code>, or <code>column-location</code>)",
+      "long": "Location of output relative to the code that generated it. The\npossible values are as follows:"
     },
     "Flags if the presentation is running in an embedded mode",
     "The display mode that will be used to show slides",
@@ -14231,12 +14245,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 151940,
+    "_internalId": 152136,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 151932,
+        "_internalId": 152128,
         "type": "enum",
         "enum": [
           "png",
@@ -14252,7 +14266,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 151939,
+        "_internalId": 152135,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/schema/document-layout.yml
+++ b/src/resources/schema/document-layout.yml
@@ -84,6 +84,9 @@
     object:
       closed: true
       properties:
+        content-mode:
+          enum: ["auto", "standard", "full", "slim"]
+          description: "Defines whether to use the standard, slim, or full content grid or to automatically select the most appropriate content grid."
         sidebar-width:
           string:
             description: "The base width of the sidebar (left) column in an HTML page."


### PR DESCRIPTION
By default, Quarto’s grid system looks and the contents of the sidebar and margin to determine whether to use a standard width content grid, a slim content grid, or a full content grid.

This is an advanced feature that would allow users to specify which content grid to use, overriding Quarto’s default behavior which is `auto`. For example:

```
grid:
  content-mode: standard
```

Will force the use of the standard grid, even when there is margin content present.

This could be useful in cases where most pages have minimal or no margin content, but an occasional page includes short asides. Currently the page layout would vary from page to page, but by specifying a standard content-mode, each page would have the same grid layout, even when margin content was present, which prevent content from ‘jumping’ as the grid shifts from page to page.

