### PR TITLE
Correctly forward `layout-valign` from knitr options to .cell Div

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -135,6 +135,7 @@
 - ([#4735](https://github.com/quarto-dev/quarto-cli/pull/4735)): Special `verbatim` and `embed` language engine for knitr's chunk are now better supported, including with special quarto cell option like `echo: fenced`.
 - ([#6775](https://github.com/quarto-dev/quarto-cli/pull/6775)): Avoid duplicating special internal `tools:quarto` R environment used for making `ojs_define()` accessible during knitting.
 - ([#6792](https://github.com/quarto-dev/quarto-cli/issues/6792)): `fig-asp` provided at YAML config level now correctly work to set `fig.asp` chunk option in **knitr**.
+- ([[#7002](https://github.com/quarto-dev/quarto-cli/issues/7002)): `layout-valign` is correctly forwarded to HTML to tweak vertical figure layout alignment for computational figures.
 
 ## OJS engine
 

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -283,7 +283,7 @@ knitr_hooks <- function(format, resourceDir, handledLanguages) {
     }
 
     # forward selected attributes
-    forward <- c("layout", "layout-nrow", "layout-ncol", "layout-align")
+    forward <- c("layout", "layout-nrow", "layout-ncol", "layout-align", "layout-valign")
     forwardAttr <- character()
     for (attr in forward) {
       value = options[[attr]]

--- a/tests/docs/smoke-all/knitr/in-chunk-layout.qmd
+++ b/tests/docs/smoke-all/knitr/in-chunk-layout.qmd
@@ -1,0 +1,77 @@
+---
+format: html
+engine: knitr
+_quarto:
+  tests:
+    html:
+      # echo: false has been set and nothing should be including 
+      ensureHtmlElements:
+        - 
+          - "#valign-bottom div.cell.quarto-layout-panel div.quarto-layout-row.quarto-layout-valign-bottom"
+          - "#valign-top div.cell.quarto-layout-panel div.quarto-layout-row.quarto-layout-valign-top"
+          - "#valign-center div.cell.quarto-layout-panel div.quarto-layout-row.quarto-layout-valign-center"
+          - "#valign-default div.cell.quarto-layout-panel div.quarto-layout-row.quarto-layout-valign-top"
+        - []
+      ensureFileRegexMatches:
+        - []
+        - []
+
+---
+
+## valign-bottom
+
+```{r}
+#| label: fig-charts1
+#| fig-cap: 
+#|   - "Speed and Stopping Distances of Cars"
+#|   - "Vapor Pressure of Mercury as a Function of Temperature"
+#| layout: "[1, 1]"
+#| layout-valign: bottom
+
+plot(cars)
+plot(pressure)
+```
+
+## valign-top
+
+```{r}
+#| label: fig-charts2
+#| fig-cap: 
+#|   - "Speed and Stopping Distances of Cars"
+#|   - "Vapor Pressure of Mercury as a Function of Temperature"
+#| layout: "[1, 1]"
+#| layout-valign: top
+
+plot(cars)
+plot(pressure)
+```
+
+## valign-center
+
+```{r}
+#| label: fig-charts3
+#| fig-cap: 
+#|   - "Speed and Stopping Distances of Cars"
+#|   - "Vapor Pressure of Mercury as a Function of Temperature"
+#| layout: "[1, 1]"
+#| layout-valign: center
+
+plot(cars)
+plot(pressure)
+```
+
+## valign-default
+
+```{r}
+#| label: fig-charts4
+#| fig-cap: 
+#|   - "Speed and Stopping Distances of Cars"
+#|   - "Vapor Pressure of Mercury as a Function of Temperature"
+#| layout: "[1, 1]"
+#| layout-valign: default
+
+plot(cars)
+plot(pressure)
+```
+
+


### PR DESCRIPTION
This fix #7002 

I added test only for `layout-valign` but we could probably add more for other configuration. 

