### PR TITLE
Improve knitr option handling in normalization

### DIFF
--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -774,7 +774,7 @@ normalize_options <- function(options) {
   # Un-normalized knitr options, and replace any existing options
   for (name in knitr_options_dashed) {
     if (name %in% names(options)) {
-      options[[sub("-", ".", name)]] <- options[[name]]
+      options[[gsub("-", ".", name)]] <- options[[name]]
       options[[name]] <- NULL
     }
   }

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -651,16 +651,17 @@ knitr_options_hook <- function(options) {
     } 
     options[["yaml.code"]] <- results$yamlSource
     
-    # some aliases
-    if (!is.null(options[["fig.format"]])) {
-      options[["dev"]] <- options[["fig.format"]]
-    }
-    if (!is.null(options[["fig.dpi"]])) {
-      options[["dpi"]] <- options[["fig.dpi"]]
-    }
   } else {
     # convert any option with fig- into fig. and out- to out.
     options <- normalize_options(options)
+  }
+
+  # some aliases not normalized
+  if (!is.null(options[["fig-format"]])) {
+    options[["dev"]] <- options[["fig-format"]]
+  }
+  if (!is.null(options[["fig-dpi"]])) {
+    options[["dpi"]] <- options[["fig-dpi"]]
   }
   
   # if there are line annotations in the code then we need to 

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -1,6 +1,12 @@
 # hooks.R
 # Copyright (C) 2020-2022 Posit Software, PBC
 
+# inline knitr:::merge_list()
+merge_list <- function(x, y) {
+    x[names(y)] <- y
+    x
+}
+
 knitr_hooks <- function(format, resourceDir, handledLanguages) {
 
   knit_hooks <- list()
@@ -639,7 +645,7 @@ knitr_options_hook <- function(options) {
         options[["message"]] = results$yaml[["warning"]]
       }
       # merge with other options
-      options <- knitr:::merge_list(options, results$yaml)
+      options <- merge_list(options, results$yaml)
       # set code
       options$code <- results$code
     } 

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -696,85 +696,87 @@ knitr_options_hook <- function(options) {
 # as support all documented knitr chunk options without the user
 # needing to replace . with -
 normalize_options <- function(options) {
-  names(options) <- sapply(names(options), function(name) {
-    if (name %in% c(
-                    # Text output 
-                    "strip-white",
-                    "class-output",
-                    "class-message",
-                    "class-warning",
-                    "class-error",
-                    "attr-output",
-                    "attr-message",
-                    "attr-warning",
-                    "attr-error",
-                    # Paged tables
-                    "max-print",
-                    "sql-max-print",
-                    "paged-print",
-                    "rows-print",
-                    "cols-print",
-                    "cols-min-print",
-                    "pages-print",
-                    "paged-print",
-                    "rownames-print",
-                    # Code decoration
-                    "tidy-opts",
-                    "class-source",
-                    "attr-source",
-                    # Cache
-                    "cache-path",
-                    "cache-vars",
-                    "cache-globals",
-                    "cache-lazy",
-                    "cache-comments",
-                    "cache-rebuild",
-                    # Plots
-                    "fig-path",
-                    "fig-keep",
-                    "fig-show",
-                    "dev-args",
-                    "fig-ext",
-                    "fig-width",
-                    "fig-height",
-                    "fig-asp",
-                    "fig-dim",
-                    "out-width",
-                    "out-height",
-                    "out-extra",
-                    "fig-retina",
-                    "resize-width",
-                    "resize-height",
-                    "fig-align",
-                    "fig-link",
-                    "fig-env",
-                    "fig-cap",
-                    "fig-alt",
-                    "fig-scap",
-                    "fig-lp",
-                    "fig-pos",
-                    "fig-subcap",
-                    "fig-ncol",
-                    "fig-sep",
-                    "fig-process",
-                    "fig-showtext",
-                    # Animation
-                    "animation-hook",
-                    "ffmpeg-bitrate",
-                    "ffmpeg-format",
-                    # Code chunk
-                    "ref-label",
-                    # Language engines
-                    "engine-path",
-                    "engine-opts",
-                    "opts-label",
-                    # Other chunk options
-                    "R-options")) {
-      sub("-", ".", name)
-    } else {
-      name
+  knitr_options_dashed <- c(
+    # Text output 
+    "strip-white",
+    "class-output",
+    "class-message",
+    "class-warning",
+    "class-error",
+    "attr-output",
+    "attr-message",
+    "attr-warning",
+    "attr-error",
+    # Paged tables
+    "max-print",
+    "sql-max-print",
+    "paged-print",
+    "rows-print",
+    "cols-print",
+    "cols-min-print",
+    "pages-print",
+    "paged-print",
+    "rownames-print",
+    # Code decoration
+    "tidy-opts",
+    "class-source",
+    "attr-source",
+    # Cache
+    "cache-path",
+    "cache-vars",
+    "cache-globals",
+    "cache-lazy",
+    "cache-comments",
+    "cache-rebuild",
+    # Plots
+    "fig-path",
+    "fig-keep",
+    "fig-show",
+    "dev-args",
+    "fig-ext",
+    "fig-width",
+    "fig-height",
+    "fig-asp",
+    "fig-dim",
+    "out-width",
+    "out-height",
+    "out-extra",
+    "fig-retina",
+    "resize-width",
+    "resize-height",
+    "fig-align",
+    "fig-link",
+    "fig-env",
+    "fig-cap",
+    "fig-alt",
+    "fig-scap",
+    "fig-lp",
+    "fig-pos",
+    "fig-subcap",
+    "fig-ncol",
+    "fig-sep",
+    "fig-process",
+    "fig-showtext",
+    # Animation
+    "animation-hook",
+    "ffmpeg-bitrate",
+    "ffmpeg-format",
+    # Code chunk
+    "ref-label",
+    # Language engines
+    "engine-path",
+    "engine-opts",
+    "opts-label",
+    # Other chunk options
+    "R-options"
+  )
+  # Un-normalized knitr options, and replace any existing options
+  for (name in knitr_options_dashed) {
+    if (name %in% names(options)) {
+      options[[sub("-", ".", name)]] <- options[[name]]
+      options[[name]] <- NULL
     }
-  }, USE.NAMES = FALSE)
+  }
   options
 }
 

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -652,11 +652,18 @@ knitr_options_hook <- function(options) {
     options[["yaml.code"]] <- results$yamlSource
     
   } else {
-    # convert any option with fig- into fig. and out- to out.
+    # from knitr 1.44 onwards the normalization is done at parsing time by knitr
+    # for all known options c(names(opts_chunk_attr), names(opts_chunk$get()))
+    # so normalization here should not be necessary anymore at some point
+    # TODO: remove normalization here in a few years 
+    #       when 1.44 is widely used version
     options <- normalize_options(options)
   }
 
   # some aliases not normalized
+  # from knitr 1.44, `fig.format` and `fig.dpi` are now alias 
+  # to `dev` and `dpi`
+  # TODO: remove below in a few years when 1.44 is widely used version
   if (!is.null(options[["fig-format"]])) {
     options[["dev"]] <- options[["fig-format"]]
   }
@@ -696,7 +703,14 @@ knitr_options_hook <- function(options) {
 # however we want to support all existing knitr code as well
 # as support all documented knitr chunk options without the user
 # needing to replace . with -
+# from knitr 1.44 onwards the normalization is done at parsing time by knitr
+# for all known options c(names(opts_chunk_attr), names(opts_chunk$get()))
+# so normalization here should not be necessary anymore at some point
+# TODO: remove normalization here in a few years 
+#       when 1.44 is widely used version
 normalize_options <- function(options) {
+  # TODO: knitr 1.44 store all known options as it does the normalization
+  #       they are in `c(names(opts_chunk_attr), names(opts_chunk$get()))`
   knitr_options_dashed <- c(
     # Text output 
     "strip-white",
@@ -771,7 +785,7 @@ normalize_options <- function(options) {
     # Other chunk options
     "R-options"
   )
-  # Un-normalized knitr options, and replace any existing options
+  # Un-normalize knitr options, and replace any existing options (e.g default one)
   for (name in knitr_options_dashed) {
     if (name %in% names(options)) {
       options[[gsub("-", ".", name)]] <- options[[name]]


### PR DESCRIPTION
Related to 
* https://github.com/quarto-dev/quarto-cli/issues/5852
* https://github.com/quarto-dev/quarto-cli/issues/6576

**knitr** 1.44 solves the above at 
* https://github.com/yihui/knitr/pull/2282 and other related commits. 

However, this PR offers a fix for users without 1.44 by correctly normalizing **and replacing** options. It correctly apply aliases also. 

This **knitr** 1.44 improvment is also now marked in comments so that we can consider cleaning the code in a few years when / if we consider that knitr 1.44 is old enough. 