### PR TITLE
add missing import to crossref.lua

### DIFF
--- a/src/command/editor-support/crossref.ts
+++ b/src/command/editor-support/crossref.ts
@@ -35,7 +35,7 @@ export const crossrefCommand = new Command()
     const cmd = [pandocBinaryPath(), "+RTS", "-K512m", "-RTS"];
     cmd.push(...[
       "--from",
-      "markdown",
+      resourcePath("filters/qmd-reader.lua"),
       "--to",
       "native",
       "--data-dir",

--- a/src/resources/filters/crossref/crossref.lua
+++ b/src/resources/filters/crossref/crossref.lua
@@ -45,6 +45,7 @@ import("../common/meta.lua")
 import("../common/table.lua")
 import("../common/string.lua")
 import("../common/debug.lua")
+import("../common/layout.lua")
 
 -- [/import]
 

--- a/tests/docs/crossrefs/all.qmd
+++ b/tests/docs/crossrefs/all.qmd
@@ -72,3 +72,27 @@ $$
 :::
 
 See @thm-line.
+
+
+```{#lst-customers .sql lst-cap="Customers Query"}
+SELECT * FROM Customers
+```
+
+Then we query the customers database (@lst-customers).
+
+
+## A section to be referenced {#sec-section}
+
+See @sec-section.
+
+## Equations
+
+Black-Scholes (@eq-black-scholes) is a mathematical model that seeks to explain the behavior of financial derivatives, most commonly options:
+
+$$
+\frac{\partial \mathrm C}{ \partial \mathrm t } + \frac{1}{2}\sigma^{2} \mathrm S^{2}
+\frac{\partial^{2} \mathrm C}{\partial \mathrm C^2}
+  + \mathrm r \mathrm S \frac{\partial \mathrm C}{\partial \mathrm S}\ =
+  \mathrm r \mathrm C 
+$$ {#eq-black-scholes}
+

--- a/tests/docs/crossrefs/editor-support/unnumbered-crossrefs.qmd
+++ b/tests/docs/crossrefs/editor-support/unnumbered-crossrefs.qmd
@@ -1,0 +1,4 @@
+# References {.unnumbered}
+
+::: {#refs}
+:::

--- a/tests/docs/crossrefs/unnumbered-crossrefs.qmd
+++ b/tests/docs/crossrefs/unnumbered-crossrefs.qmd
@@ -1,0 +1,4 @@
+# References {.unnumbered}
+
+::: {#refs}
+:::

--- a/tests/docs/crossrefs/unnumbered-crossrefs.qmd
+++ b/tests/docs/crossrefs/unnumbered-crossrefs.qmd
@@ -1,4 +1,0 @@
-# References {.unnumbered}
-
-::: {#refs}
-:::

--- a/tests/smoke/filters/editor-support.test.ts
+++ b/tests/smoke/filters/editor-support.test.ts
@@ -56,7 +56,19 @@ test({
   context: {},
   execute: async () => {
     await runEditorSupportCrossref(
-      docs("crossrefs/unnumbered-crossrefs.qmd"),
+      docs("crossrefs/editor-support/unnumbered-crossrefs.qmd"),
+    );
+  },
+  verify: [],
+  type: "smoke",
+});
+
+test({
+  name: "editor-support:crossref:smoke-3",
+  context: {},
+  execute: async () => {
+    await runEditorSupportCrossref(
+      docs("crossrefs/all.qmd"),
     );
   },
   verify: [],

--- a/tests/smoke/filters/editor-support.test.ts
+++ b/tests/smoke/filters/editor-support.test.ts
@@ -8,37 +8,56 @@ import { docs } from "../../utils.ts";
 import { test } from "../../test.ts";
 import { assertEquals } from "testing/asserts.ts";
 
+async function runEditorSupportCrossref(doc: string) {
+  let cmdLine: string;
+  switch (Deno.build.os) {
+    case "windows":
+      cmdLine = "../package/dist/bin/quarto.cmd";
+      break;
+    default:
+      cmdLine = "../package/dist/bin/quarto";
+      break;
+  }
+  const cmd = new Deno.Command(cmdLine, {
+    args: ["editor-support", "crossref"],
+    stdin: "piped",
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const child = cmd.spawn();
+  const writer = child.stdin.getWriter();
+  const buf = new TextEncoder().encode(
+    Deno.readTextFileSync(doc),
+  );
+  await writer.write(buf);
+  await writer.close();
+  const outputBuf = await child.output();
+  const status = await child.status;
+  assertEquals(status.code, 0);
+  const output = new TextDecoder().decode(outputBuf.stdout);
+  const json = JSON.parse(output);
+  return json;
+}
+
 test({
-  name: "editor-support:crossref",
+  name: "editor-support:crossref:smoke-1",
   context: {},
   execute: async () => {
-    let cmdLine: string;
-    switch (Deno.build.os) {
-      case "windows":
-        cmdLine = "../package/dist/bin/quarto.cmd";
-        break;
-      default:
-        cmdLine = "../package/dist/bin/quarto";
-        break;
-    }
-    const cmd = new Deno.Command(cmdLine, {
-      args: ["editor-support", "crossref"],
-      stdin: "piped",
-      stdout: "piped",
-      stderr: "piped",
-    });
-    const child = cmd.spawn();
-    const writer = child.stdin.getWriter();
-    const buf = new TextEncoder().encode(
-      Deno.readTextFileSync(docs("crossrefs/sections.qmd")),
-    );
-    await writer.write(buf);
-    await writer.close();
-    const outputBuf = await child.output();
-    const output = new TextDecoder().decode(outputBuf.stdout);
-    const json = JSON.parse(output);
+    const json = await runEditorSupportCrossref(docs("crossrefs/sections.qmd"));
     assertEquals(json.entries[0].key, "sec-introduction");
     assertEquals(json.entries[0].caption, "Introduction");
+  },
+  verify: [],
+  type: "smoke",
+});
+
+test({
+  name: "editor-support:crossref:smoke-2",
+  context: {},
+  execute: async () => {
+    await runEditorSupportCrossref(
+      docs("crossrefs/unnumbered-crossrefs.qmd"),
+    );
   },
   verify: [],
   type: "smoke",


### PR DESCRIPTION
Repro for bug:

```
$ cat bug.qmd
# References {.unnumbered}

::: {#refs}
:::
$ cat bug.qmd | quarto editor-support crossref
```

TODO:

- [x] add other crossref types to test
- [x] update `editor-support` to use `qmd-reader.lua`