### PR TITLE
LaTeX proof environments: don't add extra linebreaks

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -54,6 +54,7 @@
 ## PDF Format
 
 - ([#5969](https://github.com/quarto-dev/quarto-cli/issues/5969)): Correctly detect a required rerun for biblatex when using backref link options.
+- ([#6077](https://github.com/quarto-dev/quarto-cli/issues/6077)): Make sure proof environments are tight around contents.
 - ([#6907](https://github.com/quarto-dev/quarto-cli/issues/6907)): Fix issue with footnote mark line processor not triggering.
 - ([#6990](https://github.com/quarto-dev/quarto-cli/issues/6990)): Fix an issue where underscore in `filename` code cell attribute were not escaped.
 

--- a/src/resources/filters/quarto-pre/parsefiguredivs.lua
+++ b/src/resources/filters/quarto-pre/parsefiguredivs.lua
@@ -122,7 +122,7 @@ function parse_floats()
 
     local identifier = div.identifier
     local attr = pandoc.Attr(identifier, div.classes, div.attributes)
-    if (#content >= 1 and #content <= 2 and content[1].t == "Para" and
+    if (#content == 1 and content[1].t == "Para" and
         content[1].content[1].t == "Image") then
       -- if the div contains a single image, then we simply use the image as
       -- the content

--- a/tests/docs/smoke-all/2023/10/04/5637.qmd
+++ b/tests/docs/smoke-all/2023/10/04/5637.qmd
@@ -1,0 +1,27 @@
+---
+title: issue-5637
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - 
+          - "img" # the bug was causing our code to fail to find the layout entirely
+          - "div.quarto-layout-cell" # but let's also check that a layout is being computed here.
+          - "a.quarto-xref" # and that a cross-referenceable figure is available
+        - []
+---
+
+# Introduction
+
+This is a book created from markdown and executable code.
+
+::: {#fig-test layout="[1,1]"}
+
+![](cover.png)
+
+![](cover.png)
+
+Some logos.
+:::
+
+See @fig-test.

--- a/tests/docs/smoke-all/2023/10/04/6077.lua
+++ b/tests/docs/smoke-all/2023/10/04/6077.lua
@@ -1,0 +1,10 @@
+return {
+  traverse = "topdown",
+
+  Para = function(para)
+    if #para.content == 1 and para.content[1].t == "RawInline" then
+      -- don't emit RawInline in a para by itself, since that will cause a line break
+      crash()
+    end
+  end
+}

--- a/tests/docs/smoke-all/2023/10/04/6077.qmd
+++ b/tests/docs/smoke-all/2023/10/04/6077.qmd
@@ -1,0 +1,44 @@
+---
+title: "QED symbol test"
+format: latex
+filters:
+  - at: post-render
+    path: 6077.lua
+---
+
+:::{.proof}
+This is a proof.
+:::
+
+:::{.proof}
+This is a proof.
+
+This is the second para of the proof.
+:::
+
+:::{.proof}
+This is a proof.
+
+This proof ends with an image:
+
+![](./mark.jpg)
+:::
+
+:::{.proof}
+![](./mark.jpg)
+
+This is a proof.
+
+```{=latex}
+This proof ends with a raw latex block.
+```
+:::
+
+:::{.proof}
+```{=latex}
+This proof begins with a raw latex block.
+```
+
+This is a proof.
+:::
+


### PR DESCRIPTION
This closes #6077 by being more careful about the way we generate enclosing proof environments.