### PR TITLE
[knitr] Insure prefer-html works with markdown only

### DIFF
--- a/src/resources/rmd/execute.R
+++ b/src/resources/rmd/execute.R
@@ -101,7 +101,7 @@ execute <- function(input, format, tempDir, libDir, dependencies, cwd, params, r
     # This truly awful hack ensures that rmarkdown doesn't tell us we're
     # producing HTML widgets when targeting a non-html format (doing this
     # is triggered by the "prefer-html" options)
-    if (format$render$`prefer-html`) {
+    if (is_html_prefered(format)) {
       render_env <- parent.env(parent.frame())
       render_env$front_matter$always_allow_html <- TRUE
     }
@@ -112,7 +112,11 @@ execute <- function(input, format, tempDir, libDir, dependencies, cwd, params, r
 
   # determine df_print
   df_print <- format$execute$`df-print`
-  if (df_print == "paged" && !is_pandoc_html_format(format) && !format$render$`prefer-html`) {
+  if (
+    df_print == "paged" &&
+    !is_pandoc_html_format(format) &&
+    !is_html_prefered(format)
+  ) {
     df_print <- "kable"
   }
 
@@ -290,7 +294,7 @@ knitr_options <- function(format, resourceDir, handledLanguages) {
 
 
   # add screenshot force if prefer-html specified
-  if (isTRUE(format$render$`prefer-html`)) {
+  if (is_html_prefered(format)) {
     opts_chunk$screenshot.force <- FALSE
   }
 
@@ -420,8 +424,7 @@ dependencies_from_render <- function(input, files_dir, knit_meta, format) {
 
   # convert dependencies to in_header includes
   dependencies$includes <- list()
-
-  if (is_pandoc_html_format(format) || format$render$`prefer-html`) {
+  if (is_pandoc_html_format(format) || is_html_prefered(format)) {
     # get extras (e.g. html dependencies)
     # only include these html extras if we're targeting a format that
     # supports html (widgets) like this or that prefers html (e.g. Hugo)
@@ -455,7 +458,7 @@ dependencies_from_render <- function(input, files_dir, knit_meta, format) {
       }
     }
   } else if (
-    is_latex_output(format$pandoc$to) &&
+    is_pandoc_latex_output(format) &&
     rmarkdown:::has_latex_dependencies(knit_meta)
   ) {
     latex_dependencies <- rmarkdown:::flatten_latex_dependencies(knit_meta)
@@ -529,12 +532,45 @@ extract_preserve_chunks <- function(output_file, format) {
   }
 }
 
-is_pandoc_html_format <- function(format) {
-  knitr::is_html_output(format$pandoc$to, c("markdown", "epub", "gfm", "commonmark", "commonmark_x", "markua"))
+# inline knitr::pandoc_to from knitr 1.41
+# before that, the all format (w/ pandoc extension) was checked
+is_pandoc_to_format <- function(format, check_fmts) {
+  to <- gsub("[-+].*", "", format$pandoc$to)
+  to %in% check_fmts
 }
 
-is_latex_output <- function(to) {
-  knitr:::is_latex_output() || identical(to, "pdf")
+# check is pandoc$to is among html formats (html, slides, epub)
+is_pandoc_html_format <- function(format) {
+  knitr::is_html_output(
+    format$pandoc$to,
+    c("markdown", "epub", "gfm", "commonmark", "commonmark_x", "markua")
+  )
+}
+
+# check if pandoc$to is latex output
+is_pandoc_latex_output <- function(format) {
+  knitr:::is_latex_output() || is_pandoc_to_format(format, "pdf")
+}
+
+# check if pandoc$to is among markdown outputs
+is_pandoc_markdown_output <- function(format) {
+  markdown_formats <- c(
+    "markdown",
+    "markdown_github",
+    "markdown_mmd",
+    "markdown_phpextra",
+    "markdown_strict",
+    "gfm",
+    "commonmark",
+    "commonmark_x",
+    "markua"
+  )
+  is_pandoc_to_format(format, markdown_formats)
+}
+
+# `prefer-html: true` can be set in markdown format that supports HTML outputs
+is_html_prefered <- function(format) {
+  is_pandoc_markdown_output(format) && isTRUE(format$render$`prefer-html`)
 }
 
 # apply patches to output as required

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -109,7 +109,7 @@ knitr_hooks <- function(format, resourceDir, handledLanguages) {
     
     # use gifski as default animation hook for non-latex output
     if (identical(fig.show, "animate")) {
-      if (!is_latex_output(format$pandoc$to) && is.null(options[["animation.hook"]])) {
+      if (!is_pandoc_latex_output(format) && is.null(options[["animation.hook"]])) {
         options[["animation.hook"]] <- "gifski"
       }
       
@@ -512,7 +512,7 @@ knitr_hooks <- function(format, resourceDir, handledLanguages) {
 knitr_plot_hook <- function(format) {
 
   htmlOutput <- knitr:::is_html_output(format$pandoc$to)
-  latexOutput <- is_latex_output(format$pandoc$to)
+  latexOutput <- is_pandoc_latex_output(format)
   defaultFigPos <- format$render[["fig-pos"]]
 
   function(x, options) {
@@ -621,7 +621,7 @@ knitr_plot_hook <- function(format) {
       options[["fig.subcap"]] <- NULL
       
       # check for latex
-      if (is_latex_output(format$pandoc$to)) {
+      if (is_pandoc_latex_output(format)) {
         
         # include dependency on animate package
         knitr::knit_meta_add(list(

--- a/tests/DESCRIPTION
+++ b/tests/DESCRIPTION
@@ -15,4 +15,5 @@ Depends:
     tibble,
     DT,
     DBI,
-    RSQLite
+    RSQLite,
+    webshot2

--- a/tests/docs/smoke-all/2023/09/27/7041.qmd
+++ b/tests/docs/smoke-all/2023/09/27/7041.qmd
@@ -1,6 +1,7 @@
 ---
-format: typst
-output-ext: typ
+format: 
+  typst:
+    output-ext: typ
 _quarto:
   tests:
     typst:

--- a/tests/docs/smoke-all/2023/10/19/_7276-prefer-html-2.qmd
+++ b/tests/docs/smoke-all/2023/10/19/_7276-prefer-html-2.qmd
@@ -1,0 +1,19 @@
+---
+format: 
+  typst:
+    output-ext: typ
+    prefer-html: true # should not be set usually but checking it does not have impact
+_quarto:
+  tests:
+    typst:
+      ensureFileRegexMatches:
+        - ['#image\(']
+        - ['<script']
+---
+
+This test will do snapshoting of the HTML widgets, so it requires chrome / chromium with **webshot2** or phantomjs with **webshot** to work. 
+TODO: See how to configure our test suites for this
+
+```{r}
+DT::datatable(cars)
+```

--- a/tests/docs/smoke-all/2023/10/19/_7276-prefer-html.qmd
+++ b/tests/docs/smoke-all/2023/10/19/_7276-prefer-html.qmd
@@ -1,0 +1,23 @@
+---
+format: 
+  hugo-md: default
+  typst:
+    output-ext: typ
+_quarto:
+  tests:
+    hugo-md:
+      ensureFileRegexMatches:
+        - ['<script>', '<div class="datatables'] 
+        - []
+    typst:
+      ensureFileRegexMatches:
+        - ['#image\(']
+        - []
+---
+
+This test will do snapshoting of the HTML widgets, so it requires chrome / chromium with **webshot2** or phantomjs with **webshot** to work. 
+TODO: See how to configure our test suites for this
+
+```{r}
+DT::datatable(cars)
+```

--- a/tests/docs/smoke-all/typst/typst-citeproc.qmd
+++ b/tests/docs/smoke-all/typst/typst-citeproc.qmd
@@ -1,7 +1,8 @@
 ---
 title: "Citeproc and Typst"
-format: typst
-output-ext: typ
+format: 
+  typst:
+    output-ext: typ
 bibliography: refs.bib
 citeproc: true
 _quarto:

--- a/tests/docs/smoke-all/typst/typst-no-citeproc.qmd
+++ b/tests/docs/smoke-all/typst/typst-no-citeproc.qmd
@@ -1,7 +1,8 @@
 ---
 title: "Citeproc and Typst"
-format: typst
-output-ext: typ
+format: 
+  typst:
+    output-ext: typ
 bibliography: refs.bib
 bibliographystyle: "chicago-author-date"
 _quarto:

--- a/tests/renv.lock
+++ b/tests/renv.lock
@@ -13,6 +13,13 @@
     ]
   },
   "Packages": {
+    "AsioHeaders": {
+      "Package": "AsioHeaders",
+      "Version": "1.22.1-2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "85bf3bd8fa58da21a22d84fd4f4ef0a8"
+    },
     "DBI": {
       "Package": "DBI",
       "Version": "1.1.3",
@@ -301,6 +308,25 @@
         "tibble"
       ],
       "Hash": "f61dbaec772ccd2e17705c1e872e9e7c"
+    },
+    "chromote": {
+      "Package": "chromote",
+      "Version": "0.1.2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R6",
+        "curl",
+        "fastmap",
+        "jsonlite",
+        "later",
+        "magrittr",
+        "processx",
+        "promises",
+        "rlang",
+        "websocket"
+      ],
+      "Hash": "14c8f71bf7b112634b154f8a6a0867e1"
     },
     "cli": {
       "Package": "cli",
@@ -2078,6 +2104,34 @@
         "magrittr"
       ],
       "Hash": "16858ee1aba97f902d24049d4a44ef16"
+    },
+    "webshot2": {
+      "Package": "webshot2",
+      "Version": "0.1.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "callr",
+        "chromote",
+        "later",
+        "magrittr",
+        "promises"
+      ],
+      "Hash": "701b4be1af8d359271f82cb240853693"
+    },
+    "websocket": {
+      "Package": "websocket",
+      "Version": "1.4.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "AsioHeaders",
+        "R6",
+        "cpp11",
+        "later"
+      ],
+      "Hash": "76e0d400757e318cca33def29ccebbc2"
     },
     "withr": {
       "Package": "withr",

--- a/tests/smoke/render/render.ts
+++ b/tests/smoke/render/render.ts
@@ -74,8 +74,14 @@ export function testRender(
   );
 }
 
-export function cleanoutput(input: string, to: string, projectOutDir?: string) {
-  const out = outputForInput(input, to, projectOutDir);
+export function cleanoutput(
+  input: string, 
+  to: string, 
+  projectOutDir?: string,
+  // deno-lint-ignore no-explicit-any
+  metadata?: Record<string, any>,
+) {
+  const out = outputForInput(input, to, projectOutDir, metadata);
   if (existsSync(out.outputPath)) {
     Deno.removeSync(out.outputPath);
   }

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -33,7 +33,7 @@ import { outputForInput } from "../utils.ts";
 import { jupyterNotebookToMarkdown } from "../../src/command/convert/jupyter.ts";
 import { dirname, join, relative } from "path/mod.ts";
 import { existsSync, WalkEntry } from "fs/mod.ts";
-import { kOutputExt } from "../../src/config/constants.ts";
+import { kMetadataFormat, kOutputExt } from "../../src/config/constants.ts";
 
 async function fullInit() {
   await initYamlIntelligenceResourcesFromFilesystem();
@@ -113,7 +113,7 @@ function resolveTestSpecs(
         } else {
           // See if there is a project and grab it's type
           const projectOutDir = findProjectOutputDir(input);
-          const ext = metadata?.[kOutputExt];
+          const ext = metadata?.[kMetadataFormat]?.[format]?.[kOutputExt];
           const outputFile = outputForInput(input, format, projectOutDir, ext);
           if (key === "fileExists") {
             for (

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -33,7 +33,6 @@ import { outputForInput } from "../utils.ts";
 import { jupyterNotebookToMarkdown } from "../../src/command/convert/jupyter.ts";
 import { dirname, join, relative } from "path/mod.ts";
 import { existsSync, WalkEntry } from "fs/mod.ts";
-import { kMetadataFormat, kOutputExt } from "../../src/config/constants.ts";
 
 async function fullInit() {
   await initYamlIntelligenceResourcesFromFilesystem();
@@ -113,8 +112,7 @@ function resolveTestSpecs(
         } else {
           // See if there is a project and grab it's type
           const projectOutDir = findProjectOutputDir(input);
-          const ext = metadata?.[kMetadataFormat]?.[format]?.[kOutputExt];
-          const outputFile = outputForInput(input, format, projectOutDir, ext);
+          const outputFile = outputForInput(input, format, projectOutDir, metadata);
           if (key === "fileExists") {
             for (
               const [path, file] of Object.entries(
@@ -214,7 +212,7 @@ for (const { path: fileName } of files) {
           return Promise.resolve(true);
         },
         teardown: () => {
-          cleanoutput(input, format);
+          cleanoutput(input, format, undefined, metadata);
           return Promise.resolve();
         },
       });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -7,6 +7,7 @@
 
 import { basename, dirname, extname, join } from "path/mod.ts";
 import { parseFormatString } from "../src/core/pandoc/pandoc-formats.ts";
+import { kMetadataFormat, kOutputExt } from "../src/config/constants.ts";
 
 // caller is responsible for cleanup!
 export function inTempDirectory(fn: (dir: string) => unknown): unknown {
@@ -19,11 +20,13 @@ export function outputForInput(
   input: string,
   to: string,
   projectOutDir?: string,
-  ext?: string
+  // deno-lint-ignore no-explicit-any
+  metadata?: Record<string, any>,
 ) {
   // TODO: Consider improving this (e.g. for cases like Beamer, or typst)
   const dir = dirname(input);
   let stem = basename(input, extname(input));
+  let ext = metadata?.[kMetadataFormat]?.[to]?.[kOutputExt];
 
   // TODO: there's a bug where output-ext keys from a custom format are 
   // not recognized (specifically this happens for confluence)
@@ -34,6 +37,7 @@ export function outputForInput(
     ext = "xml";
   }
 
+  
   const formatDesc = parseFormatString(to);
   const baseFormat = formatDesc.baseFormat;
   if (formatDesc.baseFormat === "pdf") {


### PR DESCRIPTION
As documented in our doc this option is for generating HTML output (if necessary) even when targeting markdown.

More clean way to check for formats. (following a fix in knitr 1.41)

This closes #7276

The tests requires **webshot2** to be setup. So I need a way to make sure this is configured correctly locally for tests, and on CI. 

I'll do that later. 