### PR TITLE
fix: add `fig.asp` to known knitr option

### DIFF
--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -273,7 +273,8 @@ knitr_hooks <- function(format, resourceDir, handledLanguages) {
                     "fenced.echo", "chunk.echo", "lang",
                     "out.width.px", "out.height.px", "indent", "class.source", 
                     "class.output", "class.message", "class.warning", "class.error", "attr.source", 
-                    "attr.output", "attr.message", "attr.warning", "attr.error", "connection")
+                    "attr.output", "attr.message", "attr.warning", "attr.error", "connection",
+                    "fig.asp")
     known_opts <- c(knitr_default_opts, quarto_opts, other_opts)
     unknown_opts <- setdiff(names(options), known_opts)
     unknown_opts <- Filter(Negate(is.null), unknown_opts)
@@ -1001,5 +1002,3 @@ latex_animation <- function(x, options) {
 is_latex_output <- function(to) {
   knitr:::is_latex_output() || identical(to, "pdf")
 }
-
-


### PR DESCRIPTION
`fig.asp` is not listed as a known `knitr` option (_i.e._, `names(knitr::opts_chunk$get())`), but it is used by `knitr`.

Because `fig.asp` is not a valid div attribute, it should not be added to `forwardAttr`.
Then `forwardAttr` (if not empty, _i.e._, zero length string) triggers the creation of a div element, which is not what we want, because it conflicts with other Quarto features such as panel tabset, in addition to not being valid anyway.

Fixes #5667
