### PR TITLE
don't escape in gfm

### DIFF
--- a/src/core/handlers/mermaid.ts
+++ b/src/core/handlers/mermaid.ts
@@ -425,7 +425,7 @@ mermaid.initialize(${JSON.stringify(mermaidOpts)});
       ) {
         return mappedConcat([
           "\n``` mermaid\n",
-          escape(cellContent.value), // TODO escaping removes MappedString information.
+          cellContent.value,
           "\n```\n",
         ]);
       } else {


### PR DESCRIPTION
## Description

An attempt at fixing #5319. It simply removes the `escape(...)` call. Does this have any undesired side-effects? I also removed the TODO comment, as I _think_ this PR solves that issue?

To verify, I rendered the mermaid-demos-in-quarto files to GFM and uploaded the `_*.md` files [here](https://github.com/data-intuitive/mermaid-demos-in-quarto/tree/test_gfm/syntax). I went through all of the different `_*.md` files and didn't see anything unexpected.


## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
