### PR TITLE
Handle preamble in layout for hugo-md format

### DIFF
--- a/src/resources/filters/customnodes/panellayout.lua
+++ b/src/resources/filters/customnodes/panellayout.lua
@@ -197,9 +197,8 @@ function basic_panel_layout(layout)
     result.content:insert(pandoc.Para(quarto.utils.as_inlines(layout.float.caption_long) or {}))
   end
 
-  if layout.preamble then
-    return pandoc.Blocks({ layout.preamble, result })
-  else
-    return result
-  end
+  local res = pandoc.Blocks({})
+  panel_insert_preamble(res, layout.preamble)
+  res:insert(result)
+  
 end

--- a/src/resources/filters/layout/hugo.lua
+++ b/src/resources/filters/layout/hugo.lua
@@ -65,11 +65,12 @@ end, function(layout)
   end
   result.content:insert(pandoc.RawBlock("html", "</div>"))
 
-  if layout.preamble then
-    return pandoc.Blocks({ layout.preamble, result })
-  else
-    return result
-  end
+
+  local res = pandoc.Blocks({})
+  panel_insert_preamble(res, layout.preamble)
+  res:insert(result)
+  
+  return res
 
 end)
 

--- a/src/resources/filters/layout/hugo.lua
+++ b/src/resources/filters/layout/hugo.lua
@@ -65,11 +65,10 @@ end, function(layout)
   end
   result.content:insert(pandoc.RawBlock("html", "</div>"))
 
-
   local res = pandoc.Blocks({})
   panel_insert_preamble(res, layout.preamble)
   res:insert(result)
-  
+
   return res
 
 end)


### PR DESCRIPTION
follow-up on #7208

This was discovered after fixing our tests infrastructure that was missing test. 

I used the same logic as for other formats regarding preamble handling