### PR TITLE
Alterations to improve contrast

### DIFF
--- a/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
@@ -1145,7 +1145,6 @@ figure .quarto-notebook-link {
   padding-left: 0;
   list-style: none;
   font-size: $toc-font-size;
-  font-weight: 300;
 }
 
 .sidebar .quarto-other-links ul li a,

--- a/src/resources/formats/html/bootstrap/_bootstrap-variables.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-variables.scss
@@ -17,7 +17,7 @@ $code-block-theme-dark-threshhold: 40% !default;
 
 /* Inline Code Formatting */
 // $code-bg, $code-color, $code-padding
-$code-color: #9753b8 !default;
+$code-color: #7d12ba !default;
 
 $blue: #0d6efd !default;
 $primary: $blue !default;

--- a/src/resources/formats/html/bootstrap/themes/cosmo.scss
+++ b/src/resources/formats/html/bootstrap/themes/cosmo.scss
@@ -6,7 +6,7 @@ $theme: "cosmo" !default;
 // Color system
 //
 
-$white: #fff !default;
+$white:    #fff !default;
 $gray-100: #f8f9fa !default;
 $gray-200: #e9ecef !default;
 $gray-300: #dee2e6 !default;
@@ -16,29 +16,29 @@ $gray-600: #868e96 !default;
 $gray-700: #495057 !default;
 $gray-800: #373a3c !default;
 $gray-900: #212529 !default;
-$black: #000 !default;
+$black:    #000 !default;
 
-$blue: #1d6ec7 !default;
-$indigo: #6610f2 !default;
-$purple: #613d7c !default;
-$pink: #e83e8c !default;
-$red: #ff0039 !default;
-$orange: #f0ad4e !default;
-$yellow: #ff7518 !default;
-$green: #3fb618 !default;
-$teal: #20c997 !default;
-$cyan: #9954bb !default;
+$blue:    #2780e3 !default;
+$indigo:  #6610f2 !default;
+$purple:  #613d7c !default;
+$pink:    #e83e8c !default;
+$red:     #ff0039 !default;
+$orange:  #f0ad4e !default;
+$yellow:  #ff7518 !default;
+$green:   #3fb618 !default;
+$teal:    #20c997 !default;
+$cyan:    #9954bb !default;
 
-$primary: $blue !default;
-$secondary: $gray-800 !default;
-$success: $green !default;
-$info: $cyan !default;
-$warning: $yellow !default;
-$danger: $red !default;
-$light: $gray-100 !default;
-$dark: $gray-800 !default;
+$primary:       $blue !default;
+$secondary:     $gray-800 !default;
+$success:       $green !default;
+$info:          $cyan !default;
+$warning:       $yellow !default;
+$danger:        $red !default;
+$light:         $gray-100 !default;
+$dark:          $gray-800 !default;
 
-$min-contrast-ratio: 2.6 !default;
+$min-contrast-ratio:   2.6 !default;
 
 // Options
 
@@ -46,30 +46,31 @@ $enable-rounded: false !default;
 
 // Body
 
-$body-color: $gray-800 !default;
+$body-color:    $gray-800 !default;
 
 // Fonts
 
 // stylelint-disable-next-line value-keyword-case
-$font-family-sans-serif: "Source Sans Pro", -apple-system, BlinkMacSystemFont,
-  "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji",
-  "Segoe UI Emoji", "Segoe UI Symbol" !default;
-$headings-font-weight: 400 !default;
+$font-family-sans-serif:    "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
+$headings-font-weight:      400 !default;
 
 // Navbar
 
-$navbar-dark-hover-color: rgba($white, 1) !default;
-$navbar-light-hover-color: rgba($black, 0.9) !default;
+$navbar-dark-hover-color:       rgba($white, 1) !default;
+$navbar-light-hover-color:      rgba($black, .9) !default;
 
 // Alerts
 
-$alert-border-width: 0 !default;
+$alert-border-width:            0 !default;
 
 // Progress bars
 
-$progress-height: 0.5rem !default;
+$progress-height:               .5rem !default;
+
+
 
 /*-- scss:rules --*/
+
 
 // Variables
 
@@ -102,3 +103,5 @@ body {
     line-height: 8px;
   }
 }
+
+

--- a/src/resources/formats/html/bootstrap/themes/cosmo.scss
+++ b/src/resources/formats/html/bootstrap/themes/cosmo.scss
@@ -6,7 +6,7 @@ $theme: "cosmo" !default;
 // Color system
 //
 
-$white:    #fff !default;
+$white: #fff !default;
 $gray-100: #f8f9fa !default;
 $gray-200: #e9ecef !default;
 $gray-300: #dee2e6 !default;
@@ -16,29 +16,29 @@ $gray-600: #868e96 !default;
 $gray-700: #495057 !default;
 $gray-800: #373a3c !default;
 $gray-900: #212529 !default;
-$black:    #000 !default;
+$black: #000 !default;
 
-$blue:    #2780e3 !default;
-$indigo:  #6610f2 !default;
-$purple:  #613d7c !default;
-$pink:    #e83e8c !default;
-$red:     #ff0039 !default;
-$orange:  #f0ad4e !default;
-$yellow:  #ff7518 !default;
-$green:   #3fb618 !default;
-$teal:    #20c997 !default;
-$cyan:    #9954bb !default;
+$blue: #1d6ec7 !default;
+$indigo: #6610f2 !default;
+$purple: #613d7c !default;
+$pink: #e83e8c !default;
+$red: #ff0039 !default;
+$orange: #f0ad4e !default;
+$yellow: #ff7518 !default;
+$green: #3fb618 !default;
+$teal: #20c997 !default;
+$cyan: #9954bb !default;
 
-$primary:       $blue !default;
-$secondary:     $gray-800 !default;
-$success:       $green !default;
-$info:          $cyan !default;
-$warning:       $yellow !default;
-$danger:        $red !default;
-$light:         $gray-100 !default;
-$dark:          $gray-800 !default;
+$primary: $blue !default;
+$secondary: $gray-800 !default;
+$success: $green !default;
+$info: $cyan !default;
+$warning: $yellow !default;
+$danger: $red !default;
+$light: $gray-100 !default;
+$dark: $gray-800 !default;
 
-$min-contrast-ratio:   2.6 !default;
+$min-contrast-ratio: 2.6 !default;
 
 // Options
 
@@ -46,31 +46,30 @@ $enable-rounded: false !default;
 
 // Body
 
-$body-color:    $gray-800 !default;
+$body-color: $gray-800 !default;
 
 // Fonts
 
 // stylelint-disable-next-line value-keyword-case
-$font-family-sans-serif:    "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
-$headings-font-weight:      400 !default;
+$font-family-sans-serif: "Source Sans Pro", -apple-system, BlinkMacSystemFont,
+  "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji",
+  "Segoe UI Emoji", "Segoe UI Symbol" !default;
+$headings-font-weight: 400 !default;
 
 // Navbar
 
-$navbar-dark-hover-color:       rgba($white, 1) !default;
-$navbar-light-hover-color:      rgba($black, .9) !default;
+$navbar-dark-hover-color: rgba($white, 1) !default;
+$navbar-light-hover-color: rgba($black, 0.9) !default;
 
 // Alerts
 
-$alert-border-width:            0 !default;
+$alert-border-width: 0 !default;
 
 // Progress bars
 
-$progress-height:               .5rem !default;
-
-
+$progress-height: 0.5rem !default;
 
 /*-- scss:rules --*/
-
 
 // Variables
 
@@ -103,5 +102,3 @@ body {
     line-height: 8px;
   }
 }
-
-


### PR DESCRIPTION
This PR focuses on a few changes that should improve contrast of certain text elements (both in the Cosmo theme and also outside of Bootstrap themes). The original issue https://github.com/quarto-dev/quarto-cli/issues/5780 provides a screenshot of the contrast issues and that is included here as a means for comparison:

<img width="1026" alt="issue-5780" src="https://github.com/quarto-dev/quarto-cli/assets/5612024/8c12b13a-b1b2-4328-9a8a-b7544128b11a">

The purple text color when set against its background gray doesn't provide enough contrast. The same goes for the blue link color. It's not that the background is too dark, rather the text is too light. The right-hand nav text suffers similar problems (even though there is no text background applied). This low contrast is due to two things: small font size, narrow font size, and, on some displays, less ink due to text antialiasing being activated.

We can correct all of these by slightly darkening the text color. For the nav text, it's recommended to have the default font weight of 400 (instead of 300). Decreasing size and weight has a large effect on contrast.

With these changes, we obtain APCA (https://www.myndex.com/APCA/) contrasts between 70 and 80, which is very good. And the color darkening for this PR isn't such that colors lose their identities (they're only slight adjustments that put them in a better place according to the APCA tool).

Here is the rendered document with the CSS changes (I used the same .qmd as the reporter in the referenced issue):

<img width="1155" alt="issue-5780-changed" src="https://github.com/quarto-dev/quarto-cli/assets/5612024/4853ef21-aa6d-4b77-8c34-6fb2cc379a8a">


Fixes: https://github.com/quarto-dev/quarto-cli/issues/5780