### PR TITLE
fix: Add missing CC licences and display CC code instead of URL

### DIFF
--- a/src/format/html/format-html-appendix.ts
+++ b/src/format/html/format-html-appendix.ts
@@ -187,15 +187,12 @@ export async function processDocumentAppendix(
           if (typeof license === "string") {
             const creativeCommons = creativeCommonsLicense(license);
             if (creativeCommons) {
-              const licenseUrl = creativeCommonsUrl(
+              const licenseUrlInfo = creativeCommonsUrl(
                 creativeCommons.base,
                 format.metadata[kLang] as string | undefined,
                 creativeCommons.version,
               );
-              return {
-                url: licenseUrl,
-                text: creativeCommons.base + " " + creativeCommons.version,
-              };
+              return licenseUrlInfo;
             } else {
               return { text: license };
             }
@@ -462,15 +459,13 @@ function creativeCommonsUrl(license: string, lang?: string, version?: string) {
         `https://creativecommons.org/licenses/${licenseType.toLowerCase()}/${version}/deed.${
           lang.toLowerCase().replace("-", "_")
         }`,
-      text:
-        `https://creativecommons.org/licenses/${licenseType.toLowerCase()}/${version}/`,
+      text: `CC ${licenseType} ${version}`,
     };
   } else {
     return {
       url:
         `https://creativecommons.org/licenses/${licenseType.toLowerCase()}/${version}/`,
-      text:
-        `https://creativecommons.org/licenses/${licenseType.toLowerCase()}/${version}/`,
+      text: `CC ${licenseType} ${version}`,
     };
   }
 }

--- a/src/format/html/format-html-appendix.ts
+++ b/src/format/html/format-html-appendix.ts
@@ -41,6 +41,8 @@ const kAppendixCreativeCommonsLic = [
   "CC BY-SA",
   "CC BY-ND",
   "CC BY-NC",
+  "CC BY-NC-SA",
+  "CC BY-NC-ND",
 ];
 
 const kStylePlain = "plain";
@@ -182,7 +184,7 @@ export async function processDocumentAppendix(
         //
         // this will allow us to not include the following code.
         const normalizedLicense = (license: unknown) => {
-          if (typeof (license) === "string") {
+          if (typeof license === "string") {
             const creativeCommons = creativeCommonsLicense(license);
             if (creativeCommons) {
               const licenseUrl = creativeCommonsUrl(
@@ -192,7 +194,7 @@ export async function processDocumentAppendix(
               );
               return {
                 url: licenseUrl,
-                text: licenseUrl,
+                text: creativeCommons.base + " " + creativeCommons.version,
               };
             } else {
               return { text: license };
@@ -242,7 +244,7 @@ export async function processDocumentAppendix(
       //
       // this will allow us to not include the following code.
       const normalizedCopyright = (copyright: unknown) => {
-        if (typeof (copyright) === "string") {
+        if (typeof copyright === "string") {
           return copyright;
         } else if (copyright) {
           return (copyright as { statement?: string }).statement;

--- a/src/format/html/format-html-appendix.ts
+++ b/src/format/html/format-html-appendix.ts
@@ -434,7 +434,13 @@ function creativeCommonsLicense(
       const version = match[2];
       if (kAppendixCreativeCommonsLic.includes(base)) {
         return {
-          base: base as "CC BY" | "CC BY-SA" | "CC BY-ND" | "CC BY-NC",
+          base: base as
+            | "CC BY"
+            | "CC BY-SA"
+            | "CC BY-ND"
+            | "CC BY-NC"
+            | "CC BY-NC-ND"
+            | "CC BY-NC-SA",
           version: version || "4.0",
         };
       } else {

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -20350,10 +20350,120 @@ var require_yaml_intelligence_resources = __commonJS({
         "Information about the funding of the research reported in the article\n(for example, grants, contracts, sponsors) and any open access fees for\nthe article itself",
         "Displayable prose statement that describes the funding for the\nresearch on which a work was based.",
         "Open access provisions that apply to a work or the funding\ninformation that provided the open access provisions.",
-        "Information about awards associated with this funding.",
+        "Unique identifier assigned to an award, contract, or grant.",
+        "The name of this award",
+        "The description for this award.",
+        "Agency or organization that funded the research on which a work was\nbased.",
+        "The text describing the source of the funding.",
+        {
+          short: "Abbreviation for country where source of grant is located.",
+          long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+        },
+        "The text describing the source of the funding.",
+        {
+          short: "Abbreviation for country where source of grant is located.",
+          long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+        },
+        "Individual(s) or institution(s) to whom the award was given (for\nexample, the principal grant holder or the sponsored individual).",
+        "The id of an author or affiliation in the document metadata.",
+        "The name of an individual that was the recipient of the funding.",
+        "The institution that was the recipient of the funding.",
+        "The id of an author or affiliation in the document metadata.",
+        "The name of an individual that was the recipient of the funding.",
+        "The institution that was the recipient of the funding.",
+        "Individual(s) responsible for the intellectual content of the work\nreported in the document.",
+        "The id of an author or affiliation in the document metadata.",
+        "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+        "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
+        "The id of an author or affiliation in the document metadata.",
+        "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+        "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
+        "Unique identifier assigned to an award, contract, or grant.",
+        "The name of this award",
+        "The description for this award.",
+        "Agency or organization that funded the research on which a work was\nbased.",
+        "The text describing the source of the funding.",
+        {
+          short: "Abbreviation for country where source of grant is located.",
+          long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+        },
+        "The text describing the source of the funding.",
+        {
+          short: "Abbreviation for country where source of grant is located.",
+          long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+        },
+        "Individual(s) or institution(s) to whom the award was given (for\nexample, the principal grant holder or the sponsored individual).",
+        "The id of an author or affiliation in the document metadata.",
+        "The name of an individual that was the recipient of the funding.",
+        "The institution that was the recipient of the funding.",
+        "The id of an author or affiliation in the document metadata.",
+        "The name of an individual that was the recipient of the funding.",
+        "The institution that was the recipient of the funding.",
+        "Individual(s) responsible for the intellectual content of the work\nreported in the document.",
+        "The id of an author or affiliation in the document metadata.",
+        "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+        "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
+        "The id of an author or affiliation in the document metadata.",
+        "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+        "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
         "Displayable prose statement that describes the funding for the\nresearch on which a work was based.",
         "Open access provisions that apply to a work or the funding\ninformation that provided the open access provisions.",
-        "Information about awards associated with this funding.",
+        "Unique identifier assigned to an award, contract, or grant.",
+        "The name of this award",
+        "The description for this award.",
+        "Agency or organization that funded the research on which a work was\nbased.",
+        "The text describing the source of the funding.",
+        {
+          short: "Abbreviation for country where source of grant is located.",
+          long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+        },
+        "The text describing the source of the funding.",
+        {
+          short: "Abbreviation for country where source of grant is located.",
+          long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+        },
+        "Individual(s) or institution(s) to whom the award was given (for\nexample, the principal grant holder or the sponsored individual).",
+        "The id of an author or affiliation in the document metadata.",
+        "The name of an individual that was the recipient of the funding.",
+        "The institution that was the recipient of the funding.",
+        "The id of an author or affiliation in the document metadata.",
+        "The name of an individual that was the recipient of the funding.",
+        "The institution that was the recipient of the funding.",
+        "Individual(s) responsible for the intellectual content of the work\nreported in the document.",
+        "The id of an author or affiliation in the document metadata.",
+        "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+        "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
+        "The id of an author or affiliation in the document metadata.",
+        "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+        "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
+        "Unique identifier assigned to an award, contract, or grant.",
+        "The name of this award",
+        "The description for this award.",
+        "Agency or organization that funded the research on which a work was\nbased.",
+        "The text describing the source of the funding.",
+        {
+          short: "Abbreviation for country where source of grant is located.",
+          long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+        },
+        "The text describing the source of the funding.",
+        {
+          short: "Abbreviation for country where source of grant is located.",
+          long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+        },
+        "Individual(s) or institution(s) to whom the award was given (for\nexample, the principal grant holder or the sponsored individual).",
+        "The id of an author or affiliation in the document metadata.",
+        "The name of an individual that was the recipient of the funding.",
+        "The institution that was the recipient of the funding.",
+        "The id of an author or affiliation in the document metadata.",
+        "The name of an individual that was the recipient of the funding.",
+        "The institution that was the recipient of the funding.",
+        "Individual(s) responsible for the intellectual content of the work\nreported in the document.",
+        "The id of an author or affiliation in the document metadata.",
+        "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+        "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
+        "The id of an author or affiliation in the document metadata.",
+        "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+        "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
         {
           short: "Format to write to (e.g.&nbsp;html)",
           long: "Format to write to. Extensions can be individually enabled or\ndisabled by appending +EXTENSION or -EXTENSION to the format name\n(e.g.&nbsp;gfm+footnotes)"
@@ -20569,7 +20679,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "The text to display for the license.",
         {
           short: "The License for this document, if any. (e.g.&nbsp;<code>CC BY</code>)",
-          long: "The license for this document, if any.\nCreative Commons licenses <code>CC BY</code>, <code>CC BY-SA</code>,\n<code>CC BY-ND</code>, <code>CC BY-NC</code> will automatically generate\na license link in the document appendix. Other license text will be\nplaced in the appendix verbatim."
+          long: "The license for this document, if any.\nCreative Commons licenses <code>CC BY</code>, <code>CC BY-SA</code>,\n<code>CC BY-ND</code>, <code>CC BY-NC</code>, <code>CC BY-NC-SA</code>,\nand <code>CC BY-NC-ND</code> will automatically generate a license link\nin the document appendix. Other license text will be placed in the\nappendix verbatim."
         },
         "The type of the license.",
         "A URL to the license.",
@@ -21844,12 +21954,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 159045,
+        _internalId: 164009,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 159037,
+            _internalId: 164001,
             type: "enum",
             enum: [
               "png",
@@ -21865,7 +21975,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 159044,
+            _internalId: 164008,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -14933,7 +14933,7 @@ var require_yaml_intelligence_resources = __commonJS({
           },
           description: {
             short: "The License for this document, if any. (e.g. `CC BY`)",
-            long: "The license for this document, if any. \n\nCreative Commons licenses `CC BY`, `CC BY-SA`, `CC BY-ND`, `CC BY-NC` will automatically generate a license link\nin the document appendix. Other license text will be placed in the appendix verbatim.\n"
+            long: "The license for this document, if any. \n\nCreative Commons licenses `CC BY`, `CC BY-SA`, `CC BY-ND`, `CC BY-NC`, `CC BY-NC-SA`, and `CC BY-NC-ND` will automatically generate a license link\nin the document appendix. Other license text will be placed in the appendix verbatim.\n"
           }
         },
         {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -20351,10 +20351,120 @@ try {
           "Information about the funding of the research reported in the article\n(for example, grants, contracts, sponsors) and any open access fees for\nthe article itself",
           "Displayable prose statement that describes the funding for the\nresearch on which a work was based.",
           "Open access provisions that apply to a work or the funding\ninformation that provided the open access provisions.",
-          "Information about awards associated with this funding.",
+          "Unique identifier assigned to an award, contract, or grant.",
+          "The name of this award",
+          "The description for this award.",
+          "Agency or organization that funded the research on which a work was\nbased.",
+          "The text describing the source of the funding.",
+          {
+            short: "Abbreviation for country where source of grant is located.",
+            long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+          },
+          "The text describing the source of the funding.",
+          {
+            short: "Abbreviation for country where source of grant is located.",
+            long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+          },
+          "Individual(s) or institution(s) to whom the award was given (for\nexample, the principal grant holder or the sponsored individual).",
+          "The id of an author or affiliation in the document metadata.",
+          "The name of an individual that was the recipient of the funding.",
+          "The institution that was the recipient of the funding.",
+          "The id of an author or affiliation in the document metadata.",
+          "The name of an individual that was the recipient of the funding.",
+          "The institution that was the recipient of the funding.",
+          "Individual(s) responsible for the intellectual content of the work\nreported in the document.",
+          "The id of an author or affiliation in the document metadata.",
+          "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+          "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
+          "The id of an author or affiliation in the document metadata.",
+          "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+          "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
+          "Unique identifier assigned to an award, contract, or grant.",
+          "The name of this award",
+          "The description for this award.",
+          "Agency or organization that funded the research on which a work was\nbased.",
+          "The text describing the source of the funding.",
+          {
+            short: "Abbreviation for country where source of grant is located.",
+            long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+          },
+          "The text describing the source of the funding.",
+          {
+            short: "Abbreviation for country where source of grant is located.",
+            long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+          },
+          "Individual(s) or institution(s) to whom the award was given (for\nexample, the principal grant holder or the sponsored individual).",
+          "The id of an author or affiliation in the document metadata.",
+          "The name of an individual that was the recipient of the funding.",
+          "The institution that was the recipient of the funding.",
+          "The id of an author or affiliation in the document metadata.",
+          "The name of an individual that was the recipient of the funding.",
+          "The institution that was the recipient of the funding.",
+          "Individual(s) responsible for the intellectual content of the work\nreported in the document.",
+          "The id of an author or affiliation in the document metadata.",
+          "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+          "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
+          "The id of an author or affiliation in the document metadata.",
+          "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+          "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
           "Displayable prose statement that describes the funding for the\nresearch on which a work was based.",
           "Open access provisions that apply to a work or the funding\ninformation that provided the open access provisions.",
-          "Information about awards associated with this funding.",
+          "Unique identifier assigned to an award, contract, or grant.",
+          "The name of this award",
+          "The description for this award.",
+          "Agency or organization that funded the research on which a work was\nbased.",
+          "The text describing the source of the funding.",
+          {
+            short: "Abbreviation for country where source of grant is located.",
+            long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+          },
+          "The text describing the source of the funding.",
+          {
+            short: "Abbreviation for country where source of grant is located.",
+            long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+          },
+          "Individual(s) or institution(s) to whom the award was given (for\nexample, the principal grant holder or the sponsored individual).",
+          "The id of an author or affiliation in the document metadata.",
+          "The name of an individual that was the recipient of the funding.",
+          "The institution that was the recipient of the funding.",
+          "The id of an author or affiliation in the document metadata.",
+          "The name of an individual that was the recipient of the funding.",
+          "The institution that was the recipient of the funding.",
+          "Individual(s) responsible for the intellectual content of the work\nreported in the document.",
+          "The id of an author or affiliation in the document metadata.",
+          "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+          "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
+          "The id of an author or affiliation in the document metadata.",
+          "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+          "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
+          "Unique identifier assigned to an award, contract, or grant.",
+          "The name of this award",
+          "The description for this award.",
+          "Agency or organization that funded the research on which a work was\nbased.",
+          "The text describing the source of the funding.",
+          {
+            short: "Abbreviation for country where source of grant is located.",
+            long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+          },
+          "The text describing the source of the funding.",
+          {
+            short: "Abbreviation for country where source of grant is located.",
+            long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+          },
+          "Individual(s) or institution(s) to whom the award was given (for\nexample, the principal grant holder or the sponsored individual).",
+          "The id of an author or affiliation in the document metadata.",
+          "The name of an individual that was the recipient of the funding.",
+          "The institution that was the recipient of the funding.",
+          "The id of an author or affiliation in the document metadata.",
+          "The name of an individual that was the recipient of the funding.",
+          "The institution that was the recipient of the funding.",
+          "Individual(s) responsible for the intellectual content of the work\nreported in the document.",
+          "The id of an author or affiliation in the document metadata.",
+          "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+          "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
+          "The id of an author or affiliation in the document metadata.",
+          "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+          "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
           {
             short: "Format to write to (e.g.&nbsp;html)",
             long: "Format to write to. Extensions can be individually enabled or\ndisabled by appending +EXTENSION or -EXTENSION to the format name\n(e.g.&nbsp;gfm+footnotes)"
@@ -20570,7 +20680,7 @@ try {
           "The text to display for the license.",
           {
             short: "The License for this document, if any. (e.g.&nbsp;<code>CC BY</code>)",
-            long: "The license for this document, if any.\nCreative Commons licenses <code>CC BY</code>, <code>CC BY-SA</code>,\n<code>CC BY-ND</code>, <code>CC BY-NC</code> will automatically generate\na license link in the document appendix. Other license text will be\nplaced in the appendix verbatim."
+            long: "The license for this document, if any.\nCreative Commons licenses <code>CC BY</code>, <code>CC BY-SA</code>,\n<code>CC BY-ND</code>, <code>CC BY-NC</code>, <code>CC BY-NC-SA</code>,\nand <code>CC BY-NC-ND</code> will automatically generate a license link\nin the document appendix. Other license text will be placed in the\nappendix verbatim."
           },
           "The type of the license.",
           "A URL to the license.",
@@ -21845,12 +21955,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 159045,
+          _internalId: 164009,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 159037,
+              _internalId: 164001,
               type: "enum",
               enum: [
                 "png",
@@ -21866,7 +21976,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 159044,
+              _internalId: 164008,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -14934,7 +14934,7 @@ try {
             },
             description: {
               short: "The License for this document, if any. (e.g. `CC BY`)",
-              long: "The license for this document, if any. \n\nCreative Commons licenses `CC BY`, `CC BY-SA`, `CC BY-ND`, `CC BY-NC` will automatically generate a license link\nin the document appendix. Other license text will be placed in the appendix verbatim.\n"
+              long: "The license for this document, if any. \n\nCreative Commons licenses `CC BY`, `CC BY-SA`, `CC BY-ND`, `CC BY-NC`, `CC BY-NC-SA`, and `CC BY-NC-ND` will automatically generate a license link\nin the document appendix. Other license text will be placed in the appendix verbatim.\n"
             }
           },
           {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -13322,10 +13322,120 @@
     "Information about the funding of the research reported in the article\n(for example, grants, contracts, sponsors) and any open access fees for\nthe article itself",
     "Displayable prose statement that describes the funding for the\nresearch on which a work was based.",
     "Open access provisions that apply to a work or the funding\ninformation that provided the open access provisions.",
-    "Information about awards associated with this funding.",
+    "Unique identifier assigned to an award, contract, or grant.",
+    "The name of this award",
+    "The description for this award.",
+    "Agency or organization that funded the research on which a work was\nbased.",
+    "The text describing the source of the funding.",
+    {
+      "short": "Abbreviation for country where source of grant is located.",
+      "long": "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+    },
+    "The text describing the source of the funding.",
+    {
+      "short": "Abbreviation for country where source of grant is located.",
+      "long": "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+    },
+    "Individual(s) or institution(s) to whom the award was given (for\nexample, the principal grant holder or the sponsored individual).",
+    "The id of an author or affiliation in the document metadata.",
+    "The name of an individual that was the recipient of the funding.",
+    "The institution that was the recipient of the funding.",
+    "The id of an author or affiliation in the document metadata.",
+    "The name of an individual that was the recipient of the funding.",
+    "The institution that was the recipient of the funding.",
+    "Individual(s) responsible for the intellectual content of the work\nreported in the document.",
+    "The id of an author or affiliation in the document metadata.",
+    "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+    "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
+    "The id of an author or affiliation in the document metadata.",
+    "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+    "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
+    "Unique identifier assigned to an award, contract, or grant.",
+    "The name of this award",
+    "The description for this award.",
+    "Agency or organization that funded the research on which a work was\nbased.",
+    "The text describing the source of the funding.",
+    {
+      "short": "Abbreviation for country where source of grant is located.",
+      "long": "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+    },
+    "The text describing the source of the funding.",
+    {
+      "short": "Abbreviation for country where source of grant is located.",
+      "long": "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+    },
+    "Individual(s) or institution(s) to whom the award was given (for\nexample, the principal grant holder or the sponsored individual).",
+    "The id of an author or affiliation in the document metadata.",
+    "The name of an individual that was the recipient of the funding.",
+    "The institution that was the recipient of the funding.",
+    "The id of an author or affiliation in the document metadata.",
+    "The name of an individual that was the recipient of the funding.",
+    "The institution that was the recipient of the funding.",
+    "Individual(s) responsible for the intellectual content of the work\nreported in the document.",
+    "The id of an author or affiliation in the document metadata.",
+    "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+    "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
+    "The id of an author or affiliation in the document metadata.",
+    "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+    "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
     "Displayable prose statement that describes the funding for the\nresearch on which a work was based.",
     "Open access provisions that apply to a work or the funding\ninformation that provided the open access provisions.",
-    "Information about awards associated with this funding.",
+    "Unique identifier assigned to an award, contract, or grant.",
+    "The name of this award",
+    "The description for this award.",
+    "Agency or organization that funded the research on which a work was\nbased.",
+    "The text describing the source of the funding.",
+    {
+      "short": "Abbreviation for country where source of grant is located.",
+      "long": "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+    },
+    "The text describing the source of the funding.",
+    {
+      "short": "Abbreviation for country where source of grant is located.",
+      "long": "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+    },
+    "Individual(s) or institution(s) to whom the award was given (for\nexample, the principal grant holder or the sponsored individual).",
+    "The id of an author or affiliation in the document metadata.",
+    "The name of an individual that was the recipient of the funding.",
+    "The institution that was the recipient of the funding.",
+    "The id of an author or affiliation in the document metadata.",
+    "The name of an individual that was the recipient of the funding.",
+    "The institution that was the recipient of the funding.",
+    "Individual(s) responsible for the intellectual content of the work\nreported in the document.",
+    "The id of an author or affiliation in the document metadata.",
+    "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+    "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
+    "The id of an author or affiliation in the document metadata.",
+    "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+    "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
+    "Unique identifier assigned to an award, contract, or grant.",
+    "The name of this award",
+    "The description for this award.",
+    "Agency or organization that funded the research on which a work was\nbased.",
+    "The text describing the source of the funding.",
+    {
+      "short": "Abbreviation for country where source of grant is located.",
+      "long": "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+    },
+    "The text describing the source of the funding.",
+    {
+      "short": "Abbreviation for country where source of grant is located.",
+      "long": "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
+    },
+    "Individual(s) or institution(s) to whom the award was given (for\nexample, the principal grant holder or the sponsored individual).",
+    "The id of an author or affiliation in the document metadata.",
+    "The name of an individual that was the recipient of the funding.",
+    "The institution that was the recipient of the funding.",
+    "The id of an author or affiliation in the document metadata.",
+    "The name of an individual that was the recipient of the funding.",
+    "The institution that was the recipient of the funding.",
+    "Individual(s) responsible for the intellectual content of the work\nreported in the document.",
+    "The id of an author or affiliation in the document metadata.",
+    "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+    "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
+    "The id of an author or affiliation in the document metadata.",
+    "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
+    "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
     {
       "short": "Format to write to (e.g.&nbsp;html)",
       "long": "Format to write to. Extensions can be individually enabled or\ndisabled by appending +EXTENSION or -EXTENSION to the format name\n(e.g.&nbsp;gfm+footnotes)"
@@ -13541,7 +13651,7 @@
     "The text to display for the license.",
     {
       "short": "The License for this document, if any. (e.g.&nbsp;<code>CC BY</code>)",
-      "long": "The license for this document, if any.\nCreative Commons licenses <code>CC BY</code>, <code>CC BY-SA</code>,\n<code>CC BY-ND</code>, <code>CC BY-NC</code> will automatically generate\na license link in the document appendix. Other license text will be\nplaced in the appendix verbatim."
+      "long": "The license for this document, if any.\nCreative Commons licenses <code>CC BY</code>, <code>CC BY-SA</code>,\n<code>CC BY-ND</code>, <code>CC BY-NC</code>, <code>CC BY-NC-SA</code>,\nand <code>CC BY-NC-ND</code> will automatically generate a license link\nin the document appendix. Other license text will be placed in the\nappendix verbatim."
     },
     "The type of the license.",
     "A URL to the license.",
@@ -14816,12 +14926,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 159045,
+    "_internalId": 164009,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 159037,
+        "_internalId": 164001,
         "type": "enum",
         "enum": [
           "png",
@@ -14837,7 +14947,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 159044,
+        "_internalId": 164008,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -7905,7 +7905,7 @@
       },
       "description": {
         "short": "The License for this document, if any. (e.g. `CC BY`)",
-        "long": "The license for this document, if any. \n\nCreative Commons licenses `CC BY`, `CC BY-SA`, `CC BY-ND`, `CC BY-NC` will automatically generate a license link\nin the document appendix. Other license text will be placed in the appendix verbatim.\n"
+        "long": "The license for this document, if any. \n\nCreative Commons licenses `CC BY`, `CC BY-SA`, `CC BY-ND`, `CC BY-NC`, `CC BY-NC-SA`, and `CC BY-NC-ND` will automatically generate a license link\nin the document appendix. Other license text will be placed in the appendix verbatim.\n"
       }
     },
     {

--- a/src/resources/filters/modules/license.lua
+++ b/src/resources/filters/modules/license.lua
@@ -45,6 +45,18 @@ local licenses = {
       return ccLicenseUrl("by-nc", lang, version)
     end
   },
+  ["cc by-nc-sa"] = {
+    type = "creative-commons",
+    licenseUrl = function (lang, version) 
+      return ccLicenseUrl("by-nc-sa", lang, version)
+    end
+  },
+  ["cc by-nc-nd"] = {
+    type = "creative-commons",
+    licenseUrl = function (lang, version) 
+      return ccLicenseUrl("by-nc-nd", lang, version)
+    end
+  },
 }
 
 local function parseCCLicense(license) 
@@ -168,4 +180,3 @@ return {
     copyright = constants.kCopyright
   }
 }
-

--- a/src/resources/schema/document-metadata.yml
+++ b/src/resources/schema/document-metadata.yml
@@ -69,7 +69,7 @@
     long: |
       The license for this document, if any. 
 
-      Creative Commons licenses `CC BY`, `CC BY-SA`, `CC BY-ND`, `CC BY-NC` will automatically generate a license link
+      Creative Commons licenses `CC BY`, `CC BY-SA`, `CC BY-ND`, `CC BY-NC`, `CC BY-NC-SA`, and `CC BY-NC-ND` will automatically generate a license link
       in the document appendix. Other license text will be placed in the appendix verbatim.
 
 - name: title-meta


### PR DESCRIPTION
This PR add the missing CC licenses and also use the CC code as display test instead of the license URL.

![image](https://github.com/quarto-dev/quarto-cli/assets/8896044/0c102018-29dd-40b8-a5e0-c2035e98bbdf)

Fixes #6783