### PR TITLE
Support `from:` formats correctly

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -10,10 +10,11 @@
 ## Miscellaneous
 
 - don't report a non-existing version of Google Chrome in macOS ([#2214](https://github.com/quarto-dev/quarto-cli/issues/2214), reopened).
+- support `from: ` formats correctly ([#5377](https://github.com/quarto-dev/quarto-cli/issues/5377)).
 
 ## Docusaurus Format
 
-- Support for `code-line-numbers` in Docusaurus output ([#5152](https://github.com/quarto-dev/quarto-cli/issues/5152))
+- Support for `code-line-numbers` in Docusaurus output ([#5152](https://github.com/quarto-dev/quarto-cli/issues/5152)).
 
 ## OJS engine
 

--- a/src/resources/filters/qmd-reader.lua
+++ b/src/resources/filters/qmd-reader.lua
@@ -114,22 +114,19 @@ function Reader (inputs, opts)
   local txt, tags = escape_invalid_tags(tostring(inputs))
   local extensions = {}
 
-  for k, v in pairs(opts.extensions) do
-    extensions[v] = true
-  end
-
+  local flavor = {
+    format = "markdown",
+    extensions = {},
+  }
   if param("user-defined-from") then
-    local user_format = _quarto.format.parse_format(param("user-defined-from"))
-    for k, v in pairs(user_format.extensions) do
-      extensions[k] = v
+    flavor = _quarto.format.parse_format(param("user-defined-from"))
+  else 
+    for k, v in pairs(opts.extensions) do
+      flavor.extensions[v] = true
     end
   end
 
   -- Format flavor, i.e., which extensions should be enabled/disabled.
-  local flavor = {
-    format = "markdown",
-    extensions = extensions,
-  }
   local function restore_invalid_tags(tag)
     return tags[tag] or tag
   end
@@ -140,6 +137,7 @@ function Reader (inputs, opts)
       return cb
     end
   }
+  print(doc)
 
   return doc
 end

--- a/tests/docs/smoke-all/2023/04/11/format_underscores.qmd
+++ b/tests/docs/smoke-all/2023/04/11/format_underscores.qmd
@@ -1,6 +1,6 @@
 ---
 title: "."
-from: commonmark_x-emoji+autolink_bare_urls
+from: commonmark_x-emoji+autolink_bare_uris
 ---
 
 <div class="sphinx-docs">

--- a/tests/docs/smoke-all/2023/04/11/format_underscores.qmd
+++ b/tests/docs/smoke-all/2023/04/11/format_underscores.qmd
@@ -1,6 +1,6 @@
 ---
 title: "."
-from: commonmark_x+emoji-markdown_attribute+wikilinks_title_before_pipe
+from: commonmark_x-emoji+autolink_bare_urls
 ---
 
 <div class="sphinx-docs">

--- a/tests/docs/smoke-all/2023/05/01/5377.qmd
+++ b/tests/docs/smoke-all/2023/05/01/5377.qmd
@@ -1,0 +1,11 @@
+---
+from: commonmark_x
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ["#issue5377"]
+---
+
+{#issue5377}
+> Block quote


### PR DESCRIPTION
This closes #5377.

(Note that we can't forward our standard markdown options to user-defined formats, and so this will likely need some document-to-document tweaking of options).