### PR TITLE
fix beamer regression

### DIFF
--- a/src/resources/filters/quarto-finalize/coalesceraw.lua
+++ b/src/resources/filters/quarto-finalize/coalesceraw.lua
@@ -20,7 +20,11 @@ function coalesce_raw()
     -- flatten out divs before merging raw blocks
     table.insert(filters, {
       Div = function(div)
-        return div.content
+        -- only flatten out divs that have no classes or attributes
+        -- (see https://github.com/quarto-dev/quarto-cli/issues/6936)
+        if #div.classes == 0 and #div.attributes == 0 then
+          return div.content
+        end
       end
     })
   end


### PR DESCRIPTION
Closes #6936.

In order to be able to create RawBlock elements in LaTeX more robustly, I added a pass that coalesced divs in latex format ahead of merging consecutive RawBlocks. I missed the fact that some Pandoc writers in LaTeX subformats like Beamer check for classes in the div output. Now, we only coalesce divs if they're "purely structural".