### PR TITLE
fix(docusaurus): use lang info string

### DIFF
--- a/src/resources/extensions/quarto/docusaurus/docusaurus_writer.lua
+++ b/src/resources/extensions/quarto/docusaurus/docusaurus_writer.lua
@@ -43,6 +43,7 @@ local function tabset(node, filter)
 end
 
 local codeBlock = function(el, filename)
+  local lang = el.attr.classes[1]
   local title = filename or el.attr.attributes["filename"] or el.attr.attributes["title"]  
   local showLineNumbers = el.attr.classes:includes('number-lines')
   if lang or title or showLineNumbers then


### PR DESCRIPTION
## Description

The Docusaurus format was broken because the change in #5291 omitted the definition of the `lang` attribute.

This qmd

````qmd
---
title: test
format:
    docusaurus-md:
        code-line-numbers: true
---

```{.python title="Python"}
print("Hello World")
```

```{=html}
<p style="color: green;">Paragraph</p>
```

```{=mdx}
export const Highlight = ({children, color}) => (
  <span
    style={{
      backgroundColor: color,
      borderRadius: '2px',
      color: '#fff',
      padding: '0.2rem',
    }}>
    {children}
  </span>
);

<Highlight color="#25c2a0">Docusaurus GREEN</Highlight> and <Highlight color="#1877F2">Rams blue</Highlight> are my favorite colors.

I can write **Markdown** alongside my _JSX_!
```
````

is rendered as this. Python code block and mdx code blocks are marked as `text`.

````md
---
title: test
format:
    docusaurus-md:
        code-line-numbers: true
---

export const quartoRawHtml =
[`<p style="color: green;">Paragraph</p>`];


```text showLineNumbers title="Python"
print("Hello World")
```

<div dangerouslySetInnerHTML={{ __html: quartoRawHtml[0] }} />


```text showLineNumbers
export const Highlight = ({children, color}) => (
  <span
    style={{
      backgroundColor: color,
      borderRadius: '2px',
      color: '#fff',
      padding: '0.2rem',
    }}>
    {children}
  </span>
);

<Highlight color="#25c2a0">Docusaurus GREEN</Highlight> and <Highlight color="#1877F2">Rams blue</Highlight> are my favorite colors.

I can write **Markdown** alongside my _JSX_!
```
````

This PR change will fix rendering.

````md
---
title: test
format:
    docusaurus-md:
        code-line-numbers: true
---

export const quartoRawHtml =
[`<p style="color: green;">Paragraph</p>`];


```python showLineNumbers title="Python"
print("Hello World")
```

<div dangerouslySetInnerHTML={{ __html: quartoRawHtml[0] }} />


```mdx-code-block showLineNumbers
export const Highlight = ({children, color}) => (
  <span
    style={{
      backgroundColor: color,
      borderRadius: '2px',
      color: '#fff',
      padding: '0.2rem',
    }}>
    {children}
  </span>
);

<Highlight color="#25c2a0">Docusaurus GREEN</Highlight> and <Highlight color="#1877F2">Rams blue</Highlight> are my favorite colors.

I can write **Markdown** alongside my _JSX_!
```
````

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
