### PR TITLE
Fix regression subfloat with complex layout and subcaptions.

### DIFF
--- a/src/resources/filters/ast/runemulation.lua
+++ b/src/resources/filters/ast/runemulation.lua
@@ -33,17 +33,22 @@ local function run_emulated_filter_chain(doc, filters, afterFilterPass, profilin
       end
       -- luacov: enable
 
-      doc = run_emulated_filter(doc, v.filter)
+      if v.print_ast then
+        print(pandoc.write(doc, "native"))
+      else
 
-      add_trace(doc, v.name)
+        doc = run_emulated_filter(doc, v.filter)
 
-      -- luacov: disable
-      if profiling then
-        profiler.category = ""
+        add_trace(doc, v.name)
+
+        -- luacov: disable
+        if profiling then
+          profiler.category = ""
+        end
+        -- luacov: enable
       end
-      -- luacov: enable
     end
-    if v.filter.scriptFile then
+    if v.filter and v.filter.scriptFile then
       _quarto.withScriptFile(v.filter.scriptFile, callback)
     else
       callback()
@@ -108,7 +113,7 @@ function run_as_extended_ast(specTable)
     local finalResult = {}
   
     for i, v in ipairs(filterList) do
-      if v.filter ~= nil then
+      if v.filter ~= nil or v.print_ast then
         -- v.filter._filter_name = v.name
         table.insert(finalResult, v)
       elseif v.filters ~= nil then

--- a/src/resources/filters/layout/html.lua
+++ b/src/resources/filters/layout/html.lua
@@ -68,16 +68,17 @@ end, function(panel_layout)
   local rendered_panel
 
   if panel_layout.is_float_reftarget then
-    rendered_panel = float_reftarget_render_html_figure(
-      decorate_caption_with_crossref(quarto.FloatRefTarget({
-        identifier = panel_layout.identifier,
-        classes = panel_layout.classes,
-        attributes = panel_layout.attributes,
-        order = panel_layout.order,
-        type = panel_layout.type,
-        content = panel.content,
-        caption_long = pandoc.List({panel_layout.caption_long}),
-      })))
+    local float_node, float_tbl = quarto.FloatRefTarget({
+      identifier = panel_layout.identifier,
+      classes = panel_layout.classes,
+      attributes = panel_layout.attributes,
+      order = panel_layout.order,
+      type = panel_layout.type,
+      content = panel.content,
+      caption_long = pandoc.List({panel_layout.caption_long}),
+    })
+    decorate_caption_with_crossref(float_tbl)
+    rendered_panel = float_reftarget_render_html_figure(float_tbl)
     rendered_panel.attr = pandoc.Attr(panel_layout.identifier, {"quarto-layout-panel"})
   else
     rendered_panel = panel

--- a/src/resources/filters/layout/layout.lua
+++ b/src/resources/filters/layout/layout.lua
@@ -16,6 +16,17 @@ function layout_panels()
       if not attr_requires_panel_layout(div.attr) then
         return nil
       end
+      local nested_layout = false
+      _quarto.ast.walk(div, {
+        PanelLayout = function()
+          nested_layout = true
+        end
+      })
+      -- if we are nested then we assume the layout
+      -- has been handled by the child
+      if nested_layout then
+        return nil
+      end
       local preamble, cells = partition_cells(div)
       local layout = layout_cells(div, cells)
       return quarto.PanelLayout({
@@ -29,10 +40,20 @@ function layout_panels()
       if not attr_requires_panel_layout(attr) then
         return nil
       end
+      local nested_layout = false
+      _quarto.ast.walk(div, {
+        PanelLayout = function()
+          nested_layout = true
+        end
+      })
+      -- if we are nested then we assume the layout
+      -- has been handled by the child
+      if nested_layout then
+        return nil
+      end
 
       local preamble, cells = partition_cells(float)
       local layout = layout_cells(float, cells)
-      
       return quarto.PanelLayout({
         float = float,
         preamble = preamble,

--- a/src/resources/filters/quarto-pre/parsefiguredivs.lua
+++ b/src/resources/filters/quarto-pre/parsefiguredivs.lua
@@ -192,7 +192,7 @@ function parse_floats()
       local reftarget = quarto.FloatRefTarget({
         attr = attr,
         type = category.name,
-        content = final_content,
+        content = final_content.content,
         caption_long = {pandoc.Plain(caption.content)},
       })
       -- need to reference as a local variable because of the

--- a/tests/docs/smoke-all/2023/09/25/6993.qmd
+++ b/tests/docs/smoke-all/2023/09/25/6993.qmd
@@ -15,7 +15,8 @@ _quarto:
           - "a[href='#fig-1']"
           - "a[href='#fig-1-1']"
           - "a[href='#fig-1-2']"
-          - "a[href='#fig-2']"
+          - "a[href='#fig-2-1']"
+          - "a[href='#fig-2-2']"
         - []
 ---
 

--- a/tests/docs/smoke-all/2023/09/25/6993.qmd
+++ b/tests/docs/smoke-all/2023/09/25/6993.qmd
@@ -1,0 +1,85 @@
+---
+title: Layout test
+_quarto:
+  tests:
+    html:
+      # TODO decide the correct behavior in all cases
+      ensureFileRegexMatches:
+        - 
+          - "\\(a\\) Cars"
+          - "\\(b\\) Pressure"
+          - "\\(c\\) Mtcars"
+        - []
+      ensureHtmlElements:
+        -
+          - "a[href='#fig-1']"
+          - "a[href='#fig-1-1']"
+          - "a[href='#fig-1-2']"
+          - "a[href='#fig-2']"
+        - []
+---
+
+```{r}
+#| label: fig-1
+#| fig-cap: "Charts"
+#| fig-subcap: 
+#|   - "Cars"
+#|   - "Pressure"
+#| layout: "[1, 1]"
+
+plot(cars)
+plot(pressure)
+```
+
+See @fig-1, @fig-1-1, @fig-1-2.
+
+```{r}
+#| label: fig-2
+#| fig-cap: "Charts"
+#| layout: "[1, 1]"
+
+plot(cars)
+plot(pressure)
+```
+
+See @fig-2, @fig-2-1, @fig-2-2.
+
+```{r}
+#| label: fig-3
+#| fig-subcap: 
+#|   - "Cars"
+#|   - "Pressure"
+#| layout: "[1, 1]"
+
+plot(cars)
+plot(pressure)
+```
+
+see @fig-3, @fig-3-1, @fig-3-2.
+
+```{r}
+#| label: fig-4
+#| layout: "[1, 1]"
+
+plot(cars)
+plot(pressure)
+```
+
+See @fig-4, @fig-4-1, @fig-4-1.
+
+
+```{r}
+#| label: fig-5
+#| fig-cap: "Charts"
+#| fig-subcap: 
+#|   - "Cars"
+#|   - "Pressure"
+#|   - "Mtcars"
+#| layout: "[[3, 7], [1]]"
+
+plot(cars)
+plot(pressure)
+plot(mtcars)
+```
+
+See @fig-5, @fig-5-1, @fig-5-2, @fig-5-3.


### PR DESCRIPTION
Avoid nested PanelLayout computations from floats. Closes #6993.

Adds a regression test.

(Also adds the following debugging QOL improvement: `{ print_ast = true }` on our main.lua filter chain will print the AST output)

