### PR TITLE
Test timing: Increase timeout to 10 minutes

### DIFF
--- a/tests/test.ts
+++ b/tests/test.ts
@@ -68,7 +68,7 @@ export function testQuartoCmd(
     name,
     execute: async () => {
       const timeout = new Promise((_resolve, reject) => {
-        setTimeout(reject, 300000, "timed out after 5 minutes");
+        setTimeout(reject, 600000, "timed out after 10 minutes");
       });
       await Promise.race([
         quarto([cmd, ...args]),


### PR DESCRIPTION
Initially a timeout was added (#7224) to prevent some stale runs in CI like this one: https://github.com/quarto-dev/quarto-cli/actions/runs/6486444111

However, I believe this created new failing test as we had some test that were taking more than 5 minutes. 
Specifically this one: `tests\docs\smoke-all\2022\11\17\3359b.qmd`

In the same run as linked above, by activating timestamp, we can see that it took more than 5 minutes. 
https://github.com/quarto-dev/quarto-cli/actions/runs/6486444111/job/17614664332#step:26:292

![image](https://github.com/quarto-dev/quarto-cli/assets/6791940/291ddf9c-0083-49ac-ac43-84f910a9239f)

So I think we should increase the timeout. 

BTW, I also used tmate debugging to access the CI runners, and live debug in the github action runners. I can confirm this take a long time because there is some sort of initialisation done when doing `latexml -pdflua` which is the purpose on the test. 

@cscheid are you ok to increase and see how that goes ? 