### PR TITLE
Upgrade esbuild to 0.17.16

### DIFF
--- a/configuration
+++ b/configuration
@@ -12,7 +12,7 @@ export DENO=v1.33.2
 export DENO_DOM=v0.1.35-alpha-artifacts
 export PANDOC=3.1.2
 export DARTSASS=1.55.0
-export ESBUILD=0.15.6
+export ESBUILD=0.17.16
 
 # Bootstrap dependencies from bslib
 # (use commit hash from bslib repo)


### PR DESCRIPTION
## Description

Upgrading esbuild to 0.17.16, which upgrades golang to 1.20.3, fixing many vulnerabilities.

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
