### PR TITLE
better fix for chrome+chromium on macOS and hopefully windows.

### DIFF
--- a/src/core/cri/cri.ts
+++ b/src/core/cri/cri.ts
@@ -76,31 +76,6 @@ export async function criClient(appPath?: string, port?: number) {
   }
   const app: string = appPath || await getBrowserExecutablePath();
 
-  const version = Deno.run({
-    cmd: [app, "--version"],
-    stdout: "piped",
-    stderr: "piped",
-  });
-  const [status, stdout, _stderr] = await Promise.all([
-    version.status(),
-    version.output(),
-    version.stderrOutput(),
-  ]);
-  if (!status.success) {
-    throw new Error(`Failed to get chrome version`);
-  }
-  const versionString = new TextDecoder().decode(stdout);
-  let versionNumber = 0;
-
-  const chromeMatch = versionString.match(/Google Chrome (\d+)/);
-  if (chromeMatch) {
-    versionNumber = Number(chromeMatch[1]);
-  }
-  const chromiumMatch = versionString.match(/Chromium (\d+)/);
-  if (chromiumMatch) {
-    versionNumber = Number(chromiumMatch[1]);
-  }
-
   const cmd = [
     app,
     "--headless",
@@ -138,7 +113,7 @@ export async function criClient(appPath?: string, port?: number) {
       const maxTries = 5;
       for (let i = 0; i < maxTries; ++i) {
         try {
-          client = await cdp({ port, version: versionNumber });
+          client = await cdp({ port });
           break;
         } catch (e) {
           if (i === maxTries - 1) {

--- a/src/core/cri/deno-cri/devtools.js
+++ b/src/core/cri/deno-cri/devtools.js
@@ -52,12 +52,13 @@ export async function New(options) {
   }
   // we don't mutate here because we don't want other
   // calls to have PUT as the method
-  if (options.version >= 109) {
-    options = {
-      ...options,
-      method: "PUT",
-    };
-  }
+  //
+  // 2023-03-28: We use PUT since that works on the Chromium release given
+  // by puppeteer as well as the later chromium versions which require PUT
+  options = {
+    ...options,
+    method: "PUT",
+  };
   const result = await devToolsInterface(options);
   return JSON.parse(result);
 }


### PR DESCRIPTION
I had added a version check to control whether or not to use HTTP PUT in the cdp initialization code.

It turns out that:

1. the code I wrote for determining the chrome version doesn't work on windows
2. the older versions of chrome support using PUT.

It's the new versions which _don't_ support GET. So a much simpler fix is to just use PUT everywhere. This should close #4991.