### PR TITLE
hide conditional content from lua filters

### DIFF
--- a/tests/docs/smoke-all/2023/03/17/4867.qmd
+++ b/tests/docs/smoke-all/2023/03/17/4867.qmd
@@ -1,0 +1,18 @@
+---
+title: issue-4867
+format: latex
+_quarto:
+  tests:
+    latex:
+      ensureFileRegexMatches:
+        - []
+        - ["geometry"] # geometry package triggers on column-screen div (and shouldn't here)
+---
+
+## Introduction
+
+:::{.content-visible when-format="HTML}
+::::{.column-screen}
+Hello
+::::
+:::


### PR DESCRIPTION
This closes #4867.

The column layout filter runs before custom AST render, the phase where conditional content was removed from the document.

The intuitive fix would be to change the order of conditional content rendering, but we can't do that without mucking with the AST infrastructure and that's pretty regression prone this late in the process.

This fix is a lot more targeted, and changes the way that conditional blocks respond to filter traversals. Here, we simply hide their content from traversals depending on the format. This solves the immediate problem without risking wider changes.