### PR TITLE
[revealjs] Fix line highlight when code annotation is present

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -46,6 +46,7 @@
 - ([#5783](https://github.com/quarto-dev/quarto-cli/issues/5783)): Ensure fenced code blocks work with line numbers.
 - ([#6120](https://github.com/quarto-dev/quarto-cli/issues/6120)): `pdf-max-pages-per-slide` is now correctly setting [`pdfMaxPagesPerSlide` config](https://revealjs.com/pdf-export/#page-size) for RevealJS.
 - ([#6827](https://github.com/quarto-dev/quarto-cli/issues/6120)): Correctly layout callout in revealjs slides when changing appearance.
+- ([#7042](https://github.com/quarto-dev/quarto-cli/issues/7042)): Line highligthting now work correctly with code annotation.
 
 ## PDF Format
 

--- a/src/resources/formats/revealjs/plugins/line-highlight/line-highlight.js
+++ b/src/resources/formats/revealjs/plugins/line-highlight/line-highlight.js
@@ -165,9 +165,9 @@ window.QuartoLineHighlight = function () {
         if (typeof highlight.last === "number") {
           spanToHighlight = [].slice.call(
             codeBlock.querySelectorAll(
-              ":scope > span:nth-child(n+" +
+              ":scope > span:nth-of-type(n+" +
                 highlight.first +
-                "):nth-child(-n+" +
+                "):nth-of-type(-n+" +
                 highlight.last +
                 ")"
             )
@@ -175,7 +175,7 @@ window.QuartoLineHighlight = function () {
         } else if (typeof highlight.first === "number") {
           spanToHighlight = [].slice.call(
             codeBlock.querySelectorAll(
-              ":scope > span:nth-child(" + highlight.first + ")"
+              ":scope > span:nth-of-type(" + highlight.first + ")"
             )
           );
         }


### PR DESCRIPTION
This fix #7042

Use :nth-of-type instead of :nth-child for detecting highlights on code line

Because code annotation will add some <a> elements for annotation item in the middle of each line <span>

# Left to do 

- [ ] Add test
- [x] Add to changelog