### PR TITLE
Add missing 3rd argument to \@ifundefined

### DIFF
--- a/src/resources/filters/layout/meta.lua
+++ b/src/resources/filters/layout/meta.lua
@@ -57,11 +57,11 @@ function layout_meta_inject_latex_packages()
         metaInjectLatex(meta, function(inject)
           if (shadeColor ~= nil) then
             inject(
-              "\\@ifundefined{shadecolor}{\\definecolor{shadecolor}" .. shadeColor .. "}"
+              "\\@ifundefined{shadecolor}{\\definecolor{shadecolor}" .. shadeColor .. "}{}"
             )  
           else
             inject(
-              "\\@ifundefined{shadecolor}{\\definecolor{shadecolor}{rgb}{.97, .97, .97}}"
+              "\\@ifundefined{shadecolor}{\\definecolor{shadecolor}{rgb}{.97, .97, .97}}{}"
             )  
           end
         end)
@@ -69,7 +69,7 @@ function layout_meta_inject_latex_packages()
         metaInjectLatex(meta, function(inject)
           if (bgColor ~= nil) then
             inject(
-              "\\@ifundefined{codebgcolor}{\\definecolor{codebgcolor}" .. bgColor .. "}"
+              "\\@ifundefined{codebgcolor}{\\definecolor{codebgcolor}" .. bgColor .. "}{}"
             )  
           end
         end)


### PR DESCRIPTION
## Description

In the tex code generated by quarto, some calls of the latex command `\@ifundefined` are missing the third argument, so the next command is eaten by the macro. This PR adds an empty argument where required.

(I've included fixes for the same issue in the `acm_proc_article-sp.cls` class files. Ideally it should be fixed upstream but I couldn't find where to submit a fix.)


### Example

Rendering the following:

````
---
code-block-bg: "#000000"
keep-tex: true
format: pdf
---

```
2+2
```
````

will generate the following lines:

```
\makeatletter
\@ifundefined{shadecolor}{\definecolor{shadecolor}{rgb}{.97, .97, .97}}
\makeatother
\makeatletter
\@ifundefined{codebgcolor}{\definecolor{codebgcolor}{HTML}{000000}}
\makeatother

```

Here each call to `\@ifundefined` will eat the next `\makeatother` as third argument. The problem becomes apparent if we replace these lines with

```
\makeatletter
\@ifundefined{shadecolor}{\definecolor{shadecolor}{rgb}{.97, .97, .97}}
\@ifundefined{codebgcolor}{\definecolor{codebgcolor}{HTML}{010305}}
\makeatother
```

This should do the same thing but produces the error

```
! LaTeX Error: Missing \begin{document}.

See the LaTeX manual or LaTeX Companion for explanation.
Type  H <return>  for immediate help.
 ...                                              
                                                  
l.152 \@ifundefined{c
                     odebgcolor}{\definecolor{codebgcolor}{HTML}{010305}}
? 
```


## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
