### PR TITLE
Use better selector for capturing sidebar titles

### DIFF
--- a/src/project/types/website/website-navigation.ts
+++ b/src/project/types/website/website-navigation.ts
@@ -473,9 +473,11 @@ function navigationHtmlPostprocessor(
             if (item.id) {
               titleEl = doc.getElementById(item.id);
             } else if (item.href) {
-              titleEl = doc.querySelector(
-                `.depth${crumbCount} .sidebar-item a[href="${item.href}"] .menu-text`,
-              );
+              const titleSelector = crumbCount === 0
+                ? `.sidebar-menu-container > ul > .sidebar-item > .sidebar-item-container > a[href='${item.href}'] > .menu-text`
+                : `.depth${crumbCount} .sidebar-item a[href="${item.href}"] .menu-text`;
+              titleEl = doc.querySelector(titleSelector);
+
             }
 
             const liEl = breadCrumbEl();


### PR DESCRIPTION
- Note that depth 0 items have no depth class, so root items were always missing. Fixes #5027

