### PR TITLE
ci: no longer remove stale labels on updates

### DIFF
--- a/.github/workflows/stale-needs-repro.yml
+++ b/.github/workflows/stale-needs-repro.yml
@@ -15,7 +15,7 @@ jobs:
           stale-issue-label: "stale"
           any-of-issue-labels: "needs-repro"
           close-issue-reason: "not_planned"
-          ignore-issue-updates: true
+          ignore-issue-updates: false
           remove-issue-stale-when-updated: false
           stale-issue-message: |
             Thank you for using Quarto and reporting an issue!

--- a/.github/workflows/stale-needs-repro.yml
+++ b/.github/workflows/stale-needs-repro.yml
@@ -14,6 +14,7 @@ jobs:
           any-of-issue-labels: "needs-repro"
           close-issue-reason: "not_planned"
           ignore-issue-updates: true
+          remove-issue-stale-when-updated: false
           stale-issue-message: |
             Thank you for using Quarto and reporting an issue!
             

--- a/.github/workflows/stale-needs-repro.yml
+++ b/.github/workflows/stale-needs-repro.yml
@@ -1,3 +1,5 @@
+# Source: https://github.com/actions/stale
+
 name: 'Close stale issues and PRs'
 on:
   schedule:


### PR DESCRIPTION
This PR fixes an issue in the GHA CI workflow were any updates on "needs-repro" labelled issues triggered the action which then removed the "stale" label, thus leading to a new message byt the BOT.

This PR also revert to default (`false`) for `ignore-issue-updates: false`, _i.e._, on any updates on the issue, the countdown before closing a "stale" issue is reset.