### PR TITLE
feat(.github/DISCUSSION_TEMPLATE): add discussion templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/feature-requests.yml
+++ b/.github/DISCUSSION_TEMPLATE/feature-requests.yml
@@ -3,12 +3,13 @@ body:
   - type: markdown
     attributes: 
       value: |
-        Make sure to check [Quarto Issues](https://github.com/quarto-dev/quarto-cli/issues) and [Feature Requests GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/feature-requests) first to see if your feature request has already been discussed.
-        If it has, you can add a comment to the existing discussion instead of creating a new one.
+        First, please check [Quarto Issues](https://github.com/quarto-dev/quarto-cli/issues) and [Feature Requests GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/feature-requests) to see if your feature request has already been discussed.
+        If it has, please consider adding a comment to the existing discussion instead of creating a new one.
 
-        After checking, if you are not sure if your feature request has already been discussed, you can still create a new discussion. 😉
+        After checking, if you are not sure if your feature request has already been discussed, please create a new discussion.
+        We look forward to hearing from you.
 
-        If you want to ask for help, please use the [Q&A GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/q-a).
+        If you want to ask for help, please consider using the [Q&A GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/q-a), as it is better suited for answering your question.
 
         Finally, try to describe the best you can what you want to achieve and why you think it is important.
         This will help us to understand your request and prioritise it.
@@ -20,4 +21,4 @@ body:
       required: true
   - type: markdown
     attributes:
-      value: "_Thanks for opening this feature request!_"
+      value: "_Thank you for opening this feature request!_"

--- a/.github/DISCUSSION_TEMPLATE/feature-requests.yml
+++ b/.github/DISCUSSION_TEMPLATE/feature-requests.yml
@@ -1,0 +1,23 @@
+title: "<The (missing) feature you want to discuss>"
+body:
+  - type: markdown
+    attributes: 
+      value: |
+        Make sure to check [Quarto Issues](https://github.com/quarto-dev/quarto-cli/issues) and [Feature Requests GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/feature-requests) first to see if your feature request has already been discussed.
+        If it has, you can add a comment to the existing discussion instead of creating a new one.
+
+        After checking, if you are not sure if your feature request has already been discussed, you can still create a new discussion. 😉
+
+        If you want to ask for help, please use the [Q&A GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/q-a).
+
+        Finally, try to describe the best you can what you want to achieve and why you think it is important.
+        This will help us to understand your request and prioritise it.
+  - type: textarea
+    attributes:
+      label: Description
+      description: Start your discussion!
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: "_Thanks for opening this feature request!_"

--- a/.github/DISCUSSION_TEMPLATE/feature-requests.yml
+++ b/.github/DISCUSSION_TEMPLATE/feature-requests.yml
@@ -13,6 +13,8 @@ body:
 
         Finally, try to describe the best you can what you want to achieve and why you think it is important.
         This will help us to understand your request and prioritise it.
+
+        _Thank you for opening this feature request!_
   - type: textarea
     attributes:
       label: Description
@@ -21,4 +23,5 @@ body:
       required: true
   - type: markdown
     attributes:
-      value: "_Thank you for opening this feature request!_"
+      value: |
+        _Thank you for opening this feature request!_

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,41 @@
+title: "<Your question in one sentence (e.g., How do I preview documents with Quarto?)>"
+body:
+  - type: markdown
+    attributes: 
+      value: |
+        Make sure to check [Quarto Issues](https://github.com/quarto-dev/quarto-cli/issues) and [Q&A GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/q-a) first to see if your question/report has already been discussed.
+        If it has, you can add a comment to the existing discussion instead of creating a new one.
+
+        After checking, if you are not sure that your question/report has already been discussed, you can still create a new discussion. 😉
+  - type: textarea
+    attributes:
+      label: Description
+      description: Start your question/report!
+      placeholder: |
+          You can include Quarto document code which includes code blocks like this:
+
+          ````qmd
+          ---
+          title: "Hello Quarto!"
+          format: html
+          ---
+
+          ```py
+          print("Hello Quarto!")
+          ```
+          ````
+
+          ---
+
+          ### Additional information that can help us to help you
+
+          - What Quarto version are you using?  
+            You can find the version of Quarto you used by running `quarto --version` in your terminal.
+          - What operating system are you using?  
+            Linux Ubuntu 20.04, macOS 11.2.3, Windows 10, _etc._
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        _Thanks for opening this discussion either to ask for help or report a possible bug!_

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -3,10 +3,16 @@ body:
   - type: markdown
     attributes: 
       value: |
-        Make sure to check [Quarto Issues](https://github.com/quarto-dev/quarto-cli/issues) and [Q&A GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/q-a) first to see if your question/report has already been discussed.
-        If it has, you can add a comment to the existing discussion instead of creating a new one.
+        First, please check [Quarto Issues](https://github.com/quarto-dev/quarto-cli/issues) and [Q&A GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/q-a) first to see if your question has already been asked.
+        If it has, please consider adding a comment to the existing discussion instead of creating a new one.
 
-        After checking, if you are not sure that your question/report has already been discussed, you can still create a new discussion. 😉
+        After checking, if you are not sure if your question has already been asked, please create a new discussion.
+        We look forward to hearing from you.
+
+        Finally, try to describe the best you can what you want to achieve or what is your issue, especially by providing a complete self-contained reproducible example (as demonstrated in the below form).
+        This will help us to understand your question and answer it.
+
+        _Thank you for opening this discussion either to ask for help or to report a possible bug!_
   - type: textarea
     attributes:
       label: Description
@@ -38,4 +44,4 @@ body:
   - type: markdown
     attributes:
       value: |
-        _Thanks for opening this discussion either to ask for help or report a possible bug!_
+        _Thank you for opening this discussion either to ask for help or to report a possible bug!_

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,16 @@
+title: "<The item you want to talk about>"
+body:
+  - type: markdown
+    attributes: 
+      value: |
+        If you want to ask for a feature, please use the [Feature Requests GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/feature-requests).
+        If you want to ask for help, please use the [Q&A GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/q-a).
+  - type: textarea
+    attributes:
+      label: Description
+      description: Start your Quarto tale!
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: "_Thanks for using Quarto and talking about your use case!_"


### PR DESCRIPTION
This PR adds Github Discussion templates for the different current categories available in this repository.

| Feature Requests | Q & A | Show and Tell |
|:-:|:-:|:-:|
| <img width="896" alt="image" src="https://github.com/quarto-dev/quarto-cli/assets/8896044/6523f78b-eed5-4864-b5d9-6125011d8887"> | <img width="599" alt="image" src="https://github.com/quarto-dev/quarto-cli/assets/8896044/d3fa155f-4ced-4c12-bae0-7516eeb4b0bc"> | <img width="893" alt="image" src="https://github.com/quarto-dev/quarto-cli/assets/8896044/1bfcab60-fba7-4491-acee-122388054b0a"> |

