### PR TITLE
Use quarto number section processing for beamer format

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -105,6 +105,7 @@
 - ([#5536](https://github.com/quarto-dev/quarto-cli/issues/5536)): Correctly support Code Filename feature for Beamer output by fixing issue with float environment.
 - ([#6041](https://github.com/quarto-dev/quarto-cli/issues/6041)): Correctly support code block appearance options (`code-block-bg` and `code-block-border-left`).
 - ([#6226](https://github.com/quarto-dev/quarto-cli/issues/6226)): Correctly detect the need for an additional compilation for TOC layout when using `lualatex`
+- ([#6956](https://github.com/quarto-dev/quarto-cli/issues/6956)): Add support `number-section` to `format: beamer` to control whether sections are numbered.
 
 ## Asciidoc Format
 

--- a/src/resources/filters/crossref/sections.lua
+++ b/src/resources/filters/crossref/sections.lua
@@ -97,7 +97,7 @@ function currentSectionLevel()
 end
 
 function numberSections()
-  return not _quarto.format.isLatexOutput() and 
+  return (not _quarto.format.isLatexOutput() or _quarto.format.isBeamerOutput()) and 
          not _quarto.format.isTypstOutput() and
          (not _quarto.format.isMarkdownOutput() or _quarto.format.isMarkdownWithHtmlOutput())
          and numberSectionsOptionEnabled()

--- a/tests/docs/smoke-all/2023/09/22/beamer-numsec.qmd
+++ b/tests/docs/smoke-all/2023/09/22/beamer-numsec.qmd
@@ -1,0 +1,21 @@
+---
+title: Number Sections
+format: 
+  beamer:
+    number-sections: true
+    output-ext: tex
+_quarto:
+  tests:
+    beamer:
+      ensureFileRegexMatches:
+        - ['\{1 Section\}', '\{1[.]1 Subsection\}']
+        - []
+---
+
+## Section
+
+This is the content of the section
+
+### Subsection
+
+This is the content of the subsection

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -54,7 +54,7 @@ export function outputForInput(
     outputExt = ext 
   } else {
     outputExt = baseFormat || "html";
-    if (baseFormat === "latex" || baseFormat == "context") {
+    if (baseFormat === "latex" || baseFormat == "context" || baseFormat == "beamer") {
       outputExt = "tex";
     }
     if (baseFormat === "revealjs") {


### PR DESCRIPTION
As it seems it does not work in Pandoc (fix #6956) 

Though I don't know how `beamer` should be numbered but if a user does not want Quarto to number to add something else in preamble, then `number-sections: false` is the default. So no problem. 

Just opening the PR to not forget the idea and the possible fix, depending on what we want to do for this. 
Setting draft status so that we decide. 



