### PR TITLE
Add Cache-Control headers config into redirect response for PDF viewer

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -51,6 +51,7 @@
 - Display render output/progress for previews that take longer than 2 seconds
 - Ability to cancel an executing preview from within the progress UI
 - Automatically render missing formats (e.g. PDF, MS Word) on the fly
+- ([#5882](https://github.com/quarto-dev/quarto-cli/issues/5882)): Disable browser cache using `Cache-Control` header config in the viewer redirect for PDF preview, correctly allowing a HTML preview later on same port.
 
 ## Miscellaneous
 

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -235,6 +235,7 @@ export function maybeDisplaySocketError(e: unknown) {
 
 export function serveRedirect(url: string): Response {
   const headers = new Headers();
+  headers.set("Cache-Control", "no-store, max-age=0");
   headers.set("Location", url);
   return new Response(null, {
     status: 301,


### PR DESCRIPTION
This fixes #5882 

If we don't do that, the 301 redirect on `localhost:<port>/` to `localhost:<port>/web/viewer.html` is cached by browser (at least on Windows). This leads to HTML preview not working even for a new process when same port is used. 

We already set this configuration in our content response 
https://github.com/quarto-dev/quarto-cli/blob/9a5be08ddaf370b618e207780beabeaa8515bba2/src/core/http.ts#L176

It seems a good idea to do it also for this 301 redirect response.