### PR TITLE
only attach ojs_define etc if needed.

### DIFF
--- a/src/resources/rmd/execute.R
+++ b/src/resources/rmd/execute.R
@@ -120,7 +120,7 @@ execute <- function(input, format, tempDir, libDir, dependencies, cwd, params, r
   # we need ojs only if markdown has ojs code cells
   # inspect code cells for spaces after line breaks
 
-  needs_ojs <- grepl("\n[[:space:]]*```+\\{ojs\\}", markdown)
+  needs_ojs <- grepl("^[[:space:]]*```+\\{ojs[^}]*\\}", markdown)
   # FIXME this test isn't failing in shiny mode, but it doesn't look to be
   # breaking quarto-shiny-ojs. We should make sure this is right.
   if (!is_shiny_prerendered(knitr::opts_knit$get("rmarkdown.runtime")) &&

--- a/src/resources/rmd/execute.R
+++ b/src/resources/rmd/execute.R
@@ -117,9 +117,14 @@ execute <- function(input, format, tempDir, libDir, dependencies, cwd, params, r
     df_print = df_print
   )
 
+  # we need ojs only if markdown has ojs code cells
+  # inspect code cells for spaces after line breaks
+
+  needs_ojs <- grepl("\n[[:space:]]*```+\\{ojs\\}", markdown)
   # FIXME this test isn't failing in shiny mode, but it doesn't look to be
   # breaking quarto-shiny-ojs. We should make sure this is right.
-  if (!is_shiny_prerendered(knitr::opts_knit$get("rmarkdown.runtime"))) {
+  if (!is_shiny_prerendered(knitr::opts_knit$get("rmarkdown.runtime")) &&
+      needs_ojs) {
     attach(list(
       quarto_format = format
     ), name = "tools:quarto")


### PR DESCRIPTION
(cc @jennybc)

This PR makes it so that `search()` doesn't get polluted by the tools:quarto attach() call, which is really only needed on OJS settings.