### PR TITLE
Fix for website navigation, full width clickable for navigation or activating disclosure triangle

### DIFF
--- a/src/resources/projects/website/navigation/quarto-nav.scss
+++ b/src/resources/projects/website/navigation/quarto-nav.scss
@@ -375,6 +375,10 @@ $sidebar-section-bottom-margin: 0.2em;
   transform: rotate(90deg);
 }
 
+.sidebar-item-text {
+  width: 100%;
+}
+
 .sidebar-navigation .sidebar-divider {
   margin-left: 0;
   margin-right: 0;


### PR DESCRIPTION
This small fix to the `.side-item-text`-classed `<a>` tag ensures that there are no gaps between actual text and the disclosure triangle (which is activated to reveal children). Also increases the clickable area for links in the nav (i.e., without the triangle). Works fine even with larger amounts of text (no collision of text with disclosure triangle).

<img width="680" alt="width-nav-text-100" src="https://github.com/quarto-dev/quarto-cli/assets/5612024/86d0fccf-fcb3-4c90-96fe-d7ee4b3e2030">


Fixes: https://github.com/quarto-dev/quarto-cli/issues/5642