### PR TITLE
Use correct key with correct selector for social metadata description

### DIFF
--- a/src/project/types/website/website-meta.ts
+++ b/src/project/types/website/website-meta.ts
@@ -510,8 +510,8 @@ function metaMarkdownPipeline(format: Format, extras: FormatExtras) {
       // Meta values
       const metaVals = [{
         sel: 'meta[property="og:description"]',
-        key: kTwitterDesc,
-      }, { sel: 'meta[name="twitter:description"]', key: kOgDesc }];
+        key: kOgDesc,
+      }, { sel: 'meta[name="twitter:description"]', key: kTwitterDesc }];
 
       metaVals.forEach((metaVal) => {
         const renderedEl = rendered[metaVal.key];


### PR DESCRIPTION
Fix #5263

@dragonstyle I believe this is only an inversion in the key regarding of the selector. With PR, I correctly get the description in the `<meta>`

