### PR TITLE
Add `title-short` to LaTeX partial

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -24,6 +24,10 @@
 
 - [#5546](https://github.com/quarto-dev/quarto-cli/issues/5546): Images inside links can't be stretched, and so auto-stretch feature now ignores them.
 
+## PDF Format
+
+- [#5620](https://github.com/quarto-dev/quarto-cli/discussions/5620): Add `title-short` option.
+ 
 ## Website Listings
 
 - ([#5371](https://github.com/quarto-dev/quarto-cli/issues/5371)): Properly compute the trimmed length of descriptions included in listings.

--- a/src/resources/formats/pdf/pandoc/title.tex
+++ b/src/resources/formats/pdf/pandoc/title.tex
@@ -1,5 +1,5 @@
 $if(title)$
-\title{$title$$if(thanks)$\thanks{$thanks$}$endif$}
+\title$if(title-short)$[$title-short$]$endif${$title$$if(thanks)$\thanks{$thanks$}$endif$}
 $endif$
 $if(subtitle)$
 $if(beamer)$

--- a/tests/docs/smoke-all/2023/05/21/5620-amsart.qmd
+++ b/tests/docs/smoke-all/2023/05/21/5620-amsart.qmd
@@ -1,0 +1,13 @@
+---
+title: Short title
+_quarto:
+  tests:
+    pdf:
+      documentclass: amsart
+      title-short: Shortitle works
+---
+
+## Foo
+
+## Bar
+

--- a/tests/docs/smoke-all/2023/05/21/5620-amsart.qmd
+++ b/tests/docs/smoke-all/2023/05/21/5620-amsart.qmd
@@ -4,10 +4,12 @@ _quarto:
   tests:
     pdf:
       documentclass: amsart
-      title-short: Shortitle works
+      title-short: Short title works
 ---
 
 ## Foo
+
+\pagebreak
 
 ## Bar
 

--- a/tests/docs/smoke-all/2023/05/21/5620-beamer.qmd
+++ b/tests/docs/smoke-all/2023/05/21/5620-beamer.qmd
@@ -1,0 +1,12 @@
+---
+title: Short title
+_quarto:
+  tests:
+    beamer:
+      title-short: Shortitle works
+---
+
+## Foo
+
+## Bar
+

--- a/tests/docs/smoke-all/2023/05/21/5620-beamer.qmd
+++ b/tests/docs/smoke-all/2023/05/21/5620-beamer.qmd
@@ -3,7 +3,7 @@ title: Short title
 _quarto:
   tests:
     beamer:
-      title-short: Shortitle works
+      title-short: Short title works
 ---
 
 ## Foo


### PR DESCRIPTION
## Description

Adds `title-short` option for PDF documents. This option is supported by some LaTeX classes, such as beamer or amsart, by adding square brackets after title:

```tex
\title[Short Title]{Long Title}
```


As per https://github.com/quarto-dev/quarto-cli/discussions/5620, this syntax is consistent with what's already  in the `acs` quarto journal [template](https://github.com/quarto-journals/acs/blob/main/template.qmd). There is a question whether this should be upstream in pandoc. 

Smoke tests might be overkill so feel free to delete.

## Checklist

I have (if applicable):

- [X] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [X] updated the appropriate changelog
