### PR TITLE
Correct pass `pdf-max-pages-per-slide` to revealjs configuration

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -31,6 +31,7 @@
 
 - ([#5546](https://github.com/quarto-dev/quarto-cli/issues/5546)): Images inside links can't be stretched, and so auto-stretch feature now ignores them.
 - ([#5783](https://github.com/quarto-dev/quarto-cli/issues/5783)): Ensure fenced code blocks work with line numbers.
+- ([#6120](https://github.com/quarto-dev/quarto-cli/issues/6120)): `pdf-max-pages-per-slide` is now correctly setting [`pdfMaxPagesPerSlide` config](https://revealjs.com/pdf-export/#page-size) for RevealJS.
 
 ## PDF Format
 

--- a/src/format/reveal/constants.ts
+++ b/src/format/reveal/constants.ts
@@ -1,9 +1,8 @@
 /*
-* constants.ts
-*
-* Copyright (C) 2022 Posit Software, PBC
-*
-*/
+ * constants.ts
+ *
+ * Copyright (C) 2022 Posit Software, PBC
+ */
 
 export const kRevealJsUrl = "revealjs-url";
 export const kRevealJsConfig = "revealjs-config";
@@ -17,6 +16,7 @@ export const kCenter = "center";
 export const kCenterTitleSlide = "center-title-slide";
 export const kControlsAuto = "controlsAuto";
 export const kPreviewLinksAuto = "previewLinksAuto";
+export const kPdfMaxPagesPerSlide = "pdfMaxPagesPerSlide";
 export const kPdfSeparateFragments = "pdfSeparateFragments";
 export const kAutoAnimateEasing = "autoAnimateEasing";
 export const kAutoAnimateDuration = "autoAnimateDuration";

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -134,7 +134,6 @@ export function revealjsFormat() {
         const extraConfig: Record<string, unknown> = {
           [kControlsAuto]: controlsAuto,
           [kPreviewLinksAuto]: previewLinksAuto,
-          [kSmaller]: !!format.metadata[kSmaller],
           [kPdfSeparateFragments]: !!format.metadata[kPdfSeparateFragments],
           [kAutoAnimateEasing]: format.metadata[kAutoAnimateEasing] || "ease",
           [kAutoAnimateDuration]: format.metadata[kAutoAnimateDuration] ||

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -56,6 +56,7 @@ import {
   kCenterTitleSlide,
   kControlsAuto,
   kHashType,
+  kPdfMaxPagesPerSlide,
   kPdfSeparateFragments,
   kPreviewLinksAuto,
   kRevealJsConfig,
@@ -143,6 +144,11 @@ export function revealjsFormat() {
               ? format.metadata[kAutoAnimateUnmatched]
               : true,
         };
+
+        if (format.metadata[kPdfMaxPagesPerSlide]) {
+          extraConfig[kPdfMaxPagesPerSlide] =
+            format.metadata[kPdfMaxPagesPerSlide];
+        }
 
         // get theme info (including text highlighing mode)
         const theme = await revealTheme(format, input, libDir, services.temp);

--- a/src/format/reveal/metadata.ts
+++ b/src/format/reveal/metadata.ts
@@ -1,9 +1,8 @@
 /*
-* metadata.ts
-*
-* Copyright (C) 2022 Posit Software, PBC
-*
-*/
+ * metadata.ts
+ *
+ * Copyright (C) 2022 Posit Software, PBC
+ */
 
 import { Metadata } from "../../config/types.ts";
 import { camelToKebab, kebabToCamel } from "../../core/config.ts";
@@ -99,6 +98,7 @@ const kRevealOptions = [
   "minScale",
   "maxScale",
   "mathjax",
+  "pdfMaxPagesPerSlide",
   "pdfSeparateFragments",
   "pdfPageHeightOffset",
 ];

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -16591,6 +16591,19 @@ var require_yaml_intelligence_resources = __commonJS({
       ],
       "schema/document-reveal-print.yml": [
         {
+          name: "pdf-max-pages-per-slide",
+          tags: {
+            formats: [
+              "revealjs"
+            ]
+          },
+          schema: "number",
+          description: {
+            short: "Slides that are too tall to fit within a single page will expand onto multiple pages",
+            long: '"Slides that are too tall to fit within a single page will expand onto multiple pages. You can limit how many pages a slide may expand to using this option"\n'
+          }
+        },
+        {
           name: "pdf-separate-fragments",
           tags: {
             formats: [
@@ -19835,7 +19848,7 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         {
           short: "Show a thick left border on code blocks.",
-          long: "Specifies to apply a left border on code blocks. Provide a hex color\nto specify that the border is enabled as well as the color of the\nborder.="
+          long: "Specifies to apply a left border on code blocks. Provide a hex color\nto specify that the border is enabled as well as the color of the\nborder."
         },
         {
           short: "Show a background color for code blocks.",
@@ -21419,7 +21432,11 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
         "Manuscript configuration",
-        "internal-schema-hack"
+        "internal-schema-hack",
+        {
+          short: "Slides that are too tall to fit within a single page will expand onto\nmultiple pages",
+          long: "\u201CSlides that are too tall to fit within a single page will expand\nonto multiple pages. You can limit how many pages a slide may expand to\nusing this option\u201D"
+        }
       ],
       "schema/external-schemas.yml": [
         {
@@ -21643,12 +21660,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 158641,
+        _internalId: 158643,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 158633,
+            _internalId: 158635,
             type: "enum",
             enum: [
               "png",
@@ -21664,7 +21681,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 158640,
+            _internalId: 158642,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -16592,6 +16592,19 @@ try {
         ],
         "schema/document-reveal-print.yml": [
           {
+            name: "pdf-max-pages-per-slide",
+            tags: {
+              formats: [
+                "revealjs"
+              ]
+            },
+            schema: "number",
+            description: {
+              short: "Slides that are too tall to fit within a single page will expand onto multiple pages",
+              long: '"Slides that are too tall to fit within a single page will expand onto multiple pages. You can limit how many pages a slide may expand to using this option"\n'
+            }
+          },
+          {
             name: "pdf-separate-fragments",
             tags: {
               formats: [
@@ -19836,7 +19849,7 @@ try {
           },
           {
             short: "Show a thick left border on code blocks.",
-            long: "Specifies to apply a left border on code blocks. Provide a hex color\nto specify that the border is enabled as well as the color of the\nborder.="
+            long: "Specifies to apply a left border on code blocks. Provide a hex color\nto specify that the border is enabled as well as the color of the\nborder."
           },
           {
             short: "Show a background color for code blocks.",
@@ -21420,7 +21433,11 @@ try {
           },
           "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
           "Manuscript configuration",
-          "internal-schema-hack"
+          "internal-schema-hack",
+          {
+            short: "Slides that are too tall to fit within a single page will expand onto\nmultiple pages",
+            long: "\u201CSlides that are too tall to fit within a single page will expand\nonto multiple pages. You can limit how many pages a slide may expand to\nusing this option\u201D"
+          }
         ],
         "schema/external-schemas.yml": [
           {
@@ -21644,12 +21661,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 158641,
+          _internalId: 158643,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 158633,
+              _internalId: 158635,
               type: "enum",
               enum: [
                 "png",
@@ -21665,7 +21682,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 158640,
+              _internalId: 158642,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -9567,6 +9567,19 @@
   ],
   "schema/document-reveal-print.yml": [
     {
+      "name": "pdf-max-pages-per-slide",
+      "tags": {
+        "formats": [
+          "revealjs"
+        ]
+      },
+      "schema": "number",
+      "description": {
+        "short": "Slides that are too tall to fit within a single page will expand onto multiple pages",
+        "long": "\"Slides that are too tall to fit within a single page will expand onto multiple pages. You can limit how many pages a slide may expand to using this option\"\n"
+      }
+    },
+    {
       "name": "pdf-separate-fragments",
       "tags": {
         "formats": [
@@ -12811,7 +12824,7 @@
     },
     {
       "short": "Show a thick left border on code blocks.",
-      "long": "Specifies to apply a left border on code blocks. Provide a hex color\nto specify that the border is enabled as well as the color of the\nborder.="
+      "long": "Specifies to apply a left border on code blocks. Provide a hex color\nto specify that the border is enabled as well as the color of the\nborder."
     },
     {
       "short": "Show a background color for code blocks.",
@@ -14395,7 +14408,11 @@
     },
     "Disambiguating year suffix in author-date styles (e.g.&nbsp;“a” in “Doe,\n1999a”).",
     "Manuscript configuration",
-    "internal-schema-hack"
+    "internal-schema-hack",
+    {
+      "short": "Slides that are too tall to fit within a single page will expand onto\nmultiple pages",
+      "long": "“Slides that are too tall to fit within a single page will expand\nonto multiple pages. You can limit how many pages a slide may expand to\nusing this option”"
+    }
   ],
   "schema/external-schemas.yml": [
     {
@@ -14619,12 +14636,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 158641,
+    "_internalId": 158643,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 158633,
+        "_internalId": 158635,
         "type": "enum",
         "enum": [
           "png",
@@ -14640,7 +14657,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 158640,
+        "_internalId": 158642,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/schema/document-reveal-print.yml
+++ b/src/resources/schema/document-reveal-print.yml
@@ -1,3 +1,12 @@
+- name: pdf-max-pages-per-slide
+  tags:
+    formats: [revealjs]
+  schema: number
+  description:
+    short: "Slides that are too tall to fit within a single page will expand onto multiple pages"
+    long: |
+      "Slides that are too tall to fit within a single page will expand onto multiple pages. You can limit how many pages a slide may expand to using this option"
+
 - name: pdf-separate-fragments
   tags:
     formats: [revealjs]

--- a/tests/docs/reveal/reveal-configs.qmd
+++ b/tests/docs/reveal/reveal-configs.qmd
@@ -1,0 +1,43 @@
+---
+title: "Test custom options not supported by Pandoc"
+format:
+  revealjs: 
+    pdf-max-pages-per-slide: 1
+    smaller: true
+    auto-animate-easing: 'ease-in-out'
+    auto-animate-duration: 5
+    auto-animate-unmatched: false
+    pdf-separate-fragments: true
+---
+
+
+## a long slide
+
+- 1
+- 2
+- 3
+- 4
+- 5
+- 6
+- 7
+- 8
+- 9
+- 10
+- 11
+- 12
+- 13
+- 14
+- 15
+- 16
+- 17
+- 18
+- 19
+- 20
+
+## a short slide
+
+- 1
+- 2
+- 3
+- 4
+- 5

--- a/tests/smoke/render/render-reveal.test.ts
+++ b/tests/smoke/render/render-reveal.test.ts
@@ -7,6 +7,7 @@
 
 import { docs, fileLoader, outputForInput } from "../../utils.ts";
 import {
+ensureFileRegexMatches,
   ensureHtmlElements,
   ensureHtmlSelectorSatisfies,
 } from "../../verify.ts";
@@ -107,4 +108,18 @@ testRender(outputLocation.input, "revealjs", false, [
       return nodeList.length === 2;
     },
   ),
+]);
+
+// reveal-config
+const revealConfigs = fileLoader("reveal")("reveal-configs.qmd", "revealjs");
+testRender(revealConfigs.input, "revealjs", false, [
+  ensureFileRegexMatches(revealConfigs.output.outputPath, [
+    "pdfSeparateFragments.*true",
+    "smaller.*true",
+    "pdfSeparateFragments.*true",
+    "autoAnimateEasing.*\"ease-in-out\"",
+    "autoAnimateDuration.*5",
+    "autoAnimateUnmatched.*false",
+    "pdfMaxPagesPerSlide.*1",
+  ], [])
 ]);


### PR DESCRIPTION
This fixes #6120 

We document the configuration https://quarto.org/docs/presentations/revealjs/presenting.html#print-options 

but somehow it was not pass to RevealJS template. 

This PR 

* Add the config in schema - @cscheid is this ok to have no default ? 

* Add support for this metadata as a RevealJS meta to pass in configuration

* Fix a duplicated option (not related to #6120)

* Add tests for custom config Quarto support and that pandoc does not in default template