### PR TITLE
[knitr] Correctly write markdown content to rmd intermediate on windows

### DIFF
--- a/src/resources/rmd/execute.R
+++ b/src/resources/rmd/execute.R
@@ -20,8 +20,13 @@ execute <- function(input, format, tempDir, libDir, dependencies, cwd, params, r
   # rmd input filename
   rmd_input <- paste0(xfun::sans_ext(input), ".rmarkdown")
       
-  # swap out the input
-  write(markdown, rmd_input)
+  # swap out the input by reading then writing content.
+  # This handles `\r\n` EOL on windows in `markdown` string
+  # by spliting in lines
+  xfun::write_utf8(
+    xfun::read_utf8(textConnection(markdown, encoding = "UTF-8")),
+    rmd_input
+  )
   input <- rmd_input
       
   # remove the rmd input on exit


### PR DESCRIPTION
On Windows `markdown` content parsed by Quarto from .qmd file is passed to R part of code base as a single string using windows EOL (`\r\n`). Previously, using base::write() was writing an empty line between each original linebreak because it is based on `cat()` and does write linebreak for `\r` and `\n`.  We need the rmd intermediate as close as possible to the input .qmd

Opening this PR to run tests but I believe this will be ok and this change is for the best.

## Example

Take this simple .qmd 
````
---
title: "Test"
format: html
---

## Quarto

Quarto enables you to weave together content and executable code into a finished document. To learn more about Quarto see <https://quarto.org>.


```{r}
1 + 1
```

````

What Quarto is passing to R is this markdown content
````r
markdown <-
"---\r\ntitle: \"Test\"\r\nformat: html\r\n---\r\n\n\r\n## Quarto\r\n\r\nQuarto enables you to weave together content and executable code into a finished document. To learn more about Quarto see <https://quarto.org>.\r\n\r\n\r\n\n```{r}\r\n1 + 1\r\n```\r\n"
````

Note the `\r\n`. 

This would be the content of `.rmarkdown` intermediate used by `rmarkdown::render()` - see all the new lines. 

````markdown
---

title: "Test"

format: html

---




## Quarto



Quarto enables you to weave together content and executable code into a finished document. To learn more about Quarto see <https://quarto.org>.






```{r}

1 + 1

```


````

I am surprised that this is has not create any issue, probably because we only `knit()` using **rmarkdown** but still. 

This PR fix this on the R side by making sure we write `markdown` the right way in the .rmarkdown input file. 

We could also normalize `markdown` to have only `\n` and no `\r\n` EOL. 