### PR TITLE
better fix for #7197 and fenced code blocks

### DIFF
--- a/src/resources/filters/quarto-pre/parsefiguredivs.lua
+++ b/src/resources/filters/quarto-pre/parsefiguredivs.lua
@@ -590,15 +590,15 @@ function forward_cell_subcaps()
               index = index + 1
               return pandoc_table
             end,
-            Div = function(maybe_fig)
-              local fig = discoverFigure(maybe_fig, false) or discoverLinkedFigure(maybe_fig, false)
+            Para = function(maybe_float)
+              local fig = discoverFigure(maybe_float, false) or discoverLinkedFigure(maybe_float, false)
               if fig ~= nil then
                 fig.caption = quarto.utils.as_inlines(pandoc.Str(subcaps[index]))
                 fig.identifier = div.identifier .. "-" .. tostring(index)
                 index = index + 1
-                return maybe_fig
+                return maybe_float
               end
-            end
+            end,
           })
           return subdiv
         end

--- a/tests/docs/smoke-all/2023/10/19/7197b.qmd
+++ b/tests/docs/smoke-all/2023/10/19/7197b.qmd
@@ -1,0 +1,33 @@
+---
+title: "Table subcaption issue"
+format: html
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - 
+          - "\\(a\\) Cars"
+          - "\\(b\\) Pressure"
+        - []
+      ensureHtmlElements:
+        -
+          - "a[href=\"#tbl-example\"].quarto-xref"
+          - "a[href=\"#tbl-example-1\"].quarto-xref"
+          - "a[href=\"#tbl-example-2\"].quarto-xref"
+---
+
+
+```{r}
+#| label: tbl-example
+#| tbl-cap: "Example"
+#| tbl-subcap: 
+#|   - "Cars"
+#|   - "Pressure"
+#| echo: fenced
+
+library(knitr)
+kable(head(cars))
+kable(head(pressure))
+```
+
+See @tbl-example-1, @tbl-example-2, @tbl-example.


### PR DESCRIPTION
Closes #7197 in the case of caption, subcaptions, and `echo: fenced`.