### PR TITLE
Add support for scss chunk comments in YAML parsing

### DIFF
--- a/src/core/lib/partition-cell-options.ts
+++ b/src/core/lib/partition-cell-options.ts
@@ -344,6 +344,7 @@ export const kLangCommentChars: Record<string, string | [string, string]> = {
   d3: "//",
   node: "//",
   sass: "//",
+  scss: "//",
   coffee: "#",
   go: "//",
   asy: "//",

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -21209,9 +21209,7 @@ var require_yaml_intelligence_resources = __commonJS({
       ],
       "handlers/languages.yml": [
         "mermaid",
-        "include",
-        "dot",
-        "embed"
+        "dot"
       ],
       "handlers/lang-comment-chars.yml": {
         r: "#",
@@ -21259,6 +21257,7 @@ var require_yaml_intelligence_resources = __commonJS({
         d3: "//",
         node: "//",
         sass: "//",
+        scss: "//",
         coffee: "#",
         go: "//",
         asy: "//",
@@ -30362,6 +30361,7 @@ var kLangCommentChars = {
   d3: "//",
   node: "//",
   sass: "//",
+  scss: "//",
   coffee: "#",
   go: "//",
   asy: "//",

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -21210,9 +21210,7 @@ try {
         ],
         "handlers/languages.yml": [
           "mermaid",
-          "include",
-          "dot",
-          "embed"
+          "dot"
         ],
         "handlers/lang-comment-chars.yml": {
           r: "#",
@@ -21260,6 +21258,7 @@ try {
           d3: "//",
           node: "//",
           sass: "//",
+          scss: "//",
           coffee: "#",
           go: "//",
           asy: "//",
@@ -30376,6 +30375,7 @@ ${tidyverseInfo(
     d3: "//",
     node: "//",
     sass: "//",
+    scss: "//",
     coffee: "#",
     go: "//",
     asy: "//",

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -14185,9 +14185,7 @@
   ],
   "handlers/languages.yml": [
     "mermaid",
-    "include",
-    "dot",
-    "embed"
+    "dot"
   ],
   "handlers/lang-comment-chars.yml": {
     "r": "#",
@@ -14235,6 +14233,7 @@
     "d3": "//",
     "node": "//",
     "sass": "//",
+    "scss": "//",
     "coffee": "#",
     "go": "//",
     "asy": "//",

--- a/src/resources/filters/quarto-pre/code-annotation.lua
+++ b/src/resources/filters/quarto-pre/code-annotation.lua
@@ -39,6 +39,7 @@ local kLangCommentChars = {
   d3 = {"//"},
   node = {"//"},
   sass = {"//"},
+  scss = {"//"},
   coffee = {"#"},
   go = {"//"},
   asy = {"//"},


### PR DESCRIPTION
@cscheid is there any other addition to make to support recognizing comments options in scss chunk 

This is a supported **knitr** engine: https://bookdown.org/yihui/rmarkdown-cookbook/eng-sass.html

````markdown
---
title: "My document"
format: html
engine: knitr
---

```{scss}
//| eval: false

// Content.scss
@use 'colors' as colors;
body > content {
    padding: 40px;
    margin: auto;
    max-width: 100%
}
```

````