### PR TITLE
Correctly escape new engine inline syntax

### DIFF
--- a/src/resources/filters/quarto-pre/engine-escape.lua
+++ b/src/resources/filters/quarto-pre/engine-escape.lua
@@ -28,7 +28,10 @@ function engine_escape()
     end,
 
     Code = function(el)
+      -- handle `{{python}} code`
       el.text = el.text:gsub("^" .. patterns.engine_escape, "%1")
+      -- handles `` `{{python}} code` ``
+      el.text = el.text:gsub("^(`+)" .. patterns.engine_escape, "%1%2")
       return el
     end
   }

--- a/tests/docs/smoke-all/jupyter/inline-execution-jupyter.qmd
+++ b/tests/docs/smoke-all/jupyter/inline-execution-jupyter.qmd
@@ -6,7 +6,7 @@ _quarto:
       ensureHtmlElements:
         - ["span#ojs-element-id-1"]
       ensureFileRegexMatches:
-        - ["246"]
+        - ["246", "\\{python\\} x \\+ x","\\{ojs\\} y\\+y"]
         - []
 ---
 
@@ -19,3 +19,6 @@ y = 10
 ```
 
 Then, the value of $x + x$ will be `{python} x + x` and $y + y$ will be `{ojs} y+y`.
+
+For the above we used the new syntax `` `{{python}} x + x` `` and `` `{{ojs}} y+y` ``
+


### PR DESCRIPTION
This PR follows a slack discussion and add supports to using ``` `` `{{python}} code` `` ``` to escape the inline engine syntax to produce `` `{python} code` `` in markdown  (thus unevaluated)

I have kept the other engine escaping that was happening for ``  `{{python}} code` `` to produce  `` `{python} code` `` in markdown (thus unevaluated). I left this case as this was the one you added. 

I added to the test. 

The issue was that we process using Lua as `Code` Inline and tweaking the `el.text` element. So we need to regex to handle both case. 

Hopefully I got it right and that is what we want to escape inline. 