### PR TITLE
Quarto allows file:// URL in embed-resources mode

### DIFF
--- a/news/changelog-1.3.md
+++ b/news/changelog-1.3.md
@@ -252,3 +252,4 @@
 - Fix incorrect copying of resource files during rendering ([#4544](https://github.com/quarto-dev/quarto-cli/issues/4544))
 - Extension authors may now force files to be included in their template by writing the file / file path in the `.quartoignore` file prefixed with a `!`. For example `!README.md` ([#4061](https://github.com/quarto-dev/quarto-cli/issues/4061)).
 - Fix issue when installing extensions on older Windows ([#4203](https://github.com/quarto-dev/quarto-cli/issues/4203)).
+- When `embed-resources: true`, do not stop ObservableJS execution when using `file://` URLs. ([#6371](https://github.com/quarto-dev/quarto-cli/issues/6371)).

--- a/src/execute/ojs/compile.ts
+++ b/src/execute/ojs/compile.ts
@@ -164,9 +164,12 @@ export async function ojsCompile(
   const docToRoot = pathWithForwardSlashes(relative(docDir, rootDir));
   // the check for file:// protocol has to be done in an inline script because
   // script links are not loaded in file:// protocol cases
-  scriptContents.push(
-    `if (window.location.protocol === "file:") { alert("The OJS runtime does not work with file:// URLs. Please use a web server to view this document."); }`,
-  );
+  if (!selfContained) {
+    // Only warn if the html document is not self-contained
+    scriptContents.push(
+      `if (window.location.protocol === "file:") { alert("The OJS runtime does not work with file:// URLs. Please use a web server to view this document."); }`,
+    );
+  }
   scriptContents.push(`window._ojs.paths.runtimeToDoc = "${runtimeToDoc}";`);
   scriptContents.push(`window._ojs.paths.runtimeToRoot = "${runtimeToRoot}";`);
   scriptContents.push(`window._ojs.paths.docToRoot = "${docToRoot}";`);
@@ -792,6 +795,9 @@ export async function ojsCompile(
 
   // script to append
   const afterBody = [
+    `<script type="application/javascript">`,
+    `window._selfContained = ${selfContained}`,
+    `</script>`,
     `<script type="ojs-module-contents">`,
     JSON.stringify({ contents: moduleContents }),
     `</script>`,

--- a/src/resources/formats/html/ojs/quarto-ojs-runtime.js
+++ b/src/resources/formats/html/ojs/quarto-ojs-runtime.js
@@ -20269,7 +20269,7 @@ function createRuntime() {
   }
 
   // Are we file://? bail
-  if (window.location.protocol === "file:") {
+  if (!window._selfContained && window.location.protocol === "file:") {
     displayFileProtocolError();
     return;
   }


### PR DESCRIPTION
## Description

This is a proposed incomplete fix of #6371, mostly provided for those who need to render OJS-enabled Quarto notebooks into .html that is to be loaded via `file://` URL.

Known issues: Dynamic module loading does not work in this mode, as per https://github.com/whatwg/html/issues/8121 which disables some OJS functionality. Proceed with caution!

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
   (only a very small change)
- [x] referenced the GitHub issue this PR closes
- [x] updated the appropriate changelog
