### PR TITLE
Add optional hover to cross references

### DIFF
--- a/src/format/html/format-html-shared.ts
+++ b/src/format/html/format-html-shared.ts
@@ -38,6 +38,7 @@ export const kCodeCopy = "code-copy";
 export const kAnchorSections = "anchor-sections";
 export const kCitationsHover = "citations-hover";
 export const kFootnotesHover = "footnotes-hover";
+export const kXrefsHover = "crossrefs-hover";
 export const kSmoothScroll = "smooth-scroll";
 
 // Code Annotation

--- a/src/format/html/format-html-types.ts
+++ b/src/format/html/format-html-types.ts
@@ -14,6 +14,7 @@ export interface HtmlFormatFeatureDefaults {
   hoverFootnotes?: boolean;
   figResponsive?: boolean;
   codeAnnotations?: boolean;
+  hoverXrefs?: boolean;
 }
 
 export interface HtmlFormatTippyOptions {

--- a/src/format/html/format-html.ts
+++ b/src/format/html/format-html.ts
@@ -76,6 +76,7 @@ import {
   kSmoothScroll,
   kTabsets,
   kUtterances,
+  kXrefsHover,
   quartoBaseLayer,
   quartoGlobalCssVariableRules,
 } from "./format-html-shared.ts";
@@ -244,6 +245,11 @@ export async function htmlFormatExtras(
   } else {
     options.hoverFootnotes = format.metadata[kFootnotesHover] || false;
   }
+  if (featureDefaults.hoverXrefs) {
+    options.hoverXrefs = format.metadata[kXrefsHover] !== false;
+  } else {
+    options.hoverXrefs = format.metadata[kXrefsHover] || false;
+  }
   if (featureDefaults.figResponsive) {
     options.figResponsive = format.metadata[kFigResponsive] !== false;
   } else {
@@ -312,7 +318,7 @@ export async function htmlFormatExtras(
 
   // popper if required
   options.tippy = options.hoverCitations || options.hoverFootnotes ||
-    options.codeAnnotations;
+    options.codeAnnotations || options.hoverXrefs;
   if (bootstrap || options.tippy) {
     scripts.push({
       name: "popper.min.js",
@@ -572,6 +578,7 @@ function htmlFormatFeatureDefaults(
     hoverFootnotes: !minimal,
     figResponsive: !minimal,
     codeAnnotations: !minimal,
+    hoverXrefs: !minimal,
   };
 }
 

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -184,6 +184,7 @@ export function revealjsFormat() {
               copyCode: true,
               hoverCitations: true,
               hoverFootnotes: true,
+              hoverXrefs: false,
               figResponsive: false,
             }, // tippy options
             {

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -12009,6 +12009,17 @@ var require_yaml_intelligence_resources = __commonJS({
               }
             ]
           }
+        },
+        {
+          name: "crossrefs-hover",
+          schema: "boolean",
+          tags: {
+            formats: [
+              "$html-files"
+            ]
+          },
+          default: true,
+          description: "Enables a hover popup for cross references that shows the item being referenced."
         }
       ],
       "schema/document-editor.yml": [
@@ -19537,7 +19548,7 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         {
           short: "Include a code tools menu (for hiding and showing code).",
-          long: "Include a code tools menu (for hiding and showing code). Use\n<code>true</code> or <code>false</code> to enable or disable the\nstandard code tools menu. Specify sub-properties <code>source</code>,\n<code>toggle</code>, and <code>caption</code> to customize the behavior\nand appearnce of code tools."
+          long: "Include a code tools menu (for hiding and showing code). Use\n<code>true</code> or <code>false</code> to enable or disable the\nstandard code tools menu. Specify sub-properties <code>source</code>,\n<code>toggle</code>, and <code>caption</code> to customize the behavior\nand appearance of code tools."
         },
         {
           short: "Show a thick left border on code blocks.",
@@ -19645,6 +19656,8 @@ var require_yaml_intelligence_resources = __commonJS({
         "Location to write references (<code>block</code>,\n<code>section</code>, or <code>document</code>)",
         "Write markdown links as references rather than inline.",
         "Unique prefix for references (<code>none</code> to prevent automatic\nprefixes)",
+        "Automatically re-render for preview whenever document is saved (note\nthat this requires a preview for the saved document be already running).\nThis option currently works only within VS Code.",
+        "Enable (<code>true</code>) or disable (<code>false</code>) Zotero for\na document. Alternatively, provide a list of one or more Zotero group\nlibraries to use with the document.",
         "The identifier for this publication.",
         "The identifier value.",
         "The identifier schema (e.g.&nbsp;<code>DOI</code>, <code>ISBN-A</code>,\netc.)",
@@ -21091,7 +21104,7 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
         "internal-schema-hack",
-        "Enable (<code>true</code>) or disable (<code>false</code>) Zotero for\na document. Alternatively, provide a list of one or more Zotero group\nlibraries to use with the document."
+        "Enables a hover popup for cross references that shows the item being\nreferenced."
       ],
       "schema/external-schemas.yml": [
         {
@@ -21315,12 +21328,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 152628,
+        _internalId: 153686,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 152620,
+            _internalId: 153678,
             type: "enum",
             enum: [
               "png",
@@ -21336,7 +21349,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 152627,
+            _internalId: 153685,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -12010,6 +12010,17 @@ try {
                 }
               ]
             }
+          },
+          {
+            name: "crossrefs-hover",
+            schema: "boolean",
+            tags: {
+              formats: [
+                "$html-files"
+              ]
+            },
+            default: true,
+            description: "Enables a hover popup for cross references that shows the item being referenced."
           }
         ],
         "schema/document-editor.yml": [
@@ -19538,7 +19549,7 @@ try {
           },
           {
             short: "Include a code tools menu (for hiding and showing code).",
-            long: "Include a code tools menu (for hiding and showing code). Use\n<code>true</code> or <code>false</code> to enable or disable the\nstandard code tools menu. Specify sub-properties <code>source</code>,\n<code>toggle</code>, and <code>caption</code> to customize the behavior\nand appearnce of code tools."
+            long: "Include a code tools menu (for hiding and showing code). Use\n<code>true</code> or <code>false</code> to enable or disable the\nstandard code tools menu. Specify sub-properties <code>source</code>,\n<code>toggle</code>, and <code>caption</code> to customize the behavior\nand appearance of code tools."
           },
           {
             short: "Show a thick left border on code blocks.",
@@ -19646,6 +19657,8 @@ try {
           "Location to write references (<code>block</code>,\n<code>section</code>, or <code>document</code>)",
           "Write markdown links as references rather than inline.",
           "Unique prefix for references (<code>none</code> to prevent automatic\nprefixes)",
+          "Automatically re-render for preview whenever document is saved (note\nthat this requires a preview for the saved document be already running).\nThis option currently works only within VS Code.",
+          "Enable (<code>true</code>) or disable (<code>false</code>) Zotero for\na document. Alternatively, provide a list of one or more Zotero group\nlibraries to use with the document.",
           "The identifier for this publication.",
           "The identifier value.",
           "The identifier schema (e.g.&nbsp;<code>DOI</code>, <code>ISBN-A</code>,\netc.)",
@@ -21092,7 +21105,7 @@ try {
           },
           "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
           "internal-schema-hack",
-          "Enable (<code>true</code>) or disable (<code>false</code>) Zotero for\na document. Alternatively, provide a list of one or more Zotero group\nlibraries to use with the document."
+          "Enables a hover popup for cross references that shows the item being\nreferenced."
         ],
         "schema/external-schemas.yml": [
           {
@@ -21316,12 +21329,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 152628,
+          _internalId: 153686,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 152620,
+              _internalId: 153678,
               type: "enum",
               enum: [
                 "png",
@@ -21337,7 +21350,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 152627,
+              _internalId: 153685,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -4985,6 +4985,17 @@
           }
         ]
       }
+    },
+    {
+      "name": "crossrefs-hover",
+      "schema": "boolean",
+      "tags": {
+        "formats": [
+          "$html-files"
+        ]
+      },
+      "default": true,
+      "description": "Enables a hover popup for cross references that shows the item being referenced."
     }
   ],
   "schema/document-editor.yml": [
@@ -12513,7 +12524,7 @@
     },
     {
       "short": "Include a code tools menu (for hiding and showing code).",
-      "long": "Include a code tools menu (for hiding and showing code). Use\n<code>true</code> or <code>false</code> to enable or disable the\nstandard code tools menu. Specify sub-properties <code>source</code>,\n<code>toggle</code>, and <code>caption</code> to customize the behavior\nand appearnce of code tools."
+      "long": "Include a code tools menu (for hiding and showing code). Use\n<code>true</code> or <code>false</code> to enable or disable the\nstandard code tools menu. Specify sub-properties <code>source</code>,\n<code>toggle</code>, and <code>caption</code> to customize the behavior\nand appearance of code tools."
     },
     {
       "short": "Show a thick left border on code blocks.",
@@ -12621,6 +12632,8 @@
     "Location to write references (<code>block</code>,\n<code>section</code>, or <code>document</code>)",
     "Write markdown links as references rather than inline.",
     "Unique prefix for references (<code>none</code> to prevent automatic\nprefixes)",
+    "Automatically re-render for preview whenever document is saved (note\nthat this requires a preview for the saved document be already running).\nThis option currently works only within VS Code.",
+    "Enable (<code>true</code>) or disable (<code>false</code>) Zotero for\na document. Alternatively, provide a list of one or more Zotero group\nlibraries to use with the document.",
     "The identifier for this publication.",
     "The identifier value.",
     "The identifier schema (e.g.&nbsp;<code>DOI</code>, <code>ISBN-A</code>,\netc.)",
@@ -14067,7 +14080,7 @@
     },
     "Disambiguating year suffix in author-date styles (e.g.&nbsp;“a” in “Doe,\n1999a”).",
     "internal-schema-hack",
-    "Enable (<code>true</code>) or disable (<code>false</code>) Zotero for\na document. Alternatively, provide a list of one or more Zotero group\nlibraries to use with the document."
+    "Enables a hover popup for cross references that shows the item being\nreferenced."
   ],
   "schema/external-schemas.yml": [
     {
@@ -14291,12 +14304,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 152628,
+    "_internalId": 153686,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 152620,
+        "_internalId": 153678,
         "type": "enum",
         "enum": [
           "png",
@@ -14312,7 +14325,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 152627,
+        "_internalId": 153685,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/filters/crossref/refs.lua
+++ b/src/resources/filters/crossref/refs.lua
@@ -95,7 +95,7 @@ function resolveRefs()
   
                 -- link if requested
               if (refHyperlink()) then
-                ref = {pandoc.Link(ref, "#" .. label)}
+                ref = {pandoc.Link(ref, "#" .. label, "", pandoc.Attr("", {'quarto-xref'}))}
               end
             end
   

--- a/src/resources/formats/html/templates/quarto-html.ejs
+++ b/src/resources/formats/html/templates/quarto-html.ejs
@@ -1,4 +1,4 @@
-<% if (darkMode !== undefined || tabby || anchors || copyCode || codeTools || tippy || hoverFootnotes || hoverCitations || linkExternalIcon || linkExternalNewwindow) { %> 
+<% if (darkMode !== undefined || tabby || anchors || copyCode || codeTools || tippy || hoverFootnotes || hoverCitations || linkExternalIcon || linkExternalNewwindow || hoverXrefs) { %> 
 <script id = "quarto-html-after-body" type="application/javascript">
 
 window.document.addEventListener("DOMContentLoaded", function (event) {
@@ -339,6 +339,35 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
       const id = href.replace(/^#\/?/, "");
       const note = window.document.getElementById(id);
       return note.innerHTML;
+    });
+  }
+
+  <% } %>
+
+  <% if (hoverXrefs) { %>
+  const xrefs = window.document.querySelectorAll('a.quarto-xref');
+  for (var i=0; i<xrefs.length; i++) {
+    const xref = xrefs[i];
+    tippyHover(xref, function() {
+      let href = xref.getAttribute('href');
+      try { href = new URL(href).hash; } catch {}
+      const id = href.replace(/^#\/?/, "");
+      const note = window.document.getElementById(id);
+      if (id.startsWith('sec-')) {
+        // Special case sections, only their first couple elements
+        const container = document.createElement("div");
+        if (note.children.length > 2) {
+          for (let i = 0; i < 2; i++) {
+            container.appendChild(note.children[i].cloneNode(true));
+          }
+          return container.innerHTML
+        } else {
+          return note.innerHTML;
+        }
+      } else {
+        return note.innerHTML;
+      }
+      
     });
   }
 

--- a/src/resources/schema/document-crossref.yml
+++ b/src/resources/schema/document-crossref.yml
@@ -173,3 +173,10 @@
             appendix-delim:
               string:
                 description: The delimiter beween appendix number and title.
+
+- name: crossrefs-hover
+  schema: boolean
+  tags:
+    formats: [$html-files]
+  default: true
+  description: Enables a hover popup for cross references that shows the item being referenced.


### PR DESCRIPTION
- Allow cross references to show their reference in a tippy
- Controlled via `crossrefs-hover`
- defaults to true
- sections only show the heading + first child

