### PR TITLE
Fix serviceworkers spelling in htmlDependency check

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -149,3 +149,4 @@
 - ([#6244](https://github.com/quarto-dev/quarto-cli/issues/6244)): Code annotation now works for executable code cells using `echo: fenced`. Also it now supports HTML and Markdown code cells.
 - ([#1392](https://github.com/quarto-dev/quarto-cli/issues/1392)): Add tools and LaTeX information to `quarto check` output.
 - ([#5748](https://github.com/quarto-dev/quarto-cli/issues/5748)): Don't cleanup shared lib_dir files when using `embed-resources` within a project
+- ([#6487](https://github.com/quarto-dev/quarto-cli/discussions/6487)): Fix `serviceworkers` check in `htmlDependency` to look at the correct key.

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -1925,9 +1925,9 @@ quarto = {
          htmlDependency.scripts == nil and 
          htmlDependency.stylesheets == nil and 
          htmlDependency.resources == nil and
-         htmlDependency.seviceworkers == nil and
+         htmlDependency.serviceworkers == nil and
          htmlDependency.head == nil then
-         error("HTML dependencies must include at least one of meta, links, scripts, stylesheets, seviceworkers, or resources. All appear empty.")
+         error("HTML dependencies must include at least one of meta, links, scripts, stylesheets, serviceworkers, or resources. All appear empty.")
       end
 
       -- validate that the meta is as expected


### PR DESCRIPTION
## Description

I think there is a hiccup in validating the `serviceworkers` key in `add_html_dependency()`. If I use `serviceworkers` per the [HTML dependency documentation](https://quarto.org/docs/extensions/lua-api.html#html-dependencies), I get:

```
ERROR: HTML dependencies must include at least one of meta, links, scripts, stylesheets, seviceworkers, or resources. All appear empty.
```

Based on the Lua API call of: 

```lua
  quarto.doc.add_html_dependency({
    name = "webr-serviceworker",
    version = "0.1.1",
    serviceworkers = {"webr-serviceworker.js"} # <--- spelling?
  })
```

However, if I use `seviceworkers` as the error message indicates, all is well but the later path resolution fails.

```lua
  quarto.doc.add_html_dependency({
    name = "webr-serviceworker",
    version = "0.1.1",
    seviceworkers = {"webr-serviceworker.js"} # <--- spelling?
  })
```

This is on quarto 1.3.450 and the latest quarto build of 1.4.300(?)

With this in mind, I can get around the error by using both key entries now. 

```lua
  quarto.doc.add_html_dependency({
    name = "webr-serviceworker",
    version = "0.1.1",
    seviceworkers = {"webr-serviceworker.js"},
    serviceworkers = {"webr-serviceworker.js"}
  })
```

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [x] updated the appropriate changelog
