### PR TITLE
improve error message when attempting to run a JSON filter

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -115,6 +115,7 @@
 - Add support for relative paths in `require()` calls.
 - ([#5242](https://github.com/quarto-dev/quarto-cli/issues/5242)): Add line numbers to error messages.
 - Add support `quarto.doc.add_resource` and `quarto.doc.add_supporting`. `add_resource` will add a resource file to the current render, copying that file to the same relative location in the output directory. `add_supporting` will add a supporting file to the current render, moving that file file to the same relative location in the output directory.
+- ([#6211](https://github.com/quarto-dev/quarto-cli/pull/6211)): Improve error message when a JSON filter (or a potentially misspelled Lua filter from an extension) is not found.
 
 ## Books
 

--- a/src/resources/filters/common/wrapped-filter.lua
+++ b/src/resources/filters/common/wrapped-filter.lua
@@ -113,7 +113,21 @@ function makeWrappedJsonFilter(scriptFile, filterHandler)
             return meta
           end
         })
-        local result = pandoc.utils.run_json_filter(doc, path)
+        local success, result = pcall(pandoc.utils.run_json_filter, doc, path)
+        if not success then
+          local pandoc_error = tostring(result)
+          local filename = pandoc.path.filename(path)
+          local message = {
+            "Could not run " .. path .. " as a JSON filter.",
+            "Please make sure the file exists and is executable.",
+            "\nDid you intend '" .. filename .. "' as a Lua filter in an extension?",
+            "If so, make sure you've spelled the name of the extension correctly.",
+            "\nThe original Pandoc error follows below.",
+            pandoc_error
+          }
+          fail(table.concat(message, "\n"))
+          return nil
+        end
         if has_custom_nodes then
           doc:walk({
             Meta = function(meta)


### PR DESCRIPTION
Context: a Lua filter from an extension doesn't have a file extension. We call it like this:

```lua
filters:
  - some_filter_extension
```

This makes sense because the user doesn't know the internal name of the Lua file in the filter. However, this notation is ambiguous. If the extension doesn't exist (or, as commonly happens, is misspelled), we interpret the filter as a JSON filter. In this case, our current error message is not very helpful.

This PR improves the situation.

Example:

```
FATAL (/Users/cscheid/repos/github/quarto-dev/quarto-cli/src/resources/filters/./common/wrapped-filter.lua:128) An error occurred:
Could not run /Users/cscheid/repos/github/wch/shinycomponent/quarto/shinygrid as a JSON filter.
Please make sure the file exists and is executable.

Did you intend 'shinygrid' as a Lua filter in an extension?
If so, make sure you've spelled the name of the extension correctly.

The original Pandoc error follows below.
Error running filter /Users/cscheid/repos/github/wch/shinycomponent/quarto/shinygrid:
Could not find executable /Users/cscheid/repos/github/wch/shinycomponent/quarto/shinygrid
```
