### PR TITLE
Update to pandoc 3.1.6.1

### DIFF
--- a/configuration
+++ b/configuration
@@ -10,7 +10,7 @@
 # Binary dependencies
 export DENO=v1.33.4
 export DENO_DOM=v0.1.35-alpha-artifacts
-export PANDOC=3.1.6
+export PANDOC=3.1.6.1
 export DARTSASS=1.55.0
 export ESBUILD=0.18.15
 export TYPST=0.6.0

--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -8,7 +8,7 @@
 
 ## Dependencies
 
-- Update to Pandoc 3.1.5
+- Update to Pandoc 3.1.6.1
 - Update to Typst 0.6.0
 
 ## HTML Format

--- a/src/resources/filters/customnodes/callout.lua
+++ b/src/resources/filters/customnodes/callout.lua
@@ -263,7 +263,7 @@ function calloutDiv(node)
   local imgDiv = pandoc.Div({imgPlaceholder}, pandoc.Attr("", {"callout-icon-container"}));
 
   -- show a titled callout
-  if title ~= nil and next(title) ~= nil then
+  if title ~= nil and (pandoc.utils.type(title) == "string" or next(title) ~= nil) then
 
     -- mark the callout as being titleed
     calloutDiv.attr.classes:insert("callout-titled")

--- a/src/resources/formats/html/pandoc/html.styles
+++ b/src/resources/formats/html/pandoc/html.styles
@@ -62,6 +62,10 @@ a:visited {
 img {
   max-width: 100%;
 }
+svg {
+  height; auto;
+  max-width: 100%;
+}
 h1, h2, h3, h4, h5, h6 {
   margin-top: 1.4em;
 }

--- a/src/resources/formats/html/pandoc/styles.html
+++ b/src/resources/formats/html/pandoc/styles.html
@@ -62,6 +62,10 @@ a:visited {
 img {
   max-width: 100%;
 }
+svg {
+  height; auto;
+  max-width: 100%;
+}
 h1, h2, h3, h4, h5, h6 {
   margin-top: 1.4em;
 }


### PR DESCRIPTION

@dragonstyle They added some CSS for SVG -- just want to make sure this doesn't conflict with other things we've done for SVG or other uses of the SVG element we have. See also these docs on changes in SVG handling for self contained documents: https://github.com/jgm/pandoc/releases/tag/3.1.6.1