### PR TITLE
Don’t number asciidoc cross references

### DIFF
--- a/src/resources/filters/crossref/format.lua
+++ b/src/resources/filters/crossref/format.lua
@@ -44,7 +44,7 @@ function subrefNumber(order)
 end
 
 function prependSubrefNumber(captionContent, order)
-  if not _quarto.format.isLatexOutput() then
+  if not _quarto.format.isLatexOutput() and not _quarto.format.isAsciiDocOutput() then
     if #inlinesToString(captionContent) > 0 then
       tprepend(captionContent, { pandoc.Space() })
     end

--- a/src/resources/filters/crossref/tables.lua
+++ b/src/resources/filters/crossref/tables.lua
@@ -273,7 +273,7 @@ function prependTitlePrefix(caption, label, order)
      tprepend(caption.content, {
        pandoc.RawInline('latex', '\\label{' .. label .. '}')
      })
-  else
+  elseif not _quarto.format.isAsciiDocOutput() then
      tprepend(caption.content, tableTitlePrefix(order))
   end
 end


### PR DESCRIPTION
Asciidoc toolchain will handle numbers, captions, and so on.