### PR TITLE
[GHA] Use actions/quarto-dev to configure Quarto from dev version on each GHA workflow

### DIFF
--- a/.github/workflows/performance-check.yml
+++ b/.github/workflows/performance-check.yml
@@ -27,9 +27,7 @@ jobs:
           echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Configure Quarto
-        shell: bash
-        run: |
-          ./configure.sh
+        uses: ./.github/workflows/actions/quarto-dev
 
       - name: Test Bundle
         id: create_bundle

--- a/.github/workflows/test-bundle.yml
+++ b/.github/workflows/test-bundle.yml
@@ -27,9 +27,7 @@ jobs:
           echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Configure Quarto
-        shell: bash
-        run: |
-          ./configure.sh
+        uses: ./.github/workflows/actions/quarto-dev
 
       - name: Test Bundle
         shell: bash

--- a/.github/workflows/test-quarto-latexmk.yml
+++ b/.github/workflows/test-quarto-latexmk.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Configure Quarto
         uses: ./.github/workflows/actions/quarto-dev
 
-      - name: Test ${{ runner.os }}
+      - name: Test Windows
         if: runner.os == 'Windows'
         run: |
           cd package/src
@@ -38,7 +38,7 @@ jobs:
           cd ..\dist\bin\tinitex\x86_64-pc-windows-msvc
           .\tinitex.exe --help
 
-      - name: Test ${{ runner.os }}
+      - name: Test macOS
         if: runner.os == 'macOS'
         run: |
           cd package/src
@@ -46,7 +46,7 @@ jobs:
           ls -R ../dist/bin
           ../dist/bin/tinitex/x86_64-apple-darwin/tinitex --help
 
-      - name: Test ${{ runner.os }}
+      - name: Test Linux
         if: runner.os == 'Linux'
         run: |
           cd package/src

--- a/.github/workflows/test-quarto-latexmk.yml
+++ b/.github/workflows/test-quarto-latexmk.yml
@@ -26,12 +26,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure Quarto
+        uses: ./.github/workflows/actions/quarto-dev
+
       - name: Test ${{ runner.os }}
         if: runner.os == 'Windows'
         run: |
-          .\configure.cmd
-          package/dist/bin/quarto.cmd check
-          pwd
           cd package/src
           .\quarto-bld.cmd compile-quarto-latexmk --target x86_64-pc-windows-msvc --name tinitex
           tree ..\dist\bin /f /a
@@ -41,9 +41,6 @@ jobs:
       - name: Test ${{ runner.os }}
         if: runner.os == 'macOS'
         run: |
-          ./configure.sh
-          quarto check
-          pwd
           cd package/src
           ./quarto-bld compile-quarto-latexmk --target x86_64-apple-darwin --name tinitex
           ls -R ../dist/bin
@@ -52,9 +49,6 @@ jobs:
       - name: Test ${{ runner.os }}
         if: runner.os == 'Linux'
         run: |
-          ./configure.sh
-          quarto check
-          pwd
           cd package/src
           ./quarto-bld compile-quarto-latexmk --target x86_64-unknown-linux-gnu --name tinitex
           ls -R ../dist/bin

--- a/package/src/common/configure.ts
+++ b/package/src/common/configure.ts
@@ -46,10 +46,12 @@ export async function configure(
     }
   }
 
+  info("Building quarto-preview.js...");
   const result = buildQuartoPreviewJs(config.directoryInfo.src);
   if (!result.success) {
     throw new Error();
   }
+  info("Build completed.");
 
   // Move the quarto script into place
   info("Placing Quarto script");


### PR DESCRIPTION
Following #6822, our internal composite action `quarto-dev` which runs the configuration step has a caching step for deno_std download. 

This was not applied on other workflow than test-smokes because the other workflow was not using this internal action but called configure directly. 

This PR changes that