### PR TITLE
Adapt checking knitr capabilities to .Rprofile that would `cat()` some value

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -76,6 +76,7 @@
 - Exit if project pre or post render script fails
 - Use InternalError in typescript code, and offer a more helpful error message when an internal error happens.
 - ([#6042](https://github.com/quarto-dev/quarto-cli/issues/6042)): Correctly support empty lines in YAML blocks.
+- ([#6154](https://github.com/quarto-dev/quarto-cli/issues/6154)): `quarto check knitr` does not fail anymore when user's `.Rprofile` contains `cat()` calls.
 
 ## Docusaurus Format
 

--- a/src/core/knitr.ts
+++ b/src/core/knitr.ts
@@ -44,8 +44,8 @@ export async function knitrCapabilities() {
     });
     if (result.success && result.stdout) {
       const jsonLines = result.stdout
-        .replace(/^.*--- JSON_START ---/sm, "")
-        .replace(/--- JSON_END ---.*$/sm, "");
+        .replace(/^.*--- YAML_START ---/sm, "")
+        .replace(/--- YAML_END ---.*$/sm, "");
 
       const caps = readYamlFromString(jsonLines) as KnitrCapabilities;
       // check knitr requirement

--- a/src/core/knitr.ts
+++ b/src/core/knitr.ts
@@ -1,9 +1,8 @@
 /*
-* knitr.ts
-*
-* Copyright (C) 2020-2022 Posit Software, PBC
-*
-*/
+ * knitr.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
 
 import * as colors from "fmt/colors.ts";
 
@@ -44,7 +43,11 @@ export async function knitrCapabilities() {
       stdout: "piped",
     });
     if (result.success && result.stdout) {
-      const caps = readYamlFromString(result.stdout) as KnitrCapabilities;
+      const jsonLines = result.stdout
+        .replace(/^.*--- JSON_START ---/sm, "")
+        .replace(/--- JSON_END ---.*$/sm, "");
+
+      const caps = readYamlFromString(jsonLines) as KnitrCapabilities;
       // check knitr requirement
       const knitrVersion = caps.packages.knitr
         ? coerce(caps.packages.knitr)

--- a/src/resources/capabilities/knitr.R
+++ b/src/resources/capabilities/knitr.R
@@ -1,4 +1,5 @@
 version <- getRversion()
+cat("--- JSON_START ---\n")
 cat("versionMajor:", version$major, "\n")
 cat("versionMinor:", version$minor, "\n")
 cat("versionPatch:", version$patch, "\n")
@@ -22,3 +23,4 @@ if (requireNamespace("rmarkdown", quietly = TRUE)) {
   cat("null")
 }
 cat("\n")
+cat("--- JSON_END ---\n")

--- a/src/resources/capabilities/knitr.R
+++ b/src/resources/capabilities/knitr.R
@@ -1,5 +1,5 @@
 version <- getRversion()
-cat("--- JSON_START ---\n")
+cat("--- YAML_START ---\n")
 cat("versionMajor:", version$major, "\n")
 cat("versionMinor:", version$minor, "\n")
 cat("versionPatch:", version$patch, "\n")
@@ -23,4 +23,4 @@ if (requireNamespace("rmarkdown", quietly = TRUE)) {
   cat("null")
 }
 cat("\n")
-cat("--- JSON_END ---\n")
+cat("--- YAML_END ---\n")


### PR DESCRIPTION
This closes #6154 

The case is a user `.Rprofile` that would contain some `cat()` call. This would add some lines in `stdout`, but we currently expect all the `stdout` to be our JSON string. 

This makes the JSON parsing fails and R reported as not found (while `quarto render` works ok)

This PR adds special string content that we can match easily to unwrap the JSON content from stdout to check the capabilities. 

@jjallaire adding you as review to check this is ok to do that. I believe this is without side effect. 