### PR TITLE
Detect language within fenced code block when echo: fenced 

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -134,3 +134,4 @@
 - ([#5902](https://github.com/quarto-dev/quarto-cli/issues/5902)): Support paired shortcode syntax.
 - ([#6013](https://github.com/quarto-dev/quarto-cli/issues/6013)): Don't error if citation is passed as a boolean value in metadata via flags
 - ([#6207](https://github.com/quarto-dev/quarto-cli/issues/6207)): When QUARTO_R is set to a non-existing path, a warning is now thrown like with QUARTO_PYTHON. Quarto still fallback to search a working R version.
+- ([#6244](https://github.com/quarto-dev/quarto-cli/issues/6244)): Code annotation now works for executable code cells using `echo: fenced`. Also it now supports HTML and Markdown code cells.

--- a/src/resources/filters/quarto-pre/code-annotation.lua
+++ b/src/resources/filters/quarto-pre/code-annotation.lua
@@ -55,8 +55,9 @@ local kLangCommentChars = {
   swift = { "//" },
   javascript = { "//"},
   elm = { "#" },
-  vhdl = { "--"}
-  
+  vhdl = { "--"},
+  html = { "<!--", "-->"},
+  markdown = {"<!--", "-->"}
 }
 
 local hasAnnotations = false

--- a/src/resources/filters/quarto-pre/code-annotation.lua
+++ b/src/resources/filters/quarto-pre/code-annotation.lua
@@ -56,7 +56,7 @@ local kLangCommentChars = {
   javascript = { "//"},
   elm = { "#" },
   vhdl = { "--"}
-
+  
 }
 
 local hasAnnotations = false
@@ -150,7 +150,12 @@ end
 local function resolveCellAnnotes(codeBlockEl, processAnnotation) 
 
   -- collect any annotations on this code cell
-  local lang = codeBlockEl.attr.classes[1]  
+  local lang = codeBlockEl.attr.classes[1] 
+  -- handle fenced-echo block which will have no language
+  if lang == "cell-code" then 
+    _, _, matchedLang = string.find(codeBlockEl.text, "^`+%{%{([^%}]*)%}%}")
+    lang = matchedLang or lang
+  end
   local annotationProvider = annoteProvider(lang)
   if annotationProvider ~= nil then
     local annotations = {}
@@ -414,7 +419,7 @@ function code_annotations()
             local resolvedBlock = _quarto.ast.walk(block, {
               CodeBlock = function(el)
                 if el.attr.classes:find('cell-code') then
-                  
+
                   local cellId = resolveCellId(el.attr.identifier)
                   local codeCell = processCodeCell(el, cellId)
                   if codeCell then

--- a/tests/docs/smoke-all/2023/01/03/code-annote-simple.qmd
+++ b/tests/docs/smoke-all/2023/01/03/code-annote-simple.qmd
@@ -8,7 +8,16 @@ _quarto:
   tests: 
     html:
       ensureHtmlElements:
-        - ["a[data-target-annotation='1']", "a[data-target-annotation='2']", "div.cell-annotation > dl"]
+        - 
+          - "a[data-target-annotation='1']"
+          - "a[data-target-annotation='2']"
+          - "div.cell-annotation > dl"
+          - "div.sourceCode[id^='annotated-cell-1']"
+          - "div.sourceCode[id^='annotated-cell-2']"
+          - "div.sourceCode[id^='annotated-cell-3']"
+          - "div.sourceCode[id^='annotated-cell-4']"
+          - "div.sourceCode[id^='annotated-cell-5']"
+        - ['ol[type="1"]']
 ---
 
 ## Hi There
@@ -41,3 +50,19 @@ if (foo === "bar") {
 ```
 
 1. This is a console output
+
+```markdown
+# Some content <!-- <1> -->
+
+Some content
+```
+
+1. This is title
+
+```html
+<div> <!-- <1> -->
+content 
+<div>
+```
+
+1. This is div container in HTML

--- a/tests/docs/smoke-all/2023/07/17/echo-fenced-annotation.qmd
+++ b/tests/docs/smoke-all/2023/07/17/echo-fenced-annotation.qmd
@@ -1,0 +1,29 @@
+---
+format: html
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ['div.sourceCode[id^="annotated-cell-1"]', 'div.sourceCode[id^="annotated-cell-2"]']
+        - ['ol[type="1"]']
+---
+
+```{r}
+#| label: test-code-annotation
+#| echo: fenced
+1 + 1 # <1>
+2 + 2 # <2>
+```
+
+1.  Simple 
+2.  Very simple
+
+```{bash}
+#| eval: false
+#| echo: fenced
+echo 2 # <1>
+echo 3 # <2>
+```
+
+1.  Simple 
+2.  Very simple


### PR DESCRIPTION
Detect language within fenced code block when echo: fenced  is used for code annotationWelcome to the quarto GitHub repo!

closes #6244 

This suppose that when `echo: fenced` there won't be any language on cell and so only class found will be `cell-code`. In that case we extract from the text content of CodeBlock the language between `` ```{{lang}} `` 

We could also try to apply the regex no matter the language on the CodeBlock but it felt too wide...

This PR also adds support for HTML and Markdown code cells using HTML comments as comment chars. 