### PR TITLE
deb postrm: remove pandoc only if symlink

### DIFF
--- a/package/scripts/linux/deb/postrm
+++ b/package/scripts/linux/deb/postrm
@@ -7,6 +7,13 @@ rm -f /usr/local/bin/quarto
 else
 rm -f ~/bin/quarto
 fi
-rm -f /opt/quarto/bin/tools/pandoc
+
+# Remove pandoc symlink created by postinst
+# (before 1.4 this was a regular file that shouldn't be removed here)
+pandoc=/opt/quarto/bin/tools/pandoc
+if [ -h "$pandoc" ]
+then
+  rm -f "$pandoc"
+fi
 
 exit 0


### PR DESCRIPTION
This fixes #6901 by making sure the pandoc symlink is removed only if it is a symlink (before 1.3 it was a regular file that should not be removed by postinst).

I think that's a bit more elegant than the first solution I proposed in #6901 (using `prerm` instead of `postrm`).

## Checklist

I have (if applicable):

- [x ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
