### PR TITLE
Support code annotation for Elm code block

### DIFF
--- a/src/resources/filters/quarto-pre/code-annotation.lua
+++ b/src/resources/filters/quarto-pre/code-annotation.lua
@@ -52,7 +52,8 @@ local kLangCommentChars = {
   latex = {"%"},
   typescript = {"//"},
   swift = { "//" },
-  javascript = { "// "}
+  javascript = { "// "},
+  elm = { "#" }
 }
 
 local kCodeAnnotationsParam = 'code-annotations'


### PR DESCRIPTION
## Description

Related to #4823, follow up #4147

Allows code annotations to work in the Elm code blocks used in the output of the PRQL executable code block provided by [prqlr](https://cran.r-project.org/package=prqlr).
(Since PRQL is not a Pandoc registered language, it is configured to use Elm which has similar syntax highlighting.)

![image](https://user-images.githubusercontent.com/50911393/225276930-731e18cf-e48a-4808-be64-05d7a3760490.png)

Tested with the following qmd file. (Needs installing dev version `prqlr` from R-universe or GitHub, because of the other bug eitsupi/prqlr#109)

````qmd
---
title: test
format:
  html:
    self-contained: true
engine: knitr
code-annotations: hover
---

```{r}
#| echo: false
library(prqlr)
```

```{prql}
from mtcars # <1>
select [mpg, cyl]
```

1. Table name
````

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
