### PR TITLE
Fix tools update by correctly checking lower case name of the tools

### DIFF
--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -197,7 +197,7 @@ export async function uninstallTool(name: string, updatePath?: boolean) {
 
 export async function updateTool(name: string) {
   const summary = await toolSummary(name);
-  const installableTool = kInstallableTools[name];
+  const installableTool = kInstallableTools[name.toLowerCase()];
 
   if (installableTool && summary && summary.installed) {
     const workingDir = Deno.makeTempDirSync();


### PR DESCRIPTION
otherwise, we enter an infinite loop of updating the tools -> Yes -> not install sorry

Smallest version of the #5153 fix which we will do for 1.4
