### PR TITLE
include User-Agent header in requests to Posit Cloud

### DIFF
--- a/src/publish/posit-cloud/api/index.ts
+++ b/src/publish/posit-cloud/api/index.ts
@@ -15,6 +15,7 @@ import {
 } from "./types.ts";
 
 import { md5Hash } from "../../../core/hash.ts";
+import { quartoConfig } from "../../../core/quarto.ts";
 
 import { crypto } from "https://deno.land/std@0.185.0/crypto/mod.ts";
 
@@ -139,6 +140,7 @@ export class PositCloudClient {
 
     const headers = {
       Accept: "application/json",
+      "User-Agent": `quarto-cli/${quartoConfig.version()}`,
       ...authHeaders,
       ...contentTypeHeader,
     };


### PR DESCRIPTION
The Posit Cloud team would like visibility into which versions of Quarto are being used for publishing.