### PR TITLE
Correctly parse YAML block with empty lines

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -69,6 +69,7 @@
 - ([#5377](https://github.com/quarto-dev/quarto-cli/issues/5377)): support `from: ` formats correctly.
 - Exit if project pre or post render script fails
 - Use InternalError in typescript code, and offer a more helpful error message when an internal error happens.
+- ([#6042](https://github.com/quarto-dev/quarto-cli/issues/6042)): Correctly support empty lines in YAML blocks.
 
 ## Docusaurus Format
 

--- a/src/core/yaml.ts
+++ b/src/core/yaml.ts
@@ -95,7 +95,7 @@ export function readYamlFromMarkdown(
       // are entirely empty
       // (that's not valid for pandoc yaml blocks)
       if (
-        !yamlBlock.match(/^\n\s*\n/m) &&
+        !yamlBlock.match(/^\n\s*\n/) &&
         !yamlBlock.match(/^\n\s*\n---/m) &&
         (yamlBlock.trim().length > 0)
       ) {


### PR DESCRIPTION
Only YAML block starting with empty line are not parsed as Pandoc does not support it either

This fixes #6042 by only applying the regex at the start of the YAML block. 

Opening PR here to run the tests and checks everything is fine. 
