### PR TITLE
Restrict when ipynb heading is used as document title

### DIFF
--- a/src/core/jupyter/jupyter-filters.ts
+++ b/src/core/jupyter/jupyter-filters.ts
@@ -30,9 +30,11 @@ export async function markdownFromNotebookFile(file: string, format?: Format) {
   return markdownFromNotebookJSON(nb);
 }
 
-export function markdownFromNotebookJSON(nb: JupyterNotebook) {
-  // run the front matter fixup
-  nb = fixupFrontMatter(nb);
+export function markdownFromNotebookJSON(nb: JupyterNotebook, hasProjectTitle?: boolean) {
+  if (!hasProjectTitle) {
+    // run the front matter fixup
+    nb = fixupFrontMatter(nb);
+  }
 
   const markdown = nb.cells.reduce((md, cell) => {
     if (["markdown", "raw"].includes(cell.cell_type)) {

--- a/src/core/jupyter/jupyter-fixups.ts
+++ b/src/core/jupyter/jupyter-fixups.ts
@@ -7,6 +7,8 @@
 import { stringify } from "yaml/mod.ts";
 import { warning } from "log/mod.ts";
 
+import * as ld from "../../core/lodash.ts";
+
 import { kTitle } from "../../config/constants.ts";
 import { Metadata } from "../../config/types.ts";
 import { lines } from "../lib/text.ts";
@@ -227,6 +229,7 @@ const defaultFixups: ((
   fixupStreams,
 ];
 
+// minimal fixups: used e.g. when embedding a notebook
 const minimalFixups: ((
   nb: JupyterNotebook,
 ) => JupyterNotebook)[] = [
@@ -234,19 +237,15 @@ const minimalFixups: ((
   fixupStreams,
 ];
 
-// books can't have the front matter fixup
-export const bookFixups: JupyterFixup[] = [
-  fixupBokehCells,
-];
-
 export function fixupJupyterNotebook(
   nb: JupyterNotebook,
   nbFixups: "minimal" | "default",
-  explicitFixups?: JupyterFixup[],
+  excludeFixups?: JupyterFixup[],
 ): JupyterNotebook {
-  const fixups = explicitFixups || nbFixups === "minimal"
-    ? minimalFixups
-    : defaultFixups;
+  let fixups = nbFixups === "minimal" ? minimalFixups : defaultFixups;
+  if (excludeFixups) {
+    fixups = ld.difference(fixups, excludeFixups);
+  }
   for (const fixup of fixups) {
     nb = fixup(nb);
   }

--- a/src/execute/jupyter/jupyter.ts
+++ b/src/execute/jupyter/jupyter.ts
@@ -156,9 +156,10 @@ export const jupyterEngine: ExecutionEngine = {
 
     if (markdown === undefined) {
       if (isJupyterNotebook(file)) {
+        const hasProjectTitle = !!project?.config?.title;
         const nbJSON = Deno.readTextFileSync(file);
         nb = JSON.parse(nbJSON) as JupyterNotebook;
-        markdown = asMappedString(markdownFromNotebookJSON(nb));
+        markdown = asMappedString(markdownFromNotebookJSON(nb, hasProjectTitle));
       } else if (isPercentScript) {
         markdown = asMappedString(markdownFromJupyterPercentScript(file));
       } else {
@@ -327,6 +328,7 @@ export const jupyterEngine: ExecutionEngine = {
       options.target.input,
       options.format.pandoc.to,
     );
+
     // NOTE: for perforance reasons the 'nb' is mutated in place
     // by jupyterToMarkdown (we don't want to make a copy of a
     // potentially very large notebook) so should not be relied

--- a/tests/docs/smoke-all/2023/10/06/issue-5363/document.qmd
+++ b/tests/docs/smoke-all/2023/10/06/issue-5363/document.qmd
@@ -1,0 +1,16 @@
+---
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ["section.level2 #my-section-heading"]
+        - ["h1.title #my-section-heading"]
+---
+
+Some paragraph
+
+## [Section title]{#my-section-heading}
+
+```{python}
+2+2
+```

--- a/tests/docs/smoke-all/2023/10/06/issue-6411/_quarto.yml
+++ b/tests/docs/smoke-all/2023/10/06/issue-6411/_quarto.yml
@@ -1,0 +1,4 @@
+project:
+  output-dir: .
+
+title: "[Document title]{#my-doc-title}"

--- a/tests/docs/smoke-all/2023/10/06/issue-6411/document.qmd
+++ b/tests/docs/smoke-all/2023/10/06/issue-6411/document.qmd
@@ -1,0 +1,14 @@
+---
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ["h1.title #my-doc-title", "section.level2 #my-slide-heading"]
+        - ["h1.title #my-slide-heading"]
+---
+
+## [Slide title]{#my-slide-heading}
+
+```{python}
+2+2
+```


### PR DESCRIPTION
## Description

This is intended to fix cases where a section heading is wrongly promoted to document title.

I think the promotion feature is only meant for people who write Jupyter notebooks where they write the document title as a heading (rather than YAML). In this spirit, this PR makes the following changes:

* Promote only if the notebook is the source file (e.g. do **not** promote a heading for markdown sources where the ipynb is just an intermediate file). This fixes https://github.com/quarto-dev/quarto-cli/issues/5363

* Promote only if there is no title in the metadata. This fixes https://github.com/quarto-dev/quarto-cli/issues/6411


## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
