### PR TITLE
Update sidebar toggle icon

### DIFF
--- a/src/format/dashboard/format-dashboard-sidebar.ts
+++ b/src/format/dashboard/format-dashboard-sidebar.ts
@@ -80,8 +80,8 @@ export function processSidebars(doc: Document) {
 function sidebarToggle(id: string, doc: Document) {
   const html = `
 <button class="collapse-toggle" type="button" title="Toggle sidebar" aria-expanded="true" aria-controls="${id}">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="bi bi-arrow-bar-left collapse-icon" style="height:;width:;fill:currentColor;vertical-align:-0.125em;" aria-hidden="true" role="img">
-        <path fill-rule="evenodd" d="M12.5 15a.5.5 0 0 1-.5-.5v-13a.5.5 0 0 1 1 0v13a.5.5 0 0 1-.5.5ZM10 8a.5.5 0 0 1-.5.5H3.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L3.707 7.5H9.5a.5.5 0 0 1 .5.5Z"></path>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="bi bi-chevron-left collapse-icon" style="fill:currentColor;" aria-hidden="true" role="img">
+      <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"></path>
     </svg>
 </button>
 <script data-bslib-sidebar-init>


### PR DESCRIPTION
In bslib, we recently updated the sidebar toggle icon from [`arrow-bar-left`](https://icons.getbootstrap.com/icons/arrow-bar-left/) to [`chevron-left`](https://icons.getbootstrap.com/icons/chevron-left/). Here is the PR that makes that change (which also has some before/after screenshots) https://github.com/rstudio/bslib/pull/841.

For consistency (and simplicity), I'd recommend that Quarto makes the same change.