### PR TITLE
render jupyter percent scripts

### DIFF
--- a/src/core/jupyter/jupyter-fixups.ts
+++ b/src/core/jupyter/jupyter-fixups.ts
@@ -8,7 +8,7 @@ import { stringify } from "yaml/mod.ts";
 import { warning } from "log/mod.ts";
 
 import { kTitle } from "../../config/constants.ts";
-import { Metadata } from "../../publish/netlify/api/index.ts";
+import { Metadata } from "../../config/types.ts";
 import { lines } from "../lib/text.ts";
 import { markdownWithExtractedHeading } from "../pandoc/pandoc-partition.ts";
 import { partitionYamlFrontMatter, readYamlFromMarkdown } from "../yaml.ts";
@@ -135,17 +135,17 @@ export function fixupBokehCells(nb: JupyterNotebook): JupyterNotebook {
   return nb;
 }
 
-export function fixupFrontMatter(nb: JupyterNotebook): JupyterNotebook {
-  // helper to generate yaml
-  const asYamlText = (yaml: Metadata) => {
-    return stringify(yaml, {
-      indent: 2,
-      lineWidth: -1,
-      sortKeys: false,
-      skipInvalid: true,
-    });
-  };
+// helper to generate yaml
+export function asYamlText(yaml: Metadata) {
+  return stringify(yaml, {
+    indent: 2,
+    lineWidth: -1,
+    sortKeys: false,
+    skipInvalid: true,
+  });
+}
 
+export function fixupFrontMatter(nb: JupyterNotebook): JupyterNotebook {
   // helper to create nb lines (w/ newline after)
   const nbLines = (lns: string[]) => {
     return lns.map((line) => line.endsWith("\n") ? line : `${line}\n`);

--- a/src/core/lib/text.ts
+++ b/src/core/lib/text.ts
@@ -16,6 +16,36 @@ export function normalizeNewlines(text: string) {
   return lines(text).join("\n");
 }
 
+export function trimEmptyLines(
+  lines: string[],
+  trim: "leading" | "trailing" | "all" = "all",
+) {
+  // trim leading lines
+  if (trim === "all" || trim === "leading") {
+    const firstNonEmpty = lines.findIndex((line) => line.trim().length > 0);
+    if (firstNonEmpty === -1) {
+      return [];
+    }
+    lines = lines.slice(firstNonEmpty);
+  }
+
+  // trim trailing lines
+  if (trim === "all" || trim === "trailing") {
+    let lastNonEmpty = -1;
+    for (let i = lines.length - 1; i >= 0; i--) {
+      if (lines[i].trim().length > 0) {
+        lastNonEmpty = i;
+        break;
+      }
+    }
+    if (lastNonEmpty > -1) {
+      lines = lines.slice(0, lastNonEmpty + 1);
+    }
+  }
+
+  return lines;
+}
+
 // NB we can't use JS matchAll or replaceAll here because we need to support old
 // Chromium in the IDE
 //

--- a/src/execute/jupyter/jupyter.ts
+++ b/src/execute/jupyter/jupyter.ts
@@ -89,6 +89,11 @@ import { MappedString, mappedStringFromFile } from "../../core/mapped-text.ts";
 import { breakQuartoMd } from "../../core/lib/break-quarto-md.ts";
 import { ProjectContext } from "../../project/types.ts";
 import { isQmdFile } from "../qmd.ts";
+import {
+  isJupyterPercentScript,
+  kJupyterPercentScriptExtensions,
+  markdownFromJupyterPercentScript,
+} from "./percent.ts";
 
 export const jupyterEngine: ExecutionEngine = {
   name: kJupyterEngine,
@@ -117,10 +122,15 @@ export const jupyterEngine: ExecutionEngine = {
     }
   },
 
-  validExtensions: () => kJupyterNotebookExtensions.concat(kQmdExtensions),
+  validExtensions: () => [
+    ...kJupyterNotebookExtensions,
+    ...kJupyterPercentScriptExtensions,
+    ...kQmdExtensions,
+  ],
 
-  claimsExtension: (ext: string) => {
-    return kJupyterNotebookExtensions.includes(ext.toLowerCase());
+  claimsFile: (file: string, ext: string) => {
+    return kJupyterNotebookExtensions.includes(ext.toLowerCase()) ||
+      isJupyterPercentScript(file);
   },
 
   claimsLanguage: (_language: string) => {
@@ -136,11 +146,16 @@ export const jupyterEngine: ExecutionEngine = {
     // at some point we'll resolve a full notebook/kernelspec
     let nb: JupyterNotebook | undefined;
 
+    // cache check for percent script
+    const isPercentScript = isJupyterPercentScript(file);
+
     if (markdown === undefined) {
       if (isJupyterNotebook(file)) {
         const nbJSON = Deno.readTextFileSync(file);
         nb = JSON.parse(nbJSON) as JupyterNotebook;
         markdown = asMappedString(markdownFromNotebookJSON(nb));
+      } else if (isPercentScript) {
+        markdown = asMappedString(markdownFromJupyterPercentScript(file));
       } else {
         markdown = asMappedString(mappedStringFromFile(file));
       }
@@ -150,7 +165,7 @@ export const jupyterEngine: ExecutionEngine = {
     const metadata = readYamlFromMarkdown(markdown.value);
 
     // if this is a text markdown file then create a notebook for use as the execution target
-    if (isQmdFile(file)) {
+    if (isQmdFile(file) || isPercentScript) {
       // write a transient notebook
       const [fileDir, fileStem] = dirAndStem(file);
       const notebook = join(fileDir, fileStem + ".ipynb");
@@ -163,7 +178,6 @@ export const jupyterEngine: ExecutionEngine = {
       };
       nb = await createNotebookforTarget(target, project);
       target.data.kernelspec = nb.metadata.kernelspec;
-
       return target;
     } else if (isJupyterNotebook(file)) {
       return {
@@ -181,6 +195,8 @@ export const jupyterEngine: ExecutionEngine = {
   partitionedMarkdown: async (file: string, format?: Format) => {
     if (isJupyterNotebook(file)) {
       return partitionMarkdown(await markdownFromNotebookFile(file, format));
+    } else if (isJupyterPercentScript(file)) {
+      return partitionMarkdown(markdownFromJupyterPercentScript(file));
     } else {
       return partitionMarkdown(Deno.readTextFileSync(file));
     }
@@ -234,7 +250,11 @@ export const jupyterEngine: ExecutionEngine = {
   execute: async (options: ExecuteOptions): Promise<ExecuteResult> => {
     // create the target input if we need to (could have been removed
     // by the cleanup step of another render in this invocation)
-    if (isQmdFile(options.target.source) && !existsSync(options.target.input)) {
+    if (
+      (isQmdFile(options.target.source) ||
+        isJupyterPercentScript(options.target.source)) &&
+      !existsSync(options.target.input)
+    ) {
       await createNotebookforTarget(options.target);
     }
 
@@ -418,7 +438,10 @@ export const jupyterEngine: ExecutionEngine = {
     if (!isJupyterNotebook(input) && !input.endsWith(`.${kJupyterEngine}.md`)) {
       files.push(join(fileDir, fileStem + ".ipynb"));
     } else if (
-      isJupyterNotebook(input) && existsSync(join(fileDir, fileStem + ".qmd"))
+      isJupyterNotebook(input) &&
+      [...kQmdExtensions, ...kJupyterPercentScriptExtensions].some((ext) => {
+        return existsSync(join(fileDir, fileStem + ext));
+      })
     ) {
       files.push(input);
     }

--- a/src/execute/jupyter/percent.ts
+++ b/src/execute/jupyter/percent.ts
@@ -1,0 +1,133 @@
+/*
+ * percent.ts
+ *
+ * Copyright (C) 2020-202 Posit Software, PBC
+ */
+
+import { extname } from "path/mod.ts";
+
+import { lines } from "../../core/text.ts";
+import { trimEmptyLines } from "../../core/lib/text.ts";
+import { Metadata } from "../../config/types.ts";
+import { asYamlText } from "../../core/jupyter/jupyter-fixups.ts";
+import { pandocAttrKeyvalueFromText } from "../../core/pandoc/pandoc-attr.ts";
+import { kCellRawMimeType } from "../../config/constants.ts";
+import { mdFormatOutput, mdRawOutput } from "../../core/jupyter/jupyter.ts";
+
+export const kJupyterPercentScriptExtensions = [
+  ".py",
+  ".jl",
+  ".r",
+];
+
+export function isJupyterPercentScript(file: string) {
+  const ext = extname(file).toLowerCase();
+  if (kJupyterPercentScriptExtensions.includes(ext)) {
+    const text = Deno.readTextFileSync(file);
+    return !!text.match(/^\s*#\s*%%+\s+\[markdown|raw\]/);
+  } else {
+    return false;
+  }
+}
+
+export function markdownFromJupyterPercentScript(file: string) {
+  // determine language/kernel
+  const ext = extname(file).toLowerCase();
+  const language = ext === ".jl" ? "julia" : ext === ".r" ? "r" : "python";
+
+  // break into cells
+  const cells: PercentCell[] = [];
+  const activeCell = () => cells[cells.length - 1];
+  for (const line of lines(Deno.readTextFileSync(file).trim())) {
+    const header = percentCellHeader(line);
+    if (header) {
+      cells.push({ header, lines: [] });
+    } else {
+      activeCell()?.lines.push(line);
+    }
+  }
+
+  // resolve markdown and raw cells
+  const isTripleQuote = (line: string) => !!line.match(/^"{3,}\s*$/);
+  const asCell = (lines: string[]) => lines.join("\n") + "\n\n";
+  const stripPrefix = (line: string) => line.replace(/^#\s?/, "");
+  const cellContent = (cellLines: string[]) => {
+    if (
+      cellLines.length > 2 && isTripleQuote(cellLines[0]) &&
+      isTripleQuote(cellLines[cellLines.length - 1])
+    ) {
+      return asCell(cellLines.slice(1, cellLines.length - 1));
+    } else {
+      // commented
+      return asCell(cellLines.map(stripPrefix));
+    }
+  };
+
+  return cells.reduce((markdown, cell) => {
+    const cellLines = trimEmptyLines(cell.lines);
+    if (cell.header.type === "code") {
+      if (cell.header.metadata) {
+        const yamlText = asYamlText(cell.header.metadata);
+        cellLines.unshift(...lines(yamlText).map((line) => `#| ${line}`));
+      }
+      markdown += asCell(["```{" + language + "}", ...cellLines, "```"]);
+    } else if (cell.header.type === "markdown") {
+      markdown += cellContent(cellLines);
+    } else if (cell.header.type == "raw") {
+      let rawContent = cellContent(cellLines);
+      const format = cell.header?.metadata?.["format"];
+      const mimeType = cell.header.metadata?.[kCellRawMimeType];
+      if (typeof (mimeType) === "string") {
+        const rawBlock = mdRawOutput(mimeType, lines(rawContent));
+        rawContent = rawBlock || rawContent;
+      } else if (typeof (format) === "string") {
+        rawContent = mdFormatOutput(format, lines(rawContent));
+      }
+      markdown += rawContent;
+    }
+    return markdown;
+  }, "");
+}
+
+interface PercentCell {
+  header: PercentCellHeader;
+  lines: string[];
+}
+
+interface PercentCellHeader {
+  type: "code" | "raw" | "markdown";
+  metadata?: Metadata;
+}
+
+function percentCellHeader(line: string): PercentCellHeader | undefined {
+  const match = line.match(
+    /^\s*#\s*%%+\s*(?:\[(markdown|raw)\])?\s*(.*)?$/,
+  );
+  if (match) {
+    const type = match[1] || "code";
+    const attribs = match[2] || "";
+    if (["code", "raw", "markdown"].includes(type)) {
+      return {
+        type,
+        metadata: parsePercentAttribs(attribs),
+      } as PercentCellHeader;
+    } else {
+      throw new Error(`Invalid cell type: ${type}`);
+    }
+  }
+}
+
+function parsePercentAttribs(
+  attribs: string,
+): Metadata | undefined {
+  // skip over title
+  const match = attribs.match(/[\w\-]+=.*$/);
+  if (match) {
+    const keyValue = pandocAttrKeyvalueFromText(match[0], " ");
+    const metadata: Metadata = {};
+    keyValue.forEach((value) => {
+      metadata[value[0]] = value[1];
+    });
+    return metadata;
+  }
+}

--- a/src/execute/markdown.ts
+++ b/src/execute/markdown.ts
@@ -1,9 +1,8 @@
 /*
-* markdown.ts
-*
-* Copyright (C) 2020-2022 Posit Software, PBC
-*
-*/
+ * markdown.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
 
 import { extname } from "path/mod.ts";
 
@@ -36,7 +35,7 @@ export const markdownEngine: ExecutionEngine = {
 
   validExtensions: () => kQmdExtensions.concat(kMdExtensions),
 
-  claimsExtension: (ext: string) => {
+  claimsFile: (_file: string, ext: string) => {
     return kMdExtensions.includes(ext.toLowerCase());
   },
   claimsLanguage: (_language: string) => {

--- a/src/execute/rmd.ts
+++ b/src/execute/rmd.ts
@@ -57,7 +57,7 @@ export const knitrEngine: ExecutionEngine = {
 
   validExtensions: () => kRmdExtensions.concat(kRmdExtensions),
 
-  claimsExtension: (ext: string) => {
+  claimsFile: (_file: string, ext: string) => {
     return kRmdExtensions.includes(ext.toLowerCase());
   },
 

--- a/src/execute/types.ts
+++ b/src/execute/types.ts
@@ -28,7 +28,7 @@ export interface ExecutionEngine {
   defaultYaml: (kernel?: string) => string[];
   defaultContent: (kernel?: string) => string[];
   validExtensions: () => string[];
-  claimsExtension: (ext: string) => boolean;
+  claimsFile: (file: string, ext: string) => boolean;
   claimsLanguage: (language: string) => boolean;
   target: (
     file: string,

--- a/src/project/project-index.ts
+++ b/src/project/project-index.ts
@@ -4,8 +4,7 @@
  * Copyright (C) 2020-2022 Posit Software, PBC
  */
 
-import { basename, dirname, isAbsolute, join, relative } from "path/mod.ts";
-import { existsSync } from "fs/mod.ts";
+import { dirname, isAbsolute, join, relative } from "path/mod.ts";
 
 import * as ld from "../core/lodash.ts";
 


### PR DESCRIPTION
This PR implements support for rendering Jupyter percent scripts, which are a convention for encoding a notebook within an ordinary script file. For example, consider the following `notebook.py`:

```python
# %% [markdown]
# Some **markdown**

# %%
1 + 1
```

You can also include markdown inside a multi-line quote. For example:

```python
# %% [markdown]
"""
Some **markdown**
"""
```


Jupyter percent scripts are currently supported by a wide variety of tools including VS Code, Visual Studio, PyCharm, Spyder, and Hydrogen. See the Jupytext documentation on percent scripts for additional details: https://jupytext.readthedocs.io/en/latest/formats-scripts.html

This PR implements support for Python, Julia, and R. There is now a `claimsFile()` method on engines (which replaces `claimsExtension()`) that is used to determine if a script should be targeted as a percent script. 

@cderv It would be great if you could add comparable support for Knitr `spin()` using the `claimsFile()` method (which will need to look inside the R script to see if it uses `spin()` conventions).

@pankgeorg Once this lands you can update your Pluto engine to implement `claimsFile()` (you'll want to look inside the file to detect whether it is a Pluto notebook)

