### PR TITLE
Don’t escape HTML in item.text

### DIFF
--- a/src/resources/projects/website/templates/sidebaritem.ejs
+++ b/src/resources/projects/website/templates/sidebaritem.ejs
@@ -39,6 +39,6 @@
 <li class="px-0"><hr class="sidebar-divider hi <%- borderColor %>"></li>
 <% } else if (item.text) { %>
   <li class="sidebar-item">
-    <% partial('navicon.ejs', { item }) %> <span class="menu-text"><%- item.text %></span>
+    <% partial('navicon.ejs', { item }) %> <span class="menu-text"><%= item.text %></span>
   </li>
 <% } %>

--- a/src/resources/projects/website/templates/sidebaritem.ejs
+++ b/src/resources/projects/website/templates/sidebaritem.ejs
@@ -1,7 +1,7 @@
 <% if (item.href && item.text && !item.contents) { %>
 <li class="sidebar-item">
   <div class="sidebar-item-container"> 
-  <a href="<%- item.href %>" class="sidebar-item-text sidebar-link<%- item.active ? " active" : "" %>"<%- item.target ? ` target="${item.target}"` : "" %>><% partial('navicon.ejs', { item }) %> <span class="menu-text"><%- item.text %></span></a>
+  <a href="<%- item.href %>" class="sidebar-item-text sidebar-link<%- item.active ? " active" : "" %>"<%- item.target ? ` target="${item.target}"` : "" %>><% partial('navicon.ejs', { item }) %> <span class="menu-text"><%= item.text %></span></a>
   </div>
 </li>
 <% } else if (item.contents && item.text) { %>  
@@ -17,9 +17,9 @@
     <% if (item.contents.length > 0) { %>
       <div class="sidebar-item-container"> 
           <% if (item.href) { %>
-            <a href="<%- item.href %>" class="sidebar-item-text sidebar-link<%- item.active ? " active" : "" %>"<%- item.target ? ` target="${item.target}"` : "" %>><% partial('navicon.ejs', { item }) %> <span class="menu-text"><%- item.text %></span></a>
+            <a href="<%- item.href %>" class="sidebar-item-text sidebar-link<%- item.active ? " active" : "" %>"<%- item.target ? ` target="${item.target}"` : "" %>><% partial('navicon.ejs', { item }) %> <span class="menu-text"><%= item.text %></span></a>
           <% } else { %> 
-            <a class="sidebar-item-text sidebar-link text-start<%- isCollapsed ? " collapsed" : "" %>" data-bs-toggle="collapse" data-bs-target="#<%- sectionId %>" aria-expanded="<%- isCollapsed ? "false" : "true" %>"><% partial('navicon.ejs', { item }) %> <span class="menu-text"><%- item.text %></span></a>
+            <a class="sidebar-item-text sidebar-link text-start<%- isCollapsed ? " collapsed" : "" %>" data-bs-toggle="collapse" data-bs-target="#<%- sectionId %>" aria-expanded="<%- isCollapsed ? "false" : "true" %>"><% partial('navicon.ejs', { item }) %> <span class="menu-text"><%= item.text %></span></a>
           <% }  %>      
           <a class="sidebar-item-toggle text-start<%- isCollapsed ?  " collapsed" : "" %>" data-bs-toggle="collapse" data-bs-target="#<%- sectionId %>" aria-expanded="<%- isCollapsed ? "false" : "true" %>" aria-label="<%- language['toggle-section'] %>">
             <i class="bi bi-chevron-right ms-2"></i>
@@ -31,7 +31,7 @@
         <% }) %>
       </ul>
     <% } else { %>
-      <span class="sidebar-item-text sidebar-link text-start"><% partial('navicon.ejs', { item }) %> <span class="menu-text"><%- item.text %></span></span>
+      <span class="sidebar-item-text sidebar-link text-start"><% partial('navicon.ejs', { item }) %> <span class="menu-text"><%= item.text %></span></span>
     <% } %>
 
   </li>

--- a/tests/docs/smoke-all/website/.gitignore
+++ b/tests/docs/smoke-all/website/.gitignore
@@ -1,0 +1,4 @@
+/.quarto/
+*.html
+*.json
+site_libs/

--- a/tests/docs/smoke-all/website/_quarto.yml
+++ b/tests/docs/smoke-all/website/_quarto.yml
@@ -1,0 +1,20 @@
+project:
+  type: website
+  output-dir: .
+
+website:
+  title: "Website"
+  navbar:
+    left:
+      - href: index.qmd
+        text: Home
+      - about.qmd
+  sidebar:
+    contents:
+      - text: '<a href="https://www.charlesteague.com">Hello World</a>'
+
+format:
+  html:
+    theme: cosmo
+    css: styles.css
+    toc: true

--- a/tests/docs/smoke-all/website/about.qmd
+++ b/tests/docs/smoke-all/website/about.qmd
@@ -1,0 +1,5 @@
+---
+title: "About"
+---
+
+About this site

--- a/tests/docs/smoke-all/website/index.qmd
+++ b/tests/docs/smoke-all/website/index.qmd
@@ -1,0 +1,13 @@
+---
+title: "Website"
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - ['<a href="https://www.charlesteague.com">.*</a>']
+
+---
+
+This is a Quarto website.
+
+To learn more about Quarto websites visit <https://quarto.org/docs/websites>.

--- a/tests/docs/smoke-all/website/styles.css
+++ b/tests/docs/smoke-all/website/styles.css
@@ -1,0 +1,1 @@
+/* css styles */


### PR DESCRIPTION
A regression in Quarto 1.3 where sidebar `item.text` specified in `_quarto.yml` previously wasn't HTML escaped when rendered and now is being HTML escaped. Regression introduced when adding supporting for icons in the sidebar approx 2 months ago :(.

Test added...

Fixes #5231