### PR TITLE
Reactivate failling test for Pandoc 3.1.7

### DIFF
--- a/tests/smoke/manuscript/render-manuscript.test.ts
+++ b/tests/smoke/manuscript/render-manuscript.test.ts
@@ -31,36 +31,30 @@ testManuscriptRender(
   ipynbSingleOutputs,
 );
 
-// deactivate this test for now while pandoc 3.1.6.2 is used
-// See https://github.com/quarto-dev/quarto-cli/pull/6617#issuecomment-1695570171
-// Next Pandoc version will fix it 
-// TODO: reactivate for next pandoc version
-if (false) { 
-  const ipynbFullArticle = docs("manuscript/ipynb-full/article.ipynb");
-  const ipynbFullOutputs = [
-    "article-meca.zip",
-    "data/catalogoComunSV_1663233588717.csv",
-    "data/lapalma_ign.csv",
-    "images/la-palma-map.png",
-    "images/reservoirs.png",
-    "images/stations.png",
-    "notebooks/data-screening.ipynb",
-    "notebooks/data-screening-preview.html",
-    "notebooks/data-screening.out.ipynb",
-    "notebooks/seismic-monitoring-stations.out.ipynb",
-    "notebooks/seismic-monitoring-stations.qmd",
-    "notebooks/seismic-monitoring-stations-preview.html",
-    "notebooks/visualization-figure-creation-seaborn.ipynb",
-    "notebooks/visualization-figure-creation-seaborn-preview.html",
-    "notebooks/visualization-figure-creation-seaborn.out.ipynb",
-  ];
-  testManuscriptRender(
-    ipynbFullArticle,
-    "all",
-    ["html", "jats", "docx", "pdf"],
-    ipynbFullOutputs,
-  );
-}
+const ipynbFullArticle = docs("manuscript/ipynb-full/article.ipynb");
+const ipynbFullOutputs = [
+  "article-meca.zip",
+  "data/catalogoComunSV_1663233588717.csv",
+  "data/lapalma_ign.csv",
+  "images/la-palma-map.png",
+  "images/reservoirs.png",
+  "images/stations.png",
+  "notebooks/data-screening.ipynb",
+  "notebooks/data-screening-preview.html",
+  "notebooks/data-screening.out.ipynb",
+  "notebooks/seismic-monitoring-stations.out.ipynb",
+  "notebooks/seismic-monitoring-stations.qmd",
+  "notebooks/seismic-monitoring-stations-preview.html",
+  "notebooks/visualization-figure-creation-seaborn.ipynb",
+  "notebooks/visualization-figure-creation-seaborn-preview.html",
+  "notebooks/visualization-figure-creation-seaborn.out.ipynb",
+];
+testManuscriptRender(
+  ipynbFullArticle,
+  "all",
+  ["html", "jats", "docx", "pdf"],
+  ipynbFullOutputs,
+);
 
 const qmdSingleArticle = docs("manuscript/qmd-single/index.qmd");
 const qmdSingleOutputs = [


### PR DESCRIPTION
Revert "Deactivate manuscript test that fails with Pandoc 3.1.6.2 waiting for next Pandoc version with fix"

This reverts commit 44389a3b3e473f507651132631c2dd1e72dabdda as now Quarto uses Pandoc 3.1.7 (#6729)


