### PR TITLE
initial work on pandoc 3.1.7

### DIFF
--- a/configuration
+++ b/configuration
@@ -10,7 +10,7 @@
 # Binary dependencies
 export DENO=v1.33.4
 export DENO_DOM=v0.1.35-alpha-artifacts
-export PANDOC=3.1.6.2
+export PANDOC=3.1.7
 export DARTSASS=1.55.0
 export ESBUILD=0.18.15
 export TYPST=0.7.0

--- a/src/resources/filters/crossref/equations.lua
+++ b/src/resources/filters/crossref/equations.lua
@@ -46,7 +46,13 @@ function process_equations(blockEl)
         if _quarto.format.isLatexOutput() then
           targetInlines:insert(pandoc.RawInline("latex", "\\begin{equation}"))
           targetInlines:insert(pandoc.Span(pandoc.RawInline("latex", eq.text), pandoc.Attr(label)))
-          targetInlines:insert(pandoc.RawInline("latex", "\\label{" .. label .. "}\\end{equation}"))
+
+          -- Pandoc 3.1.7 started outputting a shadow section with a label as a link target
+          -- which would result in two identical labels being emitted.
+          -- https://github.com/jgm/pandoc/issues/9045
+          -- https://github.com/lierdakil/pandoc-crossref/issues/402
+          targetInlines:insert(pandoc.RawInline("latex", "\\end{equation}"))
+          
         elseif _quarto.format.isTypstOutput() then
           targetInlines:insert(pandoc.RawInline("typst", 
             "#set math.equation(numbering: \"(" .. inlinesToString(numberOption("eq", order)) .. ")\"); " ..

--- a/src/resources/formats/pdf/pandoc/citations.tex
+++ b/src/resources/formats/pdf/pandoc/citations.tex
@@ -1,22 +1,26 @@
 $if(csl-refs)$
+% definitions for citeproc citations
+\NewDocumentCommand\citeproctext{}{}
+\NewDocumentCommand\citeproc{mm}{%
+  \begingroup\def\citeproctext{#2}\cite{#1}\endgroup}
+% avoid brackets around text for \cite:
+\makeatletter
+ \def\@biblabel#1{}
+ \def\@cite#1#2{{#1\if@tempswa , #2\fi}}
+\makeatother
 \newlength{\cslhangindent}
 \setlength{\cslhangindent}{1.5em}
 \newlength{\csllabelwidth}
 \setlength{\csllabelwidth}{3em}
-\newlength{\cslentryspacingunit} % times entry-spacing
-\setlength{\cslentryspacingunit}{\parskip}
-\newenvironment{CSLReferences}[2] % #1 hanging-ident, #2 entry spacing
- {% don't indent paragraphs
-  \setlength{\parindent}{0pt}
-  % turn on hanging indent if param 1 is 1
-  \ifodd #1
-  \let\oldpar\par
-  \def\par{\hangindent=\cslhangindent\oldpar}
-  \fi
-  % set entry spacing
-  \setlength{\parskip}{#2\cslentryspacingunit}
- }%
- {}
+\newlength{\cslentryspacing}
+\setlength{\cslentryspacing}{0em}
+\usepackage{enumitem}
+\newlist{CSLReferences}{itemize}{1}
+\setlist[CSLReferences]{label={},
+  leftmargin=\cslhangindent,
+  itemindent=-1\cslhangindent,
+  parsep=\parskip,
+  itemsep=\cslentryspacing}
 \usepackage{calc}
 \newcommand{\CSLBlock}[1]{#1\hfill\break}
 \newcommand{\CSLLeftMargin}[1]{\parbox[t]{\csllabelwidth}{#1}}

--- a/src/resources/formats/pdf/pandoc/latex.template
+++ b/src/resources/formats/pdf/pandoc/latex.template
@@ -297,6 +297,13 @@ $-- also used for underline
   \usepackage[soul]{lua-ul}
 \else
   \usepackage{soul}
+$if(CJKmainfont)$
+  \ifXeTeX
+    % soul's \st doesn't work for CJK:
+    \usepackage{xeCJKfntef}
+    \renewcommand{\st}[1]{\sout{#1}}
+  \fi
+$endif$
 \fi
 $endif$
 \setlength{\emergencystretch}{3em} % prevent overfull lines
@@ -328,24 +335,28 @@ $if(pagestyle)$
 \pagestyle{$pagestyle$}
 $endif$
 $if(csl-refs)$
+% definitions for citeproc citations
+\NewDocumentCommand\citeproctext{}{}
+\NewDocumentCommand\citeproc{mm}{%
+  \begingroup\def\citeproctext{#2}\cite{#1}\endgroup}
+% avoid brackets around text for \cite:
+\makeatletter
+ \def\@biblabel#1{}
+ \def\@cite#1#2{{#1\if@tempswa , #2\fi}}
+\makeatother
 \newlength{\cslhangindent}
 \setlength{\cslhangindent}{1.5em}
 \newlength{\csllabelwidth}
 \setlength{\csllabelwidth}{3em}
-\newlength{\cslentryspacingunit} % times entry-spacing
-\setlength{\cslentryspacingunit}{\parskip}
-\newenvironment{CSLReferences}[2] % #1 hanging-ident, #2 entry spacing
- {% don't indent paragraphs
-  \setlength{\parindent}{0pt}
-  % turn on hanging indent if param 1 is 1
-  \ifodd #1
-  \let\oldpar\par
-  \def\par{\hangindent=\cslhangindent\oldpar}
-  \fi
-  % set entry spacing
-  \setlength{\parskip}{#2\cslentryspacingunit}
- }%
- {}
+\newlength{\cslentryspacing}
+\setlength{\cslentryspacing}{0em}
+\usepackage{enumitem}
+\newlist{CSLReferences}{itemize}{1}
+\setlist[CSLReferences]{label={},
+  leftmargin=\cslhangindent,
+  itemindent=-1\cslhangindent,
+  parsep=\parskip,
+  itemsep=\cslentryspacing}
 \usepackage{calc}
 \newcommand{\CSLBlock}[1]{#1\hfill\break}
 \newcommand{\CSLLeftMargin}[1]{\parbox[t]{\csllabelwidth}{#1}}

--- a/src/resources/formats/pdf/pandoc/template.tex
+++ b/src/resources/formats/pdf/pandoc/template.tex
@@ -239,6 +239,13 @@ $-- also used for underline
   \usepackage[soul]{lua-ul}
 \else
   \usepackage{soul}
+$if(CJKmainfont)$
+\ifXeTeX
+  % soul's \st doesn't work for CJK:
+  \usepackage{xeCJKfntef}
+  \renewcommand{\st}[1]{\sout{#1}}
+\fi
+$endif$  
 \fi
 $endif$
 \setlength{\emergencystretch}{3em} % prevent overfull lines

--- a/tests/docs/extensions/format/academic/_extensions/quarto-journals/elsevier/_extension.yml
+++ b/tests/docs/extensions/format/academic/_extensions/quarto-journals/elsevier/_extension.yml
@@ -4,7 +4,7 @@ contributes:
     common:
       date-format: full
     pdf:
-      citation-package: natbib
+      cite-method: natbib
       template-partials:
         [before-body.tex, doc-class.tex, title.tex, elsarticle.cls]
       classoption: preprint, 3p, authoryear

--- a/tests/docs/templates/elsevier/document.qmd
+++ b/tests/docs/templates/elsevier/document.qmd
@@ -56,7 +56,7 @@ bibliography: mybibfile.bib
 format:
   pdf:
     keep-tex: false
-    citation-package: natbib
+    cite-method: natbib
     template-partials: [before-body.tex, doc-class.tex, title.tex]
     classoption: preprint, 3p, authoryear
     number-sections: true


### PR DESCRIPTION
Update to Pandoc 3.1.7.

Template changes were simple and safe and exposed a bug in a couple tests which were trying to set `cite-method` and using incorrect keys.

Pandoc behavior for hyperlinking now emits `phantomsection` with a `label` as a link target, which results in duplicate labels for equations. That is fixed in `equations.lua` and is something I'd appreciate a second, better informed set of eyes (@cscheid). (see <https://github.com/jgm/pandoc/issues/9045>)