### PR TITLE
add hidden class to vault so dashboards don't pick it up

### DIFF
--- a/src/resources/filters/ast/runemulation.lua
+++ b/src/resources/filters/ast/runemulation.lua
@@ -12,7 +12,7 @@ local ensure_vault = function(doc)
  
   -- create if missing
   if vault == nil then
-    vault = pandoc.Div({}, pandoc.Attr(_quarto.ast.vault._uuid, {}, {}))
+    vault = pandoc.Div({}, pandoc.Attr(_quarto.ast.vault._uuid, {"hidden"}, {}))
     doc.blocks:insert(vault)
   end
 


### PR DESCRIPTION
This should fix the issue @wch found with dashboards. Let's hold off on touching `main` for a bit, though.