### PR TITLE
Don't add code annotation post processor for PDF when deactivated

### DIFF
--- a/src/format/pdf/format-pdf.ts
+++ b/src/format/pdf/format-pdf.ts
@@ -51,6 +51,7 @@ import { isLatexPdfEngine, pdfEngine } from "../../config/pdf.ts";
 import { formatResourcePath } from "../../core/resources.ts";
 import { kTemplatePartials } from "../../command/render/template.ts";
 import { copyTo } from "../../core/copy.ts";
+import { kCodeAnnotations } from "../html/format-html-shared.ts";
 
 export function pdfFormat(): Format {
   return mergeConfigs(
@@ -365,8 +366,10 @@ function pdfLatexPostProcessor(
     }
 
     lineProcessors.push(captionFootnoteLineProcessor());
-    lineProcessors.push(codeAnnotationPostProcessor());
-    lineProcessors.push(codeListAnnotationPostProcessor());
+    if (format.metadata[kCodeAnnotations] !== false) {
+      lineProcessors.push(codeAnnotationPostProcessor());
+      lineProcessors.push(codeListAnnotationPostProcessor());
+    }
     lineProcessors.push(longTableSidenoteProcessor());
 
     await processLines(output, lineProcessors, temp);

--- a/tests/docs/smoke-all/2023/07/24/code-annotation-false.qmd
+++ b/tests/docs/smoke-all/2023/07/24/code-annotation-false.qmd
@@ -1,0 +1,25 @@
+---
+format: html
+code-annotations: false
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ["ol > li"]
+        - []
+      ensureFileRegexMatches:
+        - ["# &lt;1&gt;"] 
+        - []
+    latex:
+      ensureFileRegexMatches:
+        - ["\\\\textless{}1\\\\textgreater{}"]
+        - ["\\\\circled"]
+    pdf:
+      noErrors: default
+---
+
+```r
+1 + 1 # <1>
+```
+
+1. Simple addition.


### PR DESCRIPTION
fix #6320 

See detailled analysis in https://github.com/quarto-dev/quarto-cli/issues/6320#issuecomment-1648065596

I believe we need to avoid adding the post processor for LaTeX when `code-annotations: false` because we won't do any Lua processing in that case 
https://github.com/quarto-dev/quarto-cli/blob/49f1bd16e341f59087b346481756be50281419da/src/resources/filters/quarto-pre/code-annotation.lua#L511-L524

