### PR TITLE
fix: do not break words in website listings

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -31,6 +31,7 @@
 ## Website Listings
 
 - ([#5371](https://github.com/quarto-dev/quarto-cli/issues/5371)): Properly compute the trimmed length of descriptions included in listings.
+- ([#5805](https://github.com/quarto-dev/quarto-cli/pull/5805)): Update the inherited `word-break: break-word` style (Bootstrap) to `word-break: keep-all` to prevent hyphenation of words in listings.
 
 ## Websites
 

--- a/src/resources/projects/website/listing/quarto-listing.scss
+++ b/src/resources/projects/website/listing/quarto-listing.scss
@@ -488,6 +488,7 @@ table.quarto-listing-table {
 
   a {
     text-decoration: none;
+    word-break: keep-all;
   }
 
   th a {


### PR DESCRIPTION
## Description

This PR proposes a small change in website listing CSS code to avoid words break which can happen in various scenarios which lead to unreadable text/tables.

### Current behaviour

<img width="647" alt="image" src="https://github.com/quarto-dev/quarto-cli/assets/8896044/d6fb04ac-2ef1-45b2-9f4e-c8e018670e76">


### Suggested behaviour

<img width="651" alt="image" src="https://github.com/quarto-dev/quarto-cli/assets/8896044/0c33da83-212c-495a-b101-1d44556df380">


