### PR TITLE
fix: add `opts_chunk_attr` to known knitr options

### DIFF
--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -261,7 +261,7 @@ knitr_hooks <- function(format, resourceDir, handledLanguages) {
     }
 
     # forward any other unknown attributes
-    knitr_default_opts <- names(knitr::opts_chunk$get())
+    knitr_default_opts <- unique(c(names(knitr:::opts_chunk_attr), names(knitr::opts_chunk$get())))
     quarto_opts <- c("label","fig.cap","fig.subcap","fig.scap","fig.link", "fig.alt",
                      "fig.align","fig.env","fig.pos","fig.num", "lst-cap", 
                      "lst-label", "classes", "panel", "column", "fig.column", "tbl.column", "fig.cap-location", 
@@ -273,8 +273,7 @@ knitr_hooks <- function(format, resourceDir, handledLanguages) {
                     "fenced.echo", "chunk.echo", "lang",
                     "out.width.px", "out.height.px", "indent", "class.source", 
                     "class.output", "class.message", "class.warning", "class.error", "attr.source", 
-                    "attr.output", "attr.message", "attr.warning", "attr.error", "connection",
-                    "fig.asp")
+                    "attr.output", "attr.message", "attr.warning", "attr.error", "connection")
     known_opts <- c(knitr_default_opts, quarto_opts, other_opts)
     unknown_opts <- setdiff(names(options), known_opts)
     unknown_opts <- Filter(Negate(is.null), unknown_opts)


### PR DESCRIPTION
Following up on #5667 and from discussion on https://github.com/yihui/knitr/pull/2260#issuecomment-1562966846, this PR proposes to use both `knitr:::opts_chunk_attr` and `knitr::opts_chunk$get()` to get `knitr` chunk options, which for now should avoid other issue as for `fig.asp`.

Note that `knitr:::opts_chunk_attr` includes 12 options not defined in `knitr::opts_chunk$get()` (icluding `fig.asp`).
While `knitr::opts_chunk$get()` has two options not defined in `knitr:::opts_chunk_attr`.