### PR TITLE
add better error message in case of incorrect permissions

### DIFF
--- a/src/execute/jupyter/jupyter-kernel.ts
+++ b/src/execute/jupyter/jupyter-kernel.ts
@@ -293,7 +293,23 @@ interface KernelTransport {
 }
 
 function kernelTransportFile(target: string) {
-  const transportsDir = quartoRuntimeDir("jt");
+  let transportsDir: string;
+
+  try {
+    transportsDir = quartoRuntimeDir("jt");
+  } catch (e) {
+    console.error("Could create runtime directory for jupyter transport.");
+    console.error(
+      "This is possibly a permission issue in the environment Quarto is running in.",
+    );
+    console.error(
+      "Please consult the following documentation for more information:",
+    );
+    console.error(
+      "https://github.com/quarto-dev/quarto-cli/issues/4594#issuecomment-1619177667",
+    );
+    throw e;
+  }
   const targetFile = normalizePath(target);
   const hash = md5Hash(targetFile).slice(0, 20);
   return join(transportsDir, hash);


### PR DESCRIPTION
See #4594, and https://github.com/quarto-dev/quarto-cli/issues/4594#issuecomment-1619177667 specifically.

This adds a more informative error message (and a link to a workaround) about misconfigured unix environments which cause problems with quarto.