### PR TITLE
Fix code-annotation: none

### DIFF
--- a/src/command/render/filters.ts
+++ b/src/command/render/filters.ts
@@ -136,7 +136,7 @@ export async function filterParamsJson(
     ...await quartoFilterParams(options, defaults),
     ...crossrefFilterParams(options, defaults),
     ...citeIndexFilterParams(options, defaults),
-    ...layoutFilterParams(options.format),
+    ...layoutFilterParams(options.format, defaults),
     ...languageFilterParams(options.format.language),
     ...jatsFilterParams(options),
     ...notebookContextFilterParams(options),

--- a/src/command/render/layout.ts
+++ b/src/command/render/layout.ts
@@ -1,14 +1,13 @@
 /*
-* layout.ts
-*
-* Copyright (C) 2020-2022 Posit Software, PBC
-*
-*/
+ * layout.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
 
 import { Document, Element } from "../../core/deno-dom.ts";
 
 import { kPageWidth } from "../../config/constants.ts";
-import { Format } from "../../config/types.ts";
+import { Format, FormatPandoc } from "../../config/types.ts";
 import { Metadata } from "../../config/types.ts";
 
 import { HtmlPostProcessResult } from "./types.ts";
@@ -21,19 +20,23 @@ import { kHtmlEmptyPostProcessResult } from "./constants.ts";
 const kAdaptiveTextHighlighting = "adaptive-text-highlighting";
 const kTextHighlighting = "text-highlighting";
 
-export function layoutFilterParams(format: Format) {
+export function layoutFilterParams(
+  format: Format,
+  defaults: FormatPandoc | undefined,
+) {
   const params: Metadata = {};
   const pageWidth = format.render[kPageWidth];
   if (pageWidth) {
     params[kPageWidth] = pageWidth;
   }
+  if (defaults) {
+    if (hasAdaptiveTheme(defaults)) {
+      params[kAdaptiveTextHighlighting] = true;
+    }
 
-  if (hasAdaptiveTheme(format.pandoc)) {
-    params[kAdaptiveTextHighlighting] = true;
-  }
-
-  if (hasTextHighlighting(format.pandoc)) {
-    params[kTextHighlighting] = true;
+    if (hasTextHighlighting(defaults)) {
+      params[kTextHighlighting] = true;
+    }
   }
 
   return params;

--- a/src/format/pdf/format-pdf.ts
+++ b/src/format/pdf/format-pdf.ts
@@ -370,7 +370,6 @@ function pdfLatexPostProcessor(
       format.metadata[kCodeAnnotations] as boolean !== false &&
       format.metadata[kCodeAnnotations] as string !== "none"
     ) {
-      console.log("NOT HERE");
       lineProcessors.push(codeAnnotationPostProcessor());
       lineProcessors.push(codeListAnnotationPostProcessor());
     }

--- a/src/format/pdf/format-pdf.ts
+++ b/src/format/pdf/format-pdf.ts
@@ -364,12 +364,17 @@ function pdfLatexPostProcessor(
       // Replace notes with side notes
       lineProcessors.push(sideNoteLineProcessor());
     }
-
     lineProcessors.push(captionFootnoteLineProcessor());
-    if (format.metadata[kCodeAnnotations] !== false) {
+
+    if (
+      format.metadata[kCodeAnnotations] as boolean !== false &&
+      format.metadata[kCodeAnnotations] as string !== "none"
+    ) {
+      console.log("NOT HERE");
       lineProcessors.push(codeAnnotationPostProcessor());
       lineProcessors.push(codeListAnnotationPostProcessor());
     }
+
     lineProcessors.push(longTableSidenoteProcessor());
 
     await processLines(output, lineProcessors, temp);

--- a/src/resources/filters/common/string.lua
+++ b/src/resources/filters/common/string.lua
@@ -42,3 +42,9 @@ end
 function patternEscape(str) 
   return str:gsub("([^%w])", "%%%1")
 end
+
+-- Escape '%' in string by replacing by '%%'
+-- This is especially useful in Lua patterns to escape a '%'
+function percentEscape(str)
+  return str:gsub("%%", "%%%%")
+end

--- a/src/resources/filters/quarto-pre/code-annotation.lua
+++ b/src/resources/filters/quarto-pre/code-annotation.lua
@@ -253,7 +253,7 @@ end
 function code_meta()
   return {
     Meta = function(meta)
-      if _quarto.format.isLatexOutput() and hasAnnotations then
+      if _quarto.format.isLatexOutput() and hasAnnotations and param(constants.kCodeAnnotationsParam) ~= constants.kCodeAnnotationStyleNone then
         -- ensure we have tikx for making the circles
         quarto.doc.use_latex_package("tikz");
         quarto.doc.include_text('in-header', [[

--- a/src/resources/filters/quarto-pre/code-annotation.lua
+++ b/src/resources/filters/quarto-pre/code-annotation.lua
@@ -55,8 +55,8 @@ local function annoteProvider(lang)
       stripAnnotation = function(line, annoteId) 
         return line:gsub(expression.strip.prefix .. annoteId .. expression.strip.suffix, "")
       end,
-      replaceAnnotation = function(line, annoteId, replacement)
-        return line:gsub(patternEscape(expression.strip.prefix .. annoteId .. expression.strip.suffix), replacement)
+      replaceAnnotation = function(line, annoteId, replacement) 
+        return line:gsub(expression.strip.prefix .. annoteId .. expression.strip.suffix, replacement)
       end,
       createComment = function(value) 
         if #commentChars == 0 then
@@ -216,7 +216,7 @@ function processLaTeXAnnotation(line, annoteNumber, annotationProvider)
   -- which will replace any of these tokens as appropriate.   
   local hasHighlighting = param('text-highlighting', false)
   if param(constants.kCodeAnnotationsParam) == constants.kCodeAnnotationStyleNone then
-    local replaced = annotationProvider.replaceAnnotation(line, annoteNumber, '') 
+    local replaced = annotationProvider.stripAnnotation(line, annoteNumber) 
     return replaced
   else
     if hasHighlighting then

--- a/src/resources/filters/quarto-pre/code-annotation.lua
+++ b/src/resources/filters/quarto-pre/code-annotation.lua
@@ -222,7 +222,7 @@ function processLaTeXAnnotation(line, annoteNumber, annotationProvider)
     if hasHighlighting then
       -- highlighting is enabled, allow the comment through
       local placeholderComment = annotationProvider.createComment("<" .. tostring(annoteNumber) .. ">")
-      local replaced = annotationProvider.replaceAnnotation(line, annoteNumber, placeholderComment) 
+      local replaced = annotationProvider.replaceAnnotation(line, annoteNumber, percentEscape(placeholderComment)) 
       return replaced
     else
       -- no highlighting enabled, ensure we use a standard comment character

--- a/tests/docs/smoke-all/code-annotations/code-annotations-none.qmd
+++ b/tests/docs/smoke-all/code-annotations/code-annotations-none.qmd
@@ -1,0 +1,43 @@
+---
+title: Hello World
+code-annotations: none
+format:
+  html: default
+_quarto:
+  tests: 
+    html:
+      ensureHtmlElements:
+        - ['#wrong ol > li']
+        - ['#good ol > li', 'span[id^="annotated-cell"]']
+      ensureFileRegexMatches:
+        - []
+        - []
+    latex:
+      ensureFileRegexMatches:
+        - ["\\\\CommentTok\\{// \\\\textless\\{\\}1\\\\textgreater\\{\\}\\}", "\\item", "definiert"]
+        - ["\\\\circled", "Inhalt"]
+---
+
+Example from: https://github.com/quarto-dev/quarto-cli/issues/5286
+
+## wrong annotation comment {#wrong}
+
+``` c
+#define CriticalVariable() \
+  uint8_t cpuSR // <1>
+```
+1. definiert lokale Variable `cpuSR` für Sicherung des aktuellen Interrupt-Zustandes
+
+## Good {#good}
+
+``` c
+#define ExitCritical()    \
+  do {                    \
+    __asm(                \
+      "ldrb r0, cpuSR \n" \ /* <1> */
+      "msr PRIMASK,r0 \n" \ /* <2> */
+    );                    \
+  } while(0)
+```
+1. Inhalt von `cpuSR` in `R0` laden
+2. `R0` nach `PRIMASK` kopieren.


### PR DESCRIPTION
@dragonstyle this fix #6332 as discussed lived together 

I added a test, and also made sure that when `code-annotations: none` 
* we don't add anything in latex preamble
* We don't post process the LaTex file to leave comment unchanged

This PR also adds a fix for highlighing opt out and latex processing. I'll add test later for this.

Plan is to regroup all smoke-all test file under same folder so that we can have a clear view of all that we test for code annotation. 

I'll do that later. 
