### PR TITLE
Import patch from conda-forge to a new quarto-bld command

### DIFF
--- a/package/src/bld.ts
+++ b/package/src/bld.ts
@@ -105,7 +105,7 @@ function getCommands() {
   );
   commands.push(
     packageCommand(makeInstallerExternal)
-      .name("install-external")
+      .name("prepare-external")
       .description("Installs Quarto-only files (no dependencies) to specified location"),
   );
   commands.push(

--- a/package/src/bld.ts
+++ b/package/src/bld.ts
@@ -16,6 +16,7 @@ import {
   compileQuartoLatexmkCommand,
 } from "./common/compile-quarto-latexmk.ts";
 import { makeInstallerWindows } from "./windows/installer.ts";
+import { makeInstallerExternal } from "./external/installer.ts";
 
 import { appendLogOptions } from "../../src/core/log.ts";
 import {
@@ -101,6 +102,11 @@ function getCommands() {
     packageCommand(makeInstallerWindows)
       .name("make-installer-win")
       .description("Builds Windows installer"),
+  );
+  commands.push(
+    packageCommand(makeInstallerExternal)
+      .name("install-external")
+      .description("Installs Quarto-only files (no dependencies) to specified location"),
   );
   commands.push(
     compileQuartoLatexmkCommand(),

--- a/package/src/external/README.md
+++ b/package/src/external/README.md
@@ -1,0 +1,4 @@
+Scripts in this folder are intended for use by external package managers, such as Conda.
+The intention is that the packaging process consists of only the minimal quarto files, and
+not any of the vendored dependencies. No packages are created by this process. Instead,
+files are put in a user-specified location such that an external packaging tool will bundle them.

--- a/package/src/external/installer.ts
+++ b/package/src/external/installer.ts
@@ -1,0 +1,30 @@
+/*
+* installer.ts
+*
+* Copyright (C) 2020-2022 Posit Software, PBC
+*
+*/
+import { join } from "path/mod.ts";
+import { copySync } from "fs/copy.ts";
+import { info } from "log/mod.ts";
+
+import { Configuration } from "../common/config.ts";
+
+export async function makeInstallerExternal(
+  configuration: Configuration,
+) {
+  info("Copying Quarto files...");
+
+  // It's expected that the external build tool will set QUARTO_DIST_PATH.
+  const workingBinPath = join(configuration.directoryInfo.dist, "bin");
+  copySync(configuration.directoryInfo.pkgWorking.bin, workingBinPath, {
+    overwrite: true,
+  });
+
+  // The assumption here is that you're installing to a shared location. The probability of a namespace conflict is pretty high.
+  // Thus, we nest the share contents in a quarto folder. At runtime, the QUARTO_SHARE_PATH env var accounts for this.
+  const workingSharePath = join( configuration.directoryInfo.dist, "share", "quarto");
+  copySync(configuration.directoryInfo.pkgWorking.share, workingSharePath, {
+    overwrite: true,
+  });
+}


### PR DESCRIPTION
From this commit version: https://github.com/conda-forge/quarto-feedstock/blob/56a863345810f5a53a19c5016dfc3fe953072f4d/recipe/patches/0001-add-external-installer-command-for-packagers-like-co.patch

This closes #6575 for https://github.com/conda-forge/quarto-feedstock/issues/27

@mfisher87 would you be able to try the PR ? 

@dragonstyle I put you as review on this for your insight. Also should we test it in our test suite ?
