### PR TITLE
more robust cleanup of sourcemapping info in CSS

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -188,3 +188,4 @@
 - ([#6697](https://github.com/quarto-dev/quarto-cli/pull/6697)): Fix issue with outputing to stdout (`quarto render <file> -o -`) on Windows.
 - ([#6705](https://github.com/quarto-dev/quarto-cli/pull/6705)): Fix issue with gfm output being removed when rendered with other formats.
 - ([#6746](https://github.com/quarto-dev/quarto-cli/issues/6746)): Let stdout and stderr finish independently to avoid deadlock.
+- ([#6807](https://github.com/quarto-dev/quarto-cli/pull/6807)): Improve sourcemapping reference cleanup in generated CSS files.

--- a/src/command/render/pandoc-html.ts
+++ b/src/command/render/pandoc-html.ts
@@ -21,6 +21,8 @@ import { TempContext } from "../../core/temp.ts";
 import { cssImports, cssResources } from "../../core/css.ts";
 import { compileSass } from "../../core/sass.ts";
 
+import { kSourceMappingRegexes } from "../../config/constants.ts";
+
 import { kQuartoHtmlDependency } from "../../format/html/format-html-constants.ts";
 import {
   kAbbrevs,
@@ -411,7 +413,10 @@ function processCssIntoExtras(
 ): CSSResult {
   extras.html = extras.html || {};
   const css = Deno.readTextFileSync(cssPath).replaceAll(
-    kSourceMappingRegex,
+    kSourceMappingRegexes[0],
+    "",
+  ).replaceAll(
+    kSourceMappingRegexes[1],
     "",
   );
 
@@ -473,7 +478,6 @@ function processCssIntoExtras(
 }
 const kVariablesRegex =
   /\/\*\! quarto-variables-start \*\/([\S\s]*)\/\*\! quarto-variables-end \*\//g;
-const kSourceMappingRegex = /\/\*\# sourceMappingURL=.* \*\//g;
 
 // Attributes for the style tag
 // Note that we default disable the dark mode and rely on JS to enable it

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -731,3 +731,8 @@ export const kLayout = "layout";
 
 // https://github.com/quarto-dev/quarto-cli/issues/3581
 export const kCliffyImplicitCwd = "5a6d2e4f-f9a2-43bc-8019-8149fbb76c85";
+
+export const kSourceMappingRegexes = [
+  /^\/\/#\s*sourceMappingURL\=.*\.map$/gm,
+  /\/\*\# sourceMappingURL=.* \*\//g,
+];


### PR DESCRIPTION
Better fix for https://github.com/quarto-dev/quarto-cli/commit/e66d909b281a6679644772027bae0f9aa58ac669 (#5793)