### PR TITLE
Don’t emulate pandoc numbering for epub output

### DIFF
--- a/src/resources/filters/crossref/sections.lua
+++ b/src/resources/filters/crossref/sections.lua
@@ -45,7 +45,7 @@ function sections()
 
       -- if the number sections option is enabled then emulate pandoc numbering
       local section = sectionNumber(crossref.index.section, level)
-      if numberSectionsOptionEnabled() and level <= numberDepth() then
+      if not _quarto.format.isEpubOutput() and numberSectionsOptionEnabled() and level <= numberDepth() then
         el.attr.attributes["number"] = section
       end
       


### PR DESCRIPTION
Starting in Pandoc 3, this results in Pandoc numbering the chapter, but we provide chapter numbering for HTML (and ePub) output, so we don’t want this.

Fixes #5278
