### PR TITLE
fix: underscore in code cell `filename` attribute in latex/pdf

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -51,6 +51,7 @@
 
 - ([#5969](https://github.com/quarto-dev/quarto-cli/issues/5969)): Correctly detect a required rerun for biblatex when using backref link options.
 - ([#6907](https://github.com/quarto-dev/quarto-cli/issues/6907)): Fix issue with footnote mark line processor not triggering.
+- ([#6990](https://github.com/quarto-dev/quarto-cli/issues/6990)): Fix an issue where underscore in `filename` code cell attribute were not escaped.
 
 ## Docusaurus Format
 

--- a/src/resources/filters/customnodes/decoratedcodeblock.lua
+++ b/src/resources/filters/customnodes/decoratedcodeblock.lua
@@ -55,7 +55,7 @@ _quarto.ast.add_renderer("DecoratedCodeBlock",
     if node.filename then
       -- if we have a filename, add it as a header
       return pandoc.Div(
-        { pandoc.Plain{pandoc.Strong{pandoc.Str(node.filename)}}, el },
+        { pandoc.Plain{pandoc.Strong{pandoc.Str(stringEscape(node.filename, "latex"))}}, el },
         pandoc.Attr("", {"code-with-filename"})
       )
     else

--- a/src/resources/filters/customnodes/decoratedcodeblock.lua
+++ b/src/resources/filters/customnodes/decoratedcodeblock.lua
@@ -55,7 +55,7 @@ _quarto.ast.add_renderer("DecoratedCodeBlock",
     if node.filename then
       -- if we have a filename, add it as a header
       return pandoc.Div(
-        { pandoc.Plain{pandoc.Strong{pandoc.Str(stringEscape(node.filename, "latex"))}}, el },
+        { pandoc.Plain{pandoc.Strong{pandoc.Str(node.filename)}}, el },
         pandoc.Attr("", {"code-with-filename"})
       )
     else
@@ -90,7 +90,7 @@ _quarto.ast.add_renderer("DecoratedCodeBlock",
         -- with both filename and captionContent we need to add a colon
         local listingCaption = pandoc.Plain({pandoc.RawInline("latex", "\\caption{")})
         listingCaption.content:insert(
-          pandoc.RawInline("latex", "\\texttt{" .. node.filename .. "}: ")
+          pandoc.RawInline("latex", "\\texttt{" .. stringEscape(node.filename, "latex") .. "}: ")
         )
         listingCaption.content:extend(captionContent)
         listingCaption.content:insert(pandoc.RawInline("latex", "}"))
@@ -99,7 +99,7 @@ _quarto.ast.add_renderer("DecoratedCodeBlock",
         local listingCaption = pandoc.Plain({pandoc.RawInline("latex", "\\caption{")})
         -- with just filename we don't add a colon
         listingCaption.content:insert(
-          pandoc.RawInline("latex", "\\texttt{" .. node.filename .. "}")
+          pandoc.RawInline("latex", "\\texttt{" .. stringEscape(node.filename, "latex") .. "}")
         )
         listingCaption.content:insert(pandoc.RawInline("latex", "}"))
         listingDiv.content:insert(listingCaption)

--- a/src/resources/filters/quarto-pre/code-filename.lua
+++ b/src/resources/filters/quarto-pre/code-filename.lua
@@ -10,6 +10,9 @@
 
 function code_filename()
   local function codeBlockWithFilename(el, filename)
+    if quarto.doc.is_format("latex") then
+      filename = string.gsub(filename, "_", "\\_")
+    end
     return quarto.DecoratedCodeBlock({
       filename = filename,
       code_block = el:clone()

--- a/src/resources/filters/quarto-pre/code-filename.lua
+++ b/src/resources/filters/quarto-pre/code-filename.lua
@@ -10,9 +10,6 @@
 
 function code_filename()
   local function codeBlockWithFilename(el, filename)
-    if quarto.doc.is_format("latex") then
-      filename = string.gsub(filename, "_", "\\_")
-    end
     return quarto.DecoratedCodeBlock({
       filename = filename,
       code_block = el:clone()

--- a/tests/docs/smoke-all/2023/09/25/issue-6990.qmd
+++ b/tests/docs/smoke-all/2023/09/25/issue-6990.qmd
@@ -1,12 +1,16 @@
 ---
 title: code filename with underscore in LaTeX
-format: latex
+format:
+  html: default
+  latex: default
 _quarto:
   tests:
+    html:
+      ensureFileRegexMatches:
+        - ["my_example.r"]
     latex:
       ensureFileRegexMatches:
-        - 
-          - "my\_example.r"
+        - ["my\\\\_example.r"]
 ---
 
 ```{.r filename="my_example.r"}

--- a/tests/docs/smoke-all/2023/09/25/issue-6990.qmd
+++ b/tests/docs/smoke-all/2023/09/25/issue-6990.qmd
@@ -1,0 +1,14 @@
+---
+title: code filename with underscore in LaTeX
+format: latex
+_quarto:
+  tests:
+    latex:
+      ensureFileRegexMatches:
+        - 
+          - "my\_example.r"
+---
+
+```{.r filename="my_example.r"}
+replicate(sample(1:10), 10)
+```


### PR DESCRIPTION
This PR adds an exception to escape underscore when the format is LaTeX in filename code cell attribute.
 
Fixes #6990

<img width="1624" alt="image" src="https://github.com/quarto-dev/quarto-cli/assets/8896044/eb57d8ca-fe51-4c4f-86df-2ad4effb912a">

