### PR TITLE
Adapt explicit matchers for detecting a required LaTeX rerun

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -31,6 +31,10 @@
 - ([#5546](https://github.com/quarto-dev/quarto-cli/issues/5546)): Images inside links can't be stretched, and so auto-stretch feature now ignores them.
 - ([#5783](https://github.com/quarto-dev/quarto-cli/issues/5783)): Ensure fenced code blocks work with line numbers.
 
+## PDF Format
+
+- ([#5969](https://github.com/quarto-dev/quarto-cli/issues/5969)): Correctly detect a required rerun for biblatex when using backref link options.
+
 ## Website Listings
 
 - ([#5371](https://github.com/quarto-dev/quarto-cli/issues/5371)): Properly compute the trimmed length of descriptions included in listings.

--- a/src/command/render/latexmk/parse-error.ts
+++ b/src/command/render/latexmk/parse-error.ts
@@ -2,7 +2,6 @@
  * log.ts
  *
  * Copyright (C) 2020-2022 Posit Software, PBC
- *
  */
 
 import { basename, join } from "path/mod.ts";
@@ -88,7 +87,7 @@ export function needsRecompilation(log: string) {
   return false;
 }
 const explicitMatchers = [
-  /(Rerun to get |Please \(re\)run | Rerun LaTeX\.)/, // explicitly request recompile
+  /(Rerun to get | Please \(re\)run | [rR]erun LaTeX\.)/, // explicitly request recompile
 ];
 
 // Resolving matchers are matchers that may resolve later in the log


### PR DESCRIPTION
We are missing this in the log file 
````
Package biblatex Warning: Please rerun LaTeX.
(biblatex)                Page breaks have changed.
````

Reproducible example in #5969

I think we just need to adapt the regex. 

@dragonstyle just asking for review to confirm that I am not missing anything else
