### PR TITLE
feature: control conditional content with boolean metadata

### DIFF
--- a/src/resources/filters/customnodes/content-hidden.lua
+++ b/src/resources/filters/customnodes/content-hidden.lua
@@ -150,12 +150,14 @@ function propertiesMatch(properties, profiles)
   if properties[constants.kWhenMeta] ~= nil then
     local v = properties[constants.kWhenMeta]
     v = split(v, ".") or { v }
-    match = match and (get_meta(v) == true)
+    local r = get_meta(v)
+    match = match and (type(r) == "boolean" and r)
   end
   if properties[constants.kUnlessMeta] ~= nil then
     local v = properties[constants.kUnlessMeta]
     v = split(v, ".") or { v }
-    match = match and not (get_meta(v) == true)
+    local r = get_meta(v)
+    match = match and not (type(r) == "boolean" and r)
   end
   if properties[constants.kWhenFormat] ~= nil then
     match = match and _quarto.format.isFormat(properties[constants.kWhenFormat])

--- a/src/resources/filters/main.lua
+++ b/src/resources/filters/main.lua
@@ -171,7 +171,10 @@ local quartoNormalize = {
   { name = "pre-table-merge-raw-html", 
     filter = table_merge_raw_html()
   },
-  
+
+  { name = "pre-content-hidden-meta",
+    filter = content_hidden_meta() },
+
   -- 2023-04-11: We want to combine these filters but parse_md_in_html_rawblocks
   -- can't be combined with parse_html_tables because combineFilters
   -- doesn't inspect the contents of the results in the inner loop.

--- a/src/resources/filters/modules/constants.lua
+++ b/src/resources/filters/modules/constants.lua
@@ -49,6 +49,8 @@ local kWhenFormat = "when-format"
 local kUnlessFormat = "unless-format"
 local kWhenProfile = "when-profile"
 local kUnlessProfile = "unless-profile"
+local kWhenMeta = "when-meta"
+local kUnlessMeta = "unless-meta"
 local kMermaidClz = 'mermaid'
 local kPositionedRefs = 'positioned-refs'
 local kTblColWidths = "tbl-colwidths"
@@ -109,6 +111,8 @@ return {
   kContentHidden = kContentHidden,
   kWhenFormat = kWhenFormat,
   kUnlessFormat = kUnlessFormat,
+  kWhenMeta = kWhenMeta,
+  kUnlessMeta = kUnlessMeta,
   kWhenProfile = kWhenProfile,
   kUnlessProfile = kUnlessProfile,
   kMermaidClz = kMermaidClz,

--- a/tests/docs/smoke-all/conditional-content/meta.qmd
+++ b/tests/docs/smoke-all/conditional-content/meta.qmd
@@ -1,39 +1,71 @@
 ---
 title: "conditional content on meta"
-check: true
+check_true: true
+check_false: false
 condition:
   path:
     to:
-      condition: true
+      condition_true: true
+      condition_false: false
 _quarto:
   tests:
     html:
       ensureHtmlElements:
-        - ["#MustBeHere", "#MustBeHereToo"]
-        - ["#CannotBeHere", "#CannotBeHereEither"]
+        - ["#MustBeHere", "#MustBeHereToo", "#MustBeHereFalse", "#MustBeHereTooFalse"]
+        - ["#CannotBeHere", "#CannotBeHereEither", "#CannotBeHereFalse"]
 ---
 
-::: {.content-hidden unless-meta="check"}
+## True checks
+
+::: {.content-hidden unless-meta="check_true"}
 
 [stuff]{#MustBeHere}
 
 :::
 
-::: {.content-visible when-meta="condition.path.to.condition"}
+::: {.content-visible when-meta="condition.path.to.condition_true"}
 
 [other stuff]{#MustBeHereToo}
 
 :::
 
 
-::: {.content-visible when-meta="nonexisting.path"}
 
-[other stuff]{#CannotBeHere}
+::: {.content-hidden when-meta="condition.path.to.condition_true"}
+
+[other stuff]{#CannotBeHereEither}
 
 :::
 
-::: {.content-hidden when-meta="condition.path.to.condition"}
 
-[other stuff]{#CannotBeHereEither}
+
+## False checks
+
+::: {.content-hidden when-meta="check_false"}
+
+[stuff]{#MustBeHereFalse}
+
+:::
+
+::: {.content-visible unless-meta="condition.path.to.condition_false"}
+
+[other stuff]{#MustBeHereTooFalse}
+
+:::
+
+
+
+::: {.content-hidden unless-meta="condition.path.to.condition_false"}
+
+[other stuff]{#CannotBeHereEitherFalse}
+
+:::
+
+
+## Nonexisting checks
+
+::: {.content-visible when-meta="nonexisting.path"}
+
+[other stuff]{#CannotBeHere}
 
 :::

--- a/tests/docs/smoke-all/conditional-content/meta.qmd
+++ b/tests/docs/smoke-all/conditional-content/meta.qmd
@@ -1,0 +1,39 @@
+---
+title: "conditional content on meta"
+check: true
+condition:
+  path:
+    to:
+      condition: true
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ["#MustBeHere", "#MustBeHereToo"]
+        - ["#CannotBeHere", "#CannotBeHereEither"]
+---
+
+::: {.content-hidden unless-meta="check"}
+
+[stuff]{#MustBeHere}
+
+:::
+
+::: {.content-visible when-meta="condition.path.to.condition"}
+
+[other stuff]{#MustBeHereToo}
+
+:::
+
+
+::: {.content-visible when-meta="nonexisting.path"}
+
+[other stuff]{#CannotBeHere}
+
+:::
+
+::: {.content-hidden when-meta="condition.path.to.condition"}
+
+[other stuff]{#CannotBeHereEither}
+
+:::


### PR DESCRIPTION
This closes #5707.

cc @aronatkins, @dragonstyle, @jjallaire 

Aron: the feature is intentionally quite narrow; we want to avoid things degenerating into a turing-complete expression language. This means each conditional block can only check the value of a single metadata entry, and only checks against `true` and `false` values.

The included test document shows the syntax.

It's also worth noting that changing the metadata on a Lua filter currently will _not_ work. This was on purpose, so that we can eventually do dependency analysis statically without having to run Pandoc. 