### PR TITLE
fix 404 when publishing from Posit Cloud project to Posit Cloud

### DIFF
--- a/src/publish/posit-cloud/posit-cloud.ts
+++ b/src/publish/posit-cloud/posit-cloud.ts
@@ -291,7 +291,7 @@ async function createContent(
     const projectApplication = await client.getApplication(
       projectApplicationId,
     );
-    const project = await client.getContent(projectApplication.id);
+    const project = await client.getContent(projectApplication.content_id);
     projectId = project.id;
     spaceId = project.space_id;
   }


### PR DESCRIPTION
## Description

The Posit Cloud publishing provider has special logic to, when publishing from a project in Posit Cloud, associate the published content with that project. That behavior was broken because we had making an API call to get the project with the wrong id.

Resolves https://github.com/quarto-dev/quarto-cli/issues/6329.

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
