### PR TITLE
title is not always present, handle accordingly

### DIFF
--- a/src/command/render/output.ts
+++ b/src/command/render/output.ts
@@ -1,9 +1,8 @@
 /*
-* output.ts
-*
-* Copyright (C) 2020-2022 Posit Software, PBC
-*
-*/
+ * output.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
 
 import {
   basename,
@@ -19,7 +18,12 @@ import { writeFileToStdout } from "../../core/console.ts";
 import { dirAndStem, expandPath } from "../../core/path.ts";
 import { partitionYamlFrontMatter } from "../../core/yaml.ts";
 
-import { kOutputExt, kOutputFile, kVariant } from "../../config/constants.ts";
+import {
+  kOutputExt,
+  kOutputFile,
+  kPreserveYaml,
+  kVariant,
+} from "../../config/constants.ts";
 
 import {
   quartoLatexmkOutputRecipe,
@@ -129,7 +133,8 @@ export function outputRecipe(
     }
 
     // complete hook for keep-yaml
-    if (recipe.keepYaml) {
+    // workaround for https://github.com/quarto-dev/quarto-cli/issues/5079
+    if (recipe.keepYaml || recipe.format.render[kPreserveYaml]) {
       completeActions.push(() => {
         // read yaml and output markdown
         const inputMd = partitionYamlFrontMatter(context.target.markdown.value);

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,9 +1,8 @@
 /*
-* constants.ts
-*
-* Copyright (C) 2020-2022 Posit Software, PBC
-*
-*/
+ * constants.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
 
 export const kMetadataFormat = "format";
 
@@ -78,6 +77,7 @@ export const kTblCap = "tbl-cap";
 export const kTblColwidths = "tbl-colwidths";
 export const kMergeIncludes = "merge-includes";
 export const kInlineIncludes = "inline-includes";
+export const kPreserveYaml = "preserve-yaml";
 export const kPreferHtml = "prefer-html";
 export const kSelfContainedMath = "self-contained-math";
 export const kBiblioConfig = "biblio-config";
@@ -158,6 +158,7 @@ export const kRenderDefaultsKeys = [
   kShortcodes,
   kTblColwidths,
   kInlineIncludes,
+  kPreserveYaml,
   kMergeIncludes,
   kSelfContainedMath,
   kLatexAutoMk,

--- a/src/config/format.ts
+++ b/src/config/format.ts
@@ -1,9 +1,8 @@
 /*
-* format.ts
-*
-* Copyright (C) 2020-2022 Posit Software, PBC
-*
-*/
+ * format.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
 
 import { kBaseFormat, kPreferHtml } from "../config/constants.ts";
 import { Format, FormatPandoc } from "./types.ts";

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -145,6 +145,7 @@ import {
   kPdfEngineOpt,
   kPdfEngineOpts,
   kPreferHtml,
+  kPreserveYaml,
   kQuartoFilters,
   kReferenceLocation,
   kRelatedFormatsTitle,
@@ -398,7 +399,8 @@ export interface FormatRender {
   [kTblColwidths]?: "auto" | boolean | number[];
   [kShortcodes]?: string[];
   [kMergeIncludes]?: boolean;
-  [kInlineIncludes]?: false;
+  [kInlineIncludes]?: boolean;
+  [kPreserveYaml]?: boolean;
   [kLatexAutoMk]?: boolean;
   [kLatexAutoInstall]?: boolean;
   [kLatexMinRuns]?: number;

--- a/src/format/formats-shared.ts
+++ b/src/format/formats-shared.ts
@@ -1,9 +1,8 @@
 /*
-* formats-shared.ts
-*
-* Copyright (C) 2020-2022 Posit Software, PBC
-*
-*/
+ * formats-shared.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
 
 import { mergeConfigs } from "../core/config.ts";
 
@@ -63,6 +62,7 @@ import {
   kOutputExt,
   kPageWidth,
   kPreferHtml,
+  kPreserveYaml,
   kQuartoVersion,
   kSelfContainedMath,
   kStandalone,
@@ -236,6 +236,7 @@ function defaultFormat(displayName: string): Format {
       [kTblColwidths]: true,
       [kMergeIncludes]: true,
       [kInlineIncludes]: false,
+      [kPreserveYaml]: false,
       [kLatexAutoMk]: true,
       [kLatexAutoInstall]: true,
       [kLatexClean]: true,

--- a/src/resources/extensions/quarto/docusaurus/_extension.yml
+++ b/src/resources/extensions/quarto/docusaurus/_extension.yml
@@ -20,6 +20,7 @@ contributes:
       writer: docusaurus_writer.lua
       output-ext: md
       inline-includes: true
+      preserve-yaml: true
       wrap: none
       fig-format: retina
       fig-width: 8

--- a/src/resources/extensions/quarto/docusaurus/_extension.yml
+++ b/src/resources/extensions/quarto/docusaurus/_extension.yml
@@ -17,6 +17,9 @@ contributes:
     format: docusaurus-md
   formats:
     md:
+      # Although we use a custom writer, we still need the variants here the lua filters to render correctly.
+      # Ideally, we would forward the variants to the custom writer.
+      variant: gfm+pipe_tables+tex_math_dollars+header_attributes+raw_html+all_symbols_escapable+backtick_code_blocks+fenced_code_blocks+space_in_atx_header+intraword_underscores+lists_without_preceding_blankline+shortcut_reference_links
       writer: docusaurus_writer.lua
       output-ext: md
       inline-includes: true

--- a/src/resources/extensions/quarto/docusaurus/docusaurus_writer.lua
+++ b/src/resources/extensions/quarto/docusaurus/docusaurus_writer.lua
@@ -70,10 +70,12 @@ function Writer(doc, opts)
     Callout = function(node)
       local admonition = pandoc.List()
       admonition:insert(pandoc.RawBlock("markdown", ":::" .. node.type))
-      admonition:insert(pandoc.Header(2, node.title))
+      if node.title then
+        admonition:insert(pandoc.Header(2, node.title))
+      end
       admonition:extend(node.content)
       admonition:insert(pandoc.RawBlock("markdown", ":::"))
-      return admonition  
+      return admonition
     end
   })
 

--- a/src/resources/extensions/quarto/docusaurus/docusaurus_writer.lua
+++ b/src/resources/extensions/quarto/docusaurus/docusaurus_writer.lua
@@ -69,12 +69,12 @@ function Writer(doc, opts)
 
     Callout = function(node)
       local admonition = pandoc.List()
-      admonition:insert(pandoc.RawBlock("markdown", ":::" .. node.type))
+      admonition:insert(pandoc.RawBlock("markdown", "\n:::" .. node.type))
       if node.title then
         admonition:insert(pandoc.Header(2, node.title))
       end
       admonition:extend(node.content)
-      admonition:insert(pandoc.RawBlock("markdown", ":::"))
+      admonition:insert(pandoc.RawBlock("markdown", ":::\n"))
       return admonition
     end
   })

--- a/src/resources/pandoc/datadir/_format.lua
+++ b/src/resources/pandoc/datadir/_format.lua
@@ -104,6 +104,10 @@ local function isBibliographyOutput()
   return tcontains(formats, FORMAT)
 end
 
+local function is_docusaurus_output()
+  return string.match(param("custom-writer"), "docusaurus_writer.lua$")
+end
+
 -- check for markdown output
 local function isMarkdownOutput()
   local formats = {
@@ -117,12 +121,12 @@ local function isMarkdownOutput()
     "commonmark_x",
     "markua"
   }
-  return tcontains(formats, FORMAT)
+  return tcontains(formats, FORMAT) or is_docusaurus_output()
 end
 
 -- check for markdown with raw_html enabled
 local function isMarkdownWithHtmlOutput()
-  return isMarkdownOutput() and tcontains(PANDOC_WRITER_OPTIONS.extensions, "raw_html")
+  return (isMarkdownOutput() and tcontains(PANDOC_WRITER_OPTIONS.extensions, "raw_html")) or is_docusaurus_output()
 end
 
 -- check for ipynb output

--- a/src/resources/pandoc/datadir/_format.lua
+++ b/src/resources/pandoc/datadir/_format.lua
@@ -105,7 +105,7 @@ local function isBibliographyOutput()
 end
 
 local function is_docusaurus_output()
-  return string.match(param("custom-writer"), "docusaurus_writer.lua$")
+  return string.match(param("custom-writer", ""), "docusaurus_writer.lua$")
 end
 
 -- check for markdown output


### PR DESCRIPTION
This fixes a bug on the docusaurus writer where if a callout has no title, render will fail.

This closes #5079.