### PR TITLE
fix: look for Julia-specific Python in JULIA_HOME

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -78,6 +78,7 @@
 - Support for executing inline expressions (e.g. `` `{python} x` ``)
 - ([#6344](https://github.com/quarto-dev/quarto-cli/issues/6344)): Somewhat improve the error message in case of YAML parsing errors in metadata of Python code cells.
 - ([#6367](https://github.com/quarto-dev/quarto-cli/issues/6367)): Fix bug with nested code cells in the generation of Jupyter notebook from .qmd files.
+- ([#6393](https://github.com/quarto-dev/quarto-cli/pull/6393)): Search `JULIA_HOME` for Julia-specific Python installations.
 
 ## Dependencies
 

--- a/src/core/jupyter/capabilities.ts
+++ b/src/core/jupyter/capabilities.ts
@@ -77,9 +77,16 @@ export async function jupyterCapabilities(kernelspec?: JupyterKernelspec) {
 const S_IXUSR = 0o100;
 
 async function getVerifiedJuliaCondaJupyterCapabilities() {
-  const home = isWindows() ? Deno.env.get("USERPROFILE") : Deno.env.get("HOME");
-  if (home) {
-    const juliaCondaPath = join(home, ".julia", "conda", "3");
+  let juliaHome = Deno.env.get("JULIA_HOME");
+  if (!juliaHome) {
+    const home = isWindows() ? Deno.env.get("USERPROFILE") : Deno.env.get("HOME");
+    if (home) {
+      juliaHome = join(home, ".julia");
+    }
+  }
+
+  if (juliaHome) {
+    const juliaCondaPath = join(juliaHome, "conda", "3");
     const bin = isWindows()
       ? ["python3.exe", "python.exe"]
       : [join("bin", "python3"), join("bin", "python")];


### PR DESCRIPTION
## Description
The current code assumes that the `.julia` dir exists in the user's home directory, but that does not hold if `JULIA_HOME` is set. Consequently, `getVerifiedJuliaCondaJupyterCapabilities` should check for that env var first and only then fall back to `$HOME/.julia`.

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [x] updated the appropriate changelog
