### PR TITLE
fix: remove section-divs as not for revealjs

### DIFF
--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -15105,7 +15105,7 @@ var require_yaml_intelligence_resources = __commonJS({
           name: "section-divs",
           tags: {
             formats: [
-              "$html-files"
+              "$html-doc"
             ]
           },
           schema: "boolean",

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -20352,6 +20352,8 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         "Configures the HTML viewer for notebooks that provide embedded\ncontent.",
         "The style of document to render. Setting this to\n<code>notebook</code> will create additional notebook style\naffordances.",
+        "Options for controlling the display and behavior of Notebook\npreviews.",
+        "Whether to show a back button in the notebook preview.",
         "Automatically generate the contents of a page from a list of Quarto\ndocuments or other custom data.",
         "Mermaid diagram options",
         "The mermaid built-in theme to use.",
@@ -21391,9 +21393,7 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
         "Manuscript configuration",
-        "internal-schema-hack",
-        "Options for controlling the display and behavior of Notebook\npreviews.",
-        "Whether to show a back button in the notebook preview."
+        "internal-schema-hack"
       ],
       "schema/external-schemas.yml": [
         {
@@ -21617,12 +21617,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 158291,
+        _internalId: 158625,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 158283,
+            _internalId: 158617,
             type: "enum",
             enum: [
               "png",
@@ -21638,7 +21638,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 158290,
+            _internalId: 158624,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -15106,7 +15106,7 @@ try {
             name: "section-divs",
             tags: {
               formats: [
-                "$html-files"
+                "$html-doc"
               ]
             },
             schema: "boolean",

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -20353,6 +20353,8 @@ try {
           },
           "Configures the HTML viewer for notebooks that provide embedded\ncontent.",
           "The style of document to render. Setting this to\n<code>notebook</code> will create additional notebook style\naffordances.",
+          "Options for controlling the display and behavior of Notebook\npreviews.",
+          "Whether to show a back button in the notebook preview.",
           "Automatically generate the contents of a page from a list of Quarto\ndocuments or other custom data.",
           "Mermaid diagram options",
           "The mermaid built-in theme to use.",
@@ -21392,9 +21394,7 @@ try {
           },
           "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
           "Manuscript configuration",
-          "internal-schema-hack",
-          "Options for controlling the display and behavior of Notebook\npreviews.",
-          "Whether to show a back button in the notebook preview."
+          "internal-schema-hack"
         ],
         "schema/external-schemas.yml": [
           {
@@ -21618,12 +21618,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 158291,
+          _internalId: 158625,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 158283,
+              _internalId: 158617,
               type: "enum",
               enum: [
                 "png",
@@ -21639,7 +21639,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 158290,
+              _internalId: 158624,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -8081,7 +8081,7 @@
       "name": "section-divs",
       "tags": {
         "formats": [
-          "$html-files"
+          "$html-doc"
         ]
       },
       "schema": "boolean",

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -13328,6 +13328,8 @@
     },
     "Configures the HTML viewer for notebooks that provide embedded\ncontent.",
     "The style of document to render. Setting this to\n<code>notebook</code> will create additional notebook style\naffordances.",
+    "Options for controlling the display and behavior of Notebook\npreviews.",
+    "Whether to show a back button in the notebook preview.",
     "Automatically generate the contents of a page from a list of Quarto\ndocuments or other custom data.",
     "Mermaid diagram options",
     "The mermaid built-in theme to use.",
@@ -14367,9 +14369,7 @@
     },
     "Disambiguating year suffix in author-date styles (e.g.&nbsp;“a” in “Doe,\n1999a”).",
     "Manuscript configuration",
-    "internal-schema-hack",
-    "Options for controlling the display and behavior of Notebook\npreviews.",
-    "Whether to show a back button in the notebook preview."
+    "internal-schema-hack"
   ],
   "schema/external-schemas.yml": [
     {
@@ -14593,12 +14593,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 158291,
+    "_internalId": 158625,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 158283,
+        "_internalId": 158617,
         "type": "enum",
         "enum": [
           "png",
@@ -14614,7 +14614,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 158290,
+        "_internalId": 158624,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/schema/document-options.yml
+++ b/src/resources/schema/document-options.yml
@@ -84,7 +84,7 @@
 
 - name: section-divs
   tags:
-    formats: [$html-files]
+    formats: [$html-doc]
   schema: boolean
   default: true
   description: |


### PR DESCRIPTION
This PR removes `section-divs` from formats other than `revealjs`.

I am not 100 % sure, if the four files needed to be modified, _i.e._, some might be generated.

The expected side effect is for the option to be removed from the `revealjs` reference guide page, indeed, headers are by design already embedded in `section` tags in Reveal.js, thus by design can't be disabled.

For short, `section-divs` is invalid and has no effect in `revealjs` format, which can lead to confusion for users.

<table>
<tr><th>HTML</th><th>Reveal.js</th></tr>
<tr>
<td>

<img width="1624" alt="Screenshot 2023-05-29 at 15 31 55" src="https://github.com/quarto-dev/quarto-web/assets/8896044/af90cf93-9838-445e-8ec9-f0abd568527b">

</td>
<td>
<img width="1624" alt="Screenshot 2023-05-29 at 15 34 53" src="https://github.com/quarto-dev/quarto-web/assets/8896044/feb8053d-3670-4496-9d48-c6627ada350f">
</td>
</tr>
</table>