### PR TITLE
markdown formats: handle code blocks with filenames as in v1.2

### DIFF
--- a/src/resources/filters/customnodes/decoratedcodeblock.lua
+++ b/src/resources/filters/customnodes/decoratedcodeblock.lua
@@ -103,6 +103,22 @@ _quarto.ast.add_handler({
         return listingDiv
       end
       return el
+    elseif _quarto.format.isMarkdownOutput() then
+      -- see https://github.com/quarto-dev/quarto-cli/issues/5112
+      -- 
+      -- This is a narrow fix for the 1.3 regression.
+      -- We still don't support listings output in markdown since that wasn't supported in 1.2 either.
+      -- But that'll be done in 1.4 with crossrefs overhaul.
+
+      if node.filename then
+        -- if we have a filename, add it as a header
+        return pandoc.Div(
+          { pandoc.Plain{pandoc.Strong{pandoc.Str(node.filename)}}, el },
+          pandoc.Attr("", {"code-with-filename"})
+        )
+      else
+        return el
+      end
     else
       -- return the code block unadorned
       -- this probably could be improved
@@ -111,10 +127,15 @@ _quarto.ast.add_handler({
   end,
 
   inner_content = function(extended_node)
-    return {}
+    return {
+      code_block = extended_node.code_block
+    }
   end,
 
   set_inner_content = function(extended_node, values)
+    if values.code_block ~= nil then
+      extended_node.code_block = values.code_block
+    end
     return extended_node
   end,
 

--- a/src/resources/filters/customnodes/decoratedcodeblock.lua
+++ b/src/resources/filters/customnodes/decoratedcodeblock.lua
@@ -127,15 +127,10 @@ _quarto.ast.add_handler({
   end,
 
   inner_content = function(extended_node)
-    return {
-      code_block = extended_node.code_block
-    }
+    return {}
   end,
 
   set_inner_content = function(extended_node, values)
-    if values.code_block ~= nil then
-      extended_node.code_block = values.code_block
-    end
     return extended_node
   end,
 

--- a/tests/docs/smoke-all/2023/04/06/5112.qmd
+++ b/tests/docs/smoke-all/2023/04/06/5112.qmd
@@ -1,0 +1,17 @@
+---
+title: foo
+format: commonmark
+keep-md: true
+_quarto:
+  tests:
+    commonmark:
+      ensureFileRegexMatches:
+        - ["this-is-the-filename.py"]
+        - []
+---
+
+```{.python filename="this-is-the-filename.py"}
+import matplotlib.pyplot as plt
+plt.plot([1,23,2,4])
+plt.show()
+```


### PR DESCRIPTION
This closes #5112. Code blocks with filenames are now handled the way they were in 1.2 in Markdown formats.

Incidentally, there was a separate bug with DecoratedCodeBlock where the CodeBlock itself wouldn't be visible to filters, so I fixed that as well.

