### PR TITLE
test.ts: add 5-minute timeout to every test in test suite

### DIFF
--- a/tests/test.ts
+++ b/tests/test.ts
@@ -67,7 +67,13 @@ export function testQuartoCmd(
   test({
     name,
     execute: async () => {
-      await quarto([cmd, ...args]);
+      const timeout = new Promise((_resolve, reject) => {
+        setTimeout(reject, 300000, "timed out after 5 minutes");
+      });
+      await Promise.race([
+        quarto([cmd, ...args]),
+        timeout,
+      ]);
     },
     verify,
     context: context || {},


### PR DESCRIPTION
This should avoid some of the hangs we see on render.