### PR TITLE
types: improve typings in memoize.ts

### DIFF
--- a/src/core/lib/memoize.ts
+++ b/src/core/lib/memoize.ts
@@ -7,19 +7,15 @@
 *
 */
 
-// TODO typings for this? It's tricky because of arity and type
-//       differences in the arguments
-export function memoize(
-  // deno-lint-ignore no-explicit-any
-  f: (...args: any[]) => any,
-  // deno-lint-ignore no-explicit-any
-  keyMemoizer: (...args: any) => string,
-  // deno-lint-ignore no-explicit-any
-): ((...args: any[]) => any) {
-  // deno-lint-ignore no-explicit-any
-  const memo: Record<string, any> = {};
-  // deno-lint-ignore no-explicit-any
-  const inner: ((...args: any[]) => any) = (...args: any[]) => {
+export function memoize<
+  const A extends readonly unknown[] = unknown[],
+  const R = unknown
+>(
+  f: (...args: A) => R,
+  keyMemoizer: (...args: A) => string,
+): (...args: A) => R {
+  const memo: Record<string, R> = {};
+  const inner: (...args: A) => R = (...args) => {
     const key = keyMemoizer(...args);
     const v = memo[key];
     if (v !== undefined) {


### PR DESCRIPTION
Hello fellow contributors! This is my first contribution to quarto, please forgive me if I missed any of the requirements for contributions; If I did miss something, kindly let me know and I'll do my best to rectify the issue in question. 

Please note, I did not submit a changelog entry since I was on a limited amount of time to get this PR wrapped up and wasn't sure how to go about that step in the checklist. Also, this is a PR for something I noticed while browsing the repo and just decided to fix on the spot. There was no predecessor issue for it (that I'm aware of). The original code _did_ have a TODO comment at the top of it though (which this PR solves in entirety), if that makes any difference.

## Description

I came across the `./core/lib/memoize.ts` file, and noticed it was in desperate need of some better types (it actually had a TODO comment at the top stating exactly that). This PR updates the types of the `memoize` utility to use generic type parameters. It also features the new `const` type parameter modifier that was released with the TypeScript 5.0 debut (shipped in Deno ~1.28, I think?).

This means that I was able to remove every single `// deno-lint-ignore no-explicit-any` directive from the file. More importantly, however, are the benefits it provides to those who use it to memoize a function: the returned function will now have an identical signature to that which was provided as its input.


### Before

```ts
// TODO typings for this? It's tricky because of arity and type
//       differences in the arguments
export function memoize(
  // deno-lint-ignore no-explicit-any
  f: (...args: any[]) => any,
  // deno-lint-ignore no-explicit-any
  keyMemoizer: (...args: any) => string,
  // deno-lint-ignore no-explicit-any
): ((...args: any[]) => any) {
  // deno-lint-ignore no-explicit-any
  const memo: Record<string, any> = {};
  // deno-lint-ignore no-explicit-any
  const inner: ((...args: any[]) => any) = (...args: any[]) => {
    const key = keyMemoizer(...args);
    const v = memo[key];
    if (v !== undefined) {
      return v;
    }
    memo[key] = f(...args);
    return memo[key];
  };
  return inner;
}
```

### After

```ts
export function memoize<
  const A extends readonly unknown[] = unknown[],
  const R = unknown,
>(
  f: (...args: A) => R,
  keyMemoizer: (...args: A) => string,
): (...args: A) => R {
  const memo: Record<string, R> = {};
  const inner: (...args: A) => R = (...args) => {
    const key = keyMemoizer(...args);
    const v = memo[key];
    if (v !== undefined) {
      return v;
    }
    memo[key] = f(...args);
    return memo[key];
  };
  return inner;
}
```

### Example of the improvements in action

```ts
function add(a: number, b: number): number {
  console.log("Computing sum...");
  return a + b;
}

const lazyAdd = memoize(add, (a, b) => `${a}-${b}`);
//     ^? const lazyAdd: (a: number, b: number) => number

// the previous code would produce this instead:
// const oldLazyAdd: (...args: any[]) => any
```

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
