### PR TITLE
Add `html-table-processing` as a cell option

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -37,7 +37,7 @@
 - ([#6714](https://github.com/quarto-dev/quarto-cli/issues/6714)): Display title block for HTML when other (non-title/author/subtitle) metadata is present.
 - ([#6833](https://github.com/quarto-dev/quarto-cli/issues/6833)): Handle partially-specified aspect ratio, width, and height attributes in `video` shortcode.
 - ([#7137](https://github.com/quarto-dev/quarto-cli/discussions/7137)): Automatically set `rel="noopener"` when setting a target on external links
-- ([#7187](https://github.com/quarto-dev/quarto-cli/issues/7187)): Add `html-table-processing: none` to document- and project-level metadata to disable HTML table processing. Add `{html-table-processing="none"}` to a fenced div to disable HTML table processing for the elements in that div. Add `html-table-processing: false` on knitr or jupyter cell to disable HTML table processing for the cell output content.
+- ([#7187](https://github.com/quarto-dev/quarto-cli/issues/7187)): Add `html-table-processing: none` to document- and project-level metadata to disable HTML table processing. Add `{html-table-processing="none"}` to a fenced div to disable HTML table processing for the elements in that div. Add `html-table-processing: none` on knitr or jupyter cell to disable HTML table processing for the cell output content.
 
 ## Appendix
 

--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -37,7 +37,7 @@
 - ([#6714](https://github.com/quarto-dev/quarto-cli/issues/6714)): Display title block for HTML when other (non-title/author/subtitle) metadata is present.
 - ([#6833](https://github.com/quarto-dev/quarto-cli/issues/6833)): Handle partially-specified aspect ratio, width, and height attributes in `video` shortcode.
 - ([#7137](https://github.com/quarto-dev/quarto-cli/discussions/7137)): Automatically set `rel="noopener"` when setting a target on external links
-- ([#7187](https://github.com/quarto-dev/quarto-cli/issues/7187)): Add `html-table-processing: none` to document- and project-level metadata to disable HTML table processing. Add `{html-table-processing="none"}` to a fenced div to disable HTML table processing for the elements in that div.
+- ([#7187](https://github.com/quarto-dev/quarto-cli/issues/7187)): Add `html-table-processing: none` to document- and project-level metadata to disable HTML table processing. Add `{html-table-processing="none"}` to a fenced div to disable HTML table processing for the elements in that div. Add `html-table-processing: false` on knitr or jupyter cell to disable HTML table processing for the cell output content.
 
 ## Appendix
 

--- a/src/core/jupyter/jupyter.ts
+++ b/src/core/jupyter/jupyter.ts
@@ -1493,7 +1493,7 @@ async function mdFromCodeCell(
           md.push(` execution_count=${output.execution_count}`);
         }
 
-        if (cell.options[kHtmlTableProcessing] === false) {
+        if (cell.options[kHtmlTableProcessing] === "none") {
           md.push(" html-table-processing=none");
         }
 

--- a/src/core/jupyter/jupyter.ts
+++ b/src/core/jupyter/jupyter.ts
@@ -109,6 +109,7 @@ import {
   kError,
   kEval,
   kFigCapLoc,
+  kHtmlTableProcessing,
   kInclude,
   kLayout,
   kLayoutAlign,
@@ -210,6 +211,7 @@ export const kJupyterCellInternalOptionKeys = [
   kCodeLineNumbers,
   kCodeSummary,
   kCodeOverflow,
+  kHtmlTableProcessing,
 ];
 
 export const kJupyterCellOptionKeys = kJupyterCellInternalOptionKeys.concat([
@@ -1489,6 +1491,10 @@ async function mdFromCodeCell(
         // add execution count if we have one
         if (typeof (output.execution_count) === "number") {
           md.push(` execution_count=${output.execution_count}`);
+        }
+
+        if (cell.options[kHtmlTableProcessing] === false) {
+          md.push(" html-table-processing=none");
         }
 
         md.push("}\n");

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -7964,6 +7964,15 @@ var require_yaml_intelligence_resources = __commonJS({
             short: "Apply explicit table column widths",
             long: "Apply explicit table column widths for markdown grid tables and pipe\ntables that are more than `columns` characters wide (72 by default). \n\nSome formats (e.g. HTML) do an excellent job automatically sizing\ntable columns and so don't benefit much from column width specifications.\nOther formats (e.g. LaTeX) require table column sizes in order to \ncorrectly flow longer cell content (this is a major reason why tables \n> 72 columns wide are assigned explicit widths by Pandoc).\n\nThis can be specified as:\n\n- `auto`: Apply markdown table column widths except when there is a\n  hyperlink in the table (which tends to throw off automatic\n  calculation of column widths based on the markdown text width of cells).\n  (`auto` is the default for HTML output formats)\n\n- `true`: Always apply markdown table widths (`true` is the default\n  for all non-HTML formats)\n\n- `false`: Never apply markdown table widths.\n\n- An array of numbers (e.g. `[40, 30, 30]`): Array of explicit width percentages.\n"
           }
+        },
+        {
+          name: "html-table-processing",
+          schema: {
+            enum: [
+              "none"
+            ]
+          },
+          description: "If `none`, do not process raw HTML table in cell output and leave it as-is"
         }
       ],
       "schema/cell-textoutput.yml": [
@@ -21048,6 +21057,7 @@ var require_yaml_intelligence_resources = __commonJS({
           short: "Specify the default dpi (dots per inch) value for conversion from\npixels to inch/ centimeters and vice versa.",
           long: "Specify the default dpi (dots per inch) value for conversion from\npixels to inch/ centimeters and vice versa. (Technically, the correct\nterm would be ppi: pixels per inch.) The default is <code>96</code>.\nWhen images contain information about dpi internally, the encoded value\nis used instead of the default specified by this option."
         },
+        "If <code>none</code>, do not process tables in HTML input.",
         "Logo image (placed in bottom right corner of slides)",
         {
           short: "Footer to include on all slides",
@@ -21918,7 +21928,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
         "Manuscript configuration",
         "internal-schema-hack",
-        "If <code>none</code>, do not process tables in HTML input."
+        "If <code>none</code>, do not process raw HTML table in cell output\nand leave it as-is"
       ],
       "schema/external-schemas.yml": [
         {
@@ -22142,12 +22152,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 168154,
+        _internalId: 168429,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 168146,
+            _internalId: 168421,
             type: "enum",
             enum: [
               "png",
@@ -22163,7 +22173,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 168153,
+            _internalId: 168428,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -7965,6 +7965,15 @@ try {
               short: "Apply explicit table column widths",
               long: "Apply explicit table column widths for markdown grid tables and pipe\ntables that are more than `columns` characters wide (72 by default). \n\nSome formats (e.g. HTML) do an excellent job automatically sizing\ntable columns and so don't benefit much from column width specifications.\nOther formats (e.g. LaTeX) require table column sizes in order to \ncorrectly flow longer cell content (this is a major reason why tables \n> 72 columns wide are assigned explicit widths by Pandoc).\n\nThis can be specified as:\n\n- `auto`: Apply markdown table column widths except when there is a\n  hyperlink in the table (which tends to throw off automatic\n  calculation of column widths based on the markdown text width of cells).\n  (`auto` is the default for HTML output formats)\n\n- `true`: Always apply markdown table widths (`true` is the default\n  for all non-HTML formats)\n\n- `false`: Never apply markdown table widths.\n\n- An array of numbers (e.g. `[40, 30, 30]`): Array of explicit width percentages.\n"
             }
+          },
+          {
+            name: "html-table-processing",
+            schema: {
+              enum: [
+                "none"
+              ]
+            },
+            description: "If `none`, do not process raw HTML table in cell output and leave it as-is"
           }
         ],
         "schema/cell-textoutput.yml": [
@@ -21049,6 +21058,7 @@ try {
             short: "Specify the default dpi (dots per inch) value for conversion from\npixels to inch/ centimeters and vice versa.",
             long: "Specify the default dpi (dots per inch) value for conversion from\npixels to inch/ centimeters and vice versa. (Technically, the correct\nterm would be ppi: pixels per inch.) The default is <code>96</code>.\nWhen images contain information about dpi internally, the encoded value\nis used instead of the default specified by this option."
           },
+          "If <code>none</code>, do not process tables in HTML input.",
           "Logo image (placed in bottom right corner of slides)",
           {
             short: "Footer to include on all slides",
@@ -21919,7 +21929,7 @@ try {
           "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
           "Manuscript configuration",
           "internal-schema-hack",
-          "If <code>none</code>, do not process tables in HTML input."
+          "If <code>none</code>, do not process raw HTML table in cell output\nand leave it as-is"
         ],
         "schema/external-schemas.yml": [
           {
@@ -22143,12 +22153,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 168154,
+          _internalId: 168429,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 168146,
+              _internalId: 168421,
               type: "enum",
               enum: [
                 "png",
@@ -22164,7 +22174,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 168153,
+              _internalId: 168428,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -936,6 +936,15 @@
         "short": "Apply explicit table column widths",
         "long": "Apply explicit table column widths for markdown grid tables and pipe\ntables that are more than `columns` characters wide (72 by default). \n\nSome formats (e.g. HTML) do an excellent job automatically sizing\ntable columns and so don't benefit much from column width specifications.\nOther formats (e.g. LaTeX) require table column sizes in order to \ncorrectly flow longer cell content (this is a major reason why tables \n> 72 columns wide are assigned explicit widths by Pandoc).\n\nThis can be specified as:\n\n- `auto`: Apply markdown table column widths except when there is a\n  hyperlink in the table (which tends to throw off automatic\n  calculation of column widths based on the markdown text width of cells).\n  (`auto` is the default for HTML output formats)\n\n- `true`: Always apply markdown table widths (`true` is the default\n  for all non-HTML formats)\n\n- `false`: Never apply markdown table widths.\n\n- An array of numbers (e.g. `[40, 30, 30]`): Array of explicit width percentages.\n"
       }
+    },
+    {
+      "name": "html-table-processing",
+      "schema": {
+        "enum": [
+          "none"
+        ]
+      },
+      "description": "If `none`, do not process raw HTML table in cell output and leave it as-is"
     }
   ],
   "schema/cell-textoutput.yml": [
@@ -14020,6 +14029,7 @@
       "short": "Specify the default dpi (dots per inch) value for conversion from\npixels to inch/ centimeters and vice versa.",
       "long": "Specify the default dpi (dots per inch) value for conversion from\npixels to inch/ centimeters and vice versa. (Technically, the correct\nterm would be ppi: pixels per inch.) The default is <code>96</code>.\nWhen images contain information about dpi internally, the encoded value\nis used instead of the default specified by this option."
     },
+    "If <code>none</code>, do not process tables in HTML input.",
     "Logo image (placed in bottom right corner of slides)",
     {
       "short": "Footer to include on all slides",
@@ -14890,7 +14900,7 @@
     "Disambiguating year suffix in author-date styles (e.g.&nbsp;“a” in “Doe,\n1999a”).",
     "Manuscript configuration",
     "internal-schema-hack",
-    "If <code>none</code>, do not process tables in HTML input."
+    "If <code>none</code>, do not process raw HTML table in cell output\nand leave it as-is"
   ],
   "schema/external-schemas.yml": [
     {
@@ -15114,12 +15124,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 168154,
+    "_internalId": 168429,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 168146,
+        "_internalId": 168421,
         "type": "enum",
         "enum": [
           "png",
@@ -15135,7 +15145,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 168153,
+        "_internalId": 168428,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/filters/normalize/parsehtml.lua
+++ b/src/resources/filters/normalize/parsehtml.lua
@@ -28,7 +28,7 @@ function parse_html_tables()
     traverse = "topdown",
     Div = function(div)
       if div.attributes[constants.kHtmlTableProcessing] == "none" then
-        return div.contents, false
+        return div.content, false
       end
     end,
     RawBlock = function(el)

--- a/src/resources/filters/normalize/parsehtml.lua
+++ b/src/resources/filters/normalize/parsehtml.lua
@@ -27,8 +27,20 @@ function parse_html_tables()
   filter = {
     traverse = "topdown",
     Div = function(div)
-      if div.attributes[constants.kHtmlTableProcessing] == "none" then
-        return div.content, false
+      if div.attributes[constants.kHtmlTableProcessing] then
+        -- catch and remove attributes
+        local htmlTableProcessing = div.attributes[constants.kHtmlTableProcessing]
+        div.attributes[constants.kHtmlTableProcessing] = nil
+        if htmlTableProcessing == "none" then
+          quarto.log.output(div.attr == pandoc.Attr())
+          if div.attr == pandoc.Attr() then
+            -- if no other attributes are set on the div, don't keep it
+            return div.content, false
+          else
+            -- when set on a div like div.cell-output-display, we need to keep it
+            return div, false
+          end
+        end
       end
     end,
     RawBlock = function(el)

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -316,7 +316,7 @@ knitr_hooks <- function(format, resourceDir, handledLanguages) {
       "tbl-column", "tbl-cap-location", "cap-location", "code-fold",
       "code-summary", "code-overflow", "code-line-numbers",
       "layout", "layout-nrow", "layout-ncol", "layout-align", "layout-valign",
-      "output",
+      "output", "html-table-processing",
       # duplicating options as they were normalized in knitr < 1.44
       "fig-column", "fig.column", "fig-cap-location", "fig.cap-location",
       # those options have been aliased in knitr 1.44

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -968,7 +968,7 @@ output_div <- function(x, label, classes, attr = NULL) {
   }
   paste0(
     div,
-    paste(paste0(".", classes), collapse = " ") ,
+    paste(paste0(".", classes), collapse = " "),
     ifelse(!is.null(attr), paste0(" ", attr), ""),
     "}\n",
     x,

--- a/src/resources/rmd/patch.R
+++ b/src/resources/rmd/patch.R
@@ -94,8 +94,13 @@ wrap_asis_output <- function(options, x) {
     x <- paste0(x, "\n\n", caption)
   }
   classes <- paste0("cell-output-display")
+  attrs <- NULL
   if (isTRUE(options[["output.hidden"]]))
     classes <- paste0(classes, " .hidden")
+
+  if (isFALSE(options[["html-table-processing"]])) {
+    attrs <- paste(attrs, "html-table-processing=none")
+  }
   
   # if this is an html table then wrap it further in ```{=html}
   # (necessary b/c we no longer do this by overriding kable_html,
@@ -106,8 +111,9 @@ wrap_asis_output <- function(options, x) {
     x <- paste0("`````{=html}\n", x, "\n`````")
   }
   
-  output_div(x, output_label_placeholder(options), classes)
+  output_div(x, output_label_placeholder(options), classes, attrs)
 }
+
 add_html_caption <- function(options, x, ...) {
   if (inherits(x, 'knit_asis_htmlwidget')) {
     wrap_asis_output(options, x)

--- a/src/resources/rmd/patch.R
+++ b/src/resources/rmd/patch.R
@@ -98,7 +98,7 @@ wrap_asis_output <- function(options, x) {
   if (isTRUE(options[["output.hidden"]]))
     classes <- paste0(classes, " .hidden")
 
-  if (isFALSE(options[["html-table-processing"]])) {
+  if (options[["html-table-processing"]] == "none") {
     attrs <- paste(attrs, "html-table-processing=none")
   }
   

--- a/src/resources/rmd/patch.R
+++ b/src/resources/rmd/patch.R
@@ -98,7 +98,7 @@ wrap_asis_output <- function(options, x) {
   if (isTRUE(options[["output.hidden"]]))
     classes <- paste0(classes, " .hidden")
 
-  if (options[["html-table-processing"]] == "none") {
+  if (identical(options[["html-table-processing"]], "none")) {
     attrs <- paste(attrs, "html-table-processing=none")
   }
   

--- a/src/resources/schema/cell-table.yml
+++ b/src/resources/schema/cell-table.yml
@@ -48,5 +48,4 @@
 - name: html-table-processing
   schema:
     enum: [none]
-  default: false
   description: If `none`, do not process raw HTML table in cell output and leave it as-is

--- a/src/resources/schema/cell-table.yml
+++ b/src/resources/schema/cell-table.yml
@@ -44,3 +44,10 @@
       - `false`: Never apply markdown table widths.
 
       - An array of numbers (e.g. `[40, 30, 30]`): Array of explicit width percentages.
+
+- name: html-table-processing
+  tags:
+    engine: knitr
+  schema: boolean
+  default: false
+  description: If `false`, do not process raw HTML table and leave it as-is

--- a/src/resources/schema/cell-table.yml
+++ b/src/resources/schema/cell-table.yml
@@ -46,8 +46,6 @@
       - An array of numbers (e.g. `[40, 30, 30]`): Array of explicit width percentages.
 
 - name: html-table-processing
-  tags:
-    engine: knitr
   schema: boolean
   default: false
   description: If `false`, do not process raw HTML table and leave it as-is

--- a/src/resources/schema/cell-table.yml
+++ b/src/resources/schema/cell-table.yml
@@ -46,6 +46,7 @@
       - An array of numbers (e.g. `[40, 30, 30]`): Array of explicit width percentages.
 
 - name: html-table-processing
-  schema: boolean
+  schema:
+    enum: [none]
   default: false
-  description: If `false`, do not process raw HTML table and leave it as-is
+  description: If `none`, do not process raw HTML table in cell output and leave it as-is

--- a/tests/docs/smoke-all/2023/10/10/issue-7187-b.qmd
+++ b/tests/docs/smoke-all/2023/10/10/issue-7187-b.qmd
@@ -5,7 +5,7 @@ _quarto:
     html:
       ensureHtmlElements:
         - []
-        - ["table.table"]
+        - ["table.table", "div[data-html-table-processing]"]
 ---
 
 ::: {html-table-processing="none"}

--- a/tests/docs/smoke-all/2023/10/10/issue-7187-jupyter.qmd
+++ b/tests/docs/smoke-all/2023/10/10/issue-7187-jupyter.qmd
@@ -5,7 +5,7 @@ _quarto:
     html:
       ensureHtmlElements:
         - []
-        - ["table[data-quarto-postprocess]"]
+        - ["table[data-quarto-postprocess]", "div[data-html-table-processing]"]
 ---
 
 ```{python}

--- a/tests/docs/smoke-all/2023/10/10/issue-7187-jupyter.qmd
+++ b/tests/docs/smoke-all/2023/10/10/issue-7187-jupyter.qmd
@@ -1,0 +1,24 @@
+---
+title: issue-7187
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - []
+        - ["table[data-quarto-postprocess]"]
+---
+
+```{python}
+#| html-table-processing: false
+#| echo: false
+import pandas as pd
+
+df = pd.DataFrame({
+    "strings": ["Adam", "Mike"],
+    "ints": [1, 3],
+    "floats": [1.123, 1000.23]
+})
+df
+```
+
+

--- a/tests/docs/smoke-all/2023/10/10/issue-7187-jupyter.qmd
+++ b/tests/docs/smoke-all/2023/10/10/issue-7187-jupyter.qmd
@@ -9,7 +9,7 @@ _quarto:
 ---
 
 ```{python}
-#| html-table-processing: false
+#| html-table-processing: none
 #| echo: false
 import pandas as pd
 

--- a/tests/docs/smoke-all/2023/10/10/issue-7187-knitr.qmd
+++ b/tests/docs/smoke-all/2023/10/10/issue-7187-knitr.qmd
@@ -1,0 +1,16 @@
+---
+title: issue-7187
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - []
+        - ["table[data-quarto-postprocess]"]
+---
+
+```{r}
+#| html-table-processing: false
+#| echo: false
+knitr::kable(cars, format = "html")
+```
+

--- a/tests/docs/smoke-all/2023/10/10/issue-7187-knitr.qmd
+++ b/tests/docs/smoke-all/2023/10/10/issue-7187-knitr.qmd
@@ -5,7 +5,7 @@ _quarto:
     html:
       ensureHtmlElements:
         - []
-        - ["table[data-quarto-postprocess]"]
+        - ["table[data-quarto-postprocess]", "div[data-html-table-processing]"]
 ---
 
 ```{r}

--- a/tests/docs/smoke-all/2023/10/10/issue-7187-knitr.qmd
+++ b/tests/docs/smoke-all/2023/10/10/issue-7187-knitr.qmd
@@ -9,7 +9,7 @@ _quarto:
 ---
 
 ```{r}
-#| html-table-processing: false
+#| html-table-processing: none
 #| echo: false
 knitr::kable(cars, format = "html")
 ```


### PR DESCRIPTION
Follow up on #7189 by support opting out from cell directly too. I think this is a really good way to be able to support any Table generation tool from R or Python without this tool to add a specific options. 

Examples: 

````markdown
---
title: no HTML processing
---

```{r}
#| html-table-processing: false
knitr::kable(cars, format = "html")
```

````

````markdown
---
title: no HTML processing
---

```{python}
#| html-table-processing: false
import pandas as pd

df = pd.DataFrame({
    "strings": ["Adam", "Mike"],
    "ints": [1, 3],
    "floats": [1.123, 1000.23]
})
df
```

````

@cscheid I used `html-table-processing: false` because it feels like a boolean option, but I have seen you used `none` instead so maybe it is better to use the same. I wasn't sure : what do you think ? 

Also I think there was an issue in #7189 
https://github.com/quarto-dev/quarto-cli/blob/880565f89b0df66b8ae0f69d30e4959e54464f58/src/resources/filters/normalize/parsehtml.lua#L29-L32
	
it should be `div.content` right ? 
	
````diff
    Div = function(div)
      if div.attributes[constants.kHtmlTableProcessing] == "none" then
-       return div.contents, false
+       return div.content, false
      end
````

You did not test for it, but my understanding is that the intention was for 
````markdown
::: {html-table-processing="none"}
<!-- content -->
:::
````
to not be shown as 
````html
<div data-html-table-processing="none">
<!--content-->
</div>
````

in output. right ? 

it is in d7c087f12a1fef7cc8909dba22de9fb775bc0347 but I tweak it in b80bbc3e9938d8b4813eed5b35f79b9c63a9e84c as with this PR we add `html-table-processing` to the existing `div.cell-output-display` so we need to keep it.

What do you think ? 