### PR TITLE
Improvment to auto install process when detecting error

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -251,3 +251,4 @@
 - ([#7032](https://github.com/quarto-dev/quarto-cli/issues/7032)): `quarto` is now correctly working when installed in a folder with spaces in path.
 - ([#7131](https://github.com/quarto-dev/quarto-cli/issues/7131)): Fix typo in ISBN entry for JATS subarticle template (author: @jasonaris).
 - ([#3599](https://github.com/quarto-dev/quarto-cli/issues/3599), [#5870](https://github.com/quarto-dev/quarto-cli/issues/5870)): Fix hash issue causing unexpected render when `freeze` is activated on Windows but re-rendered on Linux (e.g. in Github Action).
+- ([#7252](https://github.com/quarto-dev/quarto-cli/issues/7252)): Improve handling with `tlmgr` of some mismatched LaTeX support files, associated with `expl3.sty` loading.

--- a/src/command/render/latexmk/parse-error.ts
+++ b/src/command/render/latexmk/parse-error.ts
@@ -230,7 +230,7 @@ const packageMatchers = [
       return "lua-uni-algos.lua";
     },
   },
-
+  { regex: /.* Loading '([^']+)' aborted!.*/g },
   { regex: /.*! LaTeX Error: File `([^']+)' not found.*/g },
   { regex: /.* file ['`]?([^' ]+)'? not found.*/g },
   { regex: /.*the language definition file ([^ ]+) .*/g },

--- a/src/command/render/latexmk/pdf.ts
+++ b/src/command/render/latexmk/pdf.ts
@@ -156,7 +156,6 @@ async function initialCompileLatex(
   quiet?: boolean,
 ) {
   let packagesUpdated = false;
-  let tlmgrUpdated = false;
   while (true) {
     // Run the pdf engine
     const response = await runPdfEngine(
@@ -197,7 +196,6 @@ async function initialCompileLatex(
           logProgress("updating tlmgr");
         }
         await pkgMgr.updatePackages(false, true);
-        tlmgrUpdated = true;
         info("");
 
         if (!quiet) {
@@ -208,23 +206,6 @@ async function initialCompileLatex(
       }
 
       const logText = Deno.readTextFileSync(response.log);
-      // See if tlmgr just needs to be updated
-      // https://github.com/rstudio/tinytex/commit/5946a2a1bf3c6ecefbd1213178a4e473ff4c26dc
-      // https://github.com/quarto-dev/quarto-cli/issues/7087
-      if (logText.match(/.* Loading '([^']+)' aborted!/)) {
-        if (!tlmgrUpdated) {
-          continue;
-        } else {
-          // We've already tried updating, just need to throw and die
-          // We failed to install packages (but there are missing packages), give up
-          displayError(
-            "tlmgr needs to be updated, but the update failed",
-            response.log,
-            response.result,
-          );
-          return Promise.reject();
-        }
-      }
 
       // Try to find and install packages
       const packagesInstalled = await findAndInstallPackages(

--- a/src/command/render/latexmk/texlive.ts
+++ b/src/command/render/latexmk/texlive.ts
@@ -446,7 +446,7 @@ function tlmgrCommand(
   }
 }
 
-// Exectute fmtutil
+// Execute fmtutil
 // https://tug.org/texlive/doc/fmtutil.html
 function fmtutilCommand(context: TexLiveContext) {
   const fmtutil = texLiveCmd("fmtutil-sys", context);

--- a/src/command/render/latexmk/texlive.ts
+++ b/src/command/render/latexmk/texlive.ts
@@ -239,6 +239,12 @@ async function installPackage(
     if (updateResult.code !== 0) {
       return Promise.reject();
     }
+
+    // Rebuild format tree
+    const fmtutilResult = await fmtutilCommand(context);
+    if (fmtutilResult.code !== 0) {
+      return Promise.reject();
+    }
   }
 
   // Run the install command
@@ -268,6 +274,12 @@ async function installPackage(
       quiet,
     );
     if (updateResult.code !== 0) {
+      return Promise.reject();
+    }
+
+    // Rebuild format tree
+    const fmtutilResult = await fmtutilCommand(context);
+    if (fmtutilResult.code !== 0) {
       return Promise.reject();
     }
 
@@ -432,4 +444,17 @@ function tlmgrCommand(
   } else {
     return execTlmgr([tlmgr.fullPath, tlmgrCmd, ...args]);
   }
+}
+
+// Exectute fmtutil
+// https://tug.org/texlive/doc/fmtutil.html
+function fmtutilCommand(context: TexLiveContext) {
+  const fmtutil = texLiveCmd("fmtutil-sys", context);
+  return execProcess(
+    {
+      cmd: [fmtutil.fullPath, "--all"],
+      stdout: "piped",
+      stderr: "piped",
+    },
+  );
 }

--- a/src/command/render/latexmk/texlive.ts
+++ b/src/command/render/latexmk/texlive.ts
@@ -225,6 +225,22 @@ async function installPackage(
   opts?: string[],
   quiet?: boolean,
 ) {
+  // if any packages have been installed already, update packages first
+  let isInstalled = await verifyPackageInstalled(pkg, context);
+  if (isInstalled) {
+    // update tlmgr itself
+    const updateResult = await updatePackages(
+      true,
+      true,
+      context,
+      opts,
+      quiet,
+    );
+    if (updateResult.code !== 0) {
+      return Promise.reject();
+    }
+  }
+
   // Run the install command
   let installResult = await tlmgrCommand(
     "install",
@@ -240,8 +256,8 @@ async function installPackage(
     );
   }
 
-  // Check whether we should update and retry the install
-  const isInstalled = await verifyPackageInstalled(pkg, context);
+  // Check whether we should update again and retry the install
+  isInstalled = await verifyPackageInstalled(pkg, context);
   if (!isInstalled) {
     // update tlmgr itself
     const updateResult = await updatePackages(

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -74,7 +74,7 @@ export function testQuartoCmd(
     name,
     execute: async () => {
       const timeout = new Promise((_resolve, reject) => {
-        setTimeout(reject, 300000, "timed out after 5 minutes");
+        setTimeout(reject, 600000, "timed out after 10 minutes");
       });
       await Promise.race([
         quarto([cmd, ...args], undefined, context?.env),

--- a/tests/unit/latexmk/expl3-aborted.log
+++ b/tests/unit/latexmk/expl3-aborted.log
@@ -1,0 +1,17 @@
+
+
+Other content before
+
+compilation failed- tlmgr needs to be updated, but the update failed
+
+
+    LaTeX Error: Mismatched LaTeX support files detected.
+    (LaTeX)        Loading 'expl3.sty' aborted!
+    (LaTeX)        
+    (LaTeX)        The L3 programming layer in the LaTeX format
+    (LaTeX)        is dated 2023-08-29, but in your TeX tree the files require
+    (LaTeX)        at least 2023-10-10.
+    
+    For immediate help type H <return>.
+
+Other content after

--- a/tests/unit/latexmk/parse-error.test.ts
+++ b/tests/unit/latexmk/parse-error.test.ts
@@ -1,0 +1,17 @@
+/*
+* parse-error.test.ts
+*
+* Copyright (C) 2023 Posit Software, PBC
+*
+*/
+
+import { findMissingFontsAndPackages } from "../../../src/command/render/latexmk/parse-error.ts"
+import { unitTest } from "../../test.ts";
+import { assert } from "testing/asserts.ts";
+
+unitTest("findMissingPackages", async () => {
+  const logText = Deno.readTextFileSync("expl3-aborted.log")
+  assert(findMissingFontsAndPackages(logText, ".")[0] === "expl3.sty" );
+}, {
+  cwd: () => "unit/latexmk/"
+});

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -7,8 +7,6 @@
 
 import { basename, dirname, extname, join } from "path/mod.ts";
 import { parseFormatString } from "../src/core/pandoc/pandoc-formats.ts";
-import { quartoRules } from "../src/format/html/format-html-shared.ts";
-import { quarto } from "../src/quarto.ts";
 import { kMetadataFormat, kOutputExt } from "../src/config/constants.ts";
 
 // caller is responsible for cleanup!


### PR DESCRIPTION
This aims to fix #7252

This is another way to fix initial report of this problem at #7087 based on what we do in https://github.com/rstudio/tinytex R package

* `Loading 'expl3.sty' aborted!` is considered as any other error, and `expl3.sty` package will be looked for
* When triggerring install for a package, if already install we do run an update first 
* The update included a rebuild of format tree with fmtutils (https://tug.org/texlive/doc/fmtutil.html) - which could be outdated following some `tlmgr` update

Trigerring CI to see if this works ok. The issue from #7252 is hard to reproduce and test, but we haven't seen it in TinyTeX for while, after the same fix https://github.com/rstudio/tinytex/commit/5946a2a1bf3c6ecefbd1213178a4e473ff4c26dc  (https://github.com/rstudio/tinytex/issues/291)

@yihui pinging you in case you want to have a look

