### PR TITLE
Correctly flush pending annotated cell even when no block is following

### DIFF
--- a/tests/docs/smoke-all/2023/07/24/code-annotation-exec-only.qmd
+++ b/tests/docs/smoke-all/2023/07/24/code-annotation-exec-only.qmd
@@ -1,0 +1,24 @@
+---
+title: Only comment code block without annotation
+format: 
+  html:
+    code-annotations: true
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ['div.cell-code pre code']
+        - []
+      ensureFileRegexMatches:
+        - []
+        - ["# &lt;1&gt;"]
+---
+
+From https://github.com/quarto-dev/quarto-cli/issues/6313
+
+Computational code block with annotation comment but no comment.
+
+```{r}
+stats::rnorm(2) # <1>
+1 + 1
+```


### PR DESCRIPTION
This fix #6313 

When no other block follow the `cell` Div, we were not flushing any pending processed Code Cell. This PR adds a pending code cell flush before outputing results. 

I wonder if we should add a dummy test to check that block order is respected any time when no annotation is processed 🤔 
That is my only concerned here, but it seems to me we are correctly flushing in all the other case. 

By the way I refacted in a flushing function to make that more clear. Hopefully test will pass :)

@dragonstyle hope I got it right