### PR TITLE
feat: add `monoforegroundcolor` option

### DIFF
--- a/src/format/html/format-html-scss.ts
+++ b/src/format/html/format-html-scss.ts
@@ -289,9 +289,9 @@ export function resolveTextHighlightingLayer(
   if (themeDescriptor) {
     const readTextColor = (name: string) => {
       const textStyles = themeDescriptor.json["text-styles"];
-      if (textStyles && typeof (textStyles) === "object") {
+      if (textStyles && typeof textStyles === "object") {
         const commentColor = (textStyles as Record<string, unknown>)[name];
-        if (commentColor && typeof (commentColor) === "object") {
+        if (commentColor && typeof commentColor === "object") {
           const textColor =
             (commentColor as Record<string, unknown>)["text-color"];
           return textColor;
@@ -340,19 +340,19 @@ function resolveThemeLayer(
   let theme = undefined;
   let defaultDark = false;
 
-  if (typeof (themes) === "string") {
+  if (typeof themes === "string") {
     // The themes is just a string
     theme = { light: [themes] };
   } else if (Array.isArray(themes)) {
     // The themes is an array
     theme = { light: themes };
-  } else if (typeof (themes) === "object") {
+  } else if (typeof themes === "object") {
     // The themes are an object  - look at each key and
     // deal with them either as a string or a string[]
     const themeArr = (theme?: unknown): string[] => {
       const themes: string[] = [];
       if (theme) {
-        if (typeof (theme) === "string") {
+        if (typeof theme === "string") {
           themes.push(theme);
         } else if (Array.isArray(theme)) {
           themes.push(...theme);
@@ -441,6 +441,7 @@ function pandocVariablesToThemeDefaults(
   add(explicitVars, "font-family-base", metadata["mainfont"], asCssFont);
   add(explicitVars, "font-family-code", metadata["monofont"], asCssFont);
   add(explicitVars, "mono-background-color", metadata["monobackgroundcolor"]);
+  add(explicitVars, "mono-foreground-color", metadata["monoforegroundcolor"]);
 
   // Deal with sizes
   const explicitSizes = [
@@ -494,7 +495,7 @@ export const quartoBootstrapDefaults = (metadata: Metadata) => {
   const colorDefaults: string[] = [];
 
   const navbar = (metadata[kWebsite] as Metadata)?.[kSiteNavbar];
-  if (navbar && typeof (navbar) === "object") {
+  if (navbar && typeof navbar === "object") {
     // Forward navbar background color
     const navbarBackground = (navbar as Record<string, unknown>)[kBackground];
     if (navbarBackground !== undefined) {
@@ -504,9 +505,7 @@ export const quartoBootstrapDefaults = (metadata: Metadata) => {
           sassVariable(
             "navbar-bg",
             navbarBackground,
-            typeof (navbarBackground) === "string"
-              ? asBootstrapColor
-              : undefined,
+            typeof navbarBackground === "string" ? asBootstrapColor : undefined,
           ),
         ),
       );
@@ -521,9 +520,7 @@ export const quartoBootstrapDefaults = (metadata: Metadata) => {
           sassVariable(
             "navbar-fg",
             navbarForeground,
-            typeof (navbarForeground) === "string"
-              ? asBootstrapColor
-              : undefined,
+            typeof navbarForeground === "string" ? asBootstrapColor : undefined,
           ),
         ),
       );
@@ -547,7 +544,7 @@ export const quartoBootstrapDefaults = (metadata: Metadata) => {
   const sidebars = (metadata[kWebsite] as Metadata)?.[kSiteSidebar];
   const sidebar = Array.isArray(sidebars)
     ? sidebars[0]
-    : typeof (sidebars) === "object"
+    : typeof sidebars === "object"
     ? (sidebars as Metadata)
     : undefined;
 
@@ -561,7 +558,7 @@ export const quartoBootstrapDefaults = (metadata: Metadata) => {
           sassVariable(
             "sidebar-bg",
             sidebarBackground,
-            typeof (sidebarBackground) === "string"
+            typeof sidebarBackground === "string"
               ? asBootstrapColor
               : undefined,
           ),
@@ -584,7 +581,7 @@ export const quartoBootstrapDefaults = (metadata: Metadata) => {
           sassVariable(
             "sidebar-fg",
             sidebarForeground,
-            typeof (sidebarForeground) === "string"
+            typeof sidebarForeground === "string"
               ? asBootstrapColor
               : undefined,
           ),
@@ -612,7 +609,7 @@ export const quartoBootstrapDefaults = (metadata: Metadata) => {
   }
 
   const footer = (metadata[kWebsite] as Metadata)?.[kPageFooter] as Metadata;
-  if (footer !== undefined && typeof (footer) === "object") {
+  if (footer !== undefined && typeof footer === "object") {
     // Forward footer color
     const footerBg = footer[kBackground];
     if (footerBg !== undefined) {
@@ -622,7 +619,7 @@ export const quartoBootstrapDefaults = (metadata: Metadata) => {
           sassVariable(
             "footer-bg",
             footerBg,
-            typeof (footerBg) === "string" ? asBootstrapColor : undefined,
+            typeof footerBg === "string" ? asBootstrapColor : undefined,
           ),
         ),
       );
@@ -637,7 +634,7 @@ export const quartoBootstrapDefaults = (metadata: Metadata) => {
           sassVariable(
             "footer-fg",
             footerFg,
-            typeof (footerFg) === "string" ? asBootstrapColor : undefined,
+            typeof footerFg === "string" ? asBootstrapColor : undefined,
           ),
         ),
       );
@@ -661,7 +658,7 @@ export const quartoBootstrapDefaults = (metadata: Metadata) => {
     }
 
     // If the footer border is a color, set that
-    if (footerBorder !== undefined && typeof (footerBorder) === "string") {
+    if (footerBorder !== undefined && typeof footerBorder === "string") {
       resolveBootstrapColorDefault(footerBorder, colorDefaults);
       variables.push(
         outputVariable(
@@ -676,7 +673,7 @@ export const quartoBootstrapDefaults = (metadata: Metadata) => {
 
     // Forward any footer color
     const footerColor = footer[kColor];
-    if (footerColor && typeof (footerColor) === "string") {
+    if (footerColor && typeof footerColor === "string") {
       resolveBootstrapColorDefault(footerColor, colorDefaults);
       variables.push(
         outputVariable(
@@ -701,7 +698,7 @@ export const quartoBootstrapDefaults = (metadata: Metadata) => {
         sassVariable(
           kCodeBorderLeft,
           codeblockLeftBorder,
-          typeof (codeblockLeftBorder) === "string"
+          typeof codeblockLeftBorder === "string"
             ? asBootstrapColor
             : undefined,
         ),
@@ -718,7 +715,7 @@ export const quartoBootstrapDefaults = (metadata: Metadata) => {
     variables.push(outputVariable(sassVariable(
       kCodeBlockBackground,
       codeblockBackground,
-      typeof (codeblockBackground) === "string" ? asBootstrapColor : undefined,
+      typeof codeblockBackground === "string" ? asBootstrapColor : undefined,
     )));
   }
 
@@ -747,7 +744,7 @@ function resolveBootstrapColorDefault(value: unknown, variables: string[]) {
 }
 
 function bootstrapColorDefault(value: unknown) {
-  if (typeof (value) === "string") {
+  if (typeof value === "string") {
     return bootstrapColorVars[value];
   }
 }

--- a/src/format/reveal/format-reveal-theme.ts
+++ b/src/format/reveal/format-reveal-theme.ts
@@ -247,6 +247,7 @@ function pandocVariablesToRevealDefaults(
     asCssNumber,
   );
   add(explicitVars, "code-block-bg", metadata["monobackgroundcolor"]);
+  add(explicitVars, "code-block-color", metadata["monoforegroundcolor"]);
   return explicitVars;
 }
 

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -11896,6 +11896,22 @@ var require_yaml_intelligence_resources = __commonJS({
           description: "Sets the CSS `background-color` property on code elements and adds extra padding."
         },
         {
+          name: "monoforegroundcolor",
+          schema: "string",
+          tags: {
+            formats: [
+              "html",
+              "html4",
+              "html5",
+              "slidy",
+              "slideous",
+              "s5",
+              "dzslides"
+            ]
+          },
+          description: "Sets the CSS `color` property on code elements and adds extra padding."
+        },
+        {
           name: "backgroundcolor",
           schema: "string",
           tags: {
@@ -20084,6 +20100,7 @@ var require_yaml_intelligence_resources = __commonJS({
           long: 'For HTML output, sets the CSS <code>color</code> property on all\nlinks.\nFor LaTeX output, The color used for internal links using color\noptions allowed by <a href="https://ctan.org/pkg/xcolor"><code>xcolor</code></a>, including\nthe <code>dvipsnames</code>, <code>svgnames</code>, and\n<code>x11names</code> lists.\nFor ConTeXt output, sets the color for both external links and links\nwithin the document.'
         },
         "Sets the CSS <code>background-color</code> property on code elements\nand adds extra padding.",
+        "Sets the CSS <code>color</code> property on code elements and adds\nextra padding.",
         "Sets the CSS <code>background-color</code> property on the html\nelement.",
         {
           short: "The color used for external links using color options allowed by\n<code>xcolor</code>",
@@ -20346,62 +20363,10 @@ var require_yaml_intelligence_resources = __commonJS({
           long: "Specify the heading level at which to split the EPUB into separate\nchapter files. The default is to split into chapters at level-1\nheadings. This option only affects the internal composition of the EPUB,\nnot the way chapters and sections are displayed to users. Some readers\nmay be slow if the chapter files are too large, so for large documents\nwith few level-1 headings, one might want to use a chapter level of 2 or\n3."
         },
         "Information about the funding of the research reported in the article\n(for example, grants, contracts, sponsors) and any open access fees for\nthe article itself",
-        "Unique identifier assigned to an award, contract, or grant.",
         "Displayable prose statement that describes the funding for the\nresearch on which a work was based.",
         "Open access provisions that apply to a work or the funding\ninformation that provided the open access provisions.",
-        "Agency or organization that funded the research on which a work was\nbased.",
-        "The text describing the source of the funding.",
-        {
-          short: "Abbreviation for country where source of grant is located.",
-          long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
-        },
-        "The text describing the source of the funding.",
-        {
-          short: "Abbreviation for country where source of grant is located.",
-          long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
-        },
-        "Individual(s) or institution(s) to whom the award was given (for\nexample, the principal grant holder or the sponsored individual).",
-        "The id of an author or affiliation in the document metadata.",
-        "The name of an individual that was the recipient of the funding.",
-        "The institution that was the recipient of the funding.",
-        "The id of an author or affiliation in the document metadata.",
-        "The name of an individual that was the recipient of the funding.",
-        "The institution that was the recipient of the funding.",
-        "Individual(s) responsible for the intellectual content of the work\nreported in the document.",
-        "The id of an author or affiliation in the document metadata.",
-        "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
-        "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
-        "The id of an author or affiliation in the document metadata.",
-        "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
-        "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
-        "Unique identifier assigned to an award, contract, or grant.",
         "Displayable prose statement that describes the funding for the\nresearch on which a work was based.",
         "Open access provisions that apply to a work or the funding\ninformation that provided the open access provisions.",
-        "Agency or organization that funded the research on which a work was\nbased.",
-        "The text describing the source of the funding.",
-        {
-          short: "Abbreviation for country where source of grant is located.",
-          long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
-        },
-        "The text describing the source of the funding.",
-        {
-          short: "Abbreviation for country where source of grant is located.",
-          long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
-        },
-        "Individual(s) or institution(s) to whom the award was given (for\nexample, the principal grant holder or the sponsored individual).",
-        "The id of an author or affiliation in the document metadata.",
-        "The name of an individual that was the recipient of the funding.",
-        "The institution that was the recipient of the funding.",
-        "The id of an author or affiliation in the document metadata.",
-        "The name of an individual that was the recipient of the funding.",
-        "The institution that was the recipient of the funding.",
-        "Individual(s) responsible for the intellectual content of the work\nreported in the document.",
-        "The id of an author or affiliation in the document metadata.",
-        "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
-        "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
-        "The id of an author or affiliation in the document metadata.",
-        "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
-        "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
         {
           short: "Format to write to (e.g.&nbsp;html)",
           long: "Format to write to. Extensions can be individually enabled or\ndisabled by appending +EXTENSION or -EXTENSION to the format name\n(e.g.&nbsp;gfm+footnotes)"
@@ -21892,12 +21857,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 163181,
+        _internalId: 158635,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 163173,
+            _internalId: 158627,
             type: "enum",
             enum: [
               "png",
@@ -21913,7 +21878,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 163180,
+            _internalId: 158634,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -11897,6 +11897,22 @@ try {
             description: "Sets the CSS `background-color` property on code elements and adds extra padding."
           },
           {
+            name: "monoforegroundcolor",
+            schema: "string",
+            tags: {
+              formats: [
+                "html",
+                "html4",
+                "html5",
+                "slidy",
+                "slideous",
+                "s5",
+                "dzslides"
+              ]
+            },
+            description: "Sets the CSS `color` property on code elements and adds extra padding."
+          },
+          {
             name: "backgroundcolor",
             schema: "string",
             tags: {
@@ -20085,6 +20101,7 @@ try {
             long: 'For HTML output, sets the CSS <code>color</code> property on all\nlinks.\nFor LaTeX output, The color used for internal links using color\noptions allowed by <a href="https://ctan.org/pkg/xcolor"><code>xcolor</code></a>, including\nthe <code>dvipsnames</code>, <code>svgnames</code>, and\n<code>x11names</code> lists.\nFor ConTeXt output, sets the color for both external links and links\nwithin the document.'
           },
           "Sets the CSS <code>background-color</code> property on code elements\nand adds extra padding.",
+          "Sets the CSS <code>color</code> property on code elements and adds\nextra padding.",
           "Sets the CSS <code>background-color</code> property on the html\nelement.",
           {
             short: "The color used for external links using color options allowed by\n<code>xcolor</code>",
@@ -20347,62 +20364,10 @@ try {
             long: "Specify the heading level at which to split the EPUB into separate\nchapter files. The default is to split into chapters at level-1\nheadings. This option only affects the internal composition of the EPUB,\nnot the way chapters and sections are displayed to users. Some readers\nmay be slow if the chapter files are too large, so for large documents\nwith few level-1 headings, one might want to use a chapter level of 2 or\n3."
           },
           "Information about the funding of the research reported in the article\n(for example, grants, contracts, sponsors) and any open access fees for\nthe article itself",
-          "Unique identifier assigned to an award, contract, or grant.",
           "Displayable prose statement that describes the funding for the\nresearch on which a work was based.",
           "Open access provisions that apply to a work or the funding\ninformation that provided the open access provisions.",
-          "Agency or organization that funded the research on which a work was\nbased.",
-          "The text describing the source of the funding.",
-          {
-            short: "Abbreviation for country where source of grant is located.",
-            long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
-          },
-          "The text describing the source of the funding.",
-          {
-            short: "Abbreviation for country where source of grant is located.",
-            long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
-          },
-          "Individual(s) or institution(s) to whom the award was given (for\nexample, the principal grant holder or the sponsored individual).",
-          "The id of an author or affiliation in the document metadata.",
-          "The name of an individual that was the recipient of the funding.",
-          "The institution that was the recipient of the funding.",
-          "The id of an author or affiliation in the document metadata.",
-          "The name of an individual that was the recipient of the funding.",
-          "The institution that was the recipient of the funding.",
-          "Individual(s) responsible for the intellectual content of the work\nreported in the document.",
-          "The id of an author or affiliation in the document metadata.",
-          "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
-          "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
-          "The id of an author or affiliation in the document metadata.",
-          "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
-          "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
-          "Unique identifier assigned to an award, contract, or grant.",
           "Displayable prose statement that describes the funding for the\nresearch on which a work was based.",
           "Open access provisions that apply to a work or the funding\ninformation that provided the open access provisions.",
-          "Agency or organization that funded the research on which a work was\nbased.",
-          "The text describing the source of the funding.",
-          {
-            short: "Abbreviation for country where source of grant is located.",
-            long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
-          },
-          "The text describing the source of the funding.",
-          {
-            short: "Abbreviation for country where source of grant is located.",
-            long: "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
-          },
-          "Individual(s) or institution(s) to whom the award was given (for\nexample, the principal grant holder or the sponsored individual).",
-          "The id of an author or affiliation in the document metadata.",
-          "The name of an individual that was the recipient of the funding.",
-          "The institution that was the recipient of the funding.",
-          "The id of an author or affiliation in the document metadata.",
-          "The name of an individual that was the recipient of the funding.",
-          "The institution that was the recipient of the funding.",
-          "Individual(s) responsible for the intellectual content of the work\nreported in the document.",
-          "The id of an author or affiliation in the document metadata.",
-          "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
-          "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
-          "The id of an author or affiliation in the document metadata.",
-          "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
-          "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
           {
             short: "Format to write to (e.g.&nbsp;html)",
             long: "Format to write to. Extensions can be individually enabled or\ndisabled by appending +EXTENSION or -EXTENSION to the format name\n(e.g.&nbsp;gfm+footnotes)"
@@ -21893,12 +21858,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 163181,
+          _internalId: 158635,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 163173,
+              _internalId: 158627,
               type: "enum",
               enum: [
                 "png",
@@ -21914,7 +21879,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 163180,
+              _internalId: 158634,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -4868,6 +4868,22 @@
       "description": "Sets the CSS `background-color` property on code elements and adds extra padding."
     },
     {
+      "name": "monoforegroundcolor",
+      "schema": "string",
+      "tags": {
+        "formats": [
+          "html",
+          "html4",
+          "html5",
+          "slidy",
+          "slideous",
+          "s5",
+          "dzslides"
+        ]
+      },
+      "description": "Sets the CSS `color` property on code elements and adds extra padding."
+    },
+    {
       "name": "backgroundcolor",
       "schema": "string",
       "tags": {
@@ -13056,6 +13072,7 @@
       "long": "For HTML output, sets the CSS <code>color</code> property on all\nlinks.\nFor LaTeX output, The color used for internal links using color\noptions allowed by <a href=\"https://ctan.org/pkg/xcolor\"><code>xcolor</code></a>, including\nthe <code>dvipsnames</code>, <code>svgnames</code>, and\n<code>x11names</code> lists.\nFor ConTeXt output, sets the color for both external links and links\nwithin the document."
     },
     "Sets the CSS <code>background-color</code> property on code elements\nand adds extra padding.",
+    "Sets the CSS <code>color</code> property on code elements and adds\nextra padding.",
     "Sets the CSS <code>background-color</code> property on the html\nelement.",
     {
       "short": "The color used for external links using color options allowed by\n<code>xcolor</code>",
@@ -13318,62 +13335,10 @@
       "long": "Specify the heading level at which to split the EPUB into separate\nchapter files. The default is to split into chapters at level-1\nheadings. This option only affects the internal composition of the EPUB,\nnot the way chapters and sections are displayed to users. Some readers\nmay be slow if the chapter files are too large, so for large documents\nwith few level-1 headings, one might want to use a chapter level of 2 or\n3."
     },
     "Information about the funding of the research reported in the article\n(for example, grants, contracts, sponsors) and any open access fees for\nthe article itself",
-    "Unique identifier assigned to an award, contract, or grant.",
     "Displayable prose statement that describes the funding for the\nresearch on which a work was based.",
     "Open access provisions that apply to a work or the funding\ninformation that provided the open access provisions.",
-    "Agency or organization that funded the research on which a work was\nbased.",
-    "The text describing the source of the funding.",
-    {
-      "short": "Abbreviation for country where source of grant is located.",
-      "long": "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
-    },
-    "The text describing the source of the funding.",
-    {
-      "short": "Abbreviation for country where source of grant is located.",
-      "long": "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
-    },
-    "Individual(s) or institution(s) to whom the award was given (for\nexample, the principal grant holder or the sponsored individual).",
-    "The id of an author or affiliation in the document metadata.",
-    "The name of an individual that was the recipient of the funding.",
-    "The institution that was the recipient of the funding.",
-    "The id of an author or affiliation in the document metadata.",
-    "The name of an individual that was the recipient of the funding.",
-    "The institution that was the recipient of the funding.",
-    "Individual(s) responsible for the intellectual content of the work\nreported in the document.",
-    "The id of an author or affiliation in the document metadata.",
-    "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
-    "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
-    "The id of an author or affiliation in the document metadata.",
-    "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
-    "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
-    "Unique identifier assigned to an award, contract, or grant.",
     "Displayable prose statement that describes the funding for the\nresearch on which a work was based.",
     "Open access provisions that apply to a work or the funding\ninformation that provided the open access provisions.",
-    "Agency or organization that funded the research on which a work was\nbased.",
-    "The text describing the source of the funding.",
-    {
-      "short": "Abbreviation for country where source of grant is located.",
-      "long": "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
-    },
-    "The text describing the source of the funding.",
-    {
-      "short": "Abbreviation for country where source of grant is located.",
-      "long": "Abbreviation for country where source of grant is located. Whenever\npossible, ISO 3166-1 2-letter alphabetic codes should be used."
-    },
-    "Individual(s) or institution(s) to whom the award was given (for\nexample, the principal grant holder or the sponsored individual).",
-    "The id of an author or affiliation in the document metadata.",
-    "The name of an individual that was the recipient of the funding.",
-    "The institution that was the recipient of the funding.",
-    "The id of an author or affiliation in the document metadata.",
-    "The name of an individual that was the recipient of the funding.",
-    "The institution that was the recipient of the funding.",
-    "Individual(s) responsible for the intellectual content of the work\nreported in the document.",
-    "The id of an author or affiliation in the document metadata.",
-    "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
-    "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
-    "The id of an author or affiliation in the document metadata.",
-    "The name of an individual that was responsible for the intellectual\ncontent of the work reported in the document.",
-    "The institution that was responsible for the intellectual content of\nthe work reported in the document.",
     {
       "short": "Format to write to (e.g.&nbsp;html)",
       "long": "Format to write to. Extensions can be individually enabled or\ndisabled by appending +EXTENSION or -EXTENSION to the format name\n(e.g.&nbsp;gfm+footnotes)"
@@ -14864,12 +14829,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 163181,
+    "_internalId": 158635,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 163173,
+        "_internalId": 158627,
         "type": "enum",
         "enum": [
           "png",
@@ -14885,7 +14850,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 163180,
+        "_internalId": 158634,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
@@ -917,6 +917,17 @@ pre {
   }
 }
 
+@if variable-exists(mono-foreground-color) {
+  p code:not(.sourceCode),
+  li code:not(.sourceCode),
+  kbd,
+  pre:not(.sourceCode),
+  samp {
+    background-color: $mono-foreground-color;
+    padding: 0.2em;
+  }
+}
+
 // Default padding if background is set
 p code:not(.sourceCode),
 li code:not(.sourceCode),
@@ -933,6 +944,16 @@ td code:not(.sourceCode) {
     padding: 0.2em;
   } @else if variable-exists(mono-background-color) {
     padding: 0.2em;
+  }
+}
+
+p code:not(.sourceCode),
+li code:not(.sourceCode),
+td code:not(.sourceCode) {
+  @if variable-exists(mono-foreground-color) {
+    color: $mono-foreground-color;
+  } @else if variable-exists(code-color) {
+    color: $code-color;
   }
 }
 

--- a/src/resources/formats/html/pandoc/html.styles
+++ b/src/resources/formats/html/pandoc/html.styles
@@ -108,6 +108,9 @@ $if(monobackgroundcolor)$
   background-color: $monobackgroundcolor$;
   padding: .2em .4em;
 $endif$
+$if(monoforegroundcolor)$
+  color: $monoforegroundcolor$;
+$endif$
   font-size: 85%;
   margin: 0;
   hyphens: manual;
@@ -117,6 +120,9 @@ pre {
 $if(monobackgroundcolor)$
   background-color: $monobackgroundcolor$;
   padding: 1em;
+$endif$
+$if(monoforegroundcolor)$
+  color: $monoforegroundcolor$;
 $endif$
   overflow: auto;
 }

--- a/src/resources/formats/html/pandoc/styles.html
+++ b/src/resources/formats/html/pandoc/styles.html
@@ -120,6 +120,9 @@ $if(monobackgroundcolor)$
   background-color: $monobackgroundcolor$;
   padding: .2em .4em;
 $endif$
+$if(monoforegroundcolor)$
+  color: $monoforegroundcolor$;
+$endif$
   font-size: 85%;
   margin: 0;
   hyphens: manual;
@@ -129,6 +132,9 @@ pre {
 $if(monobackgroundcolor)$
   background-color: $monobackgroundcolor$;
   padding: 1em;
+$endif$
+$if(monoforegroundcolor)$
+  color: $monoforegroundcolor$;
 $endif$
   overflow: auto;
 }

--- a/src/resources/schema/document-colors.yml
+++ b/src/resources/schema/document-colors.yml
@@ -26,6 +26,12 @@
     formats: [html, html4, html5, slidy, slideous, s5, dzslides]
   description: Sets the CSS `background-color` property on code elements and adds extra padding.
 
+- name: monoforegroundcolor
+  schema: string
+  tags:
+    formats: [html, html4, html5, slidy, slideous, s5, dzslides]
+  description: Sets the CSS `color` property on code elements and adds extra padding.
+
 - name: backgroundcolor
   schema: string
   tags:


### PR DESCRIPTION
In addition to `monobackgroundcolor` option, this PR adds the `monoforegroundcolor`.
(To note, it needs the changes from #6782)

From <https://github.com/quarto-dev/quarto-cli/discussions/6780>.

@dragonstyle I made this PR mostly to open the discussion on this (thus the draft status), what do you think?

PS: auto formatting not intended 😕