### PR TITLE
force left-align for code in layout

### DIFF
--- a/src/resources/formats/html/_quarto-rules.scss
+++ b/src/resources/formats/html/_quarto-rules.scss
@@ -107,6 +107,7 @@ figure .quarto-layout-row figure figcaption {
   text-align: right;
 }
 
+.quarto-figure > figure > div.cell-annotation,
 .quarto-figure > figure > div code {
   text-align: left; /* override align center for code blocks */
 }

--- a/src/resources/formats/html/_quarto-rules.scss
+++ b/src/resources/formats/html/_quarto-rules.scss
@@ -106,6 +106,11 @@ figure .quarto-layout-row figure figcaption {
 .quarto-figure-right > figure > div /* for mermaid and dot diagrams */ {
   text-align: right;
 }
+
+.quarto-figure > figure > div code {
+  text-align: left; /* override align center for code blocks */
+}
+
 figure > p:empty {
   display: none;
 }


### PR DESCRIPTION
…  to beat the mermaid centering div setting

Fixes the rendering for the following repro case:

````
---
title: "Untitled"
format: html
---

## Section {#sec-woozy}

```{r}
#| label: fig-slot
#| fig-cap: "The Big One"
#| fig-subcap: ["First", "Second"]
plot(cars)
plot(pressure)
```
````