### PR TITLE
Add `gfm_auto_identifiers` to reader for correct ids in TOC link

### DIFF
--- a/src/format/markdown/format-markdown.ts
+++ b/src/format/markdown/format-markdown.ts
@@ -4,8 +4,9 @@
  * Copyright (C) 2020-2022 Posit Software, PBC
  */
 
-import { kOutputDivs, kVariant } from "../../config/constants.ts";
+import { kFrom, kOutputDivs, kToc, kVariant } from "../../config/constants.ts";
 import { Format } from "../../config/types.ts";
+import { pandocFormat } from "../../core/pandoc/pandoc-formats.ts";
 import { createFormat, plaintextFormat } from "../formats-shared.ts";
 import { kGfmCommonmarkVariant } from "./format-markdown-consts.ts";
 
@@ -35,6 +36,18 @@ export function gfmFormat(): Format {
     },
     render: {
       [kVariant]: kGfmCommonmarkVariant,
+    },
+    resolveFormat: (format: Format) => {
+      if (format.pandoc[kToc] === true) {
+        // we need to add gfm_auto_identifiers to reader otherwise ids for toc are not valid
+        // see https://github.com/quarto-dev/quarto-cli/issues/4917 and
+        // https://github.com/jgm/pandoc/issues/8709
+        format.pandoc[kFrom] = pandocFormat(
+          format.pandoc[kFrom] || "markdown",
+          ["gfm_auto_identifiers"],
+          [],
+        );
+      }
     },
   });
 }

--- a/tests/docs/smoke-all/2023/03/22/gha-toc-4917.qmd
+++ b/tests/docs/smoke-all/2023/03/22/gha-toc-4917.qmd
@@ -1,0 +1,17 @@
+---
+format: 
+  gfm:
+    toc: true
+_quarto:
+  tests:
+    gfm:
+      ensureFileRegexMatches:
+        - ["\\(#with-ending-dot\\)", "\\(#with-adot-in-the-middle\\)"] 
+        - ["\\(#with-ending-dot\\.\\)","\\(#with-a\\.dot-in-the-middle\\)"]
+---
+
+# A header
+
+# With ending dot.
+
+# With a.dot in the middle


### PR DESCRIPTION
due to current limitation of Pandoc https://github.com/jgm/pandoc/issues/8709

closes #4917 

I used the tweak in `resolveFormat()` as we do it elsewhere, but we also do some tweaks like that in `formatExtras()` (see revealsj format) but it seemed to late to check `pandoc[kToc]`

This could be improved by making `pandocFormat()` not add an extension if already there. 

cc @dragonstyle 

For 1.3 or 1.4 - I just wanted to deal with it now. 😅 