### PR TITLE
Fix Bug for ISBN in formats/jats/pandoc/front.xml

### DIFF
--- a/src/resources/formats/jats/pandoc/front.xml
+++ b/src/resources/formats/jats/pandoc/front.xml
@@ -111,7 +111,7 @@ $endif$</pub-date>$endif$
 
 $if(citation.volume)$<volume>$citation.volume$</volume>$endif$
 $if(citation.issue)$<issue>$citation.issue$</issue>$endif$
-$if(citation.isbn)$<issue>$citation.isbn$</isbn>$endif$
+$if(citation.isbn)$<isbn>$citation.isbn$</isbn>$endif$
 $if(citation.first-page)$<fpage>$citation.first-page$</fpage>$endif$
 $if(citation.last-page)$<lpage>$citation.last-page$</lpage>$endif$
 $if(citation.elocation-id)$<elocation-id>$citation.elocation-id$</elocation-id>$endif$


### PR DESCRIPTION
## Description

The metadata tag for ISBN in the xml file for the JATS format was erroneous.

**Proposed fix: correct the typo in line 114 by changing `<issue>` to `<isbn>`.**

Solves issue #7131

