### PR TITLE
Add cell label in Quarto render status

### DIFF
--- a/src/resources/jupyter/notebook.py
+++ b/src/resources/jupyter/notebook.py
@@ -153,27 +153,27 @@ def notebook_execute(options, status):
    # compute total code cells (for progress)
    current_code_cell = 1
    total_code_cells = sum(cell.cell_type == 'code' for cell in client.nb.cells)
-   
-   # find max id length (for progress)
-   max_id_len = max(len(cell.id) for cell in client.nb.cells)
 
+   # find max label length (for progress)   
+   max_label_len = max(len(nb_cell_yaml_options(client.nb.metadata.kernelspec.language, cell).get('label', '')) for cell in client.nb.cells)
+   
    # execute the cells
    for index, cell in enumerate(client.nb.cells):
-      # find cell id
-      source_list = cell.source.split('\n')
-      cell_id = cell.id if any(s.startswith("#| label") or s.startswith("#| id") for s in source_list) else ""
-      padding = "." * (max_id_len - len(cell_id))
-      
+      # read cell options
+      cell_options = nb_cell_yaml_options(client.nb.metadata.kernelspec.language, cell)
+      cell_label = cell_options.get('label', '')
+      padding = "." * (max_label_len - len(cell_label))
+
       # progress
       progress = (not quiet) and cell.cell_type == 'code' and index > 0
       if progress:
          status("  Cell {0}/{1}: '{2}'{3}...".format(
             current_code_cell - 1,
             total_code_cells - 1,
-            cell_id,
+            cell_label,
             padding
          ))
-
+         
       # clear cell output
       cell = cell_clear_output(cell)
 

--- a/src/resources/jupyter/notebook.py
+++ b/src/resources/jupyter/notebook.py
@@ -153,26 +153,23 @@ def notebook_execute(options, status):
    # compute total code cells (for progress)
    current_code_cell = 1
    total_code_cells = sum(cell.cell_type == 'code' for cell in client.nb.cells)
-
-   # find all the labels in the notebook
-   cell_labels = [
-      (next(iter(re.findall(r'#\| label: (.*)', cell.source)), '').strip() 
-       if cell.cell_type == 'code' else '')
-       for cell in nb.cells
-       ]
-   max_label_len = max(len(label) for label in cell_labels)
+   
+   # find max id length (for progress)
+   max_id_len = max(len(getattr(cell, "id", "")) for cell in nb.cells)
 
    # execute the cells
    for index, cell in enumerate(client.nb.cells):
+      # find cell id
+      cell_id = cell.id if hasattr(cell, "id") else ""
+      padding = "." * (max_id_len - len(cell_id))
+      
       # progress
       progress = (not quiet) and cell.cell_type == 'code' and index > 0
       if progress:
-         label = cell_labels[index]
-         padding = "." * (max_label_len - len(label))
          status("  Cell {0}/{1}: '{2}'{3}...".format(
             current_code_cell - 1,
             total_code_cells - 1,
-            label,
+            cell_id,
             padding
          ))
 

--- a/src/resources/jupyter/notebook.py
+++ b/src/resources/jupyter/notebook.py
@@ -149,19 +149,25 @@ def notebook_execute(options, status):
    # complete progress if necessary
    if (not quiet) and created:
       status("Done\n")
-      
-   # compute total code cells (for progress)
-   current_code_cell = 1
-   total_code_cells = sum(cell.cell_type == 'code' for cell in client.nb.cells)
 
-   # find max label length (for progress)   
-   max_label_len = max(len(nb_cell_yaml_options(client.nb.metadata.kernelspec.language, cell).get('label', '')) for cell in client.nb.cells)
+   current_code_cell = 1
+   total_code_cells = 0
+   cell_labels = []
+   max_label_len = 0
+
+   for cell in client.nb.cells:
+      # compute total code cells (for progress)
+      if cell.cell_type == 'code':
+         total_code_cells += 1
+      # map cells to their labels
+      label = nb_cell_yaml_options(client.nb.metadata.kernelspec.language, cell).get('label', '')
+      cell_labels.append(label)
+      # find max label length
+      max_label_len = max(max_label_len, len(label))
    
    # execute the cells
    for index, cell in enumerate(client.nb.cells):
-      # read cell options
-      cell_options = nb_cell_yaml_options(client.nb.metadata.kernelspec.language, cell)
-      cell_label = cell_options.get('label', '')
+      cell_label = cell_labels[index]
       padding = "." * (max_label_len - len(cell_label))
 
       # progress

--- a/src/resources/jupyter/notebook.py
+++ b/src/resources/jupyter/notebook.py
@@ -159,9 +159,16 @@ def notebook_execute(options, status):
       # progress
       progress = (not quiet) and cell.cell_type == 'code' and index > 0
       if progress:
-         status("  Cell {0}/{1}...".format(
-            current_code_cell- 1, total_code_cells - 1
-         ))
+        # get label
+        label = ''
+        source_lines = cell.source.split('\n')
+        label_line = next((line for line in source_lines if line.startswith('#| label:')), None)
+        if label_line:
+            label = label_line.replace('#| label:', '').strip()
+
+        status("  Cell '{0}' {1}/{2}...".format(
+           label, current_code_cell- 1, total_code_cells - 1
+        ))
          
       # clear cell output
       cell = cell_clear_output(cell)

--- a/src/resources/jupyter/notebook.py
+++ b/src/resources/jupyter/notebook.py
@@ -155,12 +155,13 @@ def notebook_execute(options, status):
    total_code_cells = sum(cell.cell_type == 'code' for cell in client.nb.cells)
    
    # find max id length (for progress)
-   max_id_len = max(len(getattr(cell, "id", "")) for cell in nb.cells)
+   max_id_len = max(len(cell.id) for cell in client.nb.cells)
 
    # execute the cells
    for index, cell in enumerate(client.nb.cells):
       # find cell id
-      cell_id = cell.id if hasattr(cell, "id") else ""
+      source_list = cell.source.split('\n')
+      cell_id = cell.id if any(s.startswith("#| label") or s.startswith("#| id") for s in source_list) else ""
       padding = "." * (max_id_len - len(cell_id))
       
       # progress


### PR DESCRIPTION
In this pull request, I've refined the visibility and interpretability of Quarto render status messages. 

Key modifications include:

- Cells with labels: The syntax has been updated from `"  Cell {0}/{1}..."` to `"  Cell '<label>' {0}/{1}..."`.

- Cells without labels: The format has been altered from `"  Cell {0}/{1}..."` to `"  Cell '' {0}/{1}..."`.

These refinements boost the readability of the script and contribute to the overall maintainability and professionalism of our codebase. I look forward to your review.