### PR TITLE
Remove unneeded `console.log()`

### DIFF
--- a/src/resources/formats/html/templates/quarto-html.ejs
+++ b/src/resources/formats/html/templates/quarto-html.ejs
@@ -440,7 +440,6 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
           const parser = new DOMParser();
           const htmlDoc = parser.parseFromString(html, "text/html");
           const note = htmlDoc.getElementById(id);
-          console.log(htmlDoc.body.innerHTML);
 
           if (note !== null) {
             const html = processXRef(id, note);


### PR DESCRIPTION
This removes the developer-facing `console.log()` from one of the .ejs templates.

Fixes: https://github.com/quarto-dev/quarto-cli/issues/5848