### PR TITLE
small correction

### DIFF
--- a/src/resources/language/_language-it.yml
+++ b/src/resources/language/_language-it.yml
@@ -1,4 +1,4 @@
-toc-title-document: "Indice del contenuto"
+toc-title-document: "Indice"
 toc-title-website: "In questa pagina"
 
 related-formats-title: "Altri Formati"


### PR DESCRIPTION
In Italian book/documents we use "Indice" for "Table of Contents".

you require too much paper work for a small typo, i.e. filling a d sending a pdf form...

if it suffice to say here that you can freely (without me claiming any rights or compensation) use my suggestion, please reuse my proposal as in this PR.