### PR TITLE
Don't overunescape engine by accident

### DIFF
--- a/src/resources/filters/modules/patterns.lua
+++ b/src/resources/filters/modules/patterns.lua
@@ -14,6 +14,7 @@ local html_table_caption = tag("[Cc][Aa][Pp][Tt][Ii][Oo][Nn]")
 local html_paged_table = "<script data[-]pagedtable[-]source type=\"application/json\">"
 local html_gt_table = "<table class=\"gt_table\">"
 local engine_escape = "{({+([^}]+)}+)}"
+local shortcode = "{{+<[^>]+>}+}"
 
 return {
   engine_escape = engine_escape,
@@ -22,5 +23,6 @@ return {
   html_table_caption = html_table_caption,
   html_table_tag_name = html_table_tag_name,
   html_table = html_table,
+  shortcode = shortcode,
   tag = tag,
 }

--- a/src/resources/filters/quarto-pre/engine-escape.lua
+++ b/src/resources/filters/quarto-pre/engine-escape.lua
@@ -28,6 +28,10 @@ function engine_escape()
     end,
 
     Code = function(el)
+      -- don't accidentally process escaped shortcodes
+      if el.text:match("^" .. patterns.shortcode) then
+        return el
+      end
       -- handle `{{python}} code`
       el.text = el.text:gsub("^" .. patterns.engine_escape, "%1")
       -- handles `` `{{python}} code` ``

--- a/tests/docs/smoke-all/2023/08/22/issue-6584.qmd
+++ b/tests/docs/smoke-all/2023/08/22/issue-6584.qmd
@@ -1,0 +1,15 @@
+---
+title: issue-6584
+format: html
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - ['{{&lt; video &gt;}}']
+        - []
+
+---
+
+## Overview
+
+You can embed videos in documents using the `{{{< video >}}}` shortcode. For example, here we embed a YouTube video:


### PR DESCRIPTION
Currently, our engine unescaping code wrongly catches shortcodes in Code nodes.

This closes #6584.