### PR TITLE
ci: add stale/close 'needs-repro' issue GHA

### DIFF
--- a/.github/workflows/stale-needs-repro.yml
+++ b/.github/workflows/stale-needs-repro.yml
@@ -17,7 +17,7 @@ jobs:
           stale-issue-message: |
             Thank you for using Quarto and reporting an issue!
             
-            Unfortunately, this issue is now considered stale because it has been open 30 days without providing a "working" reproducible example.
+            Unfortunately, this issue is now considered stale because it has been opened since 14 days without providing a "working" reproducible example to help us investigate.
             If you are still facing the issue, please review the ["Bug Reports" guide](https://quarto.org/bug-reports.html) on how to provide a fully reproducible example as a self-contained Quarto document or a link to a Git repository.
             Without a reproducible example, it is unlikely that the issue will be addressed and thus will be closed in 30 days.
 

--- a/.github/workflows/stale-needs-repro.yml
+++ b/.github/workflows/stale-needs-repro.yml
@@ -44,6 +44,6 @@ jobs:
 
             _Remove `stale` / `needs-repro` labels or this will be closed in 30 days._
           close-issue-message: |
-            This issue has been automatically closed because it has been open 60 days without providing a "working" reproducible example.
+            This issue has been automatically closed because it has been opened for some time without providing a "working" reproducible example that would help us investigate.
           days-before-stale: 14
           days-before-close: 14

--- a/.github/workflows/stale-needs-repro.yml
+++ b/.github/workflows/stale-needs-repro.yml
@@ -42,7 +42,7 @@ jobs:
             ````
             `````
 
-            _Remove `stale` / `needs-repro` labels or this will be closed in 30 days._
+            _Remove `stale` / `needs-repro` labels or this will be closed in 14 days._
           close-issue-message: |
             This issue has been automatically closed because it has been opened for some time without providing a "working" reproducible example that would help us investigate.
           days-before-stale: 14

--- a/.github/workflows/stale-needs-repro.yml
+++ b/.github/workflows/stale-needs-repro.yml
@@ -19,7 +19,7 @@ jobs:
             
             Unfortunately, this issue is now considered stale because it has been opened since 14 days without providing a "working" reproducible example to help us investigate.
             If you are still facing the issue, please review the ["Bug Reports" guide](https://quarto.org/bug-reports.html) on how to provide a fully reproducible example as a self-contained Quarto document or a link to a Git repository.
-            Without a reproducible example, it is unlikely that the issue will be addressed and thus will be closed in 30 days.
+            Without a reproducible example, it is unlikely that the issue will be addressed and thus will be closed.
 
             You can share a Quarto document using the following syntax, _i.e._, using more backticks than you have in your document (usually four ` ```` `).
             

--- a/.github/workflows/stale-needs-repro.yml
+++ b/.github/workflows/stale-needs-repro.yml
@@ -1,0 +1,49 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+permissions:
+  issues: write
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-label: "stale"
+          any-of-issue-labels: "needs-repro"
+          close-issue-reason: "not_planned"
+          ignore-issue-updates: true
+          stale-issue-message: |
+            Thank you for using Quarto and reporting an issue!
+            
+            Unfortunately, this issue is now considered stale because it has been open 30 days without providing a "working" reproducible example.
+            If you are still facing the issue, please review the ["Bug Reports" guide](https://quarto.org/bug-reports.html) on how to provide a fully reproducible example as a self-contained Quarto document or a link to a Git repository.
+            Without a reproducible example, it is unlikely that the issue will be addressed and thus will be closed in 30 days.
+
+            You can share a Quarto document using the following syntax, _i.e._, using more backticks than you have in your document (usually four ` ```` `).
+            
+            `````
+            ````qmd
+            ---
+            title: "Reproducible Quarto Document"
+            format: html
+            ---
+    
+            This is a reproducible Quarto document using `format: html`.
+            It is written in Markdown and contains embedded R code.
+            When you run the code, it will produce a plot.
+    
+            ```{r}
+            plot(cars)
+            ```
+    
+            The end.
+            ````
+            `````
+
+            _Remove `stale` / `needs-repro` labels or this will be closed in 30 days._
+          close-issue-message: |
+            This issue was closed because it has been stalled for 30 days and was lacking a "working" reproducible example.
+          days-before-stale: 30
+          days-before-close: 30

--- a/.github/workflows/stale-needs-repro.yml
+++ b/.github/workflows/stale-needs-repro.yml
@@ -45,5 +45,5 @@ jobs:
             _Remove `stale` / `needs-repro` labels or this will be closed in 30 days._
           close-issue-message: |
             This issue has been automatically closed because it has been open 60 days without providing a "working" reproducible example.
-          days-before-stale: 30
-          days-before-close: 30
+          days-before-stale: 14
+          days-before-close: 14

--- a/.github/workflows/stale-needs-repro.yml
+++ b/.github/workflows/stale-needs-repro.yml
@@ -44,6 +44,6 @@ jobs:
 
             _Remove `stale` / `needs-repro` labels or this will be closed in 30 days._
           close-issue-message: |
-            This issue was closed because it has been stalled for 30 days and was lacking a "working" reproducible example.
+            This issue has been automatically closed because it has been open 60 days without providing a "working" reproducible example.
           days-before-stale: 30
           days-before-close: 30


### PR DESCRIPTION
This PR adds a simple GitHub Action to post a reminder on issues labelled with. `needs-repro` after 30 days.
Then after an additional 30 days, if the "needs-repro" / "stale" labels are not removed, the issue is closed as not planned by default.

Note: for this to work, a "stale" label needs to be added to the repository.

Documentation for the stale GitHub Actions: <https://github.com/marketplace/actions/close-stale-issues>

### Stale comment

> Thank you for using Quarto and reporting an issue!
>         
> Unfortunately, this issue is now considered stale because it has been open 30 days without providing a "working" reproducible example.
> If you are still facing the issue, please review the ["Bug Reports" guide](https://quarto.org/bug-reports.html) on how to provide a fully reproducible example as a self-contained Quarto document or a link to a Git repository.
> Without a reproducible example, it is unlikely that the issue will be addressed and thus will be closed in 30 days.
> 
> You can share a Quarto document using the following syntax, _i.e._, using more backticks than you have in your document (usually four ` ```` `).
> 
> `````
> ````qmd
> ---
> title: "Reproducible Quarto Document"
> format: html
> ---
> 
> This is a reproducible Quarto document using `format: html`.
> It is written in Markdown and contains embedded R code.
> When you run the code, it will produce a plot.
> 
> ```{r}
> plot(cars)
> ```
> 
> The end.
> ````
> `````
> 
> _Remove `stale` / `needs-repro` labels or this will be closed in 30 days._

### Stale comment closure

> This issue has been automatically closed because it has been open 60 days without providing a "working" reproducible example.