### PR TITLE
Inline code execution for Jupyter 

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -69,6 +69,10 @@
 - Automatically render missing formats (e.g. PDF, MS Word) on the fly
 - ([#5882](https://github.com/quarto-dev/quarto-cli/issues/5882)): Disable browser cache using `Cache-Control` header config in the viewer redirect for PDF preview, correctly allowing a HTML preview later on same port.
 
+## Jupyter
+
+- Support for executing inline expressions (e.g. `` `{python} x` ``)
+
 ## Dependencies
 
 - Update to Pandoc 3.1.5

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -677,6 +677,7 @@ export const kCellLanguage = "language";
 export const kCellSlideshow = "slideshow";
 export const kCellSlideshowSlideType = "slide_type";
 export const kCellRawMimeType = "raw_mimetype";
+export const kCellUserExpressions = "user_expressions";
 
 export const kCellId = "id";
 export const kCellLabel = "label";

--- a/src/core/execute-inline.ts
+++ b/src/core/execute-inline.ts
@@ -4,6 +4,13 @@
  * Copyright (C) 2021-2022 Posit Software, PBC
  */
 
+import {
+  asMappedString,
+  mappedConcat,
+  MappedString,
+  mappedSubstring,
+} from "./lib/mapped-text.ts";
+
 export function executeInlineCodeHandler(
   language: string,
   exec: (expr: string) => string | undefined,
@@ -21,5 +28,57 @@ export function executeInlineCodeHandler(
         return match;
       }
     });
+  };
+}
+
+export function executeInlineCodeHandlerMapped(
+  language: string,
+  exec: (expr: string) => string | undefined,
+) {
+  const exprPattern = new RegExp(
+    "(^|[^`])`{" + language + "}[ \t]([^`]+)`",
+    "g",
+  );
+  return (code: MappedString) => {
+    let matches: RegExpExecArray | null;
+    const result: MappedString[] = [];
+    let prevIndex = 0;
+    while ((matches = exprPattern.exec(code.value))) {
+      // everything before the match
+      result.push(mappedSubstring(code, prevIndex, matches.index));
+      const matchMapped = mappedSubstring(
+        code,
+        matches.index,
+        matches.index + matches[0].length,
+      );
+      // the first capture group is the prefix
+      const prefixMapped = mappedSubstring(
+        code,
+        matches.index,
+        matches.index + matches[1].length,
+      );
+      // the second capture group is the expression
+      const exprStr = matches[2];
+
+      const exprResult = exec(exprStr.trim());
+      if (exprResult) {
+        result.push(prefixMapped);
+        result.push(asMappedString(exprResult));
+      } else {
+        result.push(matchMapped);
+      }
+
+      // const expr = code.slice(matches.index + matches[1].length);
+      // const result = exec(expr.trim());
+      // if (result) {
+      //   result.push(prefix);
+      //   result.push(result);
+      // } else {
+      //   result.push(code.slice(prevIndex, matches.index + matches[0].length));
+      // }
+      prevIndex = matches.index + matches[0].length;
+    }
+    result.push(mappedSubstring(code, prevIndex));
+    return mappedConcat(result);
   };
 }

--- a/src/core/execute-inline.ts
+++ b/src/core/execute-inline.ts
@@ -1,0 +1,25 @@
+/*
+ * execute-inline.ts
+ *
+ * Copyright (C) 2021-2022 Posit Software, PBC
+ */
+
+export function executeInlineCodeHandler(
+  language: string,
+  exec: (expr: string) => string | undefined,
+) {
+  const exprPattern = new RegExp(
+    "(^|[^`])`{" + language + "}[ \t]([^`]+)`",
+    "g",
+  );
+  return (code: string) => {
+    return code.replaceAll(exprPattern, (match, prefix, expr) => {
+      const result = exec(expr.trim());
+      if (result) {
+        return `${prefix}${result}`;
+      } else {
+        return match;
+      }
+    });
+  };
+}

--- a/src/core/jupyter/display-data.ts
+++ b/src/core/jupyter/display-data.ts
@@ -1,9 +1,8 @@
 /*
-* display-data.ts
-*
-* Copyright (C) 2020-2022 Posit Software, PBC
-*
-*/
+ * display-data.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
 
 import * as ld from "../../core/lodash.ts";
 
@@ -22,6 +21,7 @@ import {
 } from "../mime.ts";
 import {
   JupyterCell,
+  JupyterCellOutputData,
   JupyterOutput,
   JupyterOutputDisplayData,
   JupyterToMarkdownOptions,
@@ -43,7 +43,7 @@ export function isCaptionableData(output: JupyterOutput) {
 }
 
 export function displayDataMimeType(
-  output: JupyterOutputDisplayData,
+  output: JupyterCellOutputData,
   options: JupyterToMarkdownOptions,
 ) {
   const displayPriority = [
@@ -131,8 +131,14 @@ export function displayDataWithMarkdownMath(output: JupyterOutputDisplayData) {
   return output;
 }
 
-export function displayDataHasHtmlTable(output: JupyterOutputDisplayData) {
-  const html = output.data[kTextHtml] as string[] || undefined;
+export function displayDataHasHtmlTable(
+  output: JupyterCellOutputData,
+) {
+  const html = Array.isArray(output.data[kTextHtml])
+    ? output.data[kTextHtml] as string[]
+    : typeof (output.data[kTextHtml]) === "string"
+    ? [output.data[kTextHtml]] as string[]
+    : undefined;
   if (html) {
     const htmlLower = html.map((line) => line.toLowerCase());
     return htmlLower.some((line) => !!line.match(/<[Tt][Aa][Bb][Ll][Ee]/)) &&

--- a/src/core/jupyter/jupyter-inline.ts
+++ b/src/core/jupyter/jupyter-inline.ts
@@ -1,0 +1,67 @@
+/*
+ * jupyter-inlne.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
+
+import { kCellUserExpressions } from "../../config/constants.ts";
+import { kTextHtml, kTextLatex, kTextMarkdown, kTextPlain } from "../mime.ts";
+import { displayDataMimeType } from "./display-data.ts";
+import {
+  JupyterCellWithOptions,
+  JupyterToMarkdownOptions,
+  JupyterUserExpressionResult,
+} from "./types.ts";
+
+export function userExpressionsFromCell(
+  cell: JupyterCellWithOptions,
+): Map<string, JupyterUserExpressionResult> {
+  const userExpressions = (cell.metadata[kCellUserExpressions] || [])
+    .reduce((userExpressions, userExpression) => {
+      userExpressions.set(userExpression.expression, userExpression.result);
+      return userExpressions;
+    }, new Map<string, JupyterUserExpressionResult>());
+  return userExpressions;
+}
+
+export function resolveUserExpressions(
+  source: string[],
+  userExpressions: Map<string, JupyterUserExpressionResult>,
+  options: JupyterToMarkdownOptions,
+) {
+  // resolve user expressions
+  const exprPattern = new RegExp(
+    "(^|[^`])`{" + options.language + "}[ \t]([^`]+)`",
+    "g",
+  );
+  for (let i = 0; i < source.length; i++) {
+    let line = source[i];
+    line = line.replaceAll(exprPattern, (match, prefix, expr) => {
+      const result = userExpressions.get(expr.trim());
+      if (result) {
+        const mimeType = displayDataMimeType(result, options);
+        if (mimeType) {
+          let data = result.data[mimeType];
+          if (Array.isArray(data)) {
+            data = data.map(String).join("");
+          }
+          switch (mimeType) {
+            case kTextHtml:
+              return `${prefix}${"`"}${data}${"`"}{=html}`;
+            case kTextLatex:
+              return `${prefix}${"`"}${data}${"`"}{=tex}`;
+            case kTextMarkdown:
+            case kTextPlain:
+            default:
+              return `${prefix}${data}`;
+          }
+        } else {
+          return match;
+        }
+      } else {
+        return match;
+      }
+    });
+    source[i] = line;
+  }
+}

--- a/src/core/jupyter/types.ts
+++ b/src/core/jupyter/types.ts
@@ -34,6 +34,7 @@ import {
   kCellSlideshowSlideType,
   kCellTags,
   kCellTblColumn,
+  kCellUserExpressions,
   kCodeFold,
   kCodeLineNumbers,
   kCodeOverflow,
@@ -125,6 +126,9 @@ export interface JupyterCellMetadata {
   // nbdev language
   [kCellLanguage]?: string;
 
+  // user_expressions
+  [kCellUserExpressions]?: JupyterUserExpression[];
+
   // anything else
   [key: string]: unknown;
 }
@@ -137,6 +141,17 @@ export interface JupyterCellWithOptions extends JupyterCell {
   id: string;
   options: JupyterCellOptions;
   optionsSource: string[];
+}
+
+export interface JupyterUserExpression {
+  expression: string;
+  result: JupyterUserExpressionResult;
+}
+
+export interface JupyterUserExpressionResult {
+  data: Record<string, string>;
+  metadata: Metadata;
+  status: string;
 }
 
 export interface JupyterOutput {

--- a/src/core/jupyter/types.ts
+++ b/src/core/jupyter/types.ts
@@ -148,8 +148,11 @@ export interface JupyterUserExpression {
   result: JupyterUserExpressionResult;
 }
 
-export interface JupyterUserExpressionResult {
-  data: Record<string, string>;
+export interface JupyterCellOutputData {
+  data: { [mimeType: string]: unknown };
+}
+
+export interface JupyterUserExpressionResult extends JupyterCellOutputData {
   metadata: Metadata;
   status: string;
 }

--- a/src/execute/jupyter/jupyter.ts
+++ b/src/execute/jupyter/jupyter.ts
@@ -4,7 +4,7 @@
  * Copyright (C) 2020-2022 Posit Software, PBC
  */
 
-import { extname, join } from "path/mod.ts";
+import { join } from "path/mod.ts";
 
 import { existsSync } from "fs/mod.ts";
 

--- a/src/execute/ojs/compile.ts
+++ b/src/execute/ojs/compile.ts
@@ -671,11 +671,18 @@ export async function ojsCompile(
       ls.push(cell.sourceVerbatim);
     } else if (cell.cell_type === "markdown") {
       // Convert to native OJS inline expression syntax then delegate to lua filter
+      // TODO: for now we just do this to detect use of `{ojs} x` syntax and then
+      // throw an error indicating its unsupported. This code needs to be updated
+      // to handle mapped strings correctly.
       const markdown = executeInlineCodeHandler(
         "ojs",
         (exec) => "${" + exec + "}",
       )(cell.sourceVerbatim.value);
-      ls.push(markdown);
+      if (markdown !== cell.sourceVerbatim.value) {
+        throw new Error("`{ojs}` inline expressions not yet supported");
+      }
+
+      ls.push(cell.sourceVerbatim);
     } else if (cell.cell_type?.language === "ojs") {
       await handleOJSCell(cell);
     } else {

--- a/src/execute/ojs/compile.ts
+++ b/src/execute/ojs/compile.ts
@@ -79,7 +79,7 @@ import {
 } from "../../core/lib/mapped-text.ts";
 import { getDivAttributes } from "../../core/handlers/base.ts";
 import { pathWithForwardSlashes } from "../../core/path.ts";
-import { executeInlineCodeHandler } from "../../core/execute-inline.ts";
+import { executeInlineCodeHandlerMapped } from "../../core/execute-inline.ts";
 
 export interface OjsCompileOptions {
   source: string;
@@ -674,15 +674,12 @@ export async function ojsCompile(
       // TODO: for now we just do this to detect use of `{ojs} x` syntax and then
       // throw an error indicating its unsupported. This code needs to be updated
       // to handle mapped strings correctly.
-      const markdown = executeInlineCodeHandler(
+      const markdown = executeInlineCodeHandlerMapped(
         "ojs",
         (exec) => "${" + exec + "}",
-      )(cell.sourceVerbatim.value);
-      if (markdown !== cell.sourceVerbatim.value) {
-        throw new Error("`{ojs}` inline expressions not yet supported");
-      }
+      )(cell.sourceVerbatim);
 
-      ls.push(cell.sourceVerbatim);
+      ls.push(markdown);
     } else if (cell.cell_type?.language === "ojs") {
       await handleOJSCell(cell);
     } else {

--- a/src/execute/ojs/compile.ts
+++ b/src/execute/ojs/compile.ts
@@ -1,9 +1,8 @@
 /*
-* compile.ts
-*
-* Copyright (C) 2021-2022 Posit Software, PBC
-*
-*/
+ * compile.ts
+ *
+ * Copyright (C) 2021-2022 Posit Software, PBC
+ */
 
 import * as ld from "../../core/lodash.ts";
 import { dirname, join, relative, resolve } from "path/mod.ts";
@@ -80,6 +79,7 @@ import {
 } from "../../core/lib/mapped-text.ts";
 import { getDivAttributes } from "../../core/handlers/base.ts";
 import { pathWithForwardSlashes } from "../../core/path.ts";
+import { executeInlineCodeHandler } from "../../core/execute-inline.ts";
 
 export interface OjsCompileOptions {
   source: string;
@@ -526,8 +526,8 @@ export async function ojsCompile(
       // then pandoc will clobber our classes and our runtime error
       // reporting things will break anyway. So just don't emit
       // the source in that case.
-      const shouldEmitSource = (echoVal !== "fenced" &&
-        !(echoVal === false && isHtmlMarkdown));
+      const shouldEmitSource = echoVal !== "fenced" &&
+        !(echoVal === false && isHtmlMarkdown);
 
       const makeSubFigures = (specs: SubfigureSpec[]) => {
         let subfigIx = 1;
@@ -665,11 +665,17 @@ export async function ojsCompile(
     };
 
     if (
-      cell.cell_type === "raw" ||
-      cell.cell_type === "markdown"
+      cell.cell_type === "raw"
     ) {
       // The lua filter is in charge of this, we're a NOP.
       ls.push(cell.sourceVerbatim);
+    } else if (cell.cell_type === "markdown") {
+      // Convert to native OJS inline expression syntax then delegate to lua filter
+      const markdown = executeInlineCodeHandler(
+        "ojs",
+        (exec) => "${" + exec + "}",
+      )(cell.sourceVerbatim.value);
+      ls.push(markdown);
     } else if (cell.cell_type?.language === "ojs") {
       await handleOJSCell(cell);
     } else {

--- a/src/execute/rmd.ts
+++ b/src/execute/rmd.ts
@@ -38,7 +38,10 @@ import { postProcessRestorePreservedHtml } from "./engine-shared.ts";
 import { mappedStringFromFile } from "../core/mapped-text.ts";
 import { mappedIndexToLineCol, MappedString } from "../core/lib/mapped-text.ts";
 import { lineColToIndex } from "../core/lib/text.ts";
-import { executeInlineCodeHandler } from "../core/execute-inline.ts";
+import {
+  executeInlineCodeHandler,
+  executeInlineCodeHandlerMapped,
+} from "../core/execute-inline.ts";
 
 const kRmdExtensions = [".rmd", ".rmarkdown"];
 
@@ -99,7 +102,7 @@ export const knitrEngine: ExecutionEngine = {
         ...options,
         target: undefined,
         input: options.target.input,
-        markdown: resolveInlineExecute(options.target.markdown.value),
+        markdown: resolveInlineExecute(options.target.markdown),
       },
       options.tempDir,
       options.projectDir,
@@ -320,6 +323,8 @@ function filterAlwaysAllowHtml(s: string): string {
   return s;
 }
 
-function resolveInlineExecute(code: string) {
-  return executeInlineCodeHandler("r", (expr) => `${"`"}r ${expr}${"`"}`)(code);
+function resolveInlineExecute(code: MappedString) {
+  return executeInlineCodeHandlerMapped("r", (expr) => `${"`"}r ${expr}${"`"}`)(
+    code,
+  );
 }

--- a/src/execute/rmd.ts
+++ b/src/execute/rmd.ts
@@ -38,10 +38,7 @@ import { postProcessRestorePreservedHtml } from "./engine-shared.ts";
 import { mappedStringFromFile } from "../core/mapped-text.ts";
 import { mappedIndexToLineCol, MappedString } from "../core/lib/mapped-text.ts";
 import { lineColToIndex } from "../core/lib/text.ts";
-import {
-  executeInlineCodeHandler,
-  executeInlineCodeHandlerMapped,
-} from "../core/execute-inline.ts";
+import { executeInlineCodeHandler } from "../core/execute-inline.ts";
 
 const kRmdExtensions = [".rmd", ".rmarkdown"];
 
@@ -102,7 +99,7 @@ export const knitrEngine: ExecutionEngine = {
         ...options,
         target: undefined,
         input: options.target.input,
-        markdown: resolveInlineExecute(options.target.markdown),
+        markdown: resolveInlineExecute(options.target.markdown.value),
       },
       options.tempDir,
       options.projectDir,
@@ -323,8 +320,6 @@ function filterAlwaysAllowHtml(s: string): string {
   return s;
 }
 
-function resolveInlineExecute(code: MappedString) {
-  return executeInlineCodeHandlerMapped("r", (expr) => `${"`"}r ${expr}${"`"}`)(
-    code,
-  );
+function resolveInlineExecute(code: string) {
+  return executeInlineCodeHandler("r", (expr) => `${"`"}r ${expr}${"`"}`)(code);
 }

--- a/src/execute/rmd.ts
+++ b/src/execute/rmd.ts
@@ -38,6 +38,7 @@ import { postProcessRestorePreservedHtml } from "./engine-shared.ts";
 import { mappedStringFromFile } from "../core/mapped-text.ts";
 import { mappedIndexToLineCol, MappedString } from "../core/lib/mapped-text.ts";
 import { lineColToIndex } from "../core/lib/text.ts";
+import { executeInlineCodeHandler } from "../core/execute-inline.ts";
 
 const kRmdExtensions = [".rmd", ".rmarkdown"];
 
@@ -98,7 +99,7 @@ export const knitrEngine: ExecutionEngine = {
         ...options,
         target: undefined,
         input: options.target.input,
-        markdown: options.target.markdown.value,
+        markdown: resolveInlineExecute(options.target.markdown.value),
       },
       options.tempDir,
       options.projectDir,
@@ -317,4 +318,8 @@ function filterAlwaysAllowHtml(s: string): string {
       .replace("always_allow_html: true", "prefer-html: true");
   }
   return s;
+}
+
+function resolveInlineExecute(code: string) {
+  return executeInlineCodeHandler("r", (expr) => `${"`"}r ${expr}${"`"}`)(code);
 }

--- a/src/resources/filters/quarto-pre/engine-escape.lua
+++ b/src/resources/filters/quarto-pre/engine-escape.lua
@@ -25,6 +25,11 @@ function engine_escape()
         return "```" .. engine 
       end)
       return el
+    end,
+
+    Code = function(el)
+      el.text = el.text:gsub("^" .. patterns.engine_escape, "%1")
+      return el
     end
   }
 end

--- a/src/resources/jupyter/notebook.py
+++ b/src/resources/jupyter/notebook.py
@@ -184,8 +184,9 @@ def notebook_execute(options, status):
       cell = cell_clear_output(cell)
 
       # execute cell
+      trace("Executing cell {0}".format(index))
+      
       if cell.cell_type == 'code':
-         trace("Executing cell {0}".format(index))
          cell = cell_execute(
             client, 
             cell, 
@@ -195,8 +196,11 @@ def notebook_execute(options, status):
             index > 0 # add_to_history
          )
          cell.execution_count = current_code_cell
-         trace("Executed cell {0}".format(index))
+      elif cell.cell_type == 'markdown':
+         cell = cell_execute_inline(client, cell)
 
+      trace("Executed cell {0}".format(index))
+        
       # if this was the setup cell, see if we need to exit b/c dependencies are out of date
       if index == 0:
          kernel_deps = nb_kernel_depenencies(cell)
@@ -407,6 +411,66 @@ def cell_execute(client, cell, index, execution_count, eval_default, store_histo
    # return cell
    return cell
    
+def cell_execute_inline(client, cell):
+   
+   # helper to raise an error from a result
+   def raise_error(result):
+      ename = result.get('ename')
+      evalue = result.get('evalue')
+      raise Exception(f'{ename}: {evalue}')
+
+   # helper to clear existing user_expressions if they exist
+   def clear_user_expressions():
+      if "metadata" in cell:
+         metadata = cell.get("metadata")
+         if "user_expressions" in metadata:
+            del metadata["user_expressions"]
+   
+   # find expressions in source
+   language = client.nb.metadata.kernelspec.language
+   source = ''.join(cell.source)
+   expressions = re.findall(
+      fr'(?:^|[^`])`{{{language}}}[ \t]([^`]+)`',
+      source, 
+      re.MULTILINE
+   )
+   if len(expressions):
+      # send and wait for 'execute' kernel message w/ user_expressions
+      kc = client.kc
+      user_expressions = dict()
+      for idx, expr in enumerate(expressions):
+         user_expressions[str(idx)] = expr 
+      msg_id = kc.execute('', user_expressions = user_expressions)
+      reply = client.wait_for_reply(msg_id)
+
+      # process reply
+      content = reply.get('content')
+      if content.get('status') == 'ok': 
+         # build results (check for error on each one)
+         results = []
+         for key in user_expressions:
+            result = content.get('user_expressions').get(key)
+            if result.get('status') == 'ok':
+               results.append({
+                  'expression' : user_expressions.get(key),
+                  'result': result
+               }) 
+            elif result.get('status') == 'error':
+               raise_error(result)  
+
+         # set results into metadata
+         if not "metadata" in cell:
+            cell["metadata"] = {}
+         cell["metadata"]["user_expressions"] = results
+         
+      elif content.get('status') == 'error':
+         raise_error(content)
+   else:
+      clear_user_expressions()
+
+   # return cell
+   return cell
+
 
 def cell_clear_output(cell):
    remove_metadata = ['collapsed', 'scrolled']

--- a/src/resources/jupyter/notebook.py
+++ b/src/resources/jupyter/notebook.py
@@ -439,7 +439,7 @@ def cell_execute_inline(client, cell):
       kc = client.kc
       user_expressions = dict()
       for idx, expr in enumerate(expressions):
-         user_expressions[str(idx)] = expr 
+         user_expressions[str(idx).strip()] = expr 
       msg_id = kc.execute('', user_expressions = user_expressions)
       reply = client.wait_for_reply(msg_id)
 

--- a/tests/docs/smoke-all/jupyter/inline-execution-jupyter.qmd
+++ b/tests/docs/smoke-all/jupyter/inline-execution-jupyter.qmd
@@ -1,0 +1,21 @@
+---
+engine: jupyter
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ["span#ojs-element-id-1"]
+      ensureFileRegexMatches:
+        - ["246"]
+        - []
+---
+
+```{python}
+x = 123
+```
+
+```{ojs}
+y = 10
+```
+
+Then, the value of $x + x$ will be `{python} x + x` and $y + y$ will be `{ojs} y+y`.

--- a/tests/docs/smoke-all/knitr/inline-code-execution/new-syntax.qmd
+++ b/tests/docs/smoke-all/knitr/inline-code-execution/new-syntax.qmd
@@ -1,0 +1,21 @@
+---
+engine: knitr
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ["span#ojs-element-id-1"]
+      ensureFileRegexMatches:
+        - ["246"]
+        - []
+---
+
+```{r}
+x = 123
+```
+
+```{ojs}
+y = 10
+```
+
+Then, the value of $x + x$ will be `{r} x + x` and $y + y$ will be `{ojs} y+y`.


### PR DESCRIPTION
This PR implements support for inline code execution in the Jupyter engine using inline code with an engine prefix. For example:

````markdown
```{python}
x = 25
```

The value is `{python} x`.
````

For consistency, this syntax is also now available for R. For example, the following are equivalent:

````markdown
The threshold level is`r x`.
The threshold level is`{r} x`.
````

We also need to implement this for OJS (cc @cscheid).

Closes #5401. See #1520 and #3570 as well.


