### PR TITLE
Wrap `svg` output of `dot` cells in rawblock elements.

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -26,6 +26,7 @@
 - ([#5798](https://github.com/quarto-dev/quarto-cli/issues/5798)): Improve the layout consistency of HTML callouts.
 - ([#5856](https://github.com/quarto-dev/quarto-cli/issues/5856)): Always render the title block of HTML pages (previously would only render when title or subtitle was provided).
 - ([#5957](https://github.com/quarto-dev/quarto-cli/issues/5957)): Fix layout issues when margin footnotes are contained in headings or other formatted text.
+- ([#6163](https://github.com/quarto-dev/quarto-cli/issues/6163)): Wrap `svg` output of `dot` cells in RawBlock `html` elements.
 
 ## RevealJS Format
 

--- a/src/core/handlers/dot.ts
+++ b/src/core/handlers/dot.ts
@@ -163,6 +163,7 @@ const dotHandler: LanguageHandler = {
         svg = await setSvgSize(svg, options, fixupRevealAlignment);
       }
 
+      svg = mappedConcat(["```{=html}\n", svg, "\n```\n"]);
       return this.build(handlerContext, cell, svg, options);
     } else {
       const {

--- a/tests/docs/smoke-all/2023/07/10/6153.lua
+++ b/tests/docs/smoke-all/2023/07/10/6153.lua
@@ -1,0 +1,15 @@
+
+local svg_blocks = 0
+
+function RawBlock(el)
+  if el.text:match("svg") then
+    svg_blocks = svg_blocks + 1
+  end
+end
+
+function Pandoc(doc)
+  if svg_blocks ~= 1 then
+    error("Should have found exactly one rawblock with 'svg' in it")
+    crash_with_stack_trace()
+  end
+end

--- a/tests/docs/smoke-all/2023/07/10/6153.qmd
+++ b/tests/docs/smoke-all/2023/07/10/6153.qmd
@@ -1,0 +1,12 @@
+---
+key: X
+filters:
+  - 6153.lua
+---
+
+```{dot}
+digraph G {
+  label="Steps"
+  "1 Entferne Gruppe auf Position P5"
+}
+```


### PR DESCRIPTION
Closes #6163.