### PR TITLE
LaTeX: don't render unreferenced pandoc.Figure into float. 

### DIFF
--- a/src/resources/filters/layout/pandoc3_figure.lua
+++ b/src/resources/filters/layout/pandoc3_figure.lua
@@ -95,6 +95,17 @@ function render_pandoc3_figure()
           end
         end,
         Figure = function(figure)
+          -- this is a figure that is not cross-referenceable
+          -- if this ends up in a layout without fig-pos = H, it'll fail
+          -- 'H' forces it to not float
+          if figure.identifier == "" then
+            figure = _quarto.ast.walk(figure, {
+              Image = function(image)
+                image.attributes['fig-pos'] = 'H'
+                return image
+              end
+            })
+          end
           local image
           _quarto.ast.walk(figure, {
             Image = function(img)

--- a/tests/docs/smoke-all/2023/10/30/7429.qmd
+++ b/tests/docs/smoke-all/2023/10/30/7429.qmd
@@ -1,0 +1,20 @@
+---
+title: Test
+format: pdf
+---
+
+Example 
+
+```{python}
+#| layout-ncol: 2
+#| fig-cap: 
+#|   - "Line Plot 1"
+#|   - "Line Plot 2"
+
+import matplotlib.pyplot as plt
+plt.plot([1,23,2,4])
+plt.show()
+
+plt.plot([8,65,23,90])
+plt.show()
+```


### PR DESCRIPTION
Closes #7429. Nested Figures get [H] positioning, so they don't float.
