### PR TITLE
fix: Documentation is missing abstract from MSWord Options

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -191,3 +191,4 @@
 - ([#6746](https://github.com/quarto-dev/quarto-cli/issues/6746)): Let stdout and stderr finish independently to avoid deadlock.
 - ([#6807](https://github.com/quarto-dev/quarto-cli/pull/6807)): Improve sourcemapping reference cleanup in generated CSS files.
 - ([#6825](https://github.com/quarto-dev/quarto-cli/issues/6825)): Show filename when YAML parsing error occurs.
+- ([#6836](https://github.com/quarto-dev/quarto-cli/issues/6836)): Fix missing `docx` format for `abstract` key in reference schema.

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -11581,7 +11581,8 @@ var require_yaml_intelligence_resources = __commonJS({
               "$jats-all",
               "context",
               "ms",
-              "odt"
+              "odt",
+              "docx"
             ]
           },
           description: "Summary of document"

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -11582,7 +11582,8 @@ try {
                 "$jats-all",
                 "context",
                 "ms",
-                "odt"
+                "odt",
+                "docx"
               ]
             },
             description: "Summary of document"

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -4553,7 +4553,8 @@
           "$jats-all",
           "context",
           "ms",
-          "odt"
+          "odt",
+          "docx"
         ]
       },
       "description": "Summary of document"

--- a/src/resources/schema/document-attributes.yml
+++ b/src/resources/schema/document-attributes.yml
@@ -102,6 +102,7 @@
         context,
         ms,
         odt,
+        docx
       ]
   description: "Summary of document"
 


### PR DESCRIPTION
Fixes #6836

<table>
<tr><th>Quarto document</th><th>Word document</th></tr>
<tr>
<td>

````qmd
---
title: "Issue #6836"
format: docx
abstract: |
  This is a test of the `docx` format.
---
````

</td>
<td>
<img width="626" alt="image" src="https://github.com/quarto-dev/quarto-cli/assets/8896044/4115ef75-d274-4a49-8232-14368c57e80f">
</td>
</tr>
</table>