### PR TITLE
Change left to right to match definition

### DIFF
--- a/src/resources/schema/document-toc.yml
+++ b/src/resources/schema/document-toc.yml
@@ -39,7 +39,7 @@
       Location for table of contents (`body`, `left`, `right` (default), 'left-body', 'right-body').
       `body` - Show the Table of Contents in the center body of the document.
       `left` - Show the Table of Contents in left margin of the document.
-      `left` - Show the Table of Contents in right margin of the document.
+      `right` - Show the Table of Contents in right margin of the document.
       `left-body` - Show two Tables of Contents in both the center body and the left margin of the document.
       `right-body` - Show two Tables of Contents in both the center body and the right margin of the document.
 - name: toc-title


### PR DESCRIPTION
Welcome to the quarto GitHub repo!

We are always happy to hear feedback from our users.

To file a _pull request_, please follow these instructions carefully: <https://yihui.org/issue/#bug-reports>

If you're a collaborator from outside `quarto-dev` making changes larger than a typo, please make sure you have filed an [individual](https://posit.co/wp-content/uploads/2023/04/2023-03-13_TC_Indiv_contrib_agreement.pdf) or [corporate](https://posit.co/wp-content/uploads/2023/04/2023-03-13_TC_Corp_contrib_agreement.pdf) contributor agreement. You can send the signed copy to <jj@rstudio.com>.

Also, please complete and keep the checklist below.

## Description

Changed the key option - `left` - Show the Table of Contents in right margin of the - to `right`

````md
```py
print("Hello Quarto!")
```
````

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
