### PR TITLE
only pass siteUrl for websites also for gh-pages provider

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -238,6 +238,7 @@
 
 - Fix error publishing when an `output-dir` is specified ([#4158](https://github.com/quarto-dev/quarto-cli/issues/4158)).
 - Emit error when git <2.17.0 is used ([#4575](https://github.com/quarto-dev/quarto-cli/issues/4575)).
+- Fix error regarding `--site-url` when publishing document and not website ([#4384](https://github.com/quarto-dev/quarto-cli/issues/4384)).
 
 ## Other
 

--- a/src/publish/gh-pages/gh-pages.ts
+++ b/src/publish/gh-pages/gh-pages.ts
@@ -188,7 +188,7 @@ async function publish(
     "gh-pages",
     type,
     title,
-    target?.url,
+    type === "site" ? target?.url : undefined,
   );
 
   // allocate worktree dir


### PR DESCRIPTION
Follow up fix for #4384 and previous change c400071cdcce50826d817dd878304ad325c71286 by @jjallaire 

This is the error I got with last dev version 

````
> quarto publish gh-pages
? Update site at https://quarto-ext.github.io/lightbox/? (Y/n) » Yes
From https://github.com/quarto-ext/lightbox
 * branch            gh-pages   -> FETCH_HEAD
Rendering for publish:

ERROR: The --site-url flag can only be used when rendering projects.
````

With the PR it publish correctly.

I believe we should add this to 1.3