### PR TITLE
display error messages from Posit Cloud error responses

### DIFF
--- a/src/publish/posit-cloud/api/index.ts
+++ b/src/publish/posit-cloud/api/index.ts
@@ -9,6 +9,7 @@ import {
   Application,
   Bundle,
   Content,
+  ErrorBody,
   OutputRevision,
   Task,
   User,
@@ -168,7 +169,19 @@ export class PositCloudClient {
         return await response.text() as unknown as T;
       }
     } else if (response.status >= 400) {
-      throw new ApiError(response.status, response.statusText);
+      const json = await response.json() as unknown as ErrorBody;
+      let errorDescription = undefined;
+      if (json.error) {
+        errorDescription = json.error;
+        if (json.error_type) {
+          errorDescription = `${errorDescription}, code=${json.error_type}`;
+        }
+      }
+      throw new ApiError(
+        response.status,
+        response.statusText,
+        errorDescription,
+      );
     } else {
       throw new Error(`${response.status} - ${response.statusText}`);
     }

--- a/src/publish/posit-cloud/api/types.ts
+++ b/src/publish/posit-cloud/api/types.ts
@@ -39,3 +39,8 @@ export type Task = {
   state: string;
   error?: string;
 };
+
+export type ErrorBody = {
+  error?: string;
+  error_type?: string;
+};

--- a/src/publish/types.ts
+++ b/src/publish/types.ts
@@ -1,18 +1,22 @@
 /*
-* types.ts
-*
-* Copyright (C) 2020-2022 Posit Software, PBC
-*
-*/
+ * types.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
 
 import { ProjectContext } from "../project/types.ts";
 
 export class ApiError extends Error {
   public constructor(
     public readonly status: number,
-    public readonly statusText: string
+    public readonly statusText: string,
+    public readonly description: string | undefined = undefined,
   ) {
-    super(`API Error: ${status} - ${statusText}`);
+    let message = `API Error: ${status} - ${statusText}`;
+    if (description) {
+      message = `${message} (${description})`;
+    }
+    super(message);
   }
 }
 


### PR DESCRIPTION
When Posit Cloud returns an error response, it's not always clear what went wrong. This PR adds the error message and error code into the thrown `ApiError` so that it can be displayed to the user.