### PR TITLE
Bugfix: emit correct figcaption

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -49,6 +49,7 @@
 - Resolve Bootstrap responsive classes in tables ([#2997](https://github.com/quarto-dev/quarto-cli/issues/2997)).
 - Fine tuning of the appearance of computational and markdown table and more uniformly apply such styling.
 - Fine tuning of the appearance of header and body text.
+- Fix invalid figcaption DOM structure ([#5234](https://github.com/quarto-dev/quarto-cli/issues/5234)).
 
 ## Article Layout
 

--- a/src/resources/filters/layout/html.lua
+++ b/src/resources/filters/layout/html.lua
@@ -204,7 +204,7 @@ function renderHtmlFigure(el, render)
   
   -- render caption
   if captionInlines and #captionInlines > 0 then
-    local figureCaption = pandoc.Para({})
+    local figureCaption = pandoc.Plain({})
     figureCaption.content:insert(pandoc.RawInline(
       "html", "<figcaption>"
     ))

--- a/tests/docs/smoke-all/2023/04/18/test-caption.qmd
+++ b/tests/docs/smoke-all/2023/04/18/test-caption.qmd
@@ -1,0 +1,16 @@
+---
+title: Bug
+format: html
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - []
+        - ["<p></p><figcaption"]
+---
+
+## Hello.
+
+![This is a figure](elephant.png){#fig-elephant}
+
+Is this a thing? @fig-elephant.


### PR DESCRIPTION
We've been emitting invalid HTML for figcaptions for a while now. This PR fixes it. Closes #5234.