### PR TITLE
Add LaTeX support for fig-pos: false and forward fig-{pos,env} from mermaid,dot

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -87,6 +87,7 @@
 - Correctly download online image on Windows ([#3982](https://github.com/quarto-dev/quarto-cli/issues/3982)).
 - Permissions of `.tex` file are now correct when `keep-tex: true` ([#4380](https://github.com/quarto-dev/quarto-cli/issues/4380)).
 - Better support footnotes within Callouts in PDF / LaTeX output ([#1235](https://github.com/quarto-dev/quarto-cli/issues/1235)).
+- Allow `fig-pos: false` to support custom figure environments that don't support the `H` option ([#4832](https://github.com/quarto-dev/quarto-cli/discussions/4832)).
 
 ## Beamer Format
 
@@ -109,6 +110,11 @@
 - Add support for `%%| file` mermaid cell option ([#3665](https://github.com/quarto-dev/quarto-cli/issues/3665)).
 - Fix `code-fold` support in mermaid (and dot) diagrams ([#4423](https://github.com/quarto-dev/quarto-cli/issues/4423)).
 - Fix caption insertion in the presence of alignment specifiers with `{}` in them ([#4748](https://github.com/quarto-dev/quarto-cli/issues/4748)).
+- Support `fig-env` and `fig-pos` in mermaid diagrams in PDF format ([#4832](https://github.com/quarto-dev/quarto-cli/discussions/4832)).
+
+## Dot diagrams
+
+- Support `fig-env` and `fig-pos` in dot diagrams in PDF format ([#4832](https://github.com/quarto-dev/quarto-cli/discussions/4832)).
 
 ## Dates
 

--- a/src/core/handlers/mermaid.ts
+++ b/src/core/handlers/mermaid.ts
@@ -1,9 +1,8 @@
 /*
-* mermaid.ts
-*
-* Copyright (C) 2022 Posit Software, PBC
-*
-*/
+ * mermaid.ts
+ *
+ * Copyright (C) 2022 Posit Software, PBC
+ */
 
 import {
   LanguageCellHandlerContext,
@@ -195,9 +194,20 @@ mermaid.initialize(${JSON.stringify(mermaidOpts)});
       height?: number,
       includeCaption?: boolean,
     ) => {
-      const posSpecifier = isLatexOutput(handlerContext.options.format.pandoc)
-        ? " fig-pos='H'"
-        : "";
+      const figEnvSpecifier =
+        isLatexOutput(handlerContext.options.format.pandoc)
+          ? ` fig-env='${cell.options?.["fig-env"] || "figure"}'`
+          : "";
+      let posSpecifier = "";
+      if (
+        isLatexOutput(handlerContext.options.format.pandoc) &&
+        cell.options?.["fig-pos"] !== false
+      ) {
+        const v = Array.isArray(cell.options?.["fig-pos"])
+          ? cell.options?.["fig-pos"].join("")
+          : cell.options?.["fig-pos"];
+        posSpecifier = ` fig-pos='${v || "H"}'`;
+      }
       const idSpecifier = (cell.options?.label && includeCaption)
         ? ` #${cell.options?.label}`
         : "";
@@ -211,7 +221,7 @@ mermaid.initialize(${JSON.stringify(mermaidOpts)});
         ? (cell.options?.["fig-cap"] || "")
         : "";
 
-      return `\n![${captionSpecifier}](${sourceName}){${widthSpecifier}${heightSpecifier}${posSpecifier}${idSpecifier}}\n`;
+      return `\n![${captionSpecifier}](${sourceName}){${widthSpecifier}${heightSpecifier}${posSpecifier}${figEnvSpecifier}${idSpecifier}}\n`;
     };
     const responsive = handlerContext.options.context.format.metadata
       ?.[kFigResponsive];

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -7485,11 +7485,16 @@ var require_yaml_intelligence_resources = __commonJS({
             ]
           },
           schema: {
-            maybeArrayOf: "string"
+            anyOf: [
+              {
+                maybeArrayOf: "string"
+              },
+              false
+            ]
           },
           description: {
             short: "LaTeX figure position arrangement to be used in `\\begin{figure}[]`.",
-            long: 'LaTeX figure position arrangement to be used in `\\begin{figure}[]`.\n\nComputational figure output that is accompanied by the code \nthat produced it is given a default value of `fig-pos="H"` (so \nthat the code and figure are not inordinately separated).\n'
+            long: 'LaTeX figure position arrangement to be used in `\\begin{figure}[]`.\n\nComputational figure output that is accompanied by the code \nthat produced it is given a default value of `fig-pos="H"` (so \nthat the code and figure are not inordinately separated).\n\nIf `fig-pos` is `false`, then we don\'t use any figure position\nspecifier, which is sometimes necessary with custom figure\nenvironments (such as `sidewaysfigure`).\n'
           }
         },
         {
@@ -21209,9 +21214,7 @@ var require_yaml_intelligence_resources = __commonJS({
       ],
       "handlers/languages.yml": [
         "mermaid",
-        "include",
-        "dot",
-        "embed"
+        "dot"
       ],
       "handlers/lang-comment-chars.yml": {
         r: "#",
@@ -21269,12 +21272,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 152136,
+        _internalId: 152142,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 152128,
+            _internalId: 152134,
             type: "enum",
             enum: [
               "png",
@@ -21290,7 +21293,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 152135,
+            _internalId: 152141,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -7489,7 +7489,11 @@ var require_yaml_intelligence_resources = __commonJS({
               {
                 maybeArrayOf: "string"
               },
-              false
+              {
+                enum: [
+                  false
+                ]
+              }
             ]
           },
           description: {
@@ -19346,7 +19350,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "LaTeX environment for figure output",
         {
           short: "LaTeX figure position arrangement to be used in\n<code>\\begin{figure}[]</code>.",
-          long: 'LaTeX figure position arrangement to be used in\n<code>\\begin{figure}[]</code>.\nComputational figure output that is accompanied by the code that\nproduced it is given a default value of <code>fig-pos="H"</code> (so\nthat the code and figure are not inordinately separated).'
+          long: 'LaTeX figure position arrangement to be used in\n<code>\\begin{figure}[]</code>.\nComputational figure output that is accompanied by the code that\nproduced it is given a default value of <code>fig-pos="H"</code> (so\nthat the code and figure are not inordinately separated).\nIf <code>fig-pos</code> is <code>false</code>, then we don\u2019t use any\nfigure position specifier, which is sometimes necessary with custom\nfigure environments (such as <code>sidewaysfigure</code>).'
         },
         {
           short: "A short caption (only used in LaTeX output)",
@@ -21272,12 +21276,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 152142,
+        _internalId: 152538,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 152134,
+            _internalId: 152530,
             type: "enum",
             enum: [
               "png",
@@ -21293,7 +21297,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 152141,
+            _internalId: 152537,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -7490,7 +7490,11 @@ try {
                 {
                   maybeArrayOf: "string"
                 },
-                false
+                {
+                  enum: [
+                    false
+                  ]
+                }
               ]
             },
             description: {
@@ -19347,7 +19351,7 @@ try {
           "LaTeX environment for figure output",
           {
             short: "LaTeX figure position arrangement to be used in\n<code>\\begin{figure}[]</code>.",
-            long: 'LaTeX figure position arrangement to be used in\n<code>\\begin{figure}[]</code>.\nComputational figure output that is accompanied by the code that\nproduced it is given a default value of <code>fig-pos="H"</code> (so\nthat the code and figure are not inordinately separated).'
+            long: 'LaTeX figure position arrangement to be used in\n<code>\\begin{figure}[]</code>.\nComputational figure output that is accompanied by the code that\nproduced it is given a default value of <code>fig-pos="H"</code> (so\nthat the code and figure are not inordinately separated).\nIf <code>fig-pos</code> is <code>false</code>, then we don\u2019t use any\nfigure position specifier, which is sometimes necessary with custom\nfigure environments (such as <code>sidewaysfigure</code>).'
           },
           {
             short: "A short caption (only used in LaTeX output)",
@@ -21273,12 +21277,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 152142,
+          _internalId: 152538,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 152134,
+              _internalId: 152530,
               type: "enum",
               enum: [
                 "png",
@@ -21294,7 +21298,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 152141,
+              _internalId: 152537,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -7486,11 +7486,16 @@ try {
               ]
             },
             schema: {
-              maybeArrayOf: "string"
+              anyOf: [
+                {
+                  maybeArrayOf: "string"
+                },
+                false
+              ]
             },
             description: {
               short: "LaTeX figure position arrangement to be used in `\\begin{figure}[]`.",
-              long: 'LaTeX figure position arrangement to be used in `\\begin{figure}[]`.\n\nComputational figure output that is accompanied by the code \nthat produced it is given a default value of `fig-pos="H"` (so \nthat the code and figure are not inordinately separated).\n'
+              long: 'LaTeX figure position arrangement to be used in `\\begin{figure}[]`.\n\nComputational figure output that is accompanied by the code \nthat produced it is given a default value of `fig-pos="H"` (so \nthat the code and figure are not inordinately separated).\n\nIf `fig-pos` is `false`, then we don\'t use any figure position\nspecifier, which is sometimes necessary with custom figure\nenvironments (such as `sidewaysfigure`).\n'
             }
           },
           {
@@ -21210,9 +21215,7 @@ try {
         ],
         "handlers/languages.yml": [
           "mermaid",
-          "include",
-          "dot",
-          "embed"
+          "dot"
         ],
         "handlers/lang-comment-chars.yml": {
           r: "#",
@@ -21270,12 +21273,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 152136,
+          _internalId: 152142,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 152128,
+              _internalId: 152134,
               type: "enum",
               enum: [
                 "png",
@@ -21291,7 +21294,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 152135,
+              _internalId: 152141,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -465,7 +465,11 @@
           {
             "maybeArrayOf": "string"
           },
-          false
+          {
+            "enum": [
+              false
+            ]
+          }
         ]
       },
       "description": {
@@ -12322,7 +12326,7 @@
     "LaTeX environment for figure output",
     {
       "short": "LaTeX figure position arrangement to be used in\n<code>\\begin{figure}[]</code>.",
-      "long": "LaTeX figure position arrangement to be used in\n<code>\\begin{figure}[]</code>.\nComputational figure output that is accompanied by the code that\nproduced it is given a default value of <code>fig-pos=\"H\"</code> (so\nthat the code and figure are not inordinately separated)."
+      "long": "LaTeX figure position arrangement to be used in\n<code>\\begin{figure}[]</code>.\nComputational figure output that is accompanied by the code that\nproduced it is given a default value of <code>fig-pos=\"H\"</code> (so\nthat the code and figure are not inordinately separated).\nIf <code>fig-pos</code> is <code>false</code>, then we don’t use any\nfigure position specifier, which is sometimes necessary with custom\nfigure environments (such as <code>sidewaysfigure</code>)."
     },
     {
       "short": "A short caption (only used in LaTeX output)",
@@ -14248,12 +14252,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 152142,
+    "_internalId": 152538,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 152134,
+        "_internalId": 152530,
         "type": "enum",
         "enum": [
           "png",
@@ -14269,7 +14273,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 152141,
+        "_internalId": 152537,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -461,11 +461,16 @@
         ]
       },
       "schema": {
-        "maybeArrayOf": "string"
+        "anyOf": [
+          {
+            "maybeArrayOf": "string"
+          },
+          false
+        ]
       },
       "description": {
         "short": "LaTeX figure position arrangement to be used in `\\begin{figure}[]`.",
-        "long": "LaTeX figure position arrangement to be used in `\\begin{figure}[]`.\n\nComputational figure output that is accompanied by the code \nthat produced it is given a default value of `fig-pos=\"H\"` (so \nthat the code and figure are not inordinately separated).\n"
+        "long": "LaTeX figure position arrangement to be used in `\\begin{figure}[]`.\n\nComputational figure output that is accompanied by the code \nthat produced it is given a default value of `fig-pos=\"H\"` (so \nthat the code and figure are not inordinately separated).\n\nIf `fig-pos` is `false`, then we don't use any figure position\nspecifier, which is sometimes necessary with custom figure\nenvironments (such as `sidewaysfigure`).\n"
       }
     },
     {
@@ -14185,9 +14190,7 @@
   ],
   "handlers/languages.yml": [
     "mermaid",
-    "include",
-    "dot",
-    "embed"
+    "dot"
   ],
   "handlers/lang-comment-chars.yml": {
     "r": "#",
@@ -14245,12 +14248,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 152136,
+    "_internalId": 152142,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 152128,
+        "_internalId": 152134,
         "type": "enum",
         "enum": [
           "png",
@@ -14266,7 +14269,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 152135,
+        "_internalId": 152141,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/filters/quarto-pre/figures.lua
+++ b/src/resources/filters/quarto-pre/figures.lua
@@ -54,7 +54,13 @@ function quartoPreFigures()
         if figPos and not image.attr.attributes[kFigPos] then
           image.attr.attributes[kFigPos] = figPos
         end
+        -- remove fig-pos if it is false, since it
+        -- signals "don't use any value"
+        if image.attr.attributes[kFigPos] == "FALSE" then
+          image.attr.attributes[kFigPos] = nil
+        end
         local figEnv = param(kFigEnv)
+        
         if figEnv and not image.attr.attributes[kFigEnv] then
           image.attr.attributes[kFigEnv] = figEnv
         end

--- a/src/resources/schema/cell-figure.yml
+++ b/src/resources/schema/cell-figure.yml
@@ -60,7 +60,7 @@
   schema:
     anyOf:
       - maybeArrayOf: string
-      - false
+      - enum: [false]
   description:
     short: LaTeX figure position arrangement to be used in `\begin{figure}[]`.
     long: |

--- a/src/resources/schema/cell-figure.yml
+++ b/src/resources/schema/cell-figure.yml
@@ -58,7 +58,9 @@
     formats: [$pdf-all]
     contexts: [document-figures]
   schema:
-    maybeArrayOf: string
+    anyOf:
+      - maybeArrayOf: string
+      - false
   description:
     short: LaTeX figure position arrangement to be used in `\begin{figure}[]`.
     long: |
@@ -67,6 +69,10 @@
       Computational figure output that is accompanied by the code 
       that produced it is given a default value of `fig-pos="H"` (so 
       that the code and figure are not inordinately separated).
+
+      If `fig-pos` is `false`, then we don't use any figure position
+      specifier, which is sometimes necessary with custom figure
+      environments (such as `sidewaysfigure`).
 
 - name: fig-scap
   tags:


### PR DESCRIPTION
This fixes the issue discussed in #4832.

Two fixes are necessary. 

1. mermaid and dot need to actually support fig-env.
2. we need `fig-pos` to be possibly `false`, because some custom figure environments don't support placement (`sidewaysfigure` is the specific example in the discussion)

