### PR TITLE
regression fix: shortcodes in data-qmd attributes

### DIFF
--- a/src/resources/filters/customnodes/shortcodes.lua
+++ b/src/resources/filters/customnodes/shortcodes.lua
@@ -214,7 +214,7 @@ function shortcodes_filter()
   })
 
   local block_handler = function(node)
-    if node.t == "Para" and #node.content == 1 then
+    if (node.t == "Para" or node.t == "Plain") and #node.content == 1 then
       node = node.content[1]
     end
     local custom_data, t, kind = _quarto.ast.resolve_custom_data(node)

--- a/src/resources/filters/normalize/extractquartodom.lua
+++ b/src/resources/filters/normalize/extractquartodom.lua
@@ -1,11 +1,15 @@
+local md_shortcode = require("lpegshortcode")
+
 local function process_quarto_markdown_input_element(el)
-  if el.attributes.qmd ~= nil then
-    return pandoc.read(el.attributes.qmd, "markdown")
-  elseif el.attributes["qmd-base64"] ~= nil then
-    return pandoc.read(quarto.base64.decode(el.attributes["qmd-base64"]), "markdown")
-  else
+  if el.attributes.qmd == nil and el.attributes["qmd-base64"] == nil then
     error("process_quarto_markdown_input_element called with element that does not have qmd or qmd-base64 attribute")
+    return el
   end
+  local text = el.attributes.qmd or quarto.base64.decode(el.attributes["qmd-base64"])
+  local after_shortcodes = md_shortcode.md_shortcode:match(text)
+  local after_reading = pandoc.read(after_shortcodes, "markdown")
+  local after_parsing = after_reading:walk(parse_extended_nodes()):walk(compute_flags())
+  return after_parsing
 end
 
 function parse_md_in_html_rawblocks()
@@ -21,8 +25,6 @@ function parse_md_in_html_rawblocks()
         local doc = process_quarto_markdown_input_element(span)
         if #doc.blocks < 1 then
           return pandoc.Span({})
-          -- error("process_quarto_markdown_input_element called with empty element")
-          -- error(span.attributes.qmd)
         end
         return doc.blocks[1].content
       end

--- a/src/resources/filters/normalize/extractquartodom.lua
+++ b/src/resources/filters/normalize/extractquartodom.lua
@@ -6,7 +6,7 @@ local function process_quarto_markdown_input_element(el)
     return el
   end
   local text = el.attributes.qmd or quarto.base64.decode(el.attributes["qmd-base64"])
-  local after_shortcodes = md_shortcode.md_shortcode:match(text)
+  local after_shortcodes = md_shortcode.md_shortcode:match(text) or ""
   local after_reading = pandoc.read(after_shortcodes, "markdown")
   local after_parsing = after_reading:walk(parse_extended_nodes()):walk(compute_flags())
   return after_parsing

--- a/tests/docs/smoke-all/2023/05/30/shortcode-table-dataqmd.qmd
+++ b/tests/docs/smoke-all/2023/05/30/shortcode-table-dataqmd.qmd
@@ -1,0 +1,26 @@
+---
+title: Foo
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ["iframe"]
+---
+
+```{=html}
+<table>
+  <caption><span data-qmd="As described in @Lovelace1864, computers are great."></span></caption>
+  <thead>
+    <tr>
+      <th><span data-qmd="_Header 1_"></span></th>
+      <th><span data-qmd="_Header 2_"></span></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><span data-qmd="{{< video https://www.youtube.com/embed/wo9vZccmqwc >}}"></span></td>
+      <td>Regular output</td>
+    </tr>
+  </tbody>
+</table>
+```


### PR DESCRIPTION
This adds an explicit pass to process shortcodes that come out of `data-qmd=""` attributes. It closes a v1.3 regression and closes #5730.