### PR TITLE
don't do jupyter front matter fixups in book renders. Closes #4866

### DIFF
--- a/src/command/render/render-files.ts
+++ b/src/command/render/render-files.ts
@@ -1,9 +1,8 @@
 /*
-* render-files.ts
-*
-* Copyright (C) 2020-2022 Posit Software, PBC
-*
-*/
+ * render-files.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
 
 // ensures cell handlers are installed
 import "../../core/handlers/handlers.ts";
@@ -40,7 +39,11 @@ import {
 import { annotateOjsLineNumbers } from "../../execute/ojs/annotate-source.ts";
 import { ojsExecuteResult } from "../../execute/ojs/compile.ts";
 import { ExecuteResult, MappedExecuteResult } from "../../execute/types.ts";
-import { kProjectLibDir, ProjectContext } from "../../project/types.ts";
+import {
+  kProjectLibDir,
+  kProjectType,
+  ProjectContext,
+} from "../../project/types.ts";
 import { outputRecipe } from "./output.ts";
 import { PandocRenderCompletion, renderPandoc } from "./render.ts";
 import { renderContexts } from "./render-contexts.ts";
@@ -204,6 +207,7 @@ export async function renderExecute(
     quiet: flags.quiet,
     previewServer: context.options.previewServer,
     handledLanguages: languages(),
+    projectType: context.project?.config?.project?.[kProjectType],
   });
   popTiming();
 

--- a/src/core/jupyter/jupyter-fixups.ts
+++ b/src/core/jupyter/jupyter-fixups.ts
@@ -1,9 +1,8 @@
 /*
-* jupyter-shared.ts
-*
-* Copyright (C) 2020-2023 Posit Software, PBC
-*
-*/
+ * jupyter-shared.ts
+ *
+ * Copyright (C) 2020-2023 Posit Software, PBC
+ */
 
 import { stringify } from "encoding/yaml.ts";
 import { warning } from "log/mod.ts";
@@ -15,7 +14,7 @@ import { markdownWithExtractedHeading } from "../pandoc/pandoc-partition.ts";
 import { partitionYamlFrontMatter, readYamlFromMarkdown } from "../yaml.ts";
 import { JupyterNotebook, JupyterOutput } from "./types.ts";
 
-function fixupBokehCells(nb: JupyterNotebook): JupyterNotebook {
+export function fixupBokehCells(nb: JupyterNotebook): JupyterNotebook {
   for (const cell of nb.cells) {
     if (cell.cell_type === "code") {
       let needsFixup = false;
@@ -183,16 +182,25 @@ export function fixupFrontMatter(nb: JupyterNotebook): JupyterNotebook {
   return nb;
 }
 
-const fixups: ((
+type JupyterFixup = (nb: JupyterNotebook) => JupyterNotebook;
+
+const defaultFixups: ((
   nb: JupyterNotebook,
 ) => JupyterNotebook)[] = [
   fixupBokehCells,
   fixupFrontMatter,
 ];
 
+// books can't have the front matter fixup
+export const bookFixups: JupyterFixup[] = [
+  fixupBokehCells,
+];
+
 export function fixupJupyterNotebook(
   nb: JupyterNotebook,
+  explicitFixups?: JupyterFixup[],
 ): JupyterNotebook {
+  const fixups = explicitFixups || defaultFixups;
   for (const fixup of fixups) {
     nb = fixup(nb);
   }

--- a/src/core/jupyter/jupyter.ts
+++ b/src/core/jupyter/jupyter.ts
@@ -1,9 +1,8 @@
 /*
-* jupyter.ts
-*
-* Copyright (C) 2020-2022 Posit Software, PBC
-*
-*/
+ * jupyter.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
 
 // deno-lint-ignore-file camelcase
 
@@ -155,7 +154,7 @@ import { ProjectContext } from "../../project/types.ts";
 import { mergeConfigs } from "../config.ts";
 import { encode as encodeBase64 } from "encoding/base64.ts";
 import { isIpynbOutput } from "../../config/format.ts";
-import { fixupJupyterNotebook } from "./jupyter-fixups.ts";
+import { bookFixups, fixupJupyterNotebook } from "./jupyter-fixups.ts";
 
 export const kQuartoMimeType = "quarto_mimetype";
 export const kQuartoOutputOrder = "quarto_order";
@@ -656,7 +655,11 @@ export async function jupyterToMarkdown(
   options: JupyterToMarkdownOptions,
 ): Promise<JupyterToMarkdownResult> {
   // perform fixups
-  nb = fixupJupyterNotebook(nb);
+  const fixups = options.executeOptions.projectType === "book"
+    ? bookFixups
+    : undefined;
+
+  nb = fixupJupyterNotebook(nb, fixups);
 
   // optional content injection / html preservation for html output
   // that isn't an ipynb
@@ -1637,9 +1640,9 @@ which does not appear to be plain text: ${JSON.stringify(data)}`);
       } else {
         if (options.toHtml) {
           if (lines.some(hasAnsiEscapeCodes)) {
-            const html = (await Promise.all(
+            const html = await Promise.all(
               lines.map(convertToHtmlSpans),
-            ));
+            );
             return mdMarkdownOutput(
               [
                 "\n::: {.ansi-escaped-output}\n```{=html}\n<pre>",

--- a/src/execute/types.ts
+++ b/src/execute/types.ts
@@ -1,9 +1,8 @@
 /*
-* types.ts
-*
-* Copyright (C) 2020-2022 Posit Software, PBC
-*
-*/
+ * types.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
 import {
   kIncludeAfterBody,
   kIncludeBeforeBody,
@@ -82,6 +81,7 @@ export interface ExecuteOptions {
   quiet?: boolean;
   previewServer?: boolean;
   handledLanguages: string[]; // list of languages handled by cell language handlers, after the execution engine
+  projectType?: string;
 }
 
 // result of execution


### PR DESCRIPTION
ExecuteOptions now tracks the project type, so that jupyter fixups can depend on it.