### PR TITLE
Don't do typst fixups outside of typst. Closes #7215

### DIFF
--- a/src/resources/filters/quarto-post/typst.lua
+++ b/src/resources/filters/quarto-post/typst.lua
@@ -35,6 +35,10 @@ function render_typst()
 end
 
 function render_typst_fixups()
+  if not _quarto.format.isTypstOutput() then
+    return {}
+  end
+
   return {
     Para = function(para)
       return para:walk({

--- a/tests/docs/smoke-all/2023/10/12/7215.lua
+++ b/tests/docs/smoke-all/2023/10/12/7215.lua
@@ -1,0 +1,5 @@
+function RawInline(el)
+  if el.format == "typst" then
+    fail()
+  end
+end

--- a/tests/docs/smoke-all/2023/10/12/7215.qmd
+++ b/tests/docs/smoke-all/2023/10/12/7215.qmd
@@ -1,0 +1,9 @@
+---
+title: issue-7215
+format: html
+filters:
+  - at: post-render
+    path: 7215.lua
+---
+
+An inline image that we should not fixup in non-typst formats: ![](./an-image.png){width=200}


### PR DESCRIPTION
- we're currently (needlessly, but harmlessly) emitting typst rawinlines in more formats than typst
- if someone uses a JSON post-processing filter with Panflute specifically, this triggers a Panflute bug (Panflute hasn't caught up to Pandoc typst yet)

This PR fixes that.