### PR TITLE
fix: listing display issue caused by #7088 fix

### DIFF
--- a/src/resources/projects/website/listing/quarto-listing.scss
+++ b/src/resources/projects/website/listing/quarto-listing.scss
@@ -615,13 +615,7 @@ div.quarto-post {
 
   a {
     color: $body-color;
-    display: flex;
-    flex-direction: column;
     text-decoration: none;
-
-    div.description {
-      flex-shrink: 0;
-    }
   }
 
   .metadata {


### PR DESCRIPTION
9bd1efbd02f8930d7076d391fea98fab0240082f (#7088) introduced a style regression in listing when there is a code div in title and/or description.

Reprex:

```bash
quarto create project blog mysite
cd mysite
sed -i '' 's/Code/`Code`/g' "posts/post-with-code/index.qmd"
quarto render
```

| Before this PR | With this PR |
|--------|--------|
| <img width="731" alt="image" src="https://github.com/quarto-dev/quarto-cli/assets/8896044/d690293b-42a5-4424-8c54-ddcfc46be592"> | <img width="731" alt="image" src="https://github.com/quarto-dev/quarto-cli/assets/8896044/c19a468b-6184-4979-80cb-42a0b1878978"> | 
| <img width="724" alt="image" src="https://github.com/quarto-dev/quarto-cli/assets/8896044/ba558c1f-2dd7-4315-9090-ff17846634c0"> | <img width="727" alt="image" src="https://github.com/quarto-dev/quarto-cli/assets/8896044/3c52a04b-329c-422f-a109-7baa71abf48c"> |

