### PR TITLE
Correct invalid pattern for http URLs

### DIFF
--- a/src/resources/filters/quarto-post/pdf-images.lua
+++ b/src/resources/filters/quarto-post/pdf-images.lua
@@ -107,7 +107,7 @@ function pdfImages()
               image.src = resolvedUrls[image.src]
               return image
             else 
-              local relativePath = image.src:match('http[s]://[%w%.%:]+/(.+)')
+              local relativePath = image.src:match('https?://[%w%.%:]+/(.+)')
               if relativePath then
                 local imgMt, imgContents = pandoc.mediabag.fetch(image.src)
                 local filename = windows_safe_filename(tex_safe_filename(pandoc.path.filename(relativePath)))

--- a/src/resources/filters/quarto-pre/resourcefiles.lua
+++ b/src/resources/filters/quarto-pre/resourcefiles.lua
@@ -11,7 +11,7 @@ function resourceFiles()
     -- around this
     Image = function(el)
       local targetPath = el.src
-      if not targetPath:match('^http[s]:') and not targetPath:match('^data:') then
+      if not targetPath:match('^https?:') and not targetPath:match('^data:') then
         -- don't include this resource if it is a URL, data file or some not file path
         if pandoc.path.is_relative(targetPath) then 
           local inputDir = pandoc.path.directory(quarto.doc.input_file)

--- a/tests/docs/smoke-all/2023/03/28/remote-resources.qmd
+++ b/tests/docs/smoke-all/2023/03/28/remote-resources.qmd
@@ -1,0 +1,22 @@
+---
+title: Remote Resources Test
+author: Norah Jones
+date: last-modified
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ["#remote-resource > p:nth-child(2) > img", "#remote-resource > p:nth-child(4) > img", "#data-uri > div > figure > p:nth-child(1) > img"]
+---
+
+## Remote Resource
+
+![](https://www.charlesteague.com/blog/writing-style/west.jpg){width="488"} 
+
+[SOURCE](https://www.charlesteague.com/blog/writing-style/west.jpg)
+
+![](http://www.charlesteague.com/blog/writing-style/west.jpg){width="488"} [SOURCE](http://www.charlesteague.com/blog/writing-style/west.jpg)
+
+## Data URI
+
+![Hello World](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEYAAAAUCAAAAAAVAxSkAAABrUlEQVQ4y+3TPUvDQBgH8OdDOGa+oUMgk2MpdHIIgpSUiqC0OKirgxYX8QVFRQRpBRF8KShqLbgIYkUEteCgFVuqUEVxEIkvJFhae3m8S2KbSkcFBw9yHP88+eXucgH8kQZ/jSm4VDaIy9RKCpKac9NKgU4uEJNwhHhK3qvPBVO8rxRWmFXPF+NSM1KVMbwriAMwhDgVcrxeMZm85GR0PhvGJAAmyozJsbsxgNEir4iEjIK0SYqGd8sOR3rJAGN2BCEkOxhxMhpd8Mk0CXtZacxi1hr20mI/rzgnxayoidevcGuHXTC/q6QuYSMt1jC+gBIiMg12v2vb5NlklChiWnhmFZpwvxDGzuUzV8kOg+N8UUvNBp64vy9q3UN7gDXhwWLY2nMC3zRDibfsY7wjEkY79CdMZhrxSqqzxf4ZRPXwzWJirMicDa5KwiPeARygHXKNMQHEy3rMopDR20XNZGbJzUtrwDC/KshlLDWyqdmhxZzCsdYmf2fWZPoxCEDyfIvdtNQH0PRkH6Q51g8rFO3Qzxh2LbItcDCOpmuOsV7ntNaERe3v/lP/zO8yn4N+yNPrekmPAAAAAElFTkSuQmCC)


### PR DESCRIPTION
Both of these patterns are incorrect- they intend to match urls that start with http or https.

Fixes #4964

The LUA resource discovery is a new addition this release, so this represents a regression.

Thanks to @cderv for tracking down this issue!