### PR TITLE
Add an explicit error message when no Jupyter YAML spec and no kernel found for the detected language 

### DIFF
--- a/src/core/jupyter/jupyter.ts
+++ b/src/core/jupyter/jupyter.ts
@@ -488,9 +488,16 @@ export async function jupyterKernelspecFromMarkdown(
         }
       }
     }
-  }
-
-  if (typeof (yamlJupyter) === "string") {
+    return Promise.reject(
+      new Error(
+        `No kernel found for any language checked (${
+          Array.from(languages).join(", ")
+        }) in any of the kernelspecs checked (${
+          Array.from(kernelspecs.values()).map((k) => k.name).join(", ")
+        }).`,
+      ),
+    );
+  } else if (typeof (yamlJupyter) === "string") {
     const kernel = yamlJupyter;
     const kernelspec = await jupyterKernelspec(kernel);
     if (kernelspec) {


### PR DESCRIPTION
In current situation, we don't have an explicit error in the following situation. 

When no `jupyter` is found in YAML header, we try to guess the language from the markdown cells. And then we try to find a kernel that would work with the language. 

However, when we found no kernel that fit the language, we do not error and we continue to the part of the code _as if_  a YAML spec has been defined. 

This leads to an uninformative error. 

This PR just adds an explicit error 

````
> quarto render
ERROR: No kernel found for any language checked (python) in any of the kernelspecs checked (bash, julia-1.7, julia-1.8, julia-1.9).
````

I decided to go quite verbose, but we could remove the insertion of language and kernel. 


For the context, this was found in a very narrow case: 

* The python configured does not have Jupyter, hence no  capabilities found. 
* However, there is Julia installed with an internal conda 
* And now Quarto uses that as a fallback (https://github.com/quarto-dev/quarto-cli/pull/1931)

Problem is: The Julia internal Conda is not configured to work with other than Julia language. 
