### PR TITLE
Don't send colons to expandGlobSync (#4964)

### DIFF
--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -1,9 +1,8 @@
 /*
-* path.ts
-*
-* Copyright (C) 2020-2022 Posit Software, PBC
-*
-*/
+ * path.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
 
 import {
   basename,
@@ -161,8 +160,21 @@ export function resolvePathGlobs(
 ): ResolvedPathGlobs {
   // expand a set of globs
   const expandGlobs = (targetGlobs: string[]) => {
+    // pandoc 3 allows references to http:// in markdown,
+    // and automatically resolves those in its rendering.
+    //
+    // This is a problem for us here, because we attempt
+    // to find local files that match the globs, and
+    // on windows, this means we will call expandGlobSync
+    // with a glob that includes a colon, which causes
+    // errors in any filesystem resolution calls.
+    //
+    // So, we need to filter out any globs that are
+    // clearly going to fail the expansion: these
+    // are any files that have a colon in them.
+
     const expanded: string[] = [];
-    for (const glob of targetGlobs) {
+    for (const glob of targetGlobs.filter((glob) => glob.includes(":"))) {
       for (
         const file of expandGlobSync(
           glob,

--- a/tests/docs/smoke-all/2023/03/25/4964.qmd
+++ b/tests/docs/smoke-all/2023/03/25/4964.qmd
@@ -1,0 +1,4 @@
+---
+title: "issue-4964"
+---
+![](https://quarto.org/quarto.png){width="488"}

--- a/tests/docs/smoke-all/2023/03/25/4964.qmd
+++ b/tests/docs/smoke-all/2023/03/25/4964.qmd
@@ -1,4 +1,4 @@
 ---
 title: "issue-4964"
 ---
-![](https://quarto.org/quarto.png){width="488"}
+![](http://r-statistics.co/screenshots/ggplot_masterlist_2.png){width="488"} [SOURCE](http://r-statistics.co/Top50-Ggplot2-Visualizations-MasterList-R-Code.html)


### PR DESCRIPTION
I have a fix for #4964, but first I want to confirm that the smoke test tests/docs/smoke-all/2023/03/25/4964.qmd breaks on windows.