### PR TITLE
Fix issue with code filename feature in Beamer output

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -36,6 +36,10 @@
 
 - ([#5152](https://github.com/quarto-dev/quarto-cli/issues/5152)): Support for `code-line-numbers` in Docusaurus output.
 
+## Beamer Format
+
+- [#5536](https://github.com/quarto-dev/quarto-cli/issues/5536): Correctly support Code Filename feature for Beamer output by fixing issue with float environment.
+
 ## OJS engine
 
 - Update observablehq's runtime to version 5.6.0.

--- a/src/resources/filters/customnodes/decoratedcodeblock.lua
+++ b/src/resources/filters/customnodes/decoratedcodeblock.lua
@@ -84,7 +84,12 @@ _quarto.ast.add_renderer("DecoratedCodeBlock",
     -- further, otherwise generate the listing div and return it
     if not latexListings() then
       local listingDiv = pandoc.Div({})
-      listingDiv.content:insert(pandoc.RawBlock("latex", "\\begin{codelisting}"))
+      local position = ""
+      if _quarto.format.isBeamerOutput() then
+        -- Adjust default float positionment for beamer (#5536)
+        position = "[H]"
+      end
+      listingDiv.content:insert(pandoc.RawBlock("latex", "\\begin{codelisting}" .. position))
 
       local captionContent = node.caption
 

--- a/tests/docs/smoke-all/2023/05/15/5536-codefilename-beamer.qmd
+++ b/tests/docs/smoke-all/2023/05/15/5536-codefilename-beamer.qmd
@@ -1,0 +1,21 @@
+---
+title: codefilename with beamer
+_quarto:
+  tests:
+    beamer: default
+---
+
+## Code block
+
+```{.python filename="matplotlib1.py"}
+import matplotlib.pyplot as plt
+plt.plot([1,23,2,4])
+plt.show()
+```
+
+## Computation
+
+```{r}
+#| filename: dummy.R
+1 + 1
+```


### PR DESCRIPTION
Change default positioning to [H] for codelisting float environment in beamer when using codefilename feature

closes #5536

This is because floats in Beamer output does not work (well) - using `[H]` special positioning insure that this works in beamer output
