### PR TITLE
Correctly unset citeproc meta if set by user as we use filter

### DIFF
--- a/src/command/render/defaults.ts
+++ b/src/command/render/defaults.ts
@@ -49,6 +49,7 @@ export async function generateDefaults(
         ...(allDefaults[kFilters] || []),
       ],
       options,
+      allDefaults,
     );
     if (resolvedFilters) {
       allDefaults[kFilters] = resolvedFilters.quartoFilters;

--- a/src/command/render/filters.ts
+++ b/src/command/render/filters.ts
@@ -585,6 +585,7 @@ const kQuartoCiteProcMarker = "citeproc";
 export async function resolveFilters(
   filters: QuartoFilter[],
   options: PandocOptions,
+  pandoc: FormatPandoc,
 ): Promise<QuartoFilterSpec | undefined> {
   // build list of quarto filters
 
@@ -619,8 +620,8 @@ export async function resolveFilters(
     // If we're explicitely adding the citeproc filter, turn off
     // citeproc: true so it isn't run twice
     // See https://github.com/quarto-dev/quarto-cli/issues/2393
-    if (options.format.pandoc.citeproc === true) {
-      delete options.format.pandoc.citeproc;
+    if (pandoc.citeproc === true) {
+      delete pandoc.citeproc;
     }
 
     quartoFilters.push(kQuartoCiteProcMarker);

--- a/tests/docs/test-citeproc.qmd
+++ b/tests/docs/test-citeproc.qmd
@@ -1,0 +1,8 @@
+---
+title: "Citeproc explicit"
+format: html
+bibliography: references.bib
+citeproc: true
+---
+
+Hello [@guo2020]

--- a/tests/smoke/render/render-citeproc.test.ts
+++ b/tests/smoke/render/render-citeproc.test.ts
@@ -1,0 +1,25 @@
+/*
+* render-reveal.test.ts
+*
+* Copyright (C) 2020-2022 Posit Software, PBC
+*
+*/
+
+import { docs, outputForInput } from "../../utils.ts";
+import {
+  ensureHtmlSelectorSatisfies,
+} from "../../verify.ts";
+import { testRender } from "./render.ts";
+
+// No duplicated reference when citeproc: true
+let input = docs("test-citeproc.qmd");
+let output = outputForInput(input, "html");
+testRender(input, "html", false, [ 
+  ensureHtmlSelectorSatisfies(
+    output.outputPath,
+    "div[id='ref-guo2020']",
+    (nodeList) => {
+      return nodeList.length === 1;
+    },
+  ),
+]);


### PR DESCRIPTION
Deactivating citeproc should happen in allDefaults options that will be used for default files

fixes #5585 

As mentioned there in https://github.com/quarto-dev/quarto-cli/issues/5585#issuecomment-1551943503 

The regression was a side effect of this change I made as `resolvedFilters()` which happens now on a cloned version of options 
https://github.com/quarto-dev/quarto-cli/blob/8781ac3187fe937e9e42916d1e99fd73a6c7c6d9/src/command/render/defaults.ts#L43-L53

This change was done in https://github.com/quarto-dev/quarto-cli/pull/4348 to fix https://github.com/quarto-dev/quarto-cli/issues/4260 after a discussion with @dragonstyle 

I added a regression test so that we don't mess with this again. 


This is happening with 1.3 and 1.4. This should probably be a hot fix in 1.3. I don't know how you handle that usually. This PR is again main, and I supposed you cherry-pick for a new 1.3 release ? Where should the bullet news be in that case ? 

@dragonstyle @jjallaire I let you check this change, and do the right thing for the patch if needed. 
