### PR TITLE
Provide a ‘render-file’ lifetime when rendering single file books

### DIFF
--- a/src/command/render/render.ts
+++ b/src/command/render/render.ts
@@ -117,9 +117,9 @@ export async function renderPandoc(
     executeResult.markdown,
   );
 
+  const embedSupporting: string[] = [];
   if (notebookResult.supporting) {
-    executeResult.supporting = executeResult.supporting || [];
-    executeResult.supporting.push(notebookResult.supporting);
+    embedSupporting.push(notebookResult.supporting);
   }
 
   // Map notebook includes to pandoc includes
@@ -316,6 +316,11 @@ export async function renderPandoc(
         supporting = supporting || [];
         supporting.push(...htmlPostProcessResult.supporting);
       }
+      if (embedSupporting && embedSupporting.length > 0) {
+        supporting = supporting || [];
+        supporting.push(...embedSupporting);
+      }
+
 
       withTiming("render-cleanup", () =>
         renderCleanup(

--- a/src/format/html/format-html-notebook.ts
+++ b/src/format/html/format-html-notebook.ts
@@ -373,6 +373,8 @@ async function renderHtmlView(
       project,
     );
     if (rendered.error) {
+      // TODO: This should throw in future releases rather than warn
+      // Only adding warning for now because of timing of release of 1.3
       warning(`Failed to render preview for notebook ${nbAbsPath}`);
     }
 

--- a/src/project/types/book/book.ts
+++ b/src/project/types/book/book.ts
@@ -116,8 +116,6 @@ export const bookProjectType: ProjectType = {
   outputDir: "_book",
   cleanOutputDir: true,
   filterFormat: (source: string, format: Format, project?: ProjectContext) => {
-    // Books don't show notebook links
-    format.render[kNotebookLinks] = false;
     if (format.extensions?.book) {
       const bookExt = format.extensions?.book as BookExtension;
       if (bookExt.filterFormat) {

--- a/src/project/types/book/book.ts
+++ b/src/project/types/book/book.ts
@@ -28,6 +28,7 @@ import {
   kCrossrefChapters,
   kDate,
   kDocumentClass,
+  kNotebookLinks,
   kNumberSections,
   kPaperSize,
   kToc,
@@ -115,6 +116,8 @@ export const bookProjectType: ProjectType = {
   outputDir: "_book",
   cleanOutputDir: true,
   filterFormat: (source: string, format: Format, project?: ProjectContext) => {
+    // Books don't show notebook links
+    format.render[kNotebookLinks] = false;
     if (format.extensions?.book) {
       const bookExt = format.extensions?.book as BookExtension;
       if (bookExt.filterFormat) {

--- a/src/project/types/book/book.ts
+++ b/src/project/types/book/book.ts
@@ -28,7 +28,6 @@ import {
   kCrossrefChapters,
   kDate,
   kDocumentClass,
-  kNotebookLinks,
   kNumberSections,
   kPaperSize,
   kToc,

--- a/tests/docs/books/simple/_quarto.yml
+++ b/tests/docs/books/simple/_quarto.yml
@@ -14,8 +14,5 @@ book:
 bibliography: references.bib
 
 format:
-  html:
-    theme: cosmo
-  pdf:
-    documentclass: scrreprt
+  pdf: default
   asciidoc: default

--- a/tests/docs/books/simple/_quarto.yml
+++ b/tests/docs/books/simple/_quarto.yml
@@ -14,5 +14,6 @@ book:
 bibliography: references.bib
 
 format:
+  html: default
   pdf: default
   asciidoc: default

--- a/tests/docs/books/simple/intro.qmd
+++ b/tests/docs/books/simple/intro.qmd
@@ -2,4 +2,6 @@
 
 This is a book created from markdown and executable code.
 
+{{< embed notebooks/computations.ipynb#fig-visualization >}}
+
 See @knuth84 for additional discussion of literate programming.

--- a/tests/docs/books/simple/notebooks/computations.ipynb
+++ b/tests/docs/books/simple/notebooks/computations.ipynb
@@ -1,0 +1,103 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3a7ef254",
+   "metadata": {},
+   "source": [
+    "# Computations\n",
+    "\n",
+    "This is a simple markdown cell that has various contents in it. _What_ is up!"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "081703fc-4357-469b-a931-707a8f41d626",
+   "metadata": {
+    "raw_mimetype": "text/html",
+    "tags": []
+   },
+   "source": [
+    "<b>Hello World - this is HTML!</b>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c997cb65",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD4CAYAAADFAawfAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/NK7nSAAAACXBIWXMAAAsTAAALEwEAmpwYAAAlmElEQVR4nO3dW2zc533m8e875zM5PFOkqKMlWbabOFHsJg7StIGLdhsEe7EXLdACm13AvVgUKbqLounFdneBvdibor1YFGsk7bZo2m03aW6KNE2ySZAmcRwfYlsSJdmWRInn85zPM+9ezJAiZYocUjOcPznPBxB4Gg5/sqVH7/zek7HWIiIizuXqdAEiIrI7BbWIiMMpqEVEHE5BLSLicApqERGH87TjSQcGBuzp06fb8dQiIsfSG2+8sWKtHdzpa20J6tOnT/P666+346lFRI4lY8y9R31NrQ8REYdTUIuIOJyCWkTE4RTUIiIOp6AWEXE4BbWIiMMpqEVEHE5BLSLicApqERGHU1CLiDicglpExOEU1CIiDqegFhFxOAW1iIjDKahFRBxOQS0i4nAKahGRDiuUq7t+vS03vIiISHOm13L88/WFXR+joBYR6YBqzfKTO6u8NrWGtbs/VkEtInLIErkS/3RtgYVkoanHK6hFRA6JtZbJ+RTfv7VMqVJr+vsU1CIih6BQrvLdm0vcWkjv+3v3DGpjzEXg77Z86izwn621f7LvnyYi0oVmE3m+eW2BVL58oO/fM6ittbeADwMYY9zALPD1A/00EZEuUqtZfnJ3lZ/e3XvCcDf7bX18Brhtrb138B8pInL8JXNlvnl9nrlEcxOGu9lvUP868LeP/VNFRI6xG/MpvntzaV8ThrtpOqiNMT7gc8AXH/H1l4CXACYmJlpSnIjIUVKsVPnezSVuzO9/wnA3+xlR/yrwprV2cacvWmtfBl4GuHLlymN0Y0REjp65xoRh8oAThrvZT1D/Bmp7iIjDZYsVvnNjkWKlxlDUz1A0wFDMT1/Ih8tlWv7zajXLT6fWePXOGrXHmTHcRVNBbYwJAy8Cv92WKkREWuDeapZ/vr5Atlg/5Gh2Pb/5NY/LMBD1MxT1M9gI8IGID4/74GfTJfNl/vnaArOJ/N4PfgxNBbW1Ngv0t7USEZEDqtYsr9xe5fV7j14GV6lZFpKFbdu2XcbQF/ExGPEzFHsQ4n6Pe8+feWshzf+7uUix3JoJw91oZ6KIHGnJfJlvXjvYMriatayki6yki9yYf/D53pB3s2WyEeIhXz0ui5Uq37+1zORcqlW/hT0pqEXkyHpvMc23b7R+VJvIlUnkyry7+GD1RjTgYTDqZy1bIpFr/YThbhTUInLklKs1/uW9Zd6eTh7az0wXKqQLlUP7eVspqEXkSFnNFPnGtQVW0sVOl3JoFNQiciRYa7k+l+L7t5YoV7trq4aCWkQcr1ip8t0bS9w8wBGhx4GCWkQcbTFV4BtX5w99As9JFNQi4kjWWt68n+BH769QrXVXq+NhCmoRcZx8qcq3Jhe4s5ztdCmOoKAWEUeZXsvxzWsLZIqdWQrnRApqEXGEVt2GchwpqEWk49KFMv90bWHbIUrygIJaRDrq9nKGb11fpFCudroUx1JQi8iBWWupWajUalRrlkrNUq3W31ZqNSpV++Dzjc9t/XgtWzrUw42OKgW1iDxSoVzlZ/cT3F3JUq3V6gFc3Qja+sfqJ7efglpEPiBXqvCz+wnemk607IJWOTgFtYhsyhQrvHlvnXdmEl13noaTKahFhFShzBtT61ybTVLp8l2ATqSgFuliyVyZ16bWmJxPdf02bSdr9nLbXuBLwNOABf6dtfaVNtYlIm20li3x07tr3FpIt+3mbGmdZkfUfwp801r7b4wxPiDUxppEpE2W00Vem1rj3cW0VmscIXsGtTGmB/gU8G8BrLUloNTeskSklRZTBV69u8btpUynS5EDaGZEfQZYBv7CGPMh4A3gC9babcdaGWNeAl4CmJiYaHWdInIAc4k8P727xt0VnUJ3lLmaeIwH+AjwZ9baZ4Es8AcPP8ha+7K19oq19srg4GCLyxSRZllrmV7L8bU3Zvi716YV0sdAMyPqGWDGWvtq4+OvskNQi0hnWWu5v5bj1TtrzCZ0uNFxsmdQW2sXjDHTxpiL1tpbwGeAyfaXJiJ7yRQrzKznmFnLM72e6+rrqo6zZld9/A7wlcaKjzvA59tXkog8SrZYYWY9Xw/n9TxrWc3rd4Omgtpa+xZwpb2liMjDcqXtwbyaUTB3I+1MFHGQfKm6Gcoz6zlWFMyCglqkowrlejBPr+eZWc+zki52uiRxIAW1yCGq1SxTq1nur9VHzSuZonYIyp4U1CKHIFOscHUmyfW5JOmCbteW/VFQi7RJfeNJnndmE9xeyurwIzkwBbVIixXKVSbnU1ydSWr5nLSEglqkRRZTBd6eTvDuYlq3o0hLKahFHkO5WuPWQpp3ZpIspgqdLkeOKQW1yAGsZUu8M5Ngcj5FsazLX6W9FNQiTarWLHeWM7w9k2R6LdfpcqSLKKhF9pAulLk6m+T6bIpMUUvr5PApqEV2sHFk6DszSe4sa2mddJaCWqTBWstypsithTS3FtLamCKHZim9+0S0glq6XjJfboRzSocgyaFK5sv8+PYK7y7ufpelglq6UqFc5d3FNDcX0syu6zYUOVy5UoWf3l3j6mySmgW3Mbs+XkEtXaNcrXF3JcuN+RT3VnNUa+o7y+EqVWq8eX+dN++vb26KenI0ys+f6ee/7PJ9Cmo51mo1y/R6jpsLad5fylCqaM2zHL5qzXJtNsmrd9fIl6sAnBkI84lz/QxE/Ht+v4Jajh1rLUvpIjcX0ry7kNaSOukYay3vLmZ45c4qyXz9PsvRngAvnBtgLB5s+nmaCmpjzBSQBqpAxVqra7nEcZK5MjcWUtxaSOswpC5XrFRxG4PH7epYDfdWs/zo9irLjcsg4iEvL5wf4OxAGLNHT/ph+xlR/6K1dmVfzy7SZvlSlVuL9RUbcwmdtdHtKtUar9xZ5Wf3E7iMYaQnwHg8yHg8yEhPAI+r/cG9mCrwo/dXmG5MUkf8Hp4/28flkRgu1/4CeoNaH3IkLaYKvDWd4N2FNBVNCgowl8jz7RuLJHL1FkPVWmYTeWYTeV69C26XYXQzuEOMxAK4DxicO1nPlXjl9irvLdWX2vk9Lq6civOhk714H3Nk32xQW+BbxhgL/C9r7csPP8AY8xLwEsDExMRjFSWyk0q1xntLGd6eTjCf1OhZ6srVGq/cXuVn0wkA+sI+XnxymJ6Ql9mtN7hnS41Lg/PAGh6X4URvkLF4kJPxIEPRgwV3tljh1btrXJ9rLLVzGT483suV03ECXndLfo/NBvUnrbWzxpgh4NvGmJvW2h9sfUAjvF8GuHLlioY40jLpQpmrM0muzibJlaqdLkccZDaR5zuTiyTyZYyBK6fiPHemb7PFcX4owvmhCFBfuzzbCOqZRJ61bIn7aznur+V4BfC668E93lsfcQ9F/bu2KoqVKm/eS/Dm/XUqNYsBLo/G+PmzfUQD3pb+PpsKamvtbOPtkjHm68BzwA92/y6Rg7PWMrOe5+0ZXWMlH1Su1vjx7VXeaoyi+8M+Xrw8zHAs8MjvCfk8PDEc5YnhKFAfCc8mGsG9nmM9V+beao57qzlgFZ/bxYneACfjIcbiQQajflzGUKnVuDqT5LWp9c2ldmcbS+36m1hqdxB7BrUxJgy4rLXpxvu/DPy3tlQjXa9UqXFzIcXb0wlt55Ydza7Xe9HJR4yimxX2e7gwHOVCI7gzxQoz6zlm1/NMr+dJ5stMreaYWq0faev3uDjRG2Q1UyTVOAdmtCfAJ88PcKK3+aV2B9HMiHoY+HpjOYkH+Btr7TfbWpV0nfVsibd1EL/solyt8eP3V3lrJgFAf6Tei95tFL0fEb+HSyMxLo3EgHrLbSO0Z9ZzpAoV7q5kgXof/IVz/Zw5wFK7g9gzqK21d4APtb0S6Tq1mmVqNcvbMwmmVnQQvzzazHqO79xYIpkv4zJw5VQfz53pa+mqjYdFA14ujXq5NFoP7lS+zGwij9ft4uxgGNchBPQGLc+TQ1coV7k+l+Tt6eTmbi2RnZQqNX58e4W3Z5IADETqveihaGtG0fsRC3qJBVs7SdgsBbUcmqV0gbenk9xaSOmWbtnT9FqO79xYJFWo4DLwsdN9fOx0e0fRTqWglrYqVqq8t5hhci7FbELHicreSpUaP3p/hXdmH4yif/nyCIPR9qyoOAoU1NJy1lrmkgWuzyZ5TyfWyT48PIp+7nQfV7p0FL2VglpaJl0oc2M+zeRckvWces/SvFKlxg/fX+FqYxQ9GPXz4pPDXT2K3kpBLY+lWrPcWc5wfS7F1GoW7UuR/brfGEWnG6Po58/089FT8a4fRW+loJYDWU4XuT6X5OZCmry2dcs+WGvJl6sk82Um51Ncm00BMBT18+Ll4aYO0u82CmppWqFc5dZCmutzKRZTOhRJHq1mLZlChUS+TDJXJpkvk8iXSObLpPIVStUH8xYuA8+f7eejExpFP4qCWna1cZXV9bkUt5cyOlJUNlWqNZL5jRAub76fzJVJFcrs9kfF53HRG/QSD/u4ciquUfQeFNSyo2SuzPX5JJNzKdIFXWXVzdZzJZZSxW2j4mS+TLa4e8sr7HfTE/TSE/TSG/Rtvt8T8hLwuA5l6/VxoaCWTYVylTvLWSbnU0yvaUt3t7LWspgqcns5w53lLGu5nQ/Hcpn6NuveLQG8GcZB72Mfli8PKKi7mLWW1WyJqZUsd1eyzCUKOk60S1VqNWbW89xeznB3OUt2ywSxz+NivDdIPOTbFshRv+fAV0vJ/iiou0y5WmN6LcfUapa7KzlSOmujaxXLVe6uZrmznOXeam7bBF/E7+HcYJizgxHGeoOa5OswBXUXSObL3F3JMrWSZXotpwnBLpYulLmznOX2SobZ9fy2Cb+BiI+zAxHODYYZjPrVQ3YQBfUxVK1Z5hL5ejivZlnVAfxda6O9dWc5y+3lDEvp4ubXDDDWG9wcOfd06GQ42ZuC+pjIFiuNdkbjZazO13CkSrXGaraEyxg8boPX5cLjrr/vNqYlo9hazTKfLNQnA1ey246S9bgMp/pDnBuMcHogTLBFl69Keymoj6iNmfm7jYlAbUBxrnSh0Xpaze3aejJQD22XC6/b4HG78LgMXncjzLe8/yDgXXhd9bcuU7/s9e5KlsKWW3KCXjdnB8OcHQgz0RfCo9UYR46C+oio1Swr2SJziQLziTz313K6kduhNka0U6tZ7u7QeuoL+XC5oFy1VGo1KlVLpWqpWku5ailXqzzuHG9P0Mu5wTDnBiOM9AQO9TYSab2mg9oY4wZeB2attZ9tX0kC9XOcF5IF5hIF5hJ5FlIFtTMcLF+qcq8RzPdWcxS3/L/yug0TfSFOD4Q53R8m4t/5r12tZqnULOVqjUrNUqnWKG+8rdbfbv/69sdWapZ42Me5gTB9YZ8mA4+R/YyovwDcAGJtqqVrWWtJFSrMJ/PMJwrMJvKsZIo6ic7BrLUsZ4pMrdSXOs4nt7eeeoNeTg+EOTMQ5kRvoKkbsl0ug89l8HnUmpDtmgpqY8w48GvAfwd+r60VdYFarf6XfC6Rr7cyknlt0z4CSpUa0+u5zdU0W7dQu41hLB7kdH995BwP+TpYqRw3zY6o/wT4fSD6qAcYY14CXgKYmJh47MKOk0K50cZI1oN5UW2MI2M919i5uZplbr1AdcvLnLDfzen++qj5ZDykkbC0zZ5BbYz5LLBkrX3DGPPpRz3OWvsy8DLAlStXuv5Fe7pQ5s37Ce6v5VhVG+PIqNkHS9vuLmdJPDSrN9oT2AzngYj6wHI4mhlRvwB8zhjzr4AAEDPG/LW19jfbW9rRlC1WeG1qjaszSe0APCIq1RrTjXMu7ixnyZcftDT8Hhen+kOc6Q9zqj9M0Kd1x3L49gxqa+0XgS8CNEbU/0kh/UG5UoXXp9Z5ZyZBuaqAdrpipcrUSo7byxmmVrPb/p/FAh7ODUU4NxBhtCegg4ek47SO+jHlS1XeuLfO2zMJ9Z0dLluscGelvpV6ei237ZyLwYifs411x2ppiNPsK6ittd8Hvt+WSo6YQrnKm/fX+dl9BbSTJXIlbjfOudi6hG7jnIuNcNY5F+JkGlHvU6Fc5a3pBG/eX6dYVkA7zcb65ttL9XBezT7YFeh21TeebGynDvn0x1+OBv1JbVKpUuOt6QRv3FunUNbWbSep1SxzyfzmyHnrmnSf28WZgTDnBuuTgVpCJ0eRgnoPpUqNd2YSvH5vnbzO1nCMjUOprs0lP7BSI+SrH0J0fjDCeDykQ+/lyFNQP0K5WuOdmSSvT63p8CMHKVVq3FpMc3U2yfKWs5V7gl7OD0Y4NxRmJBbQZKAcK0ciqNOFMq9PrZPMl4n4PUQDHiIBD7GAd/PjVh3dWKnWuDaX4rW7a2SK2tbtFCuZIldnktxcSG9eGRXwurg8GuPJ0Rj9OoRIjjFHB/V+No+EfG4iAQ/RQP3SzY0wjzbCPOL37PoSuFqzXJ9L8tO7azp3wyEq1RrvL2V4Zza5bcXGaE+Anxvv4fxgRGcrS1dwZFAfZPNIrlQlV6qylCru+HVj2AzsaMDbCHEPUb+HfLnKa1PruujVIdZzJa7NJpmcS1FoLH30uV1cGo3yzFgPAxF/hysUOVyOCup8qb42+a3p1q9NthbShQrpQuUDR1JK51VrljsrGa7OJpley29+fjDq5+fGergwHNWKDelajghqbR7pXulCmWuzKa7PJck2Jm09LsOF4SjPjPcwrNuwRTob1MVKlZ/d1+aRblOzlvurOd6ZTTK1kmWjudUX8vHMeA+XRqIEdOmqyKaOBHWpUuPtmQSvT2nzSDfJFitMzqe4Npsk1ZiwdRl4YijCM2M9jPUGNXoW2cGhBnV9bXI9oLU2+Xix1lKs1CiUqxTKNfLlKsVylXzj47VciTvLmc2DkGIBD0+P9fDUiZi2covs4VD+hlSqNa7OJnltam3b9UXiPLZxE3Y9cOtBW6zUGoFbD93CTu83MbdggLMDYZ4Z7+FUX0ijZ5EmtTWoK9Ua1+dSvDaltclOVa1Z5pN57q3muL+WYyVT5KD3Hfg8LgIeFwGvu/HLRdDrxu9117d1D4SJBnRKnch+tS2or80m+cmdVQW0AyXzZe6tZrm3mmN6PfeBteoel9kM2q2hG/C4CW79eMv7fo9bZ2qItElbgnolU+Tbk4vteGo5gFKlxsx6jntrOe6t5kg+tLGnL+zjVF+IU/0hRnuCWq8scsjiod1fabYlqKu6K7CjrLWsZEr1UfNajrlEfls7w+9xcbIvtBnOakfIcTMeD1Ks1LYd3OU0IZ+bCyNRnhyJMRzz8/ldHqvp9mMiV6pwvzFivr+W27aqxgAjsQCn+uvBPBzVPYByPPUEvfzCxUHODoQxxpDMlbm9kuH2UobZRB7b4TGk1204Nxjh0miMib7mj+DdM6iNMQHgB4C/8fivWmv/6LGqlcdWrVkWkgXurdV7zUsPjRwifg8TjRHzRF9IG0jkWPO4DB8708dHT8Xxbjmoqyfk5SMTcT4yESdfqnJnJcPt5Sz3VrJ7HvTWKsbAqf4Ql0ZinBuMHKi12MyIugj8krU2Y4zxAj80xvyTtfYn+/5p8lhqNcvUapYbC2nur+Y2j/uE+jVTY73B+qi5L0Sfjv2ULnF+KMKnLgzuee9l0OfmqRM9PHWih1Klxv21+i30d5azbdl4NxwLcGk0ysXhKGH/4zUv9vxua60FMo0PvY1fakIfotVMkcn5FDcX0ttaGn0hHxONdsZYb3DbSELkuIuHvHz64hCnB8L7/l6fx8X5oQjnhyLUapbZRJ7by/XR9uOcohkLenlyJMrFkSj9LTzlsamYN8a4gTeA88D/tNa+usNjXgJeAogPnWhZgd2qWKny7kKGyfkUC6kHp/3FQ14un4hxYThKTJOA0oV8HhfPn+nj2Yl4S5aEulyGk30hTvaF+IUL2y9HbmYyMuB1c2G43nc+0dOe24WaCmprbRX4sDGmF/i6MeZpa+21hx7zMvAywMkLT2vEfQDWWqbX80zOpXh/ObO5esbndnFhOMLlEzFdMyVd7dJIlE8+MdC2lUrGGIaiAYaiAT5+rp9kvlwfaT80GelxGc4Mhrk0EuPMQLjtewj21Tix1iaMMd8DfgW4ttfjpTnJfJnJ+RQ35lPbNgiNx4M8NRrj3FBEbQ3pagNRP5++MMjJvtCh/tye4AcnI62t98UPc4K+mVUfg0C5EdJB4EXgf7S9smOu3LhmanIuxUziwUH50YBn8x7AvSZHRI47v9fFx8/286Hx3o4vKd2YjOyEZkbUo8BfNvrULuDvrbX/2N6yjidrLfPJApPzKd5bzGyu2vC4DOeHIlwejTEe11GfIgBPnYjxyScGdLoiza36eAd49hBqObYyxQo3Gq2N9dyDGeWRWKAxMRjB79E6ZxGoL2v7xUuDjPYEO12KY+ifqjapVGvcXckyOZ/i3mpucz1jyOfmydEYl0dj9IV9Ha1RxEmCPjcvnBvgqROxjrc5nEZB3UI1a5lZz3NrIc37y5nN+x9dpn4O81Mn6ucw6w+hyAPGwM+N9/CJcwPaQfsICurHZK1lKV3k1kKadxfTmxe0Qv0G7SdHolwaiRH06Q+gyFbGwHg8xKeeGGAoFuh0OY6moD6g9VyJWwtpbi2mSWzpO/cEvVwcru9MUmtDHuYyhoDX1ZVX0bldhuGYn7HeEGPxIKM9AY2gm6Sg3odsscK7i/VwXkw92LEU3NiZ1DiuUKs2BOpLLQcifgYifvojPvojPvpCPtwuw3K6yHtLGd596B/648TrNoz0BBnrDTIeDzLSE9B+gANSUO+hWKny/lKGW4tpZtbym5OCXrfh/GCEiyNRTsbVd+5mQZ+b/rBvWyj3hX27jhaHYgGGYgE+ca6f5UyR9xfrob1+hEPb53Ex1htkLF4P5+FYQLf+tIjjg3pj7fGthTTlao2w30PY7yHi9xD2u+sf+zwt/QNRqdaYWs1xayHN3dXs5lZul4Ez/WEujkQ5OxDGo9FBV/G6Df0RP/1hH/0RP4ONUA753Ad+FfXwluWVTIn3ltK8t5hhLVtq8e+gtUI+NycawTzeG2Qg4teApU0cG9SZQoUbCykm51NNvTQMet2b4R3ZFuYPPhf0PvovVM1aZtfz3HxoxQbAeG+QiyPRQ982Kp0TDXg40RvcFsqxoKetbS1jDINRP4NRP584N8BKpsh7ixneX0qzkul8aEcDHsbjwc0eczzkVZvvkDgqqCvVGndWskzOpbi/9mDtcdjn5tJojHjIS7ZYJVOskC1W6m9LFXLFKvly/ddy5tHP7zIQ8nk+EOj5UnXHFRsXh6NcGI7oqqou4HUbxuJBJvrCnO53xnneG62Uj5/rZzVT72m/t5RhpY3XS3lchljQS8/Gr1D97UC4/f9QyaN1PKg3lrdNzqe4tZCmuGXt8bnB+rbqvdYe12qWXLn6ILw3327/XKFSI9P4eCdasdFdBqP+xkULYU70BhzdyuqP+OmP+Pn5s/2sZUu8t5jmvaXmjuF8WMjnfhDEQe9mMPeGvET8CmMn6lhQ50oVbi6kmZxPsbrlZd1g1M/l0RgXR6IEm2wzuFyGSKPVMbzL4yrVGtnSQyPyYgWD4dxQWEeIHnMhn7txb2SYib7QY9+60Sl9YR/Pn+3n+bP9rGdLjZF2mqXGSiSXMcSCns3wfTiQdVzB0XOof1KrjaukJudSTK1mN2/GDnhdXBqpb6sejLbuVoSHedwueoIunUrXJbZeTzbRH2IwcvyWTsbDPp4708dzZ/pINm4mifo9mtQ7Zg4lqFc2rpKaT5Nv3E1mDJwZCHN59HAO3pbu0B/xMdEX4nR/mLF4d11PpgHI8dW2oC6Uq9xaTDM5l9p2Q3ZfyMflEzEujTz+hY8ifq+L041Wxqn+kCZ+5VhqS1Im82W+9MO726+SGonw1GiPdu5JS4zFgzwz1sN53X4jXaAtQV2s1KjWLCf7glwejXF+MOLoGXU5GkI+N5dPxHj6RA9xrcqRLtKWoA77PHz+E6eJqWcmj8kYONUf4ukTPZwdjGguQ7pSe4La71ZIHyHG1G+bmegLEfS5mU8WmEvkt120e9iiAQ+XT8R46kSPJsmk6zVzue1J4K+AYcACL1tr/7TdhUl79YXrqyNO9oUYjwe3bY1/lvpGpFShwux6nrlEnrlkftt693ZwGcOZwTDPjOmCBZGtmhlRV4D/aK190xgTBd4wxnzbWjvZ5tqkhSJ+Dyf7Qo1wDu65OsIYs7lR4vKJGAD5UpXZRCO4E3kWU0Vq1u76PM3oDXl5eqyHy6MxrQQS2UEzl9vOA/ON99PGmBvAGKCgdjCfx8V4PMhEI5xbcXZF0Ofm/FCE80MRAMrVGgvJwmZ4zycL2w6z2o3bZXhiKMLTYz26eV1kD/savhhjTlN/ZfzqDl97CXgJID50ohW1yT64XYbRnnqfeaI/xHA00PbWgdft4mSjfQL1M1eWM8XN4J5dz3/gJpOBiI+nxnp4UteTiTSt6aA2xkSArwG/a61NPfx1a+3LwMsAJy88/fivh2VPQzF/vZURD3GiN4jP09klkC6XYTgWYDgW4CMTcay1JHJlZhN51nMlzg1GGO3ReSoi+9VUUBtjvNRD+ivW2n9ob0mym5DPzcfO9HFpJErI5+x+rjGGeNinNc8ij6mZVR8G+DJww1r7x+0vSXbi87j46Kk4z0706vQzkS7TzJDsBeC3gKvGmLcan/tDa+032laVbPK4DB862cvHTveppyvSpZpZ9fFDQE3FQ+YyhqdOxHj+bJ8OGhLpcs5ucnapC8NRPn6uX7fMiAigoHaU0wMhPnFugOFYoNOliIiDKKgdYLQnwAvnBzbXI4uIbKWg7qD+iI9PnBvg3GBYa4tF5JEU1B0QC3r5+Nl+Lo1EdfCQiOxJQX2IQj43z53p45mxHl2kICJNU1AfAp/HxZVTcZ6diHd8m7eIHD0K6jbSZhURaQUFdQvFQ16GYgGGon6GYwEGo/5tB/KLiByEgvoAjIF4yMdwzM9gtB7MQzG/zuAQkbZwfFB7XIaRngBj8SA+t4tsqUq+VCFbrJIrVRofV/d+ogMyBvrDPgajAYZjfoZiAQYjfvWaReTQOC6oPS7DaG+Q8XiQsd4goz2BPVdIVGuWXKlCvlQlW6qSLVbIlapkSxVyjUDf+LhYfvQNJC5j6Iv4GI76N1sYg1E/Xq3QEJEO6nhQe92G0Z4gY/F6OI/E9g7mh7ldhmjA29ThRZVqbXMUvhHkFstQNMBAxKdlcyLiOIce1BvBPB4PMt4XYjjqP9Rw9Lhd9ARd9AR1Ip2IHA1tD2qv23CiN8h4PMR4PMhwLIBbu/FERJrWlqD2e1x88okBxnoVzCIij6stQd0b8vGx033teGoRka6jmTMREYfbM6iNMX9ujFkyxlw7jIJERGS7ZkbU/xv4lTbXISIij7BnUFtrfwCsHUItIiKyA/WoRUQcrmVBbYx5yRjzujHm9eXl5VY9rYhI12tZUFtrX7bWXrHWXhkcHGzV04qIdD21PkREHK6Z5Xl/C7wCXDTGzBhj/n37yxIRkQ177ky01v7GYRQiIiI7U+tDRMThFNQiIg6noBYRcTgFtYiIwymoRUQcTkEtIuJwCmoREYdTUIuIOJyCWkTE4RTUIiIOp6AWEXE4BbWIiMMpqEVEHE5BLSLicApqERGHU1CLiDicglpExOEU1CIiDqegFhFxOAW1iIjDKahFRBxOQS0i4nDGWtv6JzVmGbjX8idurQFgpdNFNEF1tpbqbC3V2TqnrLWDO32hLUF9FBhjXrfWXul0HXtRna2lOltLdR4OtT5ERBxOQS0i4nDdHNQvd7qAJqnO1lKdraU6D0HX9qhFRI6Kbh5Ri4gcCQpqERGH67qgNsb8uTFmyRhzrdO17MYYc9IY8z1jzKQx5rox5gudrmknxpiAMeanxpi3G3X+107X9CjGGLcx5mfGmH/sdC2PYoyZMsZcNca8ZYx5vdP1PIoxptcY81VjzE1jzA1jzMc7XdPDjDEXG/8dN36ljDG/2+m6DqLretTGmE8BGeCvrLVPd7qeRzHGjAKj1to3jTFR4A3gX1trJztc2jbGGAOErbUZY4wX+CHwBWvtTzpc2gcYY34PuALErLWf7XQ9OzHGTAFXrLWO3pxhjPlL4F+stV8yxviAkLU20eGyHskY4wZmgeettU7fjPcBXTeittb+AFjrdB17sdbOW2vfbLyfBm4AY52t6oNsXabxobfxy3H/+htjxoFfA77U6VqOOmNMD/Ap4MsA1tqSk0O64TPA7aMY0tCFQX0UGWNOA88Cr3a4lB01WgpvAUvAt621TqzzT4DfB2odrmMvFviWMeYNY8xLnS7mEc4Ay8BfNFpJXzLGhDtd1B5+HfjbThdxUApqhzPGRICvAb9rrU11up6dWGur1toPA+PAc8YYR7WUjDGfBZastW90upYmfNJa+xHgV4H/0GjVOY0H+AjwZ9baZ4Es8AedLenRGq2ZzwH/t9O1HJSC2sEaPd+vAV+x1v5Dp+vZS+Pl7/eAX+lwKQ97Afhco//7f4BfMsb8dWdL2pm1drbxdgn4OvBcZyva0Qwws+WV01epB7dT/SrwprV2sdOFHJSC2qEak3RfBm5Ya/+40/U8ijFm0BjT23g/CLwI3OxoUQ+x1n7RWjturT1N/SXwd621v9nhsj7AGBNuTBzTaCX8MuC41UnW2gVg2hhzsfGpzwCOmuR+yG9whNseUH8J01WMMX8LfBoYMMbMAH9krf1yZ6va0QvAbwFXG/1fgD+01n6jcyXtaBT4y8asugv4e2utY5e/Odww8PX6v9F4gL+x1n6zsyU90u8AX2m0Fe4An+9wPTtq/IP3IvDbna7lcXTd8jwRkaNGrQ8REYdTUIuIOJyCWkTE4RTUIiIOp6AWEXE4BbWIiMMpqEVEHO7/AxYL9vYninDiAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#| label: fig-visualization\n",
+    "#| fig-cap: A display of a line and region moving up and to the right.\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "# make data\n",
+    "np.random.seed(1)\n",
+    "x = np.linspace(0, 8, 16)\n",
+    "y1 = 3 + 4*x/8 + np.random.uniform(0.0, 0.5, len(x))\n",
+    "y2 = 1 + 2*x/8 + np.random.uniform(0.0, 0.5, len(x))\n",
+    "\n",
+    "# plot\n",
+    "fig, ax = plt.subplots()\n",
+    "\n",
+    "ax.fill_between(x, y1, y2, alpha=.5, linewidth=0)\n",
+    "ax.plot(x, (y1 + y2)/2, linewidth=2)\n",
+    "\n",
+    "ax.set(xlim=(0, 8), xticks=np.arange(1, 8),\n",
+    "       ylim=(0, 8), yticks=np.arange(1, 8))\n",
+    "\n",
+    "# Store the plot in the notebook as different MIME types\n",
+    "from IPython.display import Image, SVG, display\n",
+    "from io import BytesIO\n",
+    "\n",
+    "# SVG alternative\n",
+    "buffer = BytesIO()\n",
+    "plt.savefig(buffer, format='svg')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.2"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Jupyter embedding uses this lifetime to cache notebook data (and other code could theoretically use it to if it is assuming it is a part of the render pipeline). Since books takeover single file rendering, we should provide it there as well.

