### PR TITLE
Use the system filename separator more consistently.

### DIFF
--- a/src/project/types/website/website-sidebar-auto.ts
+++ b/src/project/types/website/website-sidebar-auto.ts
@@ -5,7 +5,7 @@
 *
 */
 
-import { basename, join, relative } from "path/mod.ts";
+import { basename, join, relative, SEP, SEP_PATTERN } from "path/mod.ts";
 import { kOrder } from "../../../config/constants.ts";
 import { asNumber } from "../../../core/cast.ts";
 
@@ -127,8 +127,8 @@ async function sidebarItemsFromAuto(
     // if this is an auto-dir that has an index page inside it
     // then re-shuffle things a bit
     if (isAutoDir) {
-      const root = nodeSet.root.split("/");
-      nodeSet.root = root.slice(0, -1).join("/");
+      const root = nodeSet.root.split(SEP_PATTERN);
+      nodeSet.root = root.slice(0, -1).join(SEP);
       nodeSet.nodes = {
         [root.slice(-1)[0]]: nodeSet.nodes,
       };
@@ -137,7 +137,7 @@ async function sidebarItemsFromAuto(
     entries.push(
       ...await nodesToEntries(
         project,
-        `${nodeSet.root ? nodeSet.root + "/" : ""}`,
+        `${nodeSet.root ? nodeSet.root + SEP : ""}`,
         nodeSet.nodes,
       ),
     );
@@ -201,7 +201,7 @@ function autoSidebarNodes(
     // split into directory heirarchy
     let result: Record<string, SidebarNodes> = {};
     inputs.forEach((p) =>
-      p.split("/").reduce(
+      p.split(SEP_PATTERN).reduce(
         (o, k) => o[k] = o[k] || {},
         result,
       )
@@ -209,7 +209,7 @@ function autoSidebarNodes(
 
     // index into the nodes based on the directory
     if (directory) {
-      directory.split("/").forEach((p) => {
+      directory.split(SEP_PATTERN).forEach((p) => {
         result = result[p];
       });
     }


### PR DESCRIPTION
I normally use macOS, but tried using Windows today and `quarto render` failed. There are several problems but this was the first one:

```
ERROR: TypeError: Cannot convert undefined or null to object

 

Stack trace:
    at Function.keys (<anonymous>)
    at findIndexFile (file:///C:/Users/ka37/Documents/quarto-cli/src/project/types/website/website-sidebar-auto.ts:311:17)
    at nodesToEntries (file:///C:/Users/ka37/Documents/quarto-cli/src/project/types/website/website-sidebar-auto.ts:254:21)
    at sidebarItemsFromAuto (file:///C:/Users/ka37/Documents/quarto-cli/src/project/types/website/website-sidebar-auto.ts:139:16)    
    at expandAutoSidebarItems (file:///C:/Users/ka37/Documents/quarto-cli/src/project/types/website/website-sidebar-auto.ts:37:31)   
    at expandAutoSidebarItems (file:///C:/Users/ka37/Documents/quarto-cli/src/project/types/website/website-sidebar-auto.ts:65:31)   
    at async resolveSidebarItems (file:///C:/Users/ka37/Documents/quarto-cli/src/project/types/website/website-navigation.ts:948:24) 
    at async sidebarEjsData (file:///C:/Users/ka37/Documents/quarto-cli/src/project/types/website/website-navigation.ts:930:3)       
    at async sidebarsEjsData (file:///C:/Users/ka37/Documents/quarto-cli/src/project/types/website/website-navigation.ts:900:22)  
```

Notice that even though this is Windows, the stack trace reports paths in posix-style format. There's a lot of hard-coded forward-slashes in various parts of the quarto code, so I'd suggest that rather than trying to get everything right, just instead follow Deno's lead here and use URL semantics for everything.

My full setup is big, but something like this in `_quarto.yml` should suffice to reproduce:

```yaml
website:
  sidebar:
    contents:
      - section: "Notes"
        icon: "pencil"
        contents: "notes/*"
```

(ideally I'd leave it that way, but on Windows I had to change that to `notes\\*`; that might be a separate bug report)