### PR TITLE
Correctly handle name attributes for proof envs

### DIFF
--- a/src/resources/filters/crossref/theorems.lua
+++ b/src/resources/filters/crossref/theorems.lua
@@ -60,8 +60,7 @@ function crossref_theorems()
           -- output
           if _quarto.format.isLatexOutput() then
             local preamble = pandoc.List()
-            preamble:insert(pandoc.RawInline("latex", 
-              "\\begin{" .. proof.env .. "}"))
+            preamble:insert(pandoc.RawInline("latex", "\\begin{" .. proof.env .. "}"))
             if name ~= nil then
               preamble:insert(pandoc.RawInline("latex", "["))
               tappend(preamble, name)

--- a/tests/docs/smoke-all/2023/10/04/6077.qmd
+++ b/tests/docs/smoke-all/2023/10/04/6077.qmd
@@ -1,10 +1,19 @@
 ---
 title: "QED symbol test"
-format: latex
-filters:
-  - at: post-render
-    path: 6077.lua
+format: 
+  latex:
+    filters:
+      - at: post-render
+        path: 6077.lua
+_quarto:
+  tests: 
+    latex:
+      ensureFileRegexMatches:
+        - []
+        - ['\n\n\\end{proof}'] 
 ---
+
+There should be no empty line between end of proof and previous content otherwise qed symbol misplaced
 
 :::{.proof}
 This is a proof.

--- a/tests/docs/smoke-all/2023/10/18/7265.qmd
+++ b/tests/docs/smoke-all/2023/10/18/7265.qmd
@@ -1,10 +1,43 @@
 ---
-title: "failing solution env"
-format: latex
+title: "Proof, Remarks, Solution env"
+_quarto:
+  tests: 
+    pdf: null
+    html: 
+      ensureHtmlElements:
+        - 
+          - "#solution-1 div.solution span.proof-title > em"
+          - "#solution-2 div.solution span.proof-title > em + strong"
+        - []
+    latex:
+      ensureFileRegexMatches:
+        - 
+          - '\\begin{solution}\[Solution 1\]'
+          - '\\begin{solution}\[\\textbf{Solution} 2\]'
+          - '\\begin{solution}\[Solution 3\]\n\\leavevmode'
+        - []
 ---
 
-### Solution
+### Solution 1
 
-::: {.solution name="The solution"}
+::: {.solution name="Solution 1"}
 The solution
+:::
+
+### Solution 2
+
+::: {.solution}
+
+# **Solution** 2 
+
+The solution
+:::
+
+### Solution 3
+
+::: {.solution name="Solution 3"}
+
+* List 
+* List 
+
 :::


### PR DESCRIPTION
without breaking qed symbol handling as this is a regression from #7139Welcome to the quarto GitHub repo!

This fix #7265 regression and adapt tests for checking output. 

It also adds support for special content from **bookdown** experience. 

