### PR TITLE
unhide Posit Cloud from providers list

### DIFF
--- a/src/publish/posit-cloud/posit-cloud.ts
+++ b/src/publish/posit-cloud/posit-cloud.ts
@@ -42,7 +42,6 @@ export const positCloudProvider: PublishProvider = {
   description: kPositCloudDescription,
   requiresServer: true,
   listOriginOnly: true,
-  hidden: true,
   accountTokens,
   authorizeToken,
   removeToken,


### PR DESCRIPTION
## Description

Support for publishing static content in Posit Cloud is now live. This change allows Posit Cloud to show in the list of publishing providers.
