### PR TITLE
Add larger offset between any link's underline to avoid collision with underscores

### DIFF
--- a/src/resources/formats/html/_quarto-rules.scss
+++ b/src/resources/formats/html/_quarto-rules.scss
@@ -385,6 +385,11 @@ div.sourceCode > iframe {
   }
 }
 
+// link styling
+a {
+  text-underline-offset: 3px;
+}
+
 // ansi escaping
 div.ansi-escaped-output {
   font-family: monospace;

--- a/tests/docs/smoke-all/2023/06/14/issue-5641.qmd
+++ b/tests/docs/smoke-all/2023/06/14/issue-5641.qmd
@@ -1,9 +1,0 @@
----
-format: html
----
-
-* normal text
-* `code text`
-* [normal link](https://quarto.org)
-* [`code link`](https://quarto.org)
-* [`testthat::test_that`](https://quarto.org)

--- a/tests/docs/smoke-all/2023/06/14/issue-5641.qmd
+++ b/tests/docs/smoke-all/2023/06/14/issue-5641.qmd
@@ -1,0 +1,9 @@
+---
+format: html
+---
+
+* normal text
+* `code text`
+* [normal link](https://quarto.org)
+* [`code link`](https://quarto.org)
+* [`testthat::test_that`](https://quarto.org)


### PR DESCRIPTION
This PR is a SCSS adjustment that applies to all `<a>` tags and sets a `text-underline-offset` length value of `3px` to avoid overstriking commonly-used underscore characters. The offset value is lower than a typical underscore but not moved so far as to appear disconnected from the text. 

This is the reporter's screenshot of the HTML render:

<img width="233" alt="text-underline-reporter-screenshot" src="https://github.com/quarto-dev/quarto-cli/assets/5612024/f95ec9bf-61bd-4565-8f6b-ffbef6fdddbf">

and here's my screenshot of a render with the change applied

<img width="780" alt="text-underline-offset-avoid-underscores" src="https://github.com/quarto-dev/quarto-cli/assets/5612024/f85c232c-6746-487a-9fcd-bef335093c53">


Fixes: https://github.com/quarto-dev/quarto-cli/issues/5641