### PR TITLE
Meca `manifest-version` is "1"

### DIFF
--- a/src/project/types/manuscript/meca.ts
+++ b/src/project/types/manuscript/meca.ts
@@ -6,7 +6,7 @@
 import { stringify } from "xml/mod.ts";
 
 export const kTypeArticleMeta = "article-metadata";
-export const kMecaVersion = "2.0";
+export const kMecaVersion = "1";
 
 export interface MecaItem {
   id?: string;


### PR DESCRIPTION
@dragonstyle I am going through and working with Quarto manifests now. Noticed that the manifest version you are writing is 2.0, I think that it should be "1" according to the [spec](https://groups.niso.org/higherlogic/ws/public/download/23902/NISO_RP-30-2020_Manuscript_Exchange_Common_Approach_MECA.pdf):

![image](https://github.com/quarto-dev/quarto-cli/assets/913249/d4a0b9e6-f55f-4563-b625-5d21e065f380)