### PR TITLE
Handle better in freeze the EOL character differences between OS

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -232,3 +232,4 @@
 - ([#7013](https://github.com/quarto-dev/quarto-cli/issues/7013)): Improve error message when there is an issue finding or running R and add more verbosity in [verbose mode](https://quarto.org/docs/troubleshooting/#verbose-mode).
 - ([#7032](https://github.com/quarto-dev/quarto-cli/issues/7032)): `quarto` is now correctly working when installed in a folder with spaces in path.
 - ([#7131](https://github.com/quarto-dev/quarto-cli/issues/7131)): Fix typo in ISBN entry for JATS subarticle template (author: @jasonaris).
+- ([#3599](https://github.com/quarto-dev/quarto-cli/issues/3599), [#5870](https://github.com/quarto-dev/quarto-cli/issues/5870)): Fix hash issue causing unexpected render when `freeze` is activated on Windows but re-rendered on Linux (e.g. in Github Action).

--- a/src/command/render/freeze.ts
+++ b/src/command/render/freeze.ts
@@ -1,9 +1,8 @@
 /*
-* freeze.ts
-*
-* Copyright (C) 2020-2022 Posit Software, PBC
-*
-*/
+ * freeze.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
 
 import {
   basename,
@@ -13,7 +12,7 @@ import {
   join,
   relative,
 } from "path/mod.ts";
-import { ensureDirSync, existsSync } from "fs/mod.ts";
+import { ensureDirSync, EOL, existsSync, format } from "fs/mod.ts";
 
 import { cloneDeep } from "../../core/lodash.ts";
 
@@ -300,7 +299,9 @@ export function removeFreezeResults(filesDir: string) {
 }
 
 function freezeInputHash(input: string) {
-  return md5Hash(Deno.readTextFileSync(input));
+  // Calculate the hash on a content with LF line ending to avoid
+  // different hash on different OS (#3599)
+  return md5Hash(format(Deno.readTextFileSync(input), EOL.LF));
 }
 
 // don't use _files suffix in freezer

--- a/src/command/render/freeze.ts
+++ b/src/command/render/freeze.ts
@@ -38,6 +38,7 @@ import { kProjectLibDir, ProjectContext } from "../../project/types.ts";
 import { projectScratchPath } from "../../project/project-scratch.ts";
 import { copyMinimal, copyTo } from "../../core/copy.ts";
 import { warning } from "log/mod.ts";
+import { isWindows } from "../../core/platform.ts";
 
 export const kProjectFreezeDir = "_freeze";
 export const kOldFreezeExecuteResults = "execute";
@@ -56,7 +57,8 @@ export function freezeExecuteResult(
     if (result.includes) {
       if (result.includes[name]) {
         result.includes[name] = result.includes[name]!.map((file) =>
-          Deno.readTextFileSync(file)
+          // Storing file content using LF line ending
+          format(Deno.readTextFileSync(file), EOL.LF)
         );
       }
     }
@@ -139,6 +141,8 @@ export function defrostExecuteResult(
           if (result.includes[name]) {
             result.includes[name] = result.includes[name]!.map((content) => {
               const includeFile = temp.createFile();
+              // Restoring content in file using the OS line ending character
+              content = format(content, isWindows() ? EOL.CRLF : EOL.LF);
               Deno.writeTextFileSync(includeFile, content);
               return includeFile;
             });


### PR DESCRIPTION
This PR aims to fix #3599 and #5870

* The hash is computed on content normalized to using `LF` - meaning we convert CRLF to LF before computing the hash.  This leads to same hash under Windows and Linux

* The content read from files to be stored the json structure in `_freeze` is also converted to use LF for EOL. This leads to having only content frozen with LF as line ending. Then when we restore, we are using the appropriate CRLF if on Windows, or using LF if not on windows. 


@cscheid this is a PR for discussion about the solution. This is showing what I add in mind to fix this Windows vs Linux issue. 

I believe this is the only place where modification are required. Obviously, it requires some testing, manual, and possibly automated. 

What do you think of this ? 
