### PR TITLE
Create a Listing Source to deal with metadata provided files

### DIFF
--- a/src/project/types/website/listing/website-listing-shared.ts
+++ b/src/project/types/website/listing/website-listing-shared.ts
@@ -193,9 +193,10 @@ export type ColumnType = "date" | "string" | "number" | "minutes";
 
 // Sources that provide Listing Items
 export enum ListingItemSource {
-  document = "document",
-  metadata = "metadata",
-  rawfile = "rawfile",
+  document = "document", // qmd input files
+  metadata = "metadata", // yaml metadata files
+  metadataDocument = "metadata-document", // yaml containing a list of input files
+  rawfile = "rawfile", // some other kind of file that we can't introspect much
 }
 
 // An individual listing item


### PR DESCRIPTION
Fixes #5048

We added a new feature this release which allows passing input files through metadata files, but it wasn't properly identifying the source when this happened, which meant that input specific field customization wasn't properly identifying.