### PR TITLE
non-lua filters: convert custom AST nodes conservatively

### DIFF
--- a/src/resources/filters/common/wrapped-filter.lua
+++ b/src/resources/filters/common/wrapped-filter.lua
@@ -101,7 +101,6 @@ function makeWrappedJsonFilter(scriptFile, filterHandler)
             if custom_node ~= nil then
               has_custom_nodes = true
               custom_node = safeguard_for_meta(custom_node)
-              quarto.utils.dump(custom_node)
               table.insert(custom_node_map, { id = raw.text, tbl = custom_node, t = t, kind = kind })
             end
           end,

--- a/src/resources/filters/common/wrapped-filter.lua
+++ b/src/resources/filters/common/wrapped-filter.lua
@@ -57,6 +57,35 @@ local function shortcodeMetatable(scriptFile)
   }
 end
 
+local function safeguard_for_meta(customnode)
+  if customnode == nil then
+    return nil
+  end
+  local result = {}
+  for k,v in pairs(customnode) do
+    local t = type(v)
+    local pt = pandoc.utils.type(v)
+    if pt == "Attr" then
+      local converted_attrs = {}
+      for i, attr in ipairs(v.attributes) do
+        table.insert(converted_attrs, {
+          attr[1], attr[2]
+        })
+      end
+      result[k] = {
+        identifier = v.identifier,
+        classes = v.classes,
+        attributes = converted_attrs
+      }
+    elseif t == "userdata" then
+      result[k] = v -- assume other pandoc objects are ok
+    elseif t == "table" then
+      result[k] = safeguard_for_meta(v)
+    end
+  end
+  return result
+end
+
 function makeWrappedJsonFilter(scriptFile, filterHandler)
   local handlers = {
     Pandoc = {
@@ -71,6 +100,8 @@ function makeWrappedJsonFilter(scriptFile, filterHandler)
             local custom_node, t, kind = _quarto.ast.resolve_custom_data(raw)
             if custom_node ~= nil then
               has_custom_nodes = true
+              custom_node = safeguard_for_meta(custom_node)
+              quarto.utils.dump(custom_node)
               table.insert(custom_node_map, { id = raw.text, tbl = custom_node, t = t, kind = kind })
             end
           end,

--- a/tests/docs/smoke-all/2023/03/30/5044.qmd
+++ b/tests/docs/smoke-all/2023/03/30/5044.qmd
@@ -1,0 +1,26 @@
+---
+format: html
+title: foo
+filters:
+  - type: json
+    path: test.py
+---
+
+
+::: callout-note
+
+Hello.
+
+:::
+
+::: panel-tabset
+
+## A
+
+A.
+
+## B
+
+B.
+
+:::

--- a/tests/docs/smoke-all/2023/03/30/test.py
+++ b/tests/docs/smoke-all/2023/03/30/test.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+import sys
+sys.stdout.write(sys.stdin.read())


### PR DESCRIPTION
Custom AST nodes are stored in tables which are serialized to JSON in non-lua filters so their contents can be inspected.

This means their contents have to be representable in Pandoc Meta, and Pandoc Attr objects aren't. So we explicitly convert them to plain tables that are.

This closes #5044 and should fix https://github.com/machow/quartodoc/issues/82.