### PR TITLE
More accurately replicate bslib's Sass code

### DIFF
--- a/configuration
+++ b/configuration
@@ -17,7 +17,7 @@ export TYPST=0.5.0
 
 # Bootstrap dependencies from bslib
 # (use commit hash from bslib repo)
-export BOOTSTRAP=8dc31b40bd9b387c4a3c36ac1f63bb853037cba6
+export BOOTSTRAP=2ce8eebf06910da5d0719c7a05b9860db5da8c0f
 export BOOTSTRAP_FONT=1.10.5
 export BOOTSWATCH=5.2.3
 


### PR DESCRIPTION
Closes #6081 (And possibly other issues connected to `{bslib}`).

This PR is aimed at getting quarto's Bootstrap Sass to more accurately reflect `{bslib}`'s Sass code. Somewhat recently, we started to adding additional components like ([cards](https://rstudio.github.io/bslib/articles/cards.html), [value boxes](https://rstudio.github.io/bslib/articles/value-boxes.html), and [sidebars](https://rstudio.github.io/bslib/articles/sidebars.html), etc). At least at the moment, the Sass/CSS for these components are added to the page-level Bootstrap dependency (to help reduce the amount of Sass calls would be needed for [themable components](https://rstudio.github.io/bslib/articles/custom-components.html)). 

This page-level Bootstrap dependency is represented by `bslib::bs_theme()`, which has some R-specific logic to pull in more than just Bootstrap alone. To help make it more transparent what else it brings in, https://github.com/rstudio/bslib/pull/655 added a `inst/css-precompiled/5/bootstrap.scss` file which captures the Sass code that `bslib::bs_theme()` generates. This PR make this file the main entry point for Bootstrap Sass (and also brings in the other files/assets that it imports).

Happy to hop on a Zoom/Slack call to go through this if that helps

### Disclaimer

I haven't verified this code actually works, but I hope it's enough to get the conversation going. FWIW, when I run `./configure.sh` locally, this code path doesn't appear to run, so I'm not quite sure what code I need to run to get these changes into my local install of quarto