### PR TITLE
fix: display metadata block even without title/subtitle

### DIFF
--- a/src/resources/formats/html/pandoc/template.html
+++ b/src/resources/formats/html/pandoc/template.html
@@ -37,9 +37,7 @@ $title-block.html()$
 $elseif(subtitle)$
 $title-block.html()$
 $elseif(by-author)$
-<header id="title-block-header" class="quarto-title-block default">
 $title-block.html()$
-</header>
 $endif$
 
 $if(toc)$

--- a/src/resources/formats/html/pandoc/template.html
+++ b/src/resources/formats/html/pandoc/template.html
@@ -36,6 +36,10 @@ $if(title)$
 $title-block.html()$
 $elseif(subtitle)$
 $title-block.html()$
+$elseif(by-author)$
+<header id="title-block-header" class="quarto-title-block default">
+$title-block.html()$
+</header>
 $endif$
 
 $if(toc)$

--- a/src/resources/formats/html/pandoc/template.html
+++ b/src/resources/formats/html/pandoc/template.html
@@ -32,13 +32,7 @@ $for(include-before)$
 $include-before$
 $endfor$
 
-$if(title)$
 $title-block.html()$
-$elseif(subtitle)$
-$title-block.html()$
-$elseif(by-author)$
-$title-block.html()$
-$endif$
 
 $if(toc)$
 $toc.html()$

--- a/src/resources/formats/html/templates/title-block.html
+++ b/src/resources/formats/html/templates/title-block.html
@@ -1,6 +1,8 @@
 <header id="title-block-header" class="quarto-title-block default">
 <div class="quarto-title">
+$if(title)$
 <h1 class="title">$title$</h1>
+$endif$
 $if(subtitle)$
 <p class="subtitle lead">$subtitle$</p>
 $endif$


### PR DESCRIPTION
This PR tweaks the HTML template to include the metadata partial as header if no title or subtitle are provided.

Fixes #5856
