### PR TITLE
Support `export:` in jupyter cells

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -13,6 +13,7 @@
 - Improve handling of YAML and titles in notebooks (auto-merge heading based title with YAML front matter)
 - Discard matplotlib, seaborn, and plotnine intermediate objects from output
 - With IJulia's miniconda python env, search for `python` in addition to `python3` ([#4821](https://github.com/quarto-dev/quarto-cli/issues/4821)).
+- Allow `export:` as a cell yaml option to support new nbdev syntax ([#3152](https://github.com/quarto-dev/quarto-cli/issues/3152)).
 
 ## Knitr engine
 

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -7057,6 +7057,15 @@ var require_yaml_intelligence_resources = __commonJS({
             short: "Notebook cell identifier",
             long: "Notebook cell identifier. Note that if there is no cell `id` then `label` \nwill be used as the cell `id` if it is present.\nSee <https://jupyter.org/enhancement-proposals/62-cell-id/cell-id.html>\nfor additional details on cell ids.\n"
           }
+        },
+        {
+          name: "export",
+          tags: {
+            engine: "jupyter"
+          },
+          schema: null,
+          hidden: true,
+          description: "nbconvert tag to export cell"
         }
       ],
       "schema/cell-cache.yml": [
@@ -21059,7 +21068,8 @@ var require_yaml_intelligence_resources = __commonJS({
           long: "Title of the volume of the item or container holding the item.\nAlso use for titles of periodical special issues, special sections,\nand the like."
         },
         "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
-        "internal-schema-hack"
+        "internal-schema-hack",
+        "nbconvert tag to export cell"
       ],
       "schema/external-schemas.yml": [
         {
@@ -21283,12 +21293,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 148648,
+        _internalId: 152480,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 148640,
+            _internalId: 152472,
             type: "enum",
             enum: [
               "png",
@@ -21304,7 +21314,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 148647,
+            _internalId: 152479,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -7058,6 +7058,15 @@ try {
               short: "Notebook cell identifier",
               long: "Notebook cell identifier. Note that if there is no cell `id` then `label` \nwill be used as the cell `id` if it is present.\nSee <https://jupyter.org/enhancement-proposals/62-cell-id/cell-id.html>\nfor additional details on cell ids.\n"
             }
+          },
+          {
+            name: "export",
+            tags: {
+              engine: "jupyter"
+            },
+            schema: null,
+            hidden: true,
+            description: "nbconvert tag to export cell"
           }
         ],
         "schema/cell-cache.yml": [
@@ -21060,7 +21069,8 @@ try {
             long: "Title of the volume of the item or container holding the item.\nAlso use for titles of periodical special issues, special sections,\nand the like."
           },
           "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
-          "internal-schema-hack"
+          "internal-schema-hack",
+          "nbconvert tag to export cell"
         ],
         "schema/external-schemas.yml": [
           {
@@ -21284,12 +21294,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 148648,
+          _internalId: 152480,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 148640,
+              _internalId: 152472,
               type: "enum",
               enum: [
                 "png",
@@ -21305,7 +21315,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 148647,
+              _internalId: 152479,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -33,6 +33,15 @@
         "short": "Notebook cell identifier",
         "long": "Notebook cell identifier. Note that if there is no cell `id` then `label` \nwill be used as the cell `id` if it is present.\nSee <https://jupyter.org/enhancement-proposals/62-cell-id/cell-id.html>\nfor additional details on cell ids.\n"
       }
+    },
+    {
+      "name": "export",
+      "tags": {
+        "engine": "jupyter"
+      },
+      "schema": null,
+      "hidden": true,
+      "description": "nbconvert tag to export cell"
     }
   ],
   "schema/cell-cache.yml": [
@@ -14035,7 +14044,8 @@
       "long": "Title of the volume of the item or container holding the item.\nAlso use for titles of periodical special issues, special sections,\nand the like."
     },
     "Disambiguating year suffix in author-date styles (e.g.&nbsp;“a” in “Doe,\n1999a”).",
-    "internal-schema-hack"
+    "internal-schema-hack",
+    "nbconvert tag to export cell"
   ],
   "schema/external-schemas.yml": [
     {
@@ -14259,12 +14269,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 148648,
+    "_internalId": 152480,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 148640,
+        "_internalId": 152472,
         "type": "enum",
         "enum": [
           "png",
@@ -14280,7 +14290,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 148647,
+        "_internalId": 152479,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/schema/cell-attributes.yml
+++ b/src/resources/schema/cell-attributes.yml
@@ -28,3 +28,10 @@
       will be used as the cell `id` if it is present.
       See <https://jupyter.org/enhancement-proposals/62-cell-id/cell-id.html>
       for additional details on cell ids.
+
+- name: export
+  tags:
+    engine: jupyter
+  schema: null
+  hidden: true
+  description: "nbconvert tag to export cell"

--- a/tests/docs/smoke-all/2023/03/24/3152.qmd
+++ b/tests/docs/smoke-all/2023/03/24/3152.qmd
@@ -1,0 +1,9 @@
+---
+format: html
+engine: jupyter
+---
+
+```{python}
+#| export: 
+print("hi")
+```


### PR DESCRIPTION
A simple change in our schemas together with a change in `nbdev` now lets us close #3152 cleanly.