### PR TITLE
Add new debug step to knitr capabilities

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -210,3 +210,4 @@
 - ([#6825](https://github.com/quarto-dev/quarto-cli/issues/6825)): Show filename when YAML parsing error occurs.
 - ([#6836](https://github.com/quarto-dev/quarto-cli/issues/6836)): Fix missing `docx` format for `abstract` key in reference schema.
 - ([#7032](https://github.com/quarto-dev/quarto-cli/issues/7032)): `quarto` is now correctly working when installed in a folder with spaces in path.
+- ([#7013](https://github.com/quarto-dev/quarto-cli/issues/7013)): Improve error message when there is an issue finding or running R and add more verbosity in [verbose mode](https://quarto.org/docs/troubleshooting/#verbose-mode).

--- a/src/command/check/check.ts
+++ b/src/command/check/check.ts
@@ -340,11 +340,11 @@ async function checkKnitrInstallation(services: RenderServices) {
       );
       info("");
     }
-  } else if (!rBin) {
+  } else if (rBin === undefined) {
     completeMessage(kMessage + "(None)\n");
     info(rInstallationMessage(kIndent));
     info("");
-  } else if (!caps) {
+  } else if (caps === undefined) {
     completeMessage(kMessage + "(None)\n");
     info(
       `Problem with running R found at ${rBin} to check environment configurations.`,

--- a/src/command/check/check.ts
+++ b/src/command/check/check.ts
@@ -4,7 +4,7 @@
  * Copyright (C) 2021-2022 Posit Software, PBC
  */
 
-import { debug, info } from "log/mod.ts";
+import { info } from "log/mod.ts";
 
 import { render } from "../render/render-shared.ts";
 import { renderServices } from "../render/render-services.ts";
@@ -19,6 +19,7 @@ import {
 } from "../../core/jupyter/jupyter-shared.ts";
 import { completeMessage, withSpinner } from "../../core/console.ts";
 import {
+  checkRBinary,
   KnitrCapabilities,
   knitrCapabilities,
   knitrCapabilitiesMessage,
@@ -30,7 +31,7 @@ import { readCodePage } from "../../core/windows.ts";
 import { RenderServices } from "../render/types.ts";
 import { jupyterKernelspecForLanguage } from "../../core/jupyter/kernels.ts";
 import { execProcess } from "../../core/process.ts";
-import { pandocBinaryPath, rBinaryPath } from "../../core/resources.ts";
+import { pandocBinaryPath } from "../../core/resources.ts";
 import { lines } from "../../core/text.ts";
 import { satisfies } from "semver/mod.ts";
 import { dartCommand } from "../../core/dart-sass.ts";
@@ -280,28 +281,6 @@ title: "Title"
   });
   if (result.error) {
     throw result.error;
-  }
-}
-
-async function checkRBinary() {
-  const rBin = await rBinaryPath("Rscript");
-  try {
-    const result = await execProcess({
-      cmd: [rBin, "--version"],
-      stdout: "piped",
-    });
-    if (result.success && result.stdout) {
-      debug(`\n++R found at ${rBin} is working.`);
-      return rBin;
-    } else {
-      debug(`\n++R found at ${rBin} is not working properly.`);
-      return undefined;
-    }
-  } catch {
-    debug(
-      `\n++ Error while checking R binary found at ${rBin}`,
-    );
-    return undefined;
   }
 }
 

--- a/src/command/check/check.ts
+++ b/src/command/check/check.ts
@@ -325,8 +325,9 @@ async function checkKnitrInstallation(services: RenderServices) {
     info("");
   } else if (caps === undefined) {
     completeMessage(kMessage + "(None)\n");
+    info(`R succesfully found at ${rBin}.`);
     info(
-      `Problem with running R found at ${rBin} to check environment configurations.`,
+      "However, a problem was encountered when checking configurations of packages.",
     );
     info("Please check your installation of R.");
     info("");

--- a/src/core/knitr.ts
+++ b/src/core/knitr.ts
@@ -68,11 +68,11 @@ export async function knitrCapabilities(rBin: string | undefined) {
       debug(
         "\n++ Parsing results to get informations about knitr capabilities",
       );
-      const jsonLines = result.stdout
+      const yamlLines = result.stdout
         .replace(/^.*--- YAML_START ---/sm, "")
         .replace(/--- YAML_END ---.*$/sm, "");
 
-      const caps = readYamlFromString(jsonLines) as KnitrCapabilities;
+      const caps = readYamlFromString(yamlLines) as KnitrCapabilities;
       // check knitr requirement
       const knitrVersion = caps.packages.knitr
         ? coerce(caps.packages.knitr)

--- a/src/core/knitr.ts
+++ b/src/core/knitr.ts
@@ -35,6 +35,7 @@ const pkgVersRequirement = {
 
 export async function knitrCapabilities() {
   try {
+    debug(`-- Checking knitr engine capabilities --`);
     const result = await execProcess({
       cmd: [
         await rBinaryPath("Rscript"),
@@ -43,6 +44,7 @@ export async function knitrCapabilities() {
       stdout: "piped",
     });
     if (result.success && result.stdout) {
+      debug("\n++Parsing results to get informations about knitr capabilities");
       const jsonLines = result.stdout
         .replace(/^.*--- YAML_START ---/sm, "")
         .replace(/--- YAML_END ---.*$/sm, "");
@@ -58,11 +60,22 @@ export async function knitrCapabilities() {
           Object.values(pkgVersRequirement["knitr"]).join(" "),
         )
         : false;
+      debug(
+        `knitr version: ${knitrVersion} - ${
+          caps.packages.knitrVersOk ? "OK" : "NOT OK"
+        }`,
+      );
       return caps;
     } else {
+      debug("\n++Problem with results of knitr capabilities check.");
       return undefined;
     }
   } catch {
+    debug(
+      `\n++ Error while running 'capabilities/knitr.R' ${
+        rBin ? "with " + rBin : ""
+      }`,
+    );
     return undefined;
   }
 }

--- a/src/core/knitr.ts
+++ b/src/core/knitr.ts
@@ -34,6 +34,28 @@ const pkgVersRequirement = {
   },
 };
 
+export async function checkRBinary() {
+  const rBin = await rBinaryPath("Rscript");
+  try {
+    const result = await execProcess({
+      cmd: [rBin, "--version"],
+      stdout: "piped",
+    });
+    if (result.success && result.stdout) {
+      debug(`\n++R found at ${rBin} is working.`);
+      return rBin;
+    } else {
+      debug(`\n++R found at ${rBin} is not working properly.`);
+      return undefined;
+    }
+  } catch {
+    debug(
+      `\n++ Error while checking R binary found at ${rBin}`,
+    );
+    return undefined;
+  }
+}
+
 export async function knitrCapabilities(rBin: string | undefined) {
   if (!rBin) return undefined;
   try {

--- a/src/core/knitr.ts
+++ b/src/core/knitr.ts
@@ -61,7 +61,6 @@ export async function knitrCapabilities(rBin: string | undefined) {
           Object.values(pkgVersRequirement["knitr"]).join(" "),
         )
         : false;
-      );
       return caps;
     } else {
       debug("\n++ Problem with results of knitr capabilities check.");

--- a/src/core/resources.ts
+++ b/src/core/resources.ts
@@ -4,7 +4,7 @@
  * Copyright (C) 2020-2022 Posit Software, PBC
  */
 
-import { warning } from "log/mod.ts";
+import { debug, warning } from "log/mod.ts";
 import { existsSync, walkSync } from "fs/mod.ts";
 import { dirname, join } from "path/mod.ts";
 import { warnOnce } from "./log.ts";
@@ -15,7 +15,6 @@ import {
   kHKeyLocalMachine,
   registryReadString,
 } from "./registry.ts";
-import { debug } from "log/mod.ts";
 
 export function resourcePath(resource?: string): string {
   const sharePath = quartoConfig.sharePath();

--- a/src/core/resources.ts
+++ b/src/core/resources.ts
@@ -143,7 +143,7 @@ export async function rBinaryPath(binary: string): Promise<string> {
         "InstallPath",
       );
       if (installPath) {
-        debug(`Found in PATH at ${join(installPath, "bin")}`);
+        debug(`Found in Windows Registry at ${join(installPath, "bin")}`);
         return join(installPath, "bin", binary);
       }
     }

--- a/src/execute/rmd.ts
+++ b/src/execute/rmd.ts
@@ -279,7 +279,8 @@ function withinActiveRenv() {
 }
 
 async function printCallRDiagnostics() {
-  const caps = await knitrCapabilities();
+  const rBin = await rBinaryPath("Rscript");
+  const caps = await knitrCapabilities(rBin);
   if (!caps) {
     info("");
     info(rInstallationMessage());

--- a/src/execute/rmd.ts
+++ b/src/execute/rmd.ts
@@ -18,6 +18,7 @@ import { partitionMarkdown } from "../core/pandoc/pandoc-partition.ts";
 import { kCodeLink } from "../config/constants.ts";
 
 import {
+  checkRBinary,
   knitrCapabilities,
   knitrCapabilitiesMessage,
   knitrInstallationMessage,
@@ -279,31 +280,39 @@ function withinActiveRenv() {
 }
 
 async function printCallRDiagnostics() {
-  const rBin = await rBinaryPath("Rscript");
-  const caps = await knitrCapabilities(rBin);
-  if (!caps) {
+  const rBin = await checkRBinary();
+  if (rBin === undefined) {
     info("");
     info(rInstallationMessage());
     info("");
   } else {
-    if (
-      !caps?.packages.rmarkdown || !caps?.packages.knitr ||
-      !caps?.packages.knitrVersOk
-    ) {
-      info("");
-      info("R installation:");
-      info(knitrCapabilitiesMessage(caps, "  "));
-      info("");
+    const caps = await knitrCapabilities(rBin);
+    if (caps === undefined) {
       info(
-        knitrInstallationMessage(
-          "",
-          caps.packages.knitr && !caps?.packages.knitrVersOk
-            ? "knitr"
-            : "rmarkdown",
-          !!caps.packages.knitr && !caps.packages.knitrVersOk,
-        ),
+        `Problem with running R found at ${rBin} to check environment configurations.`,
       );
+      info("Please check your installation of R.");
       info("");
+    } else {
+      if (
+        !caps?.packages.rmarkdown || !caps?.packages.knitr ||
+        !caps?.packages.knitrVersOk
+      ) {
+        info("");
+        info("R installation:");
+        info(knitrCapabilitiesMessage(caps, "  "));
+        info("");
+        info(
+          knitrInstallationMessage(
+            "",
+            caps.packages.knitr && !caps?.packages.knitrVersOk
+              ? "knitr"
+              : "rmarkdown",
+            !!caps.packages.knitr && !caps.packages.knitrVersOk,
+          ),
+        );
+        info("");
+      }
     }
   }
 }


### PR DESCRIPTION
This PR aims to help debug further #6960 by 

* Separating checking R binary is working (using `RScript --version`) and checking R configuration (**knitr** and **rmarkdown** package). 
* This allow to throw "Unable to locate R error" only when R found by Quarto is really not working, and throw other error regarding capabilities otherwise. 
* It also allow to add more debug line for when  `$QUARTO_LOG_LEVEL=DEBUG` is set 

