### PR TITLE
Update _language-it.yml

### DIFF
--- a/src/resources/language/_language-it.yml
+++ b/src/resources/language/_language-it.yml
@@ -85,7 +85,7 @@ crossref-lof-title: "Elenco delle Figure"
 crossref-lot-title: "Elenco delle Tabelle"
 crossref-lol-title: "Elenco degli Elenchi"
 
-environment-proof-title: "Prova"
+environment-proof-title: "Dimostrazione"
 environment-remark-title: "Osservazione"
 environment-solution-title: "Soluzione"
 


### PR DESCRIPTION
'Proof' in mathematical context is translated to 'Dimostrazione'. 'Prova' is one of the possible translations but it does not technically fit well the math jargon. For example, you write 'Dimostrazione del teorema di Pitagora' for 'Proof of the Pythagorean theorem'

Welcome to the quarto GitHub repo!

We are always happy to hear feedback from our users.

To file a _pull request_, please follow these instructions carefully: <https://yihui.org/issue/#bug-reports>

If you're a collaborator from outside `quarto-dev` making changes larger than a typo, please make sure you have filed an [individual](https://rstudioblog.files.wordpress.com/2017/05/rstudio_individual_contributor_agreement.pdf) or [corporate](https://rstudioblog.files.wordpress.com/2017/05/rstudio_corporate_contributor_agreement.pdf) contributor agreement. You can send the signed copy to jj@rstudio.com.

Also, please complete and keep the checklist below.

## Description

Please describe your PR here.

````md
```py
print("Hello Quarto!")
```
````

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
