### PR TITLE
ojs.lua: define co-recursive local functions appropriately.

### DIFF
--- a/src/resources/filters/quarto-post/ojs.lua
+++ b/src/resources/filters/quarto-post/ojs.lua
@@ -58,7 +58,18 @@ function ojs()
     return sub
   end
 
-  local function stringifyTokenInto(token, sequence)
+  local stringifyTokens
+  local stringifyTokenInto
+
+  stringifyTokens = function(sequence)
+    local result = pandoc.List()
+    for i = 1, #sequence do
+      stringifyTokenInto(sequence[i], result)
+    end
+    return table.concat(result, "")
+  end
+
+  stringifyTokenInto = function(token, sequence)
     local function unknown()
       fail("Don't know how to handle token " .. token.t)
     end
@@ -123,14 +134,6 @@ function ojs()
     end
   end
   
-  local function stringifyTokens(sequence)
-    local result = pandoc.List()
-    for i = 1, #sequence do
-      stringifyTokenInto(sequence[i], result)
-    end
-    return table.concat(result, "")
-  end
-
   local function escape_quotes(str)
     local sub, _ = string.gsub(str, '\\', '\\\\')
     sub, _ = string.gsub(sub, '"', '\\"')

--- a/tests/docs/smoke-all/2023/06/21/index.qmd
+++ b/tests/docs/smoke-all/2023/06/21/index.qmd
@@ -1,6 +1,6 @@
 ---
 title: issue-6002
---- 
+---
 
 ```{ojs}
 foo = 1

--- a/tests/docs/smoke-all/2023/06/21/index.qmd
+++ b/tests/docs/smoke-all/2023/06/21/index.qmd
@@ -1,0 +1,13 @@
+---
+title: issue-6002
+--- 
+
+```{ojs}
+foo = 1
+// this needs to be here to cause the OJS engine to be run.
+```
+
+We need this particularly complicated sequence of inline statements to trigger the bug:
+
+`${radio[0].NAME}` Gives me this: ${radio[0].NAME}. 
+Median income in ${radio[0].NAME} is $${radio[0].medincE.toLocaleString("en-US")} and the median age is ${radio[0].medageE} years old.


### PR DESCRIPTION
This closes #6002.

(No entry on the changelog because it's a 1.4 regression)