### PR TITLE
JATS Fixes

### DIFF
--- a/src/format/jats/format-jats.ts
+++ b/src/format/jats/format-jats.ts
@@ -57,7 +57,7 @@ export function jatsFormat(displayName: string, ext: string): Format {
       };
 
       // Which tagset we're using
-      const tagset = jatsTagset(format.pandoc.to || "html");
+      const tagset = jatsTagset(format.identifier["base-format"] || "jats");
 
       const metadataOverride = {
         // Link citations produces `xrefs` for the citations to the references in the bibliography so

--- a/src/resources/filters/main.lua
+++ b/src/resources/filters/main.lua
@@ -69,6 +69,7 @@ import("./quarto-post/ipynb.lua")
 import("./quarto-post/latexdiv.lua")
 import("./quarto-post/meta.lua")
 import("./quarto-post/ojs.lua")
+import("./quarto-post/jats.lua")
 import("./quarto-post/responsive.lua")
 import("./quarto-post/reveal.lua")
 import("./quarto-post/tikz.lua")
@@ -248,6 +249,7 @@ local quartoPost = {
   }) },
   { name = "post-ojs", filter = ojs() },
   { name = "post-postMetaInject", filter = quartoPostMetaInject() },
+  { name = "post-render-jats", filter = jats() },
   { name = "post-render-asciidoc", filter = renderAsciidoc() },
   { name = "post-renderExtendedNodes", filter = renderExtendedNodes() },
   { name = "post-render-pandoc-3-figures", filter = render_pandoc3_figures() },

--- a/src/resources/filters/normalize/pandoc3.lua
+++ b/src/resources/filters/normalize/pandoc3.lua
@@ -69,8 +69,15 @@ function render_pandoc3_figures()
     Para = function(para)
       if (#para.content == 1 and para.content[1].t == "Image" and
           hasFigureRef(para.content[1])) then
+        
+        -- the image
         local img = para.content[1]
-        -- quarto.utils.dump(img.caption)
+        
+        -- clear the id (otherwise the id will be present on both the image)
+        -- and the figure
+        local figAttr = img.attr:clone()
+        img.attr.identifier = ""
+        
         local caption = img.caption
         return pandoc.Figure(
           pandoc.Plain(para.content[1]),
@@ -78,7 +85,7 @@ function render_pandoc3_figures()
             short = nil,
             long = {pandoc.Plain(caption)}
           },
-          img.attr)
+          figAttr)
       end
     end,
   }

--- a/src/resources/filters/quarto-pre/callout.lua
+++ b/src/resources/filters/quarto-pre/callout.lua
@@ -817,8 +817,7 @@ function jatsCallout(node)
   end
   contents:insert(1, pandoc.RawBlock('jats', boxedStart))
   contents:insert(pandoc.RawBlock('jats', '</boxed-text>'))
-
-  return pandoc.Div(contents)
+  return contents
 end
 
 function simpleCallout(node) 

--- a/tests/docs/smoke-all/2022/12/9/jats/example.qmd
+++ b/tests/docs/smoke-all/2022/12/9/jats/example.qmd
@@ -111,6 +111,8 @@ _quarto:
           - '<fig id="fig-line">[\s\S]*?<graphic.*?>[\s\S]*?<\/fig>' # regular figure
           - '<table-wrap>[\s\S]*?<caption>[\s\S]*?<\/caption>[\s\S]*?<table>[\s\S]*?<\/table>[\s\S]*?<\/table-wrap>' #table
           - '<fig id="fig-foobar" position="float">[\s\S]*?<\/fig>' # custom figure div
+        -
+          - '<graphic id="fig-line".*/>'
 ---
 
 ## Introduction {#sec-introduction}

--- a/tests/docs/smoke-all/2022/12/9/jats/example.qmd
+++ b/tests/docs/smoke-all/2022/12/9/jats/example.qmd
@@ -113,7 +113,8 @@ _quarto:
           - '<table-wrap>[\s\S]*?<caption>[\s\S]*?<\/caption>[\s\S]*?<table>[\s\S]*?<\/table>[\s\S]*?<\/table-wrap>' #table
           - '<fig id="fig-foobar" position="float">[\s\S]*?<\/fig>' # custom figure div
         -
-          - '<graphic id="fig-line".*/>'
+          - '<graphic id="fig-line".*/>' # this id should be on the fig element, not the graphic
+          - '<boxed-text>\n\s*<boxed-text>' # no nested boxed-text
 ---
 
 ## Introduction {#sec-introduction}

--- a/tests/docs/smoke-all/2022/12/9/jats/example.qmd
+++ b/tests/docs/smoke-all/2022/12/9/jats/example.qmd
@@ -98,6 +98,7 @@ _quarto:
     jats:
       ensureFileRegexMatches:
         - 
+          - '<!DOCTYPE.*DTD JATS.*' # a JATS DTD must be present
           - '<article-meta>' # basic JATS 
           - '</article-meta>' # basic JATS 
           - '<contrib contrib-type="author" equal-contrib="yes" corresp="yes">' #author


### PR DESCRIPTION
- Pandoc 3 workaround leaves an ID that should be removed, failing JATS validation (added test)
- The template is missing a DTD declaration, failing JATS validation