### PR TITLE
Respect *-cap-location everywhere

### DIFF
--- a/src/resources/filters/crossref/crossref.lua
+++ b/src/resources/filters/crossref/crossref.lua
@@ -152,6 +152,8 @@ local quarto_normalize_filters = {
     return quarto_global_state.active_filters.normalization
   end, normalize_filter()) },
 
+  { name = "normalize-capture-reader-state", filter = normalize_capture_reader_state() },
+
   { name = "pre-table-merge-raw-html", 
     filter = table_merge_raw_html()
   },

--- a/src/resources/filters/layout/html.lua
+++ b/src/resources/filters/layout/html.lua
@@ -189,7 +189,7 @@ end)
 --       captionPara.content:insert(pandoc.RawInline("html", figcaption))
 --       tappend(captionPara.content, caption.content)
 --       captionPara.content:insert(pandoc.RawInline("html", "</figcaption>"))
---       if capLocation('fig', 'bottom') == 'bottom' then
+--       if cap_location_from_option('fig', 'bottom') == 'bottom' then
 --         panel.content:insert(captionPara)
 --       else
 --         tprepend(panel.content, { captionPara })
@@ -198,7 +198,7 @@ end)
 --       local panelCaption = pandoc.Div(caption, pandoc.Attr("", { "panel-caption" }))
 --       if hasTableRef(divEl) then
 --         panelCaption.attr.classes:insert("table-caption")
---         if capLocation('tbl', 'top') == 'bottom' then
+--         if cap_location_from_option('tbl', 'top') == 'bottom' then
 --           panel.content:insert(panelCaption)
 --         else
 --           tprepend(panel.content, { panelCaption })
@@ -312,7 +312,7 @@ function renderHtmlFigure(el, render)
     ))
     tappend(figureCaption.content, captionInlines) 
     figureCaption.content:insert(pandoc.RawInline("html", "</figcaption>"))
-    if capLocation('fig', 'bottom') == 'top' then
+    if cap_location_from_option('fig', 'bottom') == 'top' then
       figureDiv.content:insert(figureCaption)
       tappend(figureDiv.content, figure)
     else

--- a/src/resources/filters/layout/latex.lua
+++ b/src/resources/filters/layout/latex.lua
@@ -328,13 +328,7 @@ function latexCell(cell, vAlign, endOfRow, endOfTable)
   local miniPageVAlign = latexMinipageValign(vAlign)
   latexAppend(prefix, "\\begin{minipage}" .. miniPageVAlign .. "{" .. width .. "}\n")
 
-  local capType = "fig"
-  local locDefault = "bottom"
-  if isTable then
-    capType = "tbl"
-    locDefault = "top"
-  end
-  local capLoc = capLocation(capType, locDefault)
+  local capLoc = cap_location(cell)
 
   if (capLoc == "top") then
     tappend(prefix, subcap)
@@ -653,7 +647,7 @@ function renderLatexFigure(el, render)
   -- get the figure content and caption inlines
   local figureContent, captionInlines = render(figure)  
 
-  local capLoc = capLocation("fig", "bottom")  
+  local capLoc = cap_location_from_option("fig", "bottom")
 
   -- surround caption w/ appropriate latex (and end the figure)
   if captionInlines and inlinesToString(captionInlines) ~= "" then

--- a/src/resources/filters/quarto-pre/options.lua
+++ b/src/resources/filters/quarto-pre/options.lua
@@ -60,7 +60,7 @@ function parseOption(name, options, def)
   end
 end
 
-function capLocation(scope, default)
+function cap_location_from_option(scope, default)
   local loc = option(scope .. '-cap-location', option('cap-location', nil))
   if loc ~= nil then
     return inlinesToString(loc)


### PR DESCRIPTION
Closes #1829.
Closes #2196.
Closes #2154.
Closes #2221.

Tested in `pdf`, `html`, `docx`:

- `fig-cap-location` and `tbl-cap-location` in
  - div and image attributes
  - code cell metadata
  - document/project metadata
- `cap-location` in
  - div and image attributes
  - code cell metadata for images and tables
  - document/project metadata
- `lst-cap-location` in
  - code cells (in conjunction with `lst-label`)
  - code blocks

TODO: [I don't think we handle "*-cap-location: margin" uniformly and well yet. Check and fix.](https://github.com/quarto-dev/quarto-cli/issues/7455)