### PR TITLE
Do not error if file not exist on Windows

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -169,3 +169,4 @@
 - ([#6487](https://github.com/quarto-dev/quarto-cli/discussions/6487)): Fix `serviceworkers` check in `htmlDependency` to look at the correct key.
 - ([#6178](https://github.com/quarto-dev/quarto-cli/pull/6178)): When `QUARTO_LOG_LEVEL=DEBUG`, information about search for a R binary will be shown.
 - ([#5755](https://github.com/quarto-dev/quarto-cli/pull/5755)): Allow document metadata to control conditional content.
+- ([#6697](https://github.com/quarto-dev/quarto-cli/pull/6697)): Fix issue with outputing to stdout (`quarto render <file> -o -`) on Windows.

--- a/src/command/render/render.ts
+++ b/src/command/render/render.ts
@@ -13,7 +13,11 @@ import { Document, parseHtml } from "../../core/deno-dom.ts";
 import { mergeConfigs } from "../../core/config.ts";
 import { resourcePath } from "../../core/resources.ts";
 import { inputFilesDir } from "../../core/render.ts";
-import { normalizePath, pathWithForwardSlashes } from "../../core/path.ts";
+import {
+  normalizePath,
+  pathWithForwardSlashes,
+  safeExistsSync,
+} from "../../core/path.ts";
 
 import { FormatPandoc } from "../../config/types.ts";
 import {
@@ -469,7 +473,7 @@ export function renderResultFinalOutput(
 
   // if the final output doesn't exist then we must have been targetin stdout,
   // so return undefined
-  if (!existsSync(finalOutput)) {
+  if (!safeExistsSync(finalOutput)) {
     return undefined;
   }
 

--- a/tests/smoke/project/project-stdout.test.ts
+++ b/tests/smoke/project/project-stdout.test.ts
@@ -36,9 +36,6 @@ testQuartoCmd(
       if (existsSync(siteOutDir)) {
         await Deno.remove(siteOutDir, { recursive: true });
       }
-    },
-    // TODO: Make the test works for Windows
-    // https://github.com/quarto-dev/quarto-cli/issues/4194
-    ignore: Deno.build.os == "windows",
+    }
   },
 );

--- a/tests/smoke/render/render-stdout.test.ts
+++ b/tests/smoke/render/render-stdout.test.ts
@@ -1,0 +1,18 @@
+/*
+* project-render.test.ts
+*
+* Copyright (C) 2020-2023 Posit Software, PBC
+*
+*/
+import { testQuartoCmd } from "../../test.ts";
+import { docs } from "../../utils.ts";
+import { noErrorsOrWarnings } from "../../verify.ts";
+
+const input = docs("minimal.qmd");
+
+testQuartoCmd(
+  "render",
+  [input, "-o", "-"],
+  [noErrorsOrWarnings],
+  {},
+);


### PR DESCRIPTION
using stdout as output, we create some path that do not exist and we test that. But on Windows, a safe version of `existSync` is need to return `false` and not error

closes #6690
