### PR TITLE
confluence: use new custom AST renderer style

### DIFF
--- a/src/resources/extensions/quarto/confluence/publish.lua
+++ b/src/resources/extensions/quarto/confluence/publish.lua
@@ -34,8 +34,19 @@ local function injectAnchor(element, addToFront)
   return element
 end
 
+quarto._quarto.ast.add_renderer("Callout", function(_)
+  return quarto._quarto.format.isConfluenceOutput()
+end, function(callout)
+  local renderedCalloutContent =
+    pandoc.write(pandoc.Pandoc(callout.content), "html")
+  local renderString = confluence.CalloutConfluence(
+          callout.type,
+          renderedCalloutContent)
+  return pandoc.RawInline('html', renderString)
+end)
+
 function Writer (doc, opts)
-  local filter ={
+  local filter = {
     Callout = function (callout)
       local renderedCalloutContent =
         pandoc.write(pandoc.Pandoc(callout.content), "html")

--- a/tests/docs/smoke-all/confluence/callout.qmd
+++ b/tests/docs/smoke-all/confluence/callout.qmd
@@ -1,0 +1,17 @@
+---
+title: Callout test
+format: confluence-publish
+validate-yaml: false
+_quarto:
+  tests:
+    confluence-publish:
+      ensureFileRegexMatches:
+        - ["<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"1c8062cd-87de-4701-a698-fd435e057468\">"]
+        - []
+---
+
+## Overview
+
+::: {.callout-note}
+Managing Confluence content with Quarto allows you to author content in Markdown, manage that content with your usual version control tools like Git and GitHub, and leverage Quarto’s tools for including computational output.
+:::

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -25,6 +25,15 @@ export function outputForInput(
   const dir = dirname(input);
   let stem = basename(input, extname(input));
 
+  // TODO: there's a bug where output-ext keys from a custom format are 
+  // not recognized (specifically this happens for confluence)
+  //
+  // we hack it here for the time being.
+  //
+  if (to === "confluence-publish") {
+    ext = "xml";
+  }
+
   const formatDesc = parseFormatString(to);
   const baseFormat = formatDesc.baseFormat;
   if (formatDesc.baseFormat === "pdf") {


### PR DESCRIPTION
This closes #7256.

Opening for the CI to do its thing, but the PR needs improving (specifically on utils.ts and custom format extensions)