### PR TITLE
Separate custom node handlers for block and inline

### DIFF
--- a/src/resources/filters/ast/parse.lua
+++ b/src/resources/filters/ast/parse.lua
@@ -3,10 +3,10 @@
 --
 -- Copyright (C) 2022 by RStudio, PBC
 
-local function parse(node)
+local function parse(node, kind)
   for _, class in ipairs(node.attr.classes) do
     local tag = pandoc.utils.stringify(class)
-    local handler = _quarto.ast.resolve_handler(tag)
+    local handler = _quarto.ast.resolve_handler(tag, kind)
     if handler ~= nil then
       return handler.parse(node)
     end
@@ -14,9 +14,17 @@ local function parse(node)
   return node
 end
 
+local function parse_inline(node)
+  return parse(node, 'Inline')
+end
+
+local function parse_block(node)
+  return parse(node, 'Block')
+end
+
 function parse_extended_nodes() 
   return {
-    Div = parse,
-    Span = parse,
+    Div = parse_block,
+    Span = parse_inline,
   }
 end


### PR DESCRIPTION
## Description

This addresses #6940 by storing custom block and inline handlers in seperate tables. This way it is possible for the same class name (`content-visible`) to have one handler for divs and another for spans.

Currently this PR doesn't add a handler for Spans, so they don't get a custom node wrapper, but they still get a working `content-hidden` treatment, like code blocks. Without this PR, conditional spans cause an error.

If desired, I can add custom nodes for inlines (to wrap conditional spans), and wrap conditional code blocks using the existing ConditionalBlock.

I'll be happy to add some tests and documentation if the general idea is approved, and after it's decided what to do about custom nodes for conditional spans and code blocks.

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
