### PR TITLE
Fix issue 3152 - convert nbdev directives to YAML

### DIFF
--- a/src/core/jupyter/jupyter.ts
+++ b/src/core/jupyter/jupyter.ts
@@ -375,7 +375,8 @@ export async function quartoMdToJupyter(
               }
               delete yaml[key];
             } else {
-              if (!kJupyterCellOptionKeys.includes(key)) {
+              // an option value of null means that it is an nbdev-style directive
+              if (!kJupyterCellOptionKeys.includes(key) && yaml[key] !== null) {
                 cell.metadata[key] = yaml[key];
                 delete yaml[key];
               }
@@ -844,6 +845,8 @@ export function jupyterCellOptionsAsComment(
     });
     const commentChars = langCommentChars(language);
     const yamlOutput = mdTrimEmptyLines(lines(cellYaml)).map((line) => {
+      // an option value of null means that the key is a nbdev-style directive
+      line = line.replace(/: null$/, "");
       line = optionCommentPrefix(commentChars[0]) + line +
         optionCommentSuffix(commentChars[1]);
       return line + "\n";

--- a/src/core/lib/partition-cell-options.ts
+++ b/src/core/lib/partition-cell-options.ts
@@ -64,6 +64,7 @@ export function partitionCellOptions(
             yamlOption += line[line.length - 1];
           }
         }
+        yamlOption = fixNbdevDirective(yamlOption);
         yamlLines.push(yamlOption);
         optionsSource.push(line);
         continue;
@@ -95,6 +96,16 @@ export function partitionCellOptions(
     sourceStartLine: yamlLines.length,
   };
 }
+
+function fixNbdevDirective(line: string) {
+  // convert non-yaml nbdev-style directives to yaml keys with a null value
+  if (line.match(/^\w+\s*$/)) {  // e.g. export
+    return line.replace(/(\s*)$/, ": null$1");
+  } else if (line.match(/^\w+\s+[^:\s]/)) {  // e.g. default_exp foo
+    return line.replace(/(\s*)$/, ": null$1");
+  }
+  return line;
+};
 
 export async function parseAndValidateCellOptions(
   mappedYaml: MappedString,


### PR DESCRIPTION
## Description

(This likely needs more work and testing.)

Quarto assumes that `#|` directive lines are valid YAML, but nbdev directives aren't.

I've come up with a somewhat hacky workaround, which converts any nbdev directive `foo` to `foo: null` before attempting to parse it as YAML, e.g.:

```
#| default_exp foo
#| export
```

is changed to:

```
#| default_exp foo: null
#| export: null
```

When writing a code cell, it strips off the null value and just shows the plain nbdev directive again. I'm assuming that Quarto directives don't ever use a value of "null".

With these changes, it seems to be stripping the nbdev directives out of my blog posts when rendering from ipynb, and that's okay with me.

It can't currently render from qmd format if these nbdev directives are used. We would need to adjust something in how it's reading the YAML there too.

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog

It's not much code, please let me know if you do want to use it and you require me to file a contributor agreement.