### PR TITLE
Add support for `quarto.doc.add_resource` to add resources to files

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -67,6 +67,7 @@
 - ([#5461](https://github.com/quarto-dev/quarto-cli/issues/5461)): ensure return type of `stripTrailingSpace` is always `pandoc.List`.
 - Add support for relative paths in `require()` calls.
 - ([#5242](https://github.com/quarto-dev/quarto-cli/issues/5242)): Add line numbers to error messages.
+- Add support `quarto.doc.add_resource` and `quarto.doc.add_supporting`. `add_resource` will add a resouce file to the current render, copying that file to the same relative location in the output directory. `add_supporting` will add a supporting file to the current render, moving that file file to the same relative location in the output directory.
 
 ## Other Fixes and Improvements
 

--- a/src/command/render/pandoc-dependencies-resources.ts
+++ b/src/command/render/pandoc-dependencies-resources.ts
@@ -4,7 +4,11 @@
  * Copyright (C) 2020-2022 Posit Software, PBC
  */
 
-import { kFormatResources, kResources } from "../../config/constants.ts";
+import {
+  kFormatResources,
+  kResources,
+  kSupporting,
+} from "../../config/constants.ts";
 import { copyTo } from "../../core/copy.ts";
 import { lines } from "../../core/text.ts";
 
@@ -54,6 +58,7 @@ export async function processFormatResources(
 ) {
   // Read the dependency file
   const resources: string[] = [];
+  const supporting: string[] = [];
   const dependencyJsonStream = await Deno.readTextFile(dependenciesFile);
   for (const jsonBlob of lines(dependencyJsonStream)) {
     if (jsonBlob) {
@@ -83,8 +88,11 @@ export async function processFormatResources(
             ? relative(inputDir, resource.file)
             : resource.file,
         );
+      } else if (dependency.type === kSupporting) {
+        const supportingResource = dependency.content as Resource;
+        supporting.push(supportingResource.file);
       }
     }
   }
-  return { resources };
+  return { supporting, resources };
 }

--- a/src/command/render/pandoc.ts
+++ b/src/command/render/pandoc.ts
@@ -317,7 +317,9 @@ export async function runPandoc(
 
   // see if there are extras
   const postprocessors: Array<
-    (output: string) => Promise<{ supporting: string[] } | void>
+    (
+      output: string,
+    ) => Promise<{ supporting?: string[]; resources?: string[] } | void>
   > = [];
   const htmlPostprocessors: Array<HtmlPostProcessor> = [];
   const htmlFinalizers: Array<(doc: Document) => Promise<void>> = [];
@@ -1251,7 +1253,7 @@ async function resolveExtras(
 
   // Process format resources
   const resourceDependenciesPostProcessor = async (_output: string) => {
-    await processFormatResources(inputDir, dependenciesFile);
+    return await processFormatResources(inputDir, dependenciesFile);
   };
   extras.postprocessors = extras.postprocessors || [];
   extras.postprocessors.push(resourceDependenciesPostProcessor);

--- a/src/command/render/render.ts
+++ b/src/command/render/render.ts
@@ -252,11 +252,15 @@ export async function renderPandoc(
 
       // run generic postprocessors
       const postProcessSupporting: string[] = [];
+      const postProcessResources: string[] = [];
       if (pandocResult.postprocessors) {
         for (const postprocessor of pandocResult.postprocessors) {
           const result = await postprocessor(outputFile);
           if (result && result.supporting) {
             postProcessSupporting.push(...result.supporting);
+          }
+          if (result && result.resources) {
+            postProcessResources.push(...result.resources);
           }
         }
       }
@@ -361,6 +365,10 @@ export async function renderPandoc(
       };
       popTiming();
 
+      // Forward along any specific resources
+      const files = resourceFiles.concat(htmlPostProcessResult.resources)
+        .concat(postProcessResources);
+
       const result: RenderedFile = {
         isTransient: recipe.isOutputTransient,
         input: projectPath(context.target.source),
@@ -376,7 +384,7 @@ export async function renderPandoc(
           : projectPath(finalOutput!),
         resourceFiles: {
           globs: pandocResult.resources,
-          files: resourceFiles.concat(htmlPostProcessResult.resources),
+          files,
         },
         selfContained: selfContained!,
       };

--- a/src/command/render/types.ts
+++ b/src/command/render/types.ts
@@ -57,7 +57,7 @@ export interface RunPandocResult {
   inputTraits: PandocInputTraits;
   resources: string[];
   postprocessors?: Array<
-    (output: string) => Promise<{ supporting: string[] } | void>
+    (output: string) => Promise<{ supporting?: string[], resources?: string[] } | void>
   >;
   htmlPostprocessors: Array<HtmlPostProcessor>;
   htmlFinalizers?: Array<(doc: Document) => Promise<void>>;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -37,6 +37,7 @@ export const kInclude = "include";
 
 export const kResources = "resources";
 export const kFormatResources = "format-resources";
+export const kSupporting = "supporting";
 
 export const kFormatLinks = "format-links";
 export const kNotebookLinks = "notebook-links";

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -326,7 +326,9 @@ export interface FormatExtras {
   [kFilterParams]?: Record<string, unknown>;
   [kNotebooks]?: NotebookPreviewDescriptor[];
   postprocessors?: Array<
-    (output: string) => Promise<{ supporting: string[] } | void>
+    (
+      output: string,
+    ) => Promise<{ supporting?: string[]; resources?: string[] } | void>
   >;
   templateContext?: FormatTemplateContext;
   html?: {

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -2008,6 +2008,10 @@ quarto = {
       writeToDependencyFile(dependency("format-resources", { file = resolvePathExt(path)}))
     end,
 
+    add_resource = function(path)
+      writeToDependencyFile(dependency("resources", { file = resolvePathExt(path)}))
+    end,
+
     include_text = function(location, text)
       writeToDependencyFile(dependency("text", { text = text, location = resolveLocation(location)}))
     end,

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -2012,6 +2012,10 @@ quarto = {
       writeToDependencyFile(dependency("resources", { file = resolvePathExt(path)}))
     end,
 
+    add_supporting = function(path)
+      writeToDependencyFile(dependency("supporting", { file = resolvePathExt(path)}))
+    end,
+
     include_text = function(location, text)
       writeToDependencyFile(dependency("text", { text = text, location = resolveLocation(location)}))
     end,


### PR DESCRIPTION
In lua, use like:

```lua
local file = quarto.doc.input_file;
local dir = pandoc.path.directory(file);
local resource = pandoc.path.join({dir, "boat.jpg"})
quarto.doc.add_resource(resource)
```