### PR TITLE
Improved fix for 5089

### DIFF
--- a/src/resources/filters/common/url.lua
+++ b/src/resources/filters/common/url.lua
@@ -12,4 +12,13 @@ function urldecode(url)
   return url
 end
 
-
+function fullyUrlDecode(url)
+  -- decode the url until it is fully decoded (not a single pass,
+  -- but repeated until it decodes no further)
+  result = urldecode(url)
+  if result == url then
+    return result
+  else 
+    return fullyUrlDecode(result)
+  end
+end

--- a/src/resources/filters/quarto-post/pdf-images.lua
+++ b/src/resources/filters/quarto-post/pdf-images.lua
@@ -20,6 +20,19 @@ local function convert_svg(path)
   end
 end
 
+local mimeImgExts = {
+  ["image/jpeg"]="jpg",
+  ["image/gif"]="gif",
+  ["image/vnd.microsoft.icon"]="ico",
+  ["image/avif"]="avif",
+  ["image/bmp"]="bmp",
+  ["image/png"]="png",
+  ["image/svg+xml"]="svg",
+  ["image/tiff"]="tif",
+  ["image/webp"]="webp",
+}
+
+
 -- A cache of image urls that we've resolved into the mediabag
 -- keyed by {url: mediabagpath}
 local resolvedUrls = {}
@@ -109,13 +122,31 @@ function pdfImages()
             else 
               local relativePath = image.src:match('https?://[%w%.%:]+/(.+)')
               if relativePath then
-                
+
                 local imgMt, imgContents = pandoc.mediabag.fetch(image.src)
-                local decodedSrc = urldecode(image.src)
+                local decodedSrc = fullyUrlDecode(image.src)                
                 if decodedSrc == nil then
                   decodedSrc = "unknown"
                 end
-                local filename = windows_safe_filename(tex_safe_filename(pandoc.path.filename(decodedSrc)))
+
+                local function filenameFromMimeType(filename, imgMt)
+                  -- Use the mime type to compute an extension when possible
+                  -- This will allow pandoc to properly know the type, even when 
+                  -- the path to the image is a difficult to parse URI
+                  local mimeExt = mimeImgExts[imgMt]
+                  if mimeExt then
+                    local stem, _ext = pandoc.path.split_extension(filename)
+                    return stem .. '.' .. mimeExt
+                  else
+                    return filename
+                  end
+                end
+
+                -- compute the filename for this file
+                local basefilename = pandoc.path.filename(decodedSrc)
+                local safefilename = windows_safe_filename(tex_safe_filename(basefilename))
+                local filename = filenameFromMimeType(safefilename, imgMt)
+
                 if imgMt ~= nil then
                   local existingMt = pandoc.mediabag.lookup(filename)
                   local counter = 1
@@ -138,4 +169,5 @@ function pdfImages()
     end
   }
 end
+
 

--- a/tests/docs/smoke-all/2023/04/04/5089.qmd
+++ b/tests/docs/smoke-all/2023/04/04/5089.qmd
@@ -7,7 +7,6 @@ format: pdf
 
 ![](https://substackcdn.com/image/fetch/f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F9b7345d9-5f62-46dc-8062-d704c2c014a5_289x174.jpeg)
 
-
 ## Simple Url
 
 ![](https://quarto.org/quarto.png)


### PR DESCRIPTION
Fixes #5089

Improvements include:

1) If the URL has been encoded repeatedly, we will continue decoding the URL until it is completely decoded.

2) If the file extension guessed from the URL doesn’t match the mime type, we will respect the mime type and use that to form the file name.

This URL:
https://substackcdn.com/image/fetch/w_1456,c_limit,f_webp,q_auto:good,fl_progressive:steep/https%253A%252F%252Fsubstack-post-media.s3.amazonaws.com%252Fpublic%252Fimages%252Fced5d5ad-a0d6-44aa-b6f5-73c0a937d016_3553x5273.jpeg

is double URL encoded and returns a webp file (which can’t be rendered in PDFs, FYI).
