### PR TITLE
Shortcodes should be able to emit callouts

### DIFF
--- a/src/resources/filters/customnodes/shortcodes.lua
+++ b/src/resources/filters/customnodes/shortcodes.lua
@@ -214,6 +214,9 @@ function shortcodes_filter()
   })
 
   local block_handler = function(node)
+    if node.t == "Para" and #node.content == 1 then
+      node = node.content[1]
+    end
     local custom_data, t, kind = _quarto.ast.resolve_custom_data(node)
     if t ~= "Shortcode" then
       return nil

--- a/tests/docs/smoke-all/2023/05/24/5661-html.qmd
+++ b/tests/docs/smoke-all/2023/05/24/5661-html.qmd
@@ -1,0 +1,16 @@
+---
+title: "Callout-test Example"
+format: 
+  html: default
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ["div.callout"]
+        - []
+---
+
+## Heading
+
+{{< callout-test >}}
+

--- a/tests/docs/smoke-all/2023/05/24/_extensions/callout-test/_extension.yml
+++ b/tests/docs/smoke-all/2023/05/24/_extensions/callout-test/_extension.yml
@@ -1,0 +1,8 @@
+title: Callout-test
+author: Pascal Burkhard
+version: 1.0.0
+quarto-required: ">=1.3.0"
+contributes:
+  shortcodes:
+    - callout-test.lua
+

--- a/tests/docs/smoke-all/2023/05/24/_extensions/callout-test/callout-test.lua
+++ b/tests/docs/smoke-all/2023/05/24/_extensions/callout-test/callout-test.lua
@@ -1,0 +1,13 @@
+return {
+  ['callout-test'] = function(args, kwargs, meta) 
+    local calloutDiv = {}
+    calloutDiv["type"] = "note"
+    calloutDiv["icon"] = false
+    calloutDiv["title"] = "Test"
+    calloutDiv["content"] = { pandoc.Str("This is a test.") }
+    
+    calloutOut = quarto.Callout(calloutDiv)
+    
+    return calloutOut
+  end
+}


### PR DESCRIPTION
This fixes #5661 and adds the appropriate regression test.