### PR TITLE
Avoid linebreak after 'external link' icon

### DIFF
--- a/src/resources/formats/html/_quarto-rules-link-external.scss
+++ b/src/resources/formats/html/_quarto-rules-link-external.scss
@@ -1,26 +1,19 @@
 a.external:after {
-  display: inline-block;
-  height: 0.75rem;
-  width: 0.75rem;
-  margin-bottom: 0.15em;
-  margin-left: 0.25em;
   content: "";
-  vertical-align: -0.125em;
   @if variable-exists(link-color) {
     background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#{colorToRGB($link-color)}" class="bi bi-box-arrow-up-right" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z"/><path fill-rule="evenodd" d="M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z"/></svg>');
   } @else {
     background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-box-arrow-up-right" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z"/><path fill-rule="evenodd" d="M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z"/></svg>');
   }
+  background-size: contain;
   background-repeat: no-repeat;
-  background-size: 0.75rem 0.75rem;
+  background-position: center center;
+  margin-left: 0.2em;
+  padding-right: 0.75em;
 }
 
 div.sourceCode code a.external:after {
   content: none;
-}
-
-a.external {
-  display: inline-block;
 }
 
 a.external:after:hover {

--- a/src/resources/formats/html/_quarto-rules-link-external.scss
+++ b/src/resources/formats/html/_quarto-rules-link-external.scss
@@ -19,6 +19,10 @@ div.sourceCode code a.external:after {
   content: none;
 }
 
+a.external {
+  display: inline-block;
+}
+
 a.external:after:hover {
   cursor: pointer;
 }

--- a/tests/docs/smoke-all/2023/06/13/issue-4619.qmd
+++ b/tests/docs/smoke-all/2023/06/13/issue-4619.qmd
@@ -1,9 +1,0 @@
----
-format:
-  html:
-    link-external-icon: true
----
-
-This is a (marked) external link: [Quarto](https://quarto.org/){.external target="_blank"}.
-
-Size the viewport horizontally to observe the breaking behavior.

--- a/tests/docs/smoke-all/2023/06/13/issue-4619.qmd
+++ b/tests/docs/smoke-all/2023/06/13/issue-4619.qmd
@@ -1,0 +1,9 @@
+---
+format:
+  html:
+    link-external-icon: true
+---
+
+This is a (marked) external link: [Quarto](https://quarto.org/){.external target="_blank"}.
+
+Size the viewport horizontally to observe the breaking behavior.


### PR DESCRIPTION
This change addresses an unwanted line break between the link text and the outward arrow icon within those links marked as *external* links. Smoke test added in `tests/docs/smoke-all/2023/06/13`.

Fixes: https://github.com/quarto-dev/quarto-cli/issues/4619
Fixes: https://github.com/quarto-dev/quarto-cli/issues/5639


