### PR TITLE
Adapt path to Deno on windows to new folder using architecture for quarto dev

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,7 +25,7 @@
       },
       "attachSimplePort": 9229,
       "windows": {
-        "runtimeExecutable": "${workspaceFolder}\\package\\dist\\bin\\tools\\deno.exe"
+        "runtimeExecutable": "${workspaceFolder}\\package\\dist\\bin\\tools\\x86_64\\deno.exe"
       }
     },
     {
@@ -53,7 +53,7 @@
       },
       "attachSimplePort": 9229,
       "windows": {
-        "runtimeExecutable": "${workspaceFolder}\\package\\dist\\bin\\tools\\deno.exe"
+        "runtimeExecutable": "${workspaceFolder}\\package\\dist\\bin\\tools\\x86_64\\deno.exe"
       }
     }
   ]

--- a/configure.cmd
+++ b/configure.cmd
@@ -25,7 +25,10 @@ if "%QUARTO_VENDOR_BINARIES%" == "true" (
 
   ECHO Bootstrapping Deno...
   REM Download Deno
-  SET "DENO_FILE=deno-x86_64-pc-windows-msvc.zip"
+  SET DENO_ARCH_DIR=x86_64
+  MKDIR !DENO_ARCH_DIR!
+  PUSHD !DENO_ARCH_DIR!
+  SET DENO_FILE=deno-!DENO_ARCH_DIR!-pc-windows-msvc.zip
   CURL --fail -L "https://github.com/denoland/deno/releases/download/!DENO!/!DENO_FILE!" -o "!DENO_FILE!"
   REM Windows doesn't have unzip installed by default, but starting in Windows 10 build 17063 they did 
   REM include a build in 'tar' command. Windows 10 build 17063 was released in 2017.
@@ -54,7 +57,8 @@ if "%QUARTO_VENDOR_BINARIES%" == "true" (
     deno upgrade --canary --version %DENO_CANARY_COMMIT%
   )
 
-  SET QUARTO_DENO=!QUARTO_BIN_PATH!\tools\deno.exe
+  SET QUARTO_DENO=!QUARTO_BIN_PATH!\tools\!DENO_ARCH_DIR!\deno.exe
+  POPD
   POPD
 )
 

--- a/package/scripts/windows/quarto.cmd
+++ b/package/scripts/windows/quarto.cmd
@@ -91,7 +91,7 @@ IF DEFINED QUARTO_DENO_DOM (
 )
 
 IF NOT DEFINED QUARTO_DENO (
-    set "QUARTO_DENO=!SCRIPT_PATH!\tools\deno.exe"
+    set "QUARTO_DENO=!SCRIPT_PATH!\tools\x86_64\deno.exe"
 )
 
 SET "DENO_TLS_CA_STORE=system,mozilla"

--- a/package/src/quarto-bld.cmd
+++ b/package/src/quarto-bld.cmd
@@ -4,7 +4,7 @@ if NOT DEFINED WIN_CONFIG_TRANSLATED call %~dp0\store_win_configuration.bat
 call %~dp0\..\..\win_configuration.bat
 
 if NOT DEFINED QUARTO_DENO (
-  SET QUARTO_DENO=%~dp0\..\dist\bin\tools\deno.exe
+  SET QUARTO_DENO=%~dp0\..\dist\bin\tools\x86_64\deno.exe
 )
 SET "RUST_BACKTRACE=full"
 SET "DENO_NO_UPDATE_CHECK=1"

--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -26,7 +26,7 @@ $QUARTO_SRC_DIR= Join-Path $QUARTO_ROOT "src"
 # e.g quarto-cli/package/dist/bin
 $QUARTO_BIN_PATH = Join-Path $QUARTO_ROOT "package" "dist" "bin"
 # Deno binary in tools/
-$QUARTO_DENO = Join-Path $QUARTO_BIN_PATH "tools" "deno.exe"
+$QUARTO_DENO = Join-Path $QUARTO_BIN_PATH "tools" "x86_64" "deno.exe"
 
 # Shared resource folder
 # e.g quarto-cli/src/resources


### PR DESCRIPTION
closes #6818 

This follows work on #6182 where modification of windows specific configure and run file where missing

@dragonstyle do you think I missing other part that needs to be adapted following your previous work ? 

I could create a symlink on windows with `MKLINK` but I don't think this is needed. It seems the symlink exist on non-windows only for VSCODE setting. And currently, the workspace settings does not apply for windows because of `deno.exe` or `quarto.cmd` being different with extension. 

So it requires a specific tweak that I am doing locally anyway. 