### PR TITLE
include pandoc3 figure parsing in standalone crossref filter

### DIFF
--- a/src/resources/filters/crossref/crossref.lua
+++ b/src/resources/filters/crossref/crossref.lua
@@ -28,6 +28,8 @@ import("refs.lua")
 import("meta.lua")
 import("format.lua")
 import("options.lua")
+import("../normalize/flags.lua")
+import("../normalize/pandoc3.lua")
 import("../common/lunacolors.lua")
 import("../common/log.lua")
 import("../common/pandoc.lua")
@@ -53,6 +55,8 @@ initCrossrefIndex()
 -- chain of filters
 return {
   init_crossref_options(),
+  compute_flags(),
+  parse_pandoc3_figures(),
   crossref_preprocess(),
   crossref_preprocess_theorems(),
   combineFilters({


### PR DESCRIPTION
This fixes the issue of figure completions not showing up in VS Code (note they also weren't showing up in RStudio). We introduced special normalization of Pandoc 3 figures in v1.3, however the standalone crossers filter wasn't running that pass.

@cscheid I believe this is the right fix but you know the ins and outs of this much better than I do so LMK if there is a better way.

@dragonstyle Once merged we should definitely backport this fix to v1.3.
