### PR TITLE
Fix issues identified in our book asciidoc output.

### DIFF
--- a/src/resources/filters/quarto-post/render-asciidoc.lua
+++ b/src/resources/filters/quarto-post/render-asciidoc.lua
@@ -59,7 +59,7 @@ function renderAsciidoc()
       local admonitionStr;
       if el.title then
         -- A titled admonition
-        local admonitionTitle = pandoc.write(pandoc.Pandoc(el.title), "asciidoc")
+        local admonitionTitle = pandoc.write(pandoc.Pandoc({el.title}), "asciidoc")
         admonitionStr = "[" .. admonitionType .. "]\n." .. admonitionTitle .. "====\n" .. admonitionContents .. "====\n\n" 
       else
         -- A titleless admonition

--- a/src/resources/formats/asciidoc/pandoc/template.asciidoc
+++ b/src/resources/formats/asciidoc/pandoc/template.asciidoc
@@ -12,7 +12,7 @@ $elseif(date)$
 :revdate: $date$
 $endif$
 $if(description)$
-:description: $description$
+:description: $description/chomp$
 $endif$
 $if(keywords)$
 :keywords: $for(keywords)$$keywords$$sep$, $endfor$

--- a/tests/docs/smoke-all/2023/01/20/asciidoc.qmd
+++ b/tests/docs/smoke-all/2023/01/20/asciidoc.qmd
@@ -3,16 +3,33 @@ title: Test Asciidoc Article
 author:
   - Norah Jones
   - Kirk Cousins
+description: |
+  This is a description of the document. It should not have a 2 trailing newlines!
 format:
   asciidoc: default
 _quarto:
   tests: 
     asciidoc:
       ensureFileRegexMatches:
-        - ["= Test Asciidoc Article"] # looks like asciidoc
-        - [":doctype: book"] # not a book
+        - 
+          - "= Test Asciidoc Article" # looks like asciidoc
+          - ".A Callout Title With Spaces" # no newlines in callout titles
+        - 
+          - ":doctype: book" # not a book
+          - "newlines!\n\n" # no double new lines
+keywords: [cool, beans]
 ---
 
 ## Section 1
 
 Now is the time for all good men to come to the aide of their country. The quick brown fox jumps over the lazy dog.
+
+## Callout Section
+
+:::{.callout-note}
+
+## A Callout Title With Spaces
+
+This is a callout. The title shouldn't be hosed.
+
+:::


### PR DESCRIPTION
Fix issues identified in our book asciidoc output.

- Malformed document titles when a description is included
- Malformed admonition titles when title contains spaces