### PR TITLE
Github Action Housekeeping

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -434,140 +434,6 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@v3
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{needs.configure.outputs.tag_name}}
-          release_name: ${{needs.configure.outputs.release}}
-          body: |
-            ${{ needs.configure.outputs.changes }}
-          draft: ${{ inputs.draft }}
-          prerelease: ${{ inputs.pre-release }}
-
-      - name: Attach Source Tarball
-        id: attach-source-tarball
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./Source/quarto-${{needs.configure.outputs.version}}.tar.gz
-          asset_name: quarto-${{needs.configure.outputs.version}}.tar.gz
-          asset_content_type: application/gzip
-
-      - name: Attach Release Tarball
-        id: attach-release-tarball
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./Deb Zip/quarto-${{needs.configure.outputs.version}}-linux-amd64.tar.gz
-          asset_name: quarto-${{needs.configure.outputs.version}}-linux-amd64.tar.gz
-          asset_content_type: application/gzip
-
-      - name: Attach Arm64 Release Tarball
-        id: attach-arm4-release-tarball
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./Deb Arm64 Zip/quarto-${{needs.configure.outputs.version}}-linux-arm64.tar.gz
-          asset_name: quarto-${{needs.configure.outputs.version}}-linux-arm64.tar.gz
-          asset_content_type: application/gzip
-
-      - name: Attach RHEL Tarball
-        id: attach-rhel-tarball
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./RHEL Zip/quarto-${{needs.configure.outputs.version}}-linux-rhel7-amd64.tar.gz
-          asset_name: quarto-${{needs.configure.outputs.version}}-linux-rhel7-amd64.tar.gz
-          asset_content_type: application/gzip
-
-      - name: Attach Debian Installer
-        id: attach-deb-installer
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./Deb Installer/quarto-${{needs.configure.outputs.version}}-linux-amd64.deb
-          asset_name: quarto-${{needs.configure.outputs.version}}-linux-amd64.deb
-          asset_content_type: application/deb
-
-      - name: Attach Arm64 Debian Installer
-        id: attach-arm64-deb-installer
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./Deb Arm64 Installer/quarto-${{needs.configure.outputs.version}}-linux-arm64.deb
-          asset_name: quarto-${{needs.configure.outputs.version}}-linux-arm64.deb
-          asset_content_type: application/deb
-
-      - name: Attach Windows Installer
-        id: attach-win-installer
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./Windows Installer/quarto-${{needs.configure.outputs.version}}-win.msi
-          asset_name: quarto-${{needs.configure.outputs.version}}-win.msi
-          asset_content_type: application/msi
-
-      - name: Attach Windows Zip
-        id: attach-win-zip
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./Windows Zip/quarto-${{needs.configure.outputs.version}}-win.zip
-          asset_name: quarto-${{needs.configure.outputs.version}}-win.zip
-          asset_content_type: application/pkg
-
-      - name: Attach Mac Installer
-        id: attach-mac-installer
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./Mac Installer/quarto-${{needs.configure.outputs.version}}-macos.pkg
-          asset_name: quarto-${{needs.configure.outputs.version}}-macos.pkg
-          asset_content_type: application/pkg
-
-      - name: Attach Mac Zip
-        id: attach-mac-zip
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./Mac Zip/quarto-${{needs.configure.outputs.version}}-macos.tar.gz
-          asset_name: quarto-${{needs.configure.outputs.version}}-macos.tar.gz
-          asset_content_type: application/pkg
-
-      - name: Attach News
-        id: attach-news
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./News/changelog-${{needs.configure.outputs.version_base}}.md
-          asset_name: changelog.md
-          asset_content_type: text/markdown
-
       - name: Generate Checksums
         id: generate_checksum
         run: |
@@ -611,16 +477,31 @@ jobs:
           sha256sum quarto-${{needs.configure.outputs.version}}.tar.gz >> ../quarto-${{needs.configure.outputs.version}}-checksums.txt
           popd
 
-      - name: Attach Checksum
-        id: attach-checksum
-        uses: actions/upload-release-asset@v1
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: quarto-${{needs.configure.outputs.version}}-checksums.txt
-          asset_name: quarto-${{needs.configure.outputs.version}}-checksums.txt
-          asset_content_type: text/plain
+          tag_name: ${{needs.configure.outputs.tag_name}}
+          name: ${{needs.configure.outputs.release}}
+          body: |
+            ${{ needs.configure.outputs.changes }}
+          draft: ${{ inputs.draft }}
+          prerelease: ${{ inputs.pre-release }}
+          files: |
+            ./Source/quarto-${{needs.configure.outputs.version}}.tar.gz
+            ./Deb Zip/quarto-${{needs.configure.outputs.version}}-linux-amd64.tar.gz
+            ./Deb Arm64 Zip/quarto-${{needs.configure.outputs.version}}-linux-arm64.tar.gz
+            ./RHEL Zip/quarto-${{needs.configure.outputs.version}}-linux-rhel7-amd64.tar.gz
+            ./Deb Installer/quarto-${{needs.configure.outputs.version}}-linux-amd64.deb
+            ./Deb Arm64 Installer/quarto-${{needs.configure.outputs.version}}-linux-arm64.deb
+            ./Windows Installer/quarto-${{needs.configure.outputs.version}}-win.msi
+            ./Windows Zip/quarto-${{needs.configure.outputs.version}}-win.zip
+            ./Mac Installer/quarto-${{needs.configure.outputs.version}}-macos.pkg
+            ./Mac Zip/quarto-${{needs.configure.outputs.version}}-macos.tar.gz
+            ./News/changelog-${{needs.configure.outputs.version_base}}.md
+            quarto-${{needs.configure.outputs.version}}-checksums.txt
 
   docker-push:
     if: ${{ inputs.publish-release }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -269,11 +269,10 @@ jobs:
     needs: [configure]
 
     steps:
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.63.0
-          override: true
-          components: rustfmt, clippy
+      - name: Configure Rust Tools
+        run: |
+          rustup.exe toolchain install 1.63.0 --component rustfmt --component clippy --no-self-update
+          rustup.exe default 1.63.0
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -166,7 +166,7 @@ jobs:
         run: |
 
           source ./configuration
-        
+
           echo Placing custom Deno ${DENO:1}. See available versions at https://anaconda.org/conda-forge/deno/files
           curl -L https://anaconda.org/conda-forge/deno/${DENO:1}/download/linux-64/deno-${DENO:1}-he8a937b_0.conda --output deno.conda
           unzip deno.conda
@@ -372,6 +372,7 @@ jobs:
         env:
           QUARTO_APPLE_APP_DEV_ID: ${{ secrets.APPLE_SIGN_ID }}
           QUARTO_APPLE_INST_DEV_ID: ${{ secrets.APPLE_INSTALLER_ID }}
+          QUARTO_APPLE_CONNECT_TEAMID: ${{ secrets.APPLE_CONNECT_TEAMID }}
           QUARTO_APPLE_CONNECT_UN: ${{ secrets.APPLE_CONNECT_UN }}
           QUARTO_APPLE_CONNECT_PW: ${{ secrets.APPLE_CONNECT_PW }}
 

--- a/package/src/macos/installer.ts
+++ b/package/src/macos/installer.ts
@@ -35,7 +35,6 @@ export async function makeInstallerMac(config: Configuration) {
     corePackageName,
   );
   const packageIdentifier = "org.rstudio.quarto";
-  const bundleIdentifier = "org.rstudio.quarto.cli";
 
   // Product package
   const packageName = `quarto-${config.version}-macos.pkg`;
@@ -225,23 +224,19 @@ export async function makeInstallerMac(config: Configuration) {
     // Submit package for notary
     const username = getEnv("QUARTO_APPLE_CONNECT_UN", "");
     const password = getEnv("QUARTO_APPLE_CONNECT_PW", "");
+    const teamId = getEnv("QUARTO_APPLE_CONNECT_TEAMID", "");
     if (username.length > 0 && password.length > 0) {
-      const requestId = await submitNotary(
+      const requestId = await notarizeAndWait(
         packagePath,
-        bundleIdentifier,
         username,
         password,
+        teamId
       );
 
-      // Add a delay to allow the Apple servers to propagate the
-      // request Id that they've just provided
-      sleepSync(10000);
-
-      // This will succeed or throw
-      await waitForNotaryStatus(requestId, username, password);
 
       // Staple the notary to the package
       await stapleNotary(packagePath);
+
     } else {
       warning("Missing Connect credentials, not notarizing");
     }
@@ -300,33 +295,38 @@ async function signCode(
   return result;
 }
 
-async function submitNotary(
+async function notarizeAndWait(
   input: string,
-  bundleId: string,
   username: string,
   password: string,
+  teamId: string
 ) {
   const result = await runCmd(
     "xcrun",
     [
-      "altool",
-      "--notarize-app",
-      "--primary-bundle-id",
-      bundleId,
-      "--username",
+      "notarytool",
+      "submit",
+      "--apple-id",
       username,
       "--password",
       password,
-      "--file",
+      "--team-id",
+      teamId,
       input,
+      "--wait"
     ],
   );
-  const match = result.stdout.match(/RequestUUID = (.*)/);
-  if (match) {
-    const requestId = match[1];
-    return requestId;
+
+  if (result.status.success) {
+    const match = result.stdout.match(/id: (.*)/);
+    if (match) {
+      const id = match[1];
+      return id;
+    } else {
+      throw new Error("Notarization Failed to return an Id:\n" + result.stdout);
+    }
   } else {
-    throw new Error("Unable to start notarization " + result.stdout);
+    throw new Error("Notarization Failed\n" + result.stderr);
   }
 }
 


### PR DESCRIPTION
### Migrate off deprecated notary tools for MacOS

- Migrate to the latest notarization tool prior to deprecation
  https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool?changes=_3_3

### Fix GH Action Warnings

- Migrate off deprecated GitHub action and simplify creating releases 
- Migrate off abandoned rust Github action and install rust tools directly.