### PR TITLE
'tidy' option for knitr cells can also be 'formatR' or 'styler'

### DIFF
--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -7320,7 +7320,17 @@ var require_yaml_intelligence_resources = __commonJS({
           tags: {
             engine: "knitr"
           },
-          schema: "boolean",
+          schema: {
+            anyOf: [
+              "boolean",
+              {
+                enum: [
+                  "styler",
+                  "formatR"
+                ]
+              }
+            ]
+          },
           default: false,
           description: "Whether to reformat R code."
         },
@@ -21954,12 +21964,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 164009,
+        _internalId: 164015,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 164001,
+            _internalId: 164007,
             type: "enum",
             enum: [
               "png",
@@ -21975,7 +21985,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 164008,
+            _internalId: 164014,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -7321,7 +7321,17 @@ try {
             tags: {
               engine: "knitr"
             },
-            schema: "boolean",
+            schema: {
+              anyOf: [
+                "boolean",
+                {
+                  enum: [
+                    "styler",
+                    "formatR"
+                  ]
+                }
+              ]
+            },
             default: false,
             description: "Whether to reformat R code."
           },
@@ -21955,12 +21965,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 164009,
+          _internalId: 164015,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 164001,
+              _internalId: 164007,
               type: "enum",
               enum: [
                 "png",
@@ -21976,7 +21986,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 164008,
+              _internalId: 164014,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -292,7 +292,17 @@
       "tags": {
         "engine": "knitr"
       },
-      "schema": "boolean",
+      "schema": {
+        "anyOf": [
+          "boolean",
+          {
+            "enum": [
+              "styler",
+              "formatR"
+            ]
+          }
+        ]
+      },
       "default": false,
       "description": "Whether to reformat R code."
     },
@@ -14926,12 +14936,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 164009,
+    "_internalId": 164015,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 164001,
+        "_internalId": 164007,
         "type": "enum",
         "enum": [
           "png",
@@ -14947,7 +14957,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 164008,
+        "_internalId": 164014,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/schema/cell-codeoutput.yml
+++ b/src/resources/schema/cell-codeoutput.yml
@@ -117,7 +117,10 @@
 - name: tidy
   tags:
     engine: knitr
-  schema: boolean
+  schema:
+    anyOf:
+      - boolean
+      - enum: [styler, formatR]
   default: false
   description: "Whether to reformat R code."
 


### PR DESCRIPTION
This closes https://github.com/quarto-dev/quarto-cli/discussions/3118

`tidy` can also have a `formatR` or `styler` as valid option https://yihui.org/knitr/options/#code-decoration

It can also be a function, but we don't really support R code in YAML option. So I think this can be ignored from our linter for now (as it could be used with `!expr` currently, but we don't really validate this)

