### PR TITLE
Round up reading time using `Math.ceil`

### DIFF
--- a/src/project/types/website/util/discover-meta.ts
+++ b/src/project/types/website/util/discover-meta.ts
@@ -99,7 +99,7 @@ export function estimateReadingTimeMinutes(
 ): number | undefined {
   if (markdown) {
     const wordCount = markdown.split(" ").length;
-    return wordCount / kWpm;
+    return Math.ceil(wordCount / kWpm);
   }
   return 0;
 }


### PR DESCRIPTION
## Description

Fixes #4772 

Currently reading time shows up as `0 min`:

![image](https://user-images.githubusercontent.com/1813121/224511657-947a7053-a710-4ca3-a3df-15c1d1ca7bd0.png)

This PR adds `Math.ceil` to the result of `estimateReadingTimeMinutes` for markdown files.

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
