### PR TITLE
Feature: typst blocks

### DIFF
--- a/src/resources/filters/main.lua
+++ b/src/resources/filters/main.lua
@@ -62,6 +62,7 @@ import("./quarto-post/fig-cleanup.lua")
 import("./quarto-post/foldcode.lua")
 import("./quarto-post/ipynb.lua")
 import("./quarto-post/latex.lua")
+import("./quarto-post/typst.lua")
 import("./quarto-post/latexdiv.lua")
 import("./quarto-post/meta.lua")
 import("./quarto-post/ojs.lua")
@@ -328,6 +329,7 @@ local quarto_post_filters = {
   { name = "post-render-asciidoc", filter = render_asciidoc() },
   { name = "post-render-latex", filter = render_latex() },
   { name = "post-render-docx", filter = render_docx() },
+  { name = "post-render-typst", filter = render_typst() },
 
   -- extensible rendering
   { name = "post-render_extended_nodes", filter = render_extended_nodes() },

--- a/src/resources/filters/quarto-post/typst.lua
+++ b/src/resources/filters/quarto-post/typst.lua
@@ -1,0 +1,35 @@
+-- latex.lua
+-- Copyright (C) 2023 Posit Software, PBC
+--
+-- renders AST nodes to Typst
+
+
+function render_typst()
+  if not _quarto.format.isTypstOutput() then
+    return {}
+  end
+
+  return {
+    Div = function(div)
+      if div.classes:includes("block") then
+        div.classes = div.classes:filter(function(c) return c ~= "block" end)
+
+        local preamble = pandoc.Blocks({})
+        local postamble = pandoc.Blocks({})
+        preamble:insert(pandoc.RawBlock("typst", "#block("))
+        for k, v in pairs(div.attributes) do
+          -- FIXME: proper escaping of k and v
+          preamble:insert(pandoc.RawBlock("typst", k .. ":" .. v .. ",\n"))
+        end
+        preamble:insert(pandoc.RawBlock("typst", "[\n"))
+        postamble:insert(pandoc.RawBlock("typst", "])\n\n"))
+
+        local result = pandoc.Blocks({})
+        result:extend(preamble)
+        result:extend(div.content)
+        result:extend(postamble)
+        return result
+      end
+    end
+  }
+end

--- a/tests/docs/smoke-all/typst/block-divs.qmd
+++ b/tests/docs/smoke-all/typst/block-divs.qmd
@@ -1,0 +1,10 @@
+---
+title: "typst blocks"
+format: typst
+---
+
+::: {.block fill="rgb(\"ff0000\")"}
+
+This is a block with red background (yuck.)
+
+:::


### PR DESCRIPTION
Fenced divs with `.block` class get expanded into `#block(k1=v1, k2=v2, [...content])`.