### PR TITLE
fix: use sans serif font for kbd

### DIFF
--- a/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
@@ -1187,6 +1187,7 @@ kbd,
   border: 1px solid;
   border-radius: 5px;
   border-color: $table-border-color;
+  font-family: $font-family-sans-serif;
 }
 
 // tweak pandoc default hanging indent


### PR DESCRIPTION
This PR proposes to use sans serif SASS variable for kbd tags/classes instead of monospace which messes with alignment amongst other things for symbols.

Fixes #5879

On macOS, this change produces
<img width="682" alt="image" src="https://github.com/quarto-dev/quarto-cli/assets/8896044/388b780b-0568-43a9-9414-0d8873374bb4">

<details><summary>See Quarto document.</summary>

````qmd
---
title: "Quarto Playground"
format: html
---

This is a playground for Quarto.

To print, press {{< kbd Shift-Ctrl-P >}}.
To open an existing new project,
press {{< kbd mac=Shift-Command-O win=Shift-Control-O linux=Shift-Ctrl-L >}}.
````
</details>
