### PR TITLE
Bugfix/7344

### DIFF
--- a/src/core/resources.ts
+++ b/src/core/resources.ts
@@ -29,13 +29,13 @@ export function formatResourcePath(format: string, resource: string) {
   return join(resourcePath("formats"), format, resource);
 }
 
-export function architectureToolsPath(path: string) {
+export function architectureToolsPath(binary: string) {
   const arch = Deno.build.arch;
-  const archDir = join(arch, path);
-  return toolsPath(archDir);
+  const archBinaryPath = join(arch, binary);
+  return toolsPath(binary, archBinaryPath);
 }
 
-export function toolsPath(binary: string): string {
+export function toolsPath(binary: string, defaultPath?: string): string {
   const displayWarning = () => {
     warnOnce(
       `Specified ${binaryEnvKey} does not exist, using built in ${binary}`,
@@ -72,8 +72,7 @@ export function toolsPath(binary: string): string {
       }
     }
   }
-
-  return join(quartoConfig.toolsPath(), binary);
+  return join(quartoConfig.toolsPath(), defaultPath || binary);
 }
 
 export function pandocBinaryPath(): string {

--- a/src/core/run/deno.ts
+++ b/src/core/run/deno.ts
@@ -8,11 +8,7 @@ import { existsSync, expandGlobSync } from "fs/mod.ts";
 import { extname, join, normalize } from "path/mod.ts";
 import { quartoCacheDir } from "../appdirs.ts";
 import { execProcess } from "../process.ts";
-import {
-  architectureToolsPath,
-  resourcePath,
-  toolsPath,
-} from "../resources.ts";
+import { architectureToolsPath, resourcePath } from "../resources.ts";
 import { RunHandler, RunHandlerOptions } from "./types.ts";
 import { removeIfExists } from "../path.ts";
 import { copyTo } from "../copy.ts";


### PR DESCRIPTION
Preserve the proper environment var name when making architecture path
This should address the issue https://github.com/quarto-dev/quarto-cli/issues/7344  raised in https://github.com/NixOS/nixpkgs/pull/263108

Thanks to @b-rodrigues and @minijackson for their diligence in identifying the issue.