### PR TITLE
support non-ascii characters in subref labels

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -204,6 +204,7 @@
 
 - ([#2551](https://github.com/quarto-dev/quarto-cli/issues/2551)): Support crossreferenceable figures without captions.
 - ([#6620](https://github.com/quarto-dev/quarto-cli/issues/6620)): Introduce `FloatRefTarget` AST nodes that generalize crossref targets to include figures, tables, and custom floating elements.
+- ([#7200](https://github.com/quarto-dev/quarto-cli/issues/7200)): Support Unicode in subref labels.
 
 ## Other Fixes and Improvements
 

--- a/src/resources/filters/crossref/format.lua
+++ b/src/resources/filters/crossref/format.lua
@@ -182,12 +182,18 @@ function formatNumberOption(type, order, default)
   elseif (string.match(numberStyle, "^alpha ")) then
     -- permits the user to include the character that they'd like
     -- to start the numbering with (e.g. alpha a vs. alpha A)
-    local startIndexChar = string.sub(numberStyle, -1)
-    if (startIndexChar == " ") then
+    local s = split(numberStyle, " ") 
+    local startIndexChar = s[2]
+    if (startIndexChar == nil or startIndexChar == " ") then
       startIndexChar = "a"
     end
+    -- local startIndexChar = string.sub(numberStyle, -1)
+    -- if (startIndexChar == " ") then
+    --   startIndexChar = "a"
+    -- end
+    -- print(numberStyle)
     local startIndex = utf8.codepoint(startIndexChar)
-    return resolve(string.char(startIndex + num - 1))
+    return resolve(utf8.char(startIndex + num - 1))
   elseif (string.match(numberStyle, "^roman")) then
     -- permits the user to express `roman` or `roman i` or `roman I` to
     -- use lower / uppper case roman numerals

--- a/tests/docs/smoke-all/2023/10/11/unicode-subref-labels.qmd
+++ b/tests/docs/smoke-all/2023/10/11/unicode-subref-labels.qmd
@@ -1,0 +1,14 @@
+---
+title: "BugDemo"
+format: html
+crossref:
+  subref-labels: alpha α
+---
+
+```{r}
+#| label: fig-rawCN
+#| fig-cap: Raw copy number profile.
+#| fig-subcap: ["a", "b"]
+plot(1, 2)
+plot(3, 4)
+```


### PR DESCRIPTION
This should work and currently doesn't:

````
---
crossref:
  subref-labels: alpha α
---
````

We need to use utf8.char instead of string.char.