### PR TITLE
improve yaml reading and handling of backticks. Closes #6344 and #6367.

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -76,6 +76,8 @@
 ## Jupyter
 
 - Support for executing inline expressions (e.g. `` `{python} x` ``)
+- ([#6344](https://github.com/quarto-dev/quarto-cli/issues/6344)): Somewhat improve the error message in case of YAML parsing errors in metadata of Python code cells.
+- ([#6367](https://github.com/quarto-dev/quarto-cli/issues/6367)): Fix bug with nested code cells in the generation of Jupyter notebook from .qmd files.
 
 ## Dependencies
 

--- a/src/core/lib/break-quarto-md.ts
+++ b/src/core/lib/break-quarto-md.ts
@@ -44,7 +44,7 @@ export async function breakQuartoMd(
     "^\\s*(```+)\\s*\\{([=A-Za-z]+)( *[ ,].*)?\\}\\s*$",
   );
   const startCodeRegEx = /^```/;
-  const endCodeRegEx = /^\s*```+\s*$/;
+  const endCodeRegEx = /^\s*(```+)\s*$/;
 
   let language = ""; // current language block
   let directiveParams: Shortcode | undefined = undefined;
@@ -213,13 +213,14 @@ export async function breakQuartoMd(
       language = (m as string[])[2];
       await flushLineBuffer("markdown", i);
       inCodeCell = true;
-      inCode = tickCount(line.substring);
+      inCode = (m as string[])[1].length;
+
       codeStartRange = line;
 
       // end code block: ^``` (tolerate trailing ws)
     } else if (
       endCodeRegEx.test(line.substring) &&
-      (inCode && tickCount(line.substring) === inCode)
+      (inCode && (line.substring.match(endCodeRegEx)!)[1].length === inCode)
     ) {
       // in a code cell, flush it
       if (inCodeCell) {

--- a/src/core/lib/break-quarto-md.ts
+++ b/src/core/lib/break-quarto-md.ts
@@ -41,7 +41,7 @@ export async function breakQuartoMd(
   // regexes
   const yamlRegEx = /^---\s*$/;
   const startCodeCellRegEx = new RegExp(
-    "^\\s*```+\\s*\\{([=A-Za-z]+)( *[ ,].*)?\\}\\s*$",
+    "^\\s*(```+)\\s*\\{([=A-Za-z]+)( *[ ,].*)?\\}\\s*$",
   );
   const startCodeRegEx = /^```/;
   const endCodeRegEx = /^\s*```+\s*$/;
@@ -210,15 +210,16 @@ export async function breakQuartoMd(
     } // begin code cell: ^```python
     else if (startCodeCellRegEx.test(line.substring) && inPlainText()) {
       const m = line.substring.match(startCodeCellRegEx);
-      language = (m as string[])[1];
+      language = (m as string[])[2];
       await flushLineBuffer("markdown", i);
       inCodeCell = true;
+      inCode = tickCount(line.substring);
       codeStartRange = line;
 
       // end code block: ^``` (tolerate trailing ws)
     } else if (
       endCodeRegEx.test(line.substring) &&
-      (inCodeCell || (inCode && tickCount(line.substring) === inCode))
+      (inCode && tickCount(line.substring) === inCode)
     ) {
       // in a code cell, flush it
       if (inCodeCell) {

--- a/tests/docs/smoke-all/2023/07/28/6367.qmd
+++ b/tests/docs/smoke-all/2023/07/28/6367.qmd
@@ -1,0 +1,22 @@
+---
+format: gfm
+keep-md: true
+jupyter:
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+# example
+
+````{python}
+# using the f-string means the python string uses 2 curly braces in its syntax,
+# but the string itself is just single curly braces
+# otherwise, quarto tries to execute the code (a separate issue)
+# but quarto sees and interprets the double curly braces as a non-executable code block
+doc = f"""
+    ```{{python}}
+    ```
+"""
+````


### PR DESCRIPTION
Two fixes for src/core/jupyter.ts.