### PR TITLE
[revealjs] Do no autostretch images inside links

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -18,6 +18,10 @@
 - ([#5393](https://github.com/quarto-dev/quarto-cli/issues/5393)): Properly set color of headings without using opacity.
 - ([#5431](https://github.com/quarto-dev/quarto-cli/issues/5431)): Properly apply column positioning to title metadata.
 
+## RevealJS Format
+
+- [#5546](https://github.com/quarto-dev/quarto-cli/issues/5546): Images inside links can't be stretched, and so auto-stretch feature now ignores them.
+
 ## Website Listings
 
 - ([#5371](https://github.com/quarto-dev/quarto-cli/issues/5371)): Properly compute the trimmed length of descriptions included in listings.

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -787,7 +787,9 @@ function applyStretch(doc: Document, autoStretch: boolean) {
           !imageEl.getAttribute("style")?.match("height:") &&
           !imageEl.hasAttribute("height") &&
           // do not add when .absolute is used
-          !imageEl.classList.contains("absolute")
+          !imageEl.classList.contains("absolute") &&
+          // do not add when image is inside a link
+          imageEl.parentElement?.nodeName !== "A"
         ) {
           imageEl.classList.add("r-stretch");
         }

--- a/tests/docs/reveal/stretch.qmd
+++ b/tests/docs/reveal/stretch.qmd
@@ -249,3 +249,7 @@ Something here as an aside
 See the feature https://quarto.org/docs/presentations/revealjs/advanced.html#absolute-position from
 
 ![](https://quarto.org/quarto.png){.absolute width=500}
+
+## No auto stretch if image is inside linke {#link}
+
+[![](https://quarto.org/docs/blog/posts/2023-04-26-1.3-release/arthur-chauvineau-Dn7P1U26ZkE-unsplash.jpeg)](https://google.com)

--- a/tests/smoke/render/render-reveal.test.ts
+++ b/tests/smoke/render/render-reveal.test.ts
@@ -71,6 +71,7 @@ testRender(input, "revealjs", false, [
     "#custom-divs-knitr-caption img.r-stretch",
     "#aside img.r-stretch",
     "#absolute img.r-stretch",
+    "#link img.r-stretch",
   ]),
 ]);
 


### PR DESCRIPTION
fixes #5546 

Images inside links will now be ignored from auto stretch to preserve the links. 