### PR TITLE
lua: recompute allOptions after user filters

### DIFF
--- a/src/resources/filters/main.lua
+++ b/src/resources/filters/main.lua
@@ -178,6 +178,13 @@ local quartoNormalize = {
 local quartoPre = {
   -- quarto-pre
   { name = "pre-quartoBeforeExtendedUserFilters", filters = make_wrapped_user_filters("beforeQuartoFilters") },
+
+  -- https://github.com/quarto-dev/quarto-cli/issues/5031
+  -- recompute options object in case user filters have changed meta
+  -- this will need to change in the future; users will have to indicate
+  -- when they mutate options
+  { name = "pre-quartoAfterUserFilters", filter = initOptions() },
+
   { name = "normalize-parse-pandoc3-figures", filter = parse_pandoc3_figures() },
   { name = "pre-bibliographyFormats", filter = bibliographyFormats() }, 
   { name = "pre-shortCodesBlocks", filter = shortCodesBlocks() } ,

--- a/tests/docs/smoke-all/2023/03/30/custom.lua
+++ b/tests/docs/smoke-all/2023/03/30/custom.lua
@@ -1,0 +1,4 @@
+function Meta(meta)
+  meta["new"] = "new meta"
+  return meta
+end

--- a/tests/docs/smoke-all/2023/03/30/issue-5031.qmd
+++ b/tests/docs/smoke-all/2023/03/30/issue-5031.qmd
@@ -1,0 +1,13 @@
+---
+title: "Untitled"
+format: gfm
+filters: ["custom.lua"]
+_quarto:
+  tests:
+    gfm:
+      ensureFileRegexMatches:
+        - []
+        - ["\\?meta:new"]
+---
+
+What is defined in the lua filter: "{{< meta new >}}"


### PR DESCRIPTION
This closes #5031 to avoid a 1.2->1.3 regression.

With that said, this incurs a performance hit for every single document render, so we will eventually need to change this behavior. In the future, user filters that actively change document meta will need to use a new API (details to be determined).

(cc @cderv @mcanouil)