### PR TITLE
typst: wrap image with attributes in a Para with a `#box([])`. 

### DIFF
--- a/src/resources/filters/main.lua
+++ b/src/resources/filters/main.lua
@@ -337,6 +337,7 @@ local quarto_post_filters = {
   -- format fixups post rendering
   { name = "post-render-html-fixups", filter = render_html_fixups() },
   { name = "post-render-ipynb-fixups", filter = render_ipynb_fixups() },
+  { name = "post-render-typst-fixups", filter = render_typst_fixups() },
 
   { name = "post-userAfterQuartoFilters", filters = make_wrapped_user_filters("afterQuartoFilters") },
 }

--- a/src/resources/filters/quarto-post/typst.lua
+++ b/src/resources/filters/quarto-post/typst.lua
@@ -33,3 +33,22 @@ function render_typst()
     end
   }
 end
+
+function render_typst_fixups()
+  return {
+    Para = function(para)
+      return para:walk({
+        Image = function(image)
+          if image.attributes["width"] == nil and image.attributes["height"] == nil then
+            return nil
+          end
+          return pandoc.Inlines({
+            pandoc.RawInline("typst", "#box(["),
+            image,
+            pandoc.RawInline("typst", "])"),
+          })
+        end
+      })
+    end
+  }
+end

--- a/tests/docs/smoke-all/2023/09/26/6977.qmd
+++ b/tests/docs/smoke-all/2023/09/26/6977.qmd
@@ -1,0 +1,16 @@
+---
+format: typst
+# FIXME no _quarto tests support yet
+---
+
+This is a paragraph with an inline image ![](./page-menu-icon.jpg){height="1em"}.
+
+::: {#fig-1}
+
+![](./page-menu-icon.jpg)
+
+A caption
+
+:::
+
+See @fig-1.


### PR DESCRIPTION
Closes #6977.

While https://github.com/jgm/pandoc/pull/9105 isn't merged, we can work around it locally.
