### PR TITLE
[R] Use ... in `add_html_caption()` as we overwrite knitr's internals

### DIFF
--- a/src/resources/rmd/patch.R
+++ b/src/resources/rmd/patch.R
@@ -108,7 +108,7 @@ wrap_asis_output <- function(options, x) {
   
   output_div(x, output_label_placeholder(options), classes)
 }
-add_html_caption <- function(options, x) {
+add_html_caption <- function(options, x, ...) {
   if (inherits(x, 'knit_asis_htmlwidget')) {
     wrap_asis_output(options, x)
   } else {


### PR DESCRIPTION
Fixes #5702 

**knitr** 1.43 has a new feature to support aria-labelledby on HTML Widget, but it was done by adding an argument to `add_html_caption()` that we override in Quarto. 

This means the function we pass to **knitr** does not have the correct number of argument anymore. 

Using `...` in function we replace in knitr's namespace should prevent this error. 

I only did this specific function to make a possible hot fix minimal, but we should probably do that in all our `assignInNamespace()` call. 

@jjallaire do you think this should be "fixed" here ? Or should **knitr** track and know what Quarto is using internally to pay attention to changes ? It seems to me Quarto should adapt, but I may be wrong

More generally, we may need to reconsider the interaction in knitr for Quarto. Maybe we need to add specific hooks in **knitr**. 
This I understand that we don't want to depend on a specific **knitr** version. If the latter is the policy, we need to protect and adapt more closely to change in **knitr**.  

As a feedback for us, this shows that we really need to tests Quarto against current dev version of knitr (and rmarkdown probably). Our current usage of renv prevent that right now. 