### PR TITLE
Callout content requires no wrapping when converted to HTML

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -77,6 +77,10 @@
 
 - ([#6589](https://github.com/quarto-dev/quarto-cli/issues/6589)): Don't crash when `format: asciidoc` with a missing title.
 
+## Confluence Format
+
+- ([#7256](https://github.com/quarto-dev/quarto-cli/issues/7256)): No undesired newline are created anymore in Callouts.
+
 ## Website Listings
 
 - ([#4800](https://github.com/quarto-dev/quarto-cli/issues/4800)): Add support for including an `xml-stylesheet` in listings. Use the `xml-stylesheet: example.xsl` under `feed:` to provide a path to an XSL style sheet to style your RSS feed.

--- a/src/resources/extensions/quarto/confluence/publish.lua
+++ b/src/resources/extensions/quarto/confluence/publish.lua
@@ -38,7 +38,7 @@ quarto._quarto.ast.add_renderer("Callout", function(_)
   return quarto._quarto.format.isConfluenceOutput()
 end, function(callout)
   local renderedCalloutContent =
-    pandoc.write(pandoc.Pandoc(callout.content), "html")
+    pandoc.write(pandoc.Pandoc(callout.content), "html", { wrap_text = "none" })
   local renderString = confluence.CalloutConfluence(
           callout.type,
           renderedCalloutContent)
@@ -100,7 +100,7 @@ function Writer (doc, opts)
         return pandoc.RawBlock('html', rawBlock.text)
       end
 
-      -- Raw blocks inclding arbirtary HTML like JavaScript are not supported in CSF
+      -- Raw blocks including arbirtary HTML like JavaScript are not supported in CSF
       return ""
     end,
     RawInline = function (inline)

--- a/src/resources/extensions/quarto/confluence/publish.lua
+++ b/src/resources/extensions/quarto/confluence/publish.lua
@@ -47,14 +47,6 @@ end)
 
 function Writer (doc, opts)
   local filter = {
-    Callout = function (callout)
-      local renderedCalloutContent =
-        pandoc.write(pandoc.Pandoc(callout.content), "html")
-      local renderString = confluence.CalloutConfluence(
-              callout.type,
-              renderedCalloutContent)
-      return pandoc.RawInline('html', renderString)
-    end,
     Image = function (image)
       local renderString = confluence.CaptionedImageConfluence(
               image.src,

--- a/tests/docs/smoke-all/confluence/callout.qmd
+++ b/tests/docs/smoke-all/confluence/callout.qmd
@@ -5,13 +5,48 @@ validate-yaml: false
 _quarto:
   tests:
     confluence-publish:
+      ensureHtmlElements:
+        - 
+          - '#note + ac\:structured-macro[ac\:name="info"] code'
+          - '#warning + ac\:structured-macro[ac\:name="note"]'
+          - '#tip + ac\:structured-macro[ac\:name="tip"]'
+          - '#caution + ac\:structured-macro[ac\:name="note"]'
+          - '#important + ac\:structured-macro[ac\:name="warning"]'
+        - []
       ensureFileRegexMatches:
-        - ["<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"1c8062cd-87de-4701-a698-fd435e057468\">"]
+        - 
+          - '<ac:rich-text-body>[^\n]+</ac:rich-text-body>' # no newline created
         - []
 ---
 
-## Overview
+The below callout should not be rendered with undesired line breaks.
+
+## Note
 
 ::: {.callout-note}
+Note that there are five types of callouts, including: `note`, `tip`, `warning`, `caution`, and `important`.
+:::
+
+## Warning 
+
+::: {.callout-warning}
+Managing Confluence content with Quarto allows you to author content in Markdown, manage that content with your usual version control tools like Git and GitHub, and leverage Quarto’s tools for including computational output.
+:::
+
+## Tip
+
+::: {.callout-tip}
+Managing Confluence content with Quarto allows you to author content in Markdown, manage that content with your usual version control tools like Git and GitHub, and leverage Quarto’s tools for including computational output.
+:::
+
+## Caution
+
+::: {.callout-caution}
+Managing Confluence content with Quarto allows you to author content in Markdown, manage that content with your usual version control tools like Git and GitHub, and leverage Quarto’s tools for including computational output.
+:::
+
+## Important
+
+::: {.callout-important}
 Managing Confluence content with Quarto allows you to author content in Markdown, manage that content with your usual version control tools like Git and GitHub, and leverage Quarto’s tools for including computational output.
 :::


### PR DESCRIPTION
This follows #7258 and this fix formatting issue in Confluence where undesired newlines were added. (fix #7256)

Test is also adapted for confluence, as DomParser know how to handle the xml output (at least for checking). We use a more richer content to test also for markdown rendering.

This has been tested also on the confluence test server for publishing

