### PR TITLE
Revert to Pandoc 3.1.2

### DIFF
--- a/configuration
+++ b/configuration
@@ -10,7 +10,7 @@
 # Binary dependencies
 export DENO=v1.33.4
 export DENO_DOM=v0.1.35-alpha-artifacts
-export PANDOC=3.1.6.1
+export PANDOC=3.1.2
 export DARTSASS=1.55.0
 export ESBUILD=0.18.15
 export TYPST=0.7.0

--- a/package/src/common/update-pandoc.ts
+++ b/package/src/common/update-pandoc.ts
@@ -129,7 +129,7 @@ async function writeVariants(
   const extended = ld.uniq(extArr);
   info(`  ${extended.length} extensions (after adding extended).`);
 
-  const extArrExpanded = extended.toSorted().flatMap((ext: string) => {
+  const extArrExpanded = extended.toSorted().flatMap((ext) => {
     return [`"+${ext}"`, `"-${ext}"`];
   });
 
@@ -199,7 +199,6 @@ async function writePandocTemplates(
   const latexOutdir = join(formatSrcDir, "pdf", "pandoc");
   const revealOutdir = join(formatSrcDir, "revealjs", "pandoc");
   const asciidocOutdir = join(formatSrcDir, "asciidoc", "pandoc");
-  const typstOutdir = join(formatSrcDir, "typst", "pandoc");
 
   const templateDirFiles: Record<string, Array<{ from: string; to?: string }>> =
     {
@@ -221,13 +220,8 @@ async function writePandocTemplates(
         { from: "default.latex", to: "latex.template" },
       ],
       [asciidocOutdir]: [
-        { from: "default.asciidoc", to: "asciidoc.template" },
+        { from: "default.asciidoctor", to: "asciidoc.template" },
       ],
-      [typstOutdir]: [
-        { from: "default.typst", to: "typst.template" },
-        { from: "definitions.typst" },
-        { from: "template.typst" }
-      ]
     };
 
   // Move templates

--- a/src/format/asciidoc/format-asciidoc.ts
+++ b/src/format/asciidoc/format-asciidoc.ts
@@ -65,7 +65,7 @@ export function asciidocFormat(): Format {
             "template.asciidoc",
           ),
         ),
-        to: "asciidoc",
+        to: "asciidoctor",
       },
       extensions: {
         book: asciidocBookExtension,

--- a/src/format/typst/format-typst.ts
+++ b/src/format/typst/format-typst.ts
@@ -8,6 +8,7 @@ import { join } from "path/mod.ts";
 
 import { RenderServices } from "../../command/render/types.ts";
 import {
+  kBibliography,
   kCiteproc,
   kColumns,
   kDefaultImageExtension,
@@ -15,8 +16,10 @@ import {
   kFigHeight,
   kFigWidth,
   kNumberSections,
+  kReferences,
   kSectionNumbering,
   kShiftHeadingLevelBy,
+  kVariables,
   kVariant,
   kWrap,
 } from "../../config/constants.ts";
@@ -42,6 +45,10 @@ export function typstFormat(): Format {
       [kDefaultImageExtension]: "svg",
       [kWrap]: "none",
       [kCiteproc]: false,
+      // TODO: Patch to do what Pandoc > 3.1.2 will do next when `+citations` (the default) is set.
+      [kVariables]: {
+        citations: true,
+      },
     },
     resolveFormat: typstResolveFormat,
     formatExtras: (
@@ -109,16 +116,13 @@ export function typstFormat(): Format {
 function typstResolveFormat(format: Format) {
   // Pandoc citeproc with typst output requires adjustment
   // https://github.com/jgm/pandoc/commit/e89a3edf24a025d5bb0fe8c4c7a8e6e0208fa846
-  if (
-    format.pandoc?.[kCiteproc] === true &&
-    !format.pandoc.to?.includes("-citations") &&
-    !format.render[kVariant]?.includes("-citations")
-  ) {
+  if (format.pandoc?.[kCiteproc] === true) {
     // citeproc: false is the default, so user setting it to true means they want to use
     // Pandoc's citeproc which requires `citations` extensions to be disabled (e.g typst-citations)
-    // This adds the variants for them if not set already
     format.render[kVariant] = [format.render?.[kVariant], "-citations"].join(
       "",
     );
+    format.pandoc[kVariables] = format.pandoc[kVariables] || {};
+    format.pandoc[kVariables]["citations"] = false;
   }
 }

--- a/src/resources/filters/layout/asciidoc.lua
+++ b/src/resources/filters/layout/asciidoc.lua
@@ -14,7 +14,7 @@ function asciidocFigure(image)
   -- caption
   local captionText = nil
   if image.caption and #image.caption > 0 then
-    captionText = pandoc.write(pandoc.Pandoc({image.caption}), "asciidoc")
+    captionText = pandoc.write(pandoc.Pandoc({image.caption}), "asciidoctor")
     captionText = captionText:gsub("\n", " ")
   end
   if captionText ~= nil then
@@ -45,7 +45,7 @@ function asciidocDivFigure(el)
   -- return the figure and caption
   local caption = refCaptionFromDiv(el)
   if caption then
-    local renderedCaption = pandoc.write(pandoc.Pandoc({caption}), "asciidoc")
+    local renderedCaption = pandoc.write(pandoc.Pandoc({caption}), "asciidoctor")
     figure:insert(pandoc.RawBlock('asciidoc', '.' .. renderedCaption))
   end
   

--- a/src/resources/filters/main.lua
+++ b/src/resources/filters/main.lua
@@ -66,6 +66,7 @@ import("./quarto-post/ojs.lua")
 import("./quarto-post/jats.lua")
 import("./quarto-post/responsive.lua")
 import("./quarto-post/reveal.lua")
+import("./quarto-post/typst.lua")
 import("./quarto-post/tikz.lua")
 import("./quarto-post/pdf-images.lua")
 import("./quarto-post/cellcleanup.lua")
@@ -321,6 +322,7 @@ local quartoPost = {
   { name = "post-render-asciidoc", filter = render_asciidoc() },
   { name = "post-render-latex", filter = render_latex() },
   { name = "post-render-docx", filter = render_docx() },
+  { name = "post-render-typst", filter = render_typst() },
 
   -- extensible rendering
   { name = "post-render_extended_nodes", filter = render_extended_nodes() },

--- a/src/resources/filters/quarto-post/render-asciidoc.lua
+++ b/src/resources/filters/quarto-post/render-asciidoc.lua
@@ -73,7 +73,7 @@ function render_asciidoc()
     end,
     Inlines = function(el)
       -- Walk inlines and see if there is an inline code followed directly by a note. 
-      -- If there is, place a space there (because otherwise asciidoc may be very confused)
+      -- If there is, place a space there (because otherwise asciidoctor may be very confused)
       for i, v in ipairs(el) do
 
         if v.t == "Code" then

--- a/src/resources/filters/quarto-post/typst.lua
+++ b/src/resources/filters/quarto-post/typst.lua
@@ -1,0 +1,17 @@
+-- typst.lua
+-- Copyright (C) 2021-2022 Posit Software, PBC
+
+function render_typst()
+  if _quarto.format.isTypstOutput() then
+    return {
+      Note = function(el)
+        local inlines = pandoc.List{pandoc.RawInline("typst", "#footnote[")}
+        inlines:extend(pandoc.utils.blocks_to_inlines(el.content))
+        inlines:insert(pandoc.RawInline("typst", "]"))
+        return inlines
+      end
+    }
+  else
+    return {}
+  end
+end

--- a/src/resources/formats/html/pandoc/html.styles
+++ b/src/resources/formats/html/pandoc/html.styles
@@ -62,10 +62,6 @@ a:visited {
 img {
   max-width: 100%;
 }
-svg {
-  height; auto;
-  max-width: 100%;
-}
 h1, h2, h3, h4, h5, h6 {
   margin-top: 1.4em;
 }
@@ -180,11 +176,8 @@ span.smallcaps{font-variant: small-caps;}
 div.columns{display: flex; gap: min(4vw, 1.5em);}
 div.column{flex: auto; overflow-x: auto;}
 div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-/* The extra [class] is a hack that increases specificity enough to
-   override a similar rule in reveal.js */
-ul.task-list[class]{list-style: none;}
+ul.task-list{list-style: none;}
 ul.task-list li input[type="checkbox"] {
-  font-size: inherit;
   width: 0.8em;
   margin: 0 0.8em 0.2em -1.6em;
   vertical-align: middle;

--- a/src/resources/formats/html/pandoc/styles.html
+++ b/src/resources/formats/html/pandoc/styles.html
@@ -62,10 +62,6 @@ a:visited {
 img {
   max-width: 100%;
 }
-svg {
-  height; auto;
-  max-width: 100%;
-}
 h1, h2, h3, h4, h5, h6 {
   margin-top: 1.4em;
 }

--- a/src/resources/formats/pdf/pandoc/latex.template
+++ b/src/resources/formats/pdf/pandoc/latex.template
@@ -363,7 +363,7 @@ $if(babel-lang)$
 $if(mainfont)$
 \ifPDFTeX
 \else
-\babelfont{rm}[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$]{$mainfont$}
+\babelfont[$babel-lang$]{rm}[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$]{$mainfont$}
 \fi
 $endif$
 $endif$

--- a/src/resources/formats/pdf/pandoc/template.tex
+++ b/src/resources/formats/pdf/pandoc/template.tex
@@ -276,7 +276,7 @@ $if(babel-lang)$
 $if(mainfont)$
 \ifPDFTeX
 \else
-\babelfont{rm}[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$]{$mainfont$}
+\babelfont[$babel-lang$]{rm}[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$]{$mainfont$}
 \fi
 $endif$
 $endif$

--- a/src/resources/formats/typst/pandoc/quarto/biblio.typ
+++ b/src/resources/formats/typst/pandoc/quarto/biblio.typ
@@ -1,10 +1,10 @@
 $if(citations)$
 $if(bibliographystyle)$
-
 #set bibliography(style: "$bibliographystyle$")
 $endif$
-$if(bibliography)$
 
-#bibliography($for(bibliography)$"$bibliography$"$sep$,$endfor$)
-$endif$
+$for(bibliography)$
+
+#bibliography("$bibliography$")
+$endfor$
 $endif$

--- a/src/resources/formats/typst/pandoc/typst.template
+++ b/src/resources/formats/typst/pandoc/typst.template
@@ -82,16 +82,24 @@ $endif$
 
 $body$
 
-$if(citations)$
+$if(notes)$
+#v(1em)
+#block[
+#horizontalrule
+#set text(size: .88em)
+#v(3pt) // otherwise first note marker is swallowed, bug?
+
+$notes$
+]
+$endif$
 $if(bibliographystyle)$
 
 #set bibliography(style: "$bibliographystyle$")
 $endif$
-$if(bibliography)$
+$for(bibliography)$
 
-#bibliography($for(bibliography)$"$bibliography$"$sep$,$endfor$)
-$endif$
-$endif$
+#bibliography("$bibliography$")
+$endfor$
 $for(include-after)$
 
 $include-after$

--- a/tests/docs/smoke-all/typst/typst-citeproc.qmd
+++ b/tests/docs/smoke-all/typst/typst-citeproc.qmd
@@ -8,7 +8,7 @@ _quarto:
   tests: 
     typst:
       ensureFileRegexMatches:
-      - ['<refs>', '<ref-Cronbach_1951>']
+      - ['\#label\("refs"\)']
       - ['\#bibliography\([^)]*\)']
 ---
 

--- a/tests/docs/smoke-all/typst/typst-no-citeproc.qmd
+++ b/tests/docs/smoke-all/typst/typst-no-citeproc.qmd
@@ -9,7 +9,7 @@ _quarto:
     typst:
       ensureFileRegexMatches:
       - ['\#set bibliography\(style\: [^)]*\)', '\#bibliography\([^)]*\)', '\#cite\([^)]*\)']
-      - ['<refs>', '<ref-Cronbach_1951>']
+      - ['\#label\("refs"\)']
 ---
 
 Hello [@Cronbach_1951]


### PR DESCRIPTION
We've noticed that new behavior introduced in Pandoc 3.1.4 affects `--id-prefix` such that IDs in visual editor documents all get the prefix (as opposed to just footnotes). This issue is reported here: https://github.com/quarto-dev/quarto-cli/issues/6548

This PR takes us back to a previous version of Pandoc while we wait for some upstream change/resolution.

