### PR TITLE
Fix bad regex on detecting ojs blocks

### DIFF
--- a/src/resources/rmd/execute.R
+++ b/src/resources/rmd/execute.R
@@ -120,7 +120,7 @@ execute <- function(input, format, tempDir, libDir, dependencies, cwd, params, r
   # we need ojs only if markdown has ojs code cells
   # inspect code cells for spaces after line breaks
 
-  needs_ojs <- grepl("^[[:space:]]*```+\\{ojs[^}]*\\}", markdown)
+  needs_ojs <- grepl("(\n|^)[[:space:]]*```+\\{ojs[^}]*\\}", markdown)
   # FIXME this test isn't failing in shiny mode, but it doesn't look to be
   # breaking quarto-shiny-ojs. We should make sure this is right.
   if (!is_shiny_prerendered(knitr::opts_knit$get("rmarkdown.runtime")) &&

--- a/tests/docs/smoke-all/2023/04/04/ojs_define.qmd
+++ b/tests/docs/smoke-all/2023/04/04/ojs_define.qmd
@@ -1,0 +1,11 @@
+---
+title: test
+---
+
+```{r}
+ojs_define(foo = "1")
+```
+
+```{ojs}
+1 + 2
+```


### PR DESCRIPTION
Our attempt to fix the introduction of the ojs_define environments has a bad regex. This fixes an issue reported to us on [fosstodon](https://fosstodon.org/@smach/110141844960217115)

