### PR TITLE
fix typo in regex

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -88,6 +88,7 @@
 - Permissions of `.tex` file are now correct when `keep-tex: true` ([#4380](https://github.com/quarto-dev/quarto-cli/issues/4380)).
 - Better support footnotes within Callouts in PDF / LaTeX output ([#1235](https://github.com/quarto-dev/quarto-cli/issues/1235)).
 - Allow `fig-pos: false` to support custom figure environments that don't support the `H` option ([#4832](https://github.com/quarto-dev/quarto-cli/discussions/4832)).
+- Allow `fig-pos:` to specify complex arguments with square and curly braces ([#4854](https://github.com/quarto-dev/quarto-cli/discussions/4854)).
 
 ## Beamer Format
 

--- a/src/resources/filters/layout/latex.lua
+++ b/src/resources/filters/layout/latex.lua
@@ -315,7 +315,7 @@ end
 function latexBeginEnv(env, pos, inline)
   local beginEnv = "\\begin{" .. env .. "}"
   if pos then
-    if not string.find(pos, "^%[") then
+    if not string.find(pos, "^[%[{]") then
       pos = "[" .. pos .. "]"
     end
     beginEnv = beginEnv .. pos

--- a/src/resources/filters/layout/latex.lua
+++ b/src/resources/filters/layout/latex.lua
@@ -315,7 +315,7 @@ end
 function latexBeginEnv(env, pos, inline)
   local beginEnv = "\\begin{" .. env .. "}"
   if pos then
-    if not string.find(pos, "^%[{") then
+    if not string.find(pos, "^%[") then
       pos = "[" .. pos .. "]"
     end
     beginEnv = beginEnv .. pos


### PR DESCRIPTION
This fixes the intended behavior of supporting square brackets in the `fig-pos` attribute for latex figures.

Addresses #4854 