### PR TITLE
Correctly create annotation in latex when multiple digits

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -58,6 +58,7 @@
 - ([#6077](https://github.com/quarto-dev/quarto-cli/issues/6077)): Make sure proof environments are tight around contents.
 - ([#6907](https://github.com/quarto-dev/quarto-cli/issues/6907)): Fix issue with footnote mark line processor not triggering.
 - ([#6990](https://github.com/quarto-dev/quarto-cli/issues/6990)): Fix an issue where underscore in `filename` code cell attribute were not escaped.
+- ([#7175](https://github.com/quarto-dev/quarto-cli/issues/7175)): Fix an issue with code annotations when more than one digit is used for annotation number.
 
 ## Docusaurus Format
 

--- a/src/format/pdf/format-pdf.ts
+++ b/src/format/pdf/format-pdf.ts
@@ -1004,7 +1004,7 @@ const codeAnnotationPostProcessor = () => {
   };
 };
 
-const kListAnnotationRegex = /(.*)5CB6E08D-list-annote-(\d)(.*)/g;
+const kListAnnotationRegex = /(.*)5CB6E08D-list-annote-(\d+)(.*)/g;
 const codeListAnnotationPostProcessor = () => {
   return (line: string): string | undefined => {
     return line.replaceAll(

--- a/tests/docs/smoke-all/2023/01/03/code-annote-latex.qmd
+++ b/tests/docs/smoke-all/2023/01/03/code-annote-latex.qmd
@@ -8,7 +8,11 @@ _quarto:
   tests: 
     latex:
       ensureFileRegexMatches:
-        - ["\\\\item\\[\\\\circled\\{1\\}\\]"]
+        - 
+          - '\\item\[\\circled\{1\}\]'
+          - '\\NormalTok\{\\circled\{1\}\}'
+          - '\\item\[\\circled\{11\}\]'
+          - '\\NormalTok\{\\circled\{11\}\}'
 ---
 
 ## Hi There
@@ -21,3 +25,35 @@ if (foo === "bar") {
 ```
 
 1. This is a console output
+
+
+## Using multiple number 
+
+From https://github.com/quarto-dev/quarto-cli/issues/7175
+
+```{julia}
+line1 = "a" # <1>
+line2 = "b" # <2>
+line3 = "c" # <3>
+line4 = "d" # <4>
+line5 = "e" # <5>
+line6 = "f" # <6>
+line7 = "g" # <7>
+line8 = "h" # <8>
+line9 = "i" # <9>
+line10 = "j" # <10>
+line11 = "k" # <11>
+line12 = "l" # <12>
+```
+1. Annotation Displayed Correctly
+2. Annotation Displayed Correctly
+3. Annotation Displayed Correctly
+4. Annotation Displayed Correctly
+5. Annotation Displayed Correctly
+6. Annotation Displayed Correctly
+7. Annotation Displayed Correctly
+8. Annotation Displayed Correctly
+9. Annotation Displayed Correctly
+10. Annotation Displayed Incorrectly
+11. Annotation Displayed Incorrectly
+12. Annotation Displayed Incorrectly


### PR DESCRIPTION
fix #7175

This was a small regex issue
