### PR TITLE
ci: never auto-close needs-repro/stale issues

### DIFF
--- a/.github/workflows/stale-needs-repro.yml
+++ b/.github/workflows/stale-needs-repro.yml
@@ -51,4 +51,4 @@ jobs:
           close-issue-message: |
             This issue has been automatically closed because it has been opened for some time without providing a "working" reproducible example that would help us investigate.
           days-before-stale: 14
-          days-before-close: 14
+          days-before-close: -1


### PR DESCRIPTION
As briefly discussed with @jjallaire, let's not close issues with "needs-repro" and "stale".
Only keep the bot message to ask again for a reproducible example after 14 days, then "stale" after an additional 14 days.
We'll know from the "stale" label that there were no update, but the issue will remain open until we're absolutely sure, there is no bug, thus manually closing it.