### PR TITLE
Fix revealjs callout formatting

### DIFF
--- a/src/resources/filters/customnodes/callout.lua
+++ b/src/resources/filters/customnodes/callout.lua
@@ -350,7 +350,7 @@ function epubCallout(node)
   local imgDiv = pandoc.Div({imgPlaceholder}, pandoc.Attr("", {"callout-icon-container"}));
 
   -- title
-  if title ~= nil then
+  if title ~= nil and (pandoc.utils.type(title) == "string" or next(title) ~= nil) then
     local callout_title = pandoc.Div({}, pandoc.Attr("", {"callout-title"}))
     if hasIcon then
       callout_title.content:insert(imgDiv)

--- a/src/resources/filters/customnodes/callout.lua
+++ b/src/resources/filters/customnodes/callout.lua
@@ -339,7 +339,7 @@ function epubCallout(node)
   local calloutAppearance = node.appearance
   local hasIcon = node.icon
 
-  if calloutAppearance == constants.kCalloutAppearanceDefault and pandoc.utils.stringify(title) == nil then
+  if calloutAppearance == constants.kCalloutAppearanceDefault and pandoc.utils.stringify(title) == "" then
     title = displayName(type)
   end
   

--- a/src/resources/filters/customnodes/callout.lua
+++ b/src/resources/filters/customnodes/callout.lua
@@ -376,7 +376,7 @@ function epubCallout(node)
   if hasIcon == false then
     attributes:insert("no-icon")
   end
-  if title ~= nil then
+  if title ~= nil and (pandoc.utils.type(title) == "string" or next(title) ~= nil) then
     attributes:insert("callout-titled")
   end
   attributes:insert("callout-style-" .. calloutAppearance)

--- a/tests/docs/callouts.qmd
+++ b/tests/docs/callouts.qmd
@@ -2,7 +2,7 @@
 title: Hello Callout!
 ---
 
-## Overview of callouts
+## Overview of callouts {#overview}
 
 ::: {.callout-warning}
 Callouts provide a simple way to attract attention, for example, to this warning.
@@ -24,6 +24,8 @@ Note that there are five types of callouts, including: `note`, `tip`, `warning`,
 This is an example of a callout with a caption.
 :::
 
+## Callout with markup {#markup}
+
 ::: {.callout-tip}
 ## Caption with **formatted** text, like `function_name()`
 
@@ -40,4 +42,28 @@ This is an example of a 'collapsed' caution callout that can be expanded by the 
 ## Exercise
 
 You can also use a plain `callout` class to get a simple callout treatment.
+:::
+
+## Callout Appearance {#appearance}
+
+::: {.callout-caution appearance="simple"}
+A simple callout with no title
+:::
+
+::: {.callout-caution appearance="default"}
+A default callout with no title
+:::
+
+::: {.callout-caution appearance="default" icon="false"}
+A default callout with no title or icon
+:::
+
+::: {.callout-caution appearance="simple" icon="false"}
+A simple callout with no title or icon
+:::
+
+## Minimal
+
+::: {.callout-caution appearance="minimal"}
+A minimal callout with no title
 :::

--- a/tests/smoke/render/render-callout.test.ts
+++ b/tests/smoke/render/render-callout.test.ts
@@ -44,6 +44,35 @@ testRender(input, "html", false, [
   ]),
 ]);
 
+testRender(input, "revealjs", false, [
+  ensureHtmlElements(htmlOutput.outputPath, [
+    // callout environments are created
+    "div.callout-warning",
+    "div.callout-important",
+    "div.callout-note",
+    "div.callout-tip",
+    "div.callout-caution",
+    "div.callout.no-icon",
+    // formatting is kept in caption
+    "#markup div.callout-tip > div.callout-body > div.callout-title strong > code",
+    "#markup div.callout-caution > div.callout-body > div.callout-content code",
+    "#markup div.callout-none.no-icon.callout-titled.callout-style-simple > div.callout-body > div.callout-content code",
+    // appearance correctly modify structure
+    "#overview div.callout-style-default.callout-titled > div.callout-body > div.callout-title > div.callout-icon-container + p > strong", // default: title and icon correctly set
+    "#overview div.callout-style-default.callout-titled > div.callout-body > div.callout-title + div.callout-content", // default: title and content correctly set
+    "#appearance div.callout-style-simple > div.callout-body > div.callout-icon-container + div.callout-content", // simple: icon and content correctly set
+    "#appearance div.callout-style-default.callout-titled > div.callout-body > div.callout-title + div.callout-content", // default: title and content correctly set
+    "#appearance div.callout-style-default.no-icon.callout-titled > div.callout-body > div.callout-title + div.callout-content", // default no icon: title and content correctly set
+    "#appearance div.callout-style-simple.no-icon > div.callout-body", // simple no icon: content correctly set
+    "#minimal div.callout-style-simple.no-icon > div.callout-body > div.callout-content", // minimal
+  ], 
+  [
+    "#appearance div.callout-style-default.no-icon.callout-titled > div.callout-body > div.callout-title > div.callout-icon-container", // default no icon: title and content correctly set
+    "#appearance div.callout-style-simple.no-icon > div.callout-body > div.callout-icon-container", // simple no icon
+    "#minimal div.callout-style-simple.no-icon > div.callout-body > div.callout-icon-container"
+  ]),
+]);
+
 const teXOutput = outputForInput(input, "latex");
 testRender(input, "latex", true, [
   ensureFileRegexMatches(teXOutput.outputPath, [

--- a/tests/smoke/render/render-callout.test.ts
+++ b/tests/smoke/render/render-callout.test.ts
@@ -29,6 +29,18 @@ testRender(input, "html", false, [
     // formatting is kept in caption
     "div.callout-tip > div.callout-header > div.callout-title-container > strong",
     "div.callout-tip > div.callout-header > div.callout-title-container > code",
+    // appearance correctly modify structure
+    "#appearance div.callout-style-simple > div.callout-body > div.callout-icon-container + div.callout-body-container",
+    "#appearance div.callout-style-default.callout-titled > div.callout-header > div.callout-icon-container + div.callout-title-container",
+    "#appearance div.callout-style-default.callout-titled > div.callout-header + div.callout-body-container",
+    "#appearance div.callout-style-default.no-icon.callout-titled > div.callout-header > div.callout-icon-container > i.no-icon",
+    "#appearance div.callout-style-default.no-icon.callout-titled > div.callout-header > div.callout-icon-container + div.callout-title-container",
+    "#appearance div.callout-style-simple.no-icon > div.callout-body",
+    "#minimal div.callout-style-simple.no-icon > div.callout-body",
+  ], 
+  [
+    "#appearance div.callout-style-simple.no-icon > div.callout-header",
+    "#minimal div.callout-style-simple.no-icon > div.callout-header"
   ]),
 ]);
 


### PR DESCRIPTION
Fix #6827

We did not detect because not tests so I added some. 

Basically, we did some modification and fixed callout for HTML case, but not for EPUB + REVEALJS. 

* Handle callout title as empty table : Same fix for epub and reveal than 6721856
* Callout title are no more nil : Same fix as 239a3a9



