### PR TITLE
return unparsed unprocessed shortcode when not recognized.

### DIFF
--- a/tests/docs/smoke-all/2023/10/02/7108.qmd
+++ b/tests/docs/smoke-all/2023/10/02/7108.qmd
@@ -1,0 +1,16 @@
+---
+title: "Test"
+format: hugo-md
+_quarto:
+  tests:
+    hugo-md:
+      ensureFileRegexMatches:
+        - ["{{< noticeowl \"learn\" >}}", "{{< noticeowl2 \"learn2\" >}}"]
+        - []
+---
+
+The below shortcode is not known and should be passed as-is
+
+{{< noticeowl "learn" >}}
+
+This inline shortcode should also be preserved {{< noticeowl2 "learn2" >}} and not touched.


### PR DESCRIPTION
Fixes an early 1.4 regression I introduced with qmd-reader and early parsing of shortcodes. I had missed that we need to send along unprocessed shortcodes. I apologize.

This adds a regression test to avoid future breakage.

Closes #7108.