### PR TITLE
TeX Live 2023 uses `bin/windows` and no more `bin/win32`

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -222,6 +222,7 @@
 - Add `title` attribute for callouts (can be used rather than heading for defining the title)
 - Handle more varieties of raw HTML for Docusaurus output
 - Read and process DOM one-file-at-time in books and websites to reduce total memory usage ([#4350](https://github.com/quarto-dev/quarto-cli/issues/4350)).
+- Fix issue with TeX Live 2023 bin paths on Windows ([#4906](https://github.com/quarto-dev/quarto-cli/issues/4906)).
 
 ## Pandoc filter changes
 

--- a/src/tools/impl/tinytex-info.ts
+++ b/src/tools/impl/tinytex-info.ts
@@ -5,7 +5,7 @@
 *
 */
 
-import { expandPath } from "../../core/path.ts";
+import { expandPath, safeExistsSync } from "../../core/path.ts";
 import { join } from "path/mod.ts";
 import { getenv } from "../../core/env.ts";
 
@@ -37,8 +37,12 @@ export function tinyTexBinDir(): string | undefined {
   const basePath = tinyTexInstallDir();
   if (basePath) {
     switch (Deno.build.os) {
-      case "windows":
-        return join(basePath, "bin\\win32\\");
+      case "windows": {
+        // TeX Live 2023 use windows now. Previous version were using win32
+        const winPath = join(basePath, "bin\\win32\\");
+        if (safeExistsSync(winPath)) return (winPath);
+        return join(basePath, "bin\\windows\\");
+      }
       case "linux":
         return join(basePath, `bin/${Deno.build.arch}-linux`);
       case "darwin":

--- a/src/tools/impl/tinytex.ts
+++ b/src/tools/impl/tinytex.ts
@@ -263,14 +263,26 @@ function binFolder(installDir: string) {
     }
   };
 
-  // Find the tlmgr and note its location
-  return Deno.build.os === "windows"
-    ? join(
+  const winBinFolder = () => {
+    // TeX Live 2023 use windows now. Previous version were using win32
+    const oldBinFolder = join(
       installDir,
       "bin",
       "win32",
-    )
-    : nixBinFolder();
+    );
+    if (existsSync(oldBinFolder)) {
+      return oldBinFolder;
+    } else {
+      return join(
+        installDir,
+        "bin",
+        "windows",
+      );
+    }
+  };
+
+  // Find the tlmgr and note its location
+  return Deno.build.os === "windows" ? winBinFolder() : nixBinFolder();
 }
 
 async function afterInstall(context: InstallContext) {


### PR DESCRIPTION
Try the older one and use the newer otherwise

We probably need to adapt the installer too 🤔  I'll check that. 

@dragonstyle opening to discuss... I am not sure that testing for existence is always safe. Do we use the function once TinyTeX is installed always ? 

Also we have two similar function as you can see here - can we refactor or is this because tools/ command files can't use a function exported by another file maybe ? 

This fix #4906 