### PR TITLE
walk individual nodes correctly. Closes #5001

### DIFF
--- a/src/resources/filters/ast/customnodes.lua
+++ b/src/resources/filters/ast/customnodes.lua
@@ -95,6 +95,16 @@ function run_emulated_filter(doc, filter, top_level)
     end
   end
 
+  local custom = resolve_custom_node(doc)
+  if custom then
+    local custom_data, t, kind = _quarto.ast.resolve_custom_data(custom)
+    local result, recurse = process_custom(custom_data, t, kind, custom)
+    if result == nil then
+      return doc
+    end
+    return result, recurse
+  end
+
   function wrapped_filter.Plain(node)
     local custom = resolve_custom_node(node)
 

--- a/src/resources/filters/crossref/preprocess.lua
+++ b/src/resources/filters/crossref/preprocess.lua
@@ -104,7 +104,7 @@ function crossrefPreprocess()
             Block = pandoc.Blocks,
             Inline = pandoc.Inlines
           }
-          doc.blocks[i] = _quarto.ast.walk(ctor[pandoc.utils.type(el)]({ el }), walkRefs(parentId))[1]
+          doc.blocks[i] = _quarto.ast.walk(el, walkRefs(parentId))
         end
       end
 

--- a/src/resources/filters/crossref/preprocess.lua
+++ b/src/resources/filters/crossref/preprocess.lua
@@ -100,7 +100,11 @@ function crossrefPreprocess()
               el.content:insert(err)
             end
           end
-          doc.blocks[i] = _quarto.ast.walk(el, walkRefs(parentId))
+          local ctor = {
+            Block = pandoc.Blocks,
+            Inline = pandoc.Inlines
+          }
+          doc.blocks[i] = _quarto.ast.walk(ctor[pandoc.utils.type(el)]({ el }), walkRefs(parentId))[1]
         end
       end
 
@@ -110,5 +114,4 @@ function crossrefPreprocess()
   }
 end
 
-
-
+debug_5001 = 0

--- a/src/resources/filters/crossref/preprocess.lua
+++ b/src/resources/filters/crossref/preprocess.lua
@@ -113,5 +113,3 @@ function crossrefPreprocess()
     end
   }
 end
-
-debug_5001 = 0

--- a/src/resources/filters/crossref/preprocess.lua
+++ b/src/resources/filters/crossref/preprocess.lua
@@ -100,10 +100,6 @@ function crossrefPreprocess()
               el.content:insert(err)
             end
           end
-          local ctor = {
-            Block = pandoc.Blocks,
-            Inline = pandoc.Inlines
-          }
           doc.blocks[i] = _quarto.ast.walk(el, walkRefs(parentId))
         end
       end


### PR DESCRIPTION
Consider the following ([documented, but unintuitive --- see the first sentence of the second paragraph](https://pandoc.org/lua-filters.html#type-block:walk)) behavior of Pandoc nodes:

```lua
  local plain = pandoc.Plain({ pandoc.Str("hello") })
  local doc = pandoc.Pandoc({ plain })
  doc:walk({ 
    Plain = function() 
      print("HELLO 1") 
    end
  })
  plain:walk({ 
    Plain = function() 
      print("HELLO 2") 
    end
  })
  -- will print HELLO 1 but not HELLO 2
```

This means our implementation of preprocess.lua is incorrect; we can't call walk directly on nodes and expect it to work. We wrap each of those around an `Inlines` or `Blocks` as needed.

