### PR TITLE
set project dir if this is a project render

### DIFF
--- a/src/command/preview/preview.ts
+++ b/src/command/preview/preview.ts
@@ -419,6 +419,7 @@ async function renderForPreview(
     flags,
     pandocArgs: pandocArgs,
     previewServer: true,
+    setProjectDir: project !== undefined,
   });
   if (renderResult.error) {
     throw renderResult.error;


### PR DESCRIPTION
Rendering all in a manuscript project

```
quarto preview /manuscript-project/index.qmd --to all --no-browser --no-watch-inputs
```

will fail because the manuscript.lua file uses `quarto.project.directory` which is in turn provided by an environment variable. The above path for previewing will never set this path, even if there is a project, making the project directory unavailable in LUA.

This seems like an improvement to me (probably just a bug we haven't run into yet), but wanted to check whether you can think of things this might break....