### PR TITLE
add content_category to create output/revision API calls to Posit Cloud

### DIFF
--- a/src/publish/common/bundle.ts
+++ b/src/publish/common/bundle.ts
@@ -14,6 +14,29 @@ import { PublishFiles } from "../provider-types.ts";
 import { TempContext } from "../../core/temp-types.ts";
 import { md5HashBytes } from "../../core/hash.ts";
 
+interface ManifestMetadata {
+  appmode: string;
+  primary_rmd: string | null;
+  primary_html: string;
+  content_category: string | null;
+  has_parameters: boolean;
+}
+
+interface Manifest {
+  version: number;
+  locale: string;
+  platform: string;
+  metadata: ManifestMetadata;
+  packages: null;
+  files: Record<string, { checksum: string }>;
+  users: null;
+}
+
+export interface BundleData {
+  bundlePath: string;
+  manifest: Manifest;
+}
+
 /** Creates a compressed bundle file in the format required by Posit Connect and Cloud.
  * @param type Whether this is a site or document.
  * @param files Information on what should be included in the bundle.
@@ -24,7 +47,7 @@ export async function createBundle(
   type: "site" | "document",
   files: PublishFiles,
   tempContext: TempContext,
-): Promise<string> {
+): Promise<BundleData> {
   // create file md5 checksums
   const manifestFiles: Record<string, { checksum: string }> = {};
   for (const file of files.files) {
@@ -95,5 +118,8 @@ export async function createBundle(
     .pipeTo(dest.writable);
 
   // return tar.gz
-  return targzFile;
+  return {
+    bundlePath: targzFile,
+    manifest,
+  };
 }

--- a/src/publish/posit-cloud/api/index.ts
+++ b/src/publish/posit-cloud/api/index.ts
@@ -55,6 +55,7 @@ export class PositCloudClient {
     name: string,
     spaceId: number | null,
     projectId: number | null,
+    contentCategory: string | null,
   ): Promise<Content> {
     return this.post<Content>(
       "outputs",
@@ -63,6 +64,7 @@ export class PositCloudClient {
         application_type: "static",
         space: spaceId,
         project: projectId,
+        content_category: contentCategory,
       }),
     );
   }
@@ -93,8 +95,13 @@ export class PositCloudClient {
     return this.get<Task>(`tasks/${id}`, { legacy: "false" });
   }
 
-  public createRevision(outputId: number) {
-    return this.post<OutputRevision>(`outputs/${outputId}/revisions`);
+  public createRevision(outputId: number, contentCategory: string | null) {
+    return this.post<OutputRevision>(
+      `outputs/${outputId}/revisions`,
+      JSON.stringify({
+        content_category: contentCategory,
+      }),
+    );
   }
 
   public getContent(id: number | string): Promise<Content> {

--- a/src/publish/rsconnect/rsconnect.ts
+++ b/src/publish/rsconnect/rsconnect.ts
@@ -254,8 +254,12 @@ async function publish(
     await withSpinner({
       message: () => `Uploading files`,
     }, async () => {
-      const bundleTargz = await createBundle(type, publishFiles, tempContext);
-      const bundleBytes = Deno.readFileSync(bundleTargz);
+      const { bundlePath } = await createBundle(
+        type,
+        publishFiles,
+        tempContext,
+      );
+      const bundleBytes = Deno.readFileSync(bundlePath);
       const bundleBlob = new Blob([bundleBytes.buffer]);
       const bundle = await client.uploadBundle(target!.id, bundleBlob);
       task = await client.deployBundle(bundle);


### PR DESCRIPTION
Posit Cloud needs `content_category` in these API calls to populate the category at entity creation time instead of when we unpack the bundle.