### PR TITLE
LaTeX crossrefs: #215 fixes

### DIFF
--- a/src/resources/filters/crossref/custom.lua
+++ b/src/resources/filters/crossref/custom.lua
@@ -61,6 +61,9 @@ function initialize_custom_crossref_categories(meta)
     add_crossref_category(obj_entry)
 
     if quarto.doc.isFormat("pdf") then
+      local function as_latex(inlines)
+        return trim(pandoc.write(pandoc.Pandoc(inlines), "latex"))
+      end
       metaInjectLatex(meta, function(inject)
         local env_name = entry["latex-env"]
         local name = entry["name"]
@@ -80,7 +83,7 @@ function initialize_custom_crossref_categories(meta)
         usePackage("float") .. "\n" ..
         "\\floatstyle{plain}\n" ..
         "\\@ifundefined{c@chapter}{\\newfloat{" .. env_name .. "}{h}{" .. list_of_name .. "}}{\\newfloat{" .. env_name .. "}{h}{" .. list_of_name .. "}[chapter]}\n" ..
-        "\\floatname{".. env_name .. "}{" .. titleString(ref_type, env_prefix) .. "}\n"
+        "\\floatname{".. env_name .. "}{" .. as_latex(title(ref_type, env_prefix)) .. "}\n"
         )
 
         -- FIXME this is a bit of hack for the case of custom categories with

--- a/src/resources/filters/crossref/meta.lua
+++ b/src/resources/filters/crossref/meta.lua
@@ -56,7 +56,9 @@ function crossrefMetaInject()
           elseif titleDelim == "none" or titleDelim == "" then
             inject("\\captionsetup{labelsep=none}\n")
           else
-            fail("Invalid value for 'title-delim' option in PDF: " .. titleDelim .. ". The valid values are '', 'none', ':', 'colon', '.', 'period', ' ', 'space', and 'quad'")
+            warn("\nIgnoring invalid value for 'title-delim' option in PDF: " .. titleDelim .. "." ..
+                 "\nThe valid values in the caption LaTeX package are:" ..
+                 "\n'', 'none', ':', 'colon', '.', 'period', ' ', 'space', and 'quad'")
           end
         end
         

--- a/src/resources/filters/crossref/meta.lua
+++ b/src/resources/filters/crossref/meta.lua
@@ -41,6 +41,22 @@ function crossrefMetaInject()
             "\\newcommand*\\listoflistings{\\listof{codelisting}{" .. listOfTitle("lol", "List of Listings") .. "}}\n"
           )
         end
+
+        -- title-delim
+        local titleDelim = pandoc.utils.stringify(crossrefOption("title-delim"))
+        if titleDelim == ":" or titleDelim == "colon" then
+          inject("\\captionsetup{labelsep=colon}\n")
+        elseif titleDelim == "." or titleDelim == "period" then
+          inject("\\captionsetup{labelsep=period}\n")
+        elseif titleDelim == " " or titleDelim == "space" then
+          inject("\\captionsetup{labelsep=space}\n")
+        elseif titleDelim == "quad" then
+          inject("\\captionsetup{labelsep=quad}\n")
+        elseif titleDelim == "none" or titleDelim == "" then
+          inject("\\captionsetup{labelsep=none}\n")
+        else
+          fail("Invalid value for 'title-delim' option in PDF: " .. titleDelim .. ". The valid values are '', 'none', ':', 'colon', '.', 'period', ' ', 'space', and 'quad'")
+        end
         
         local theoremIncludes = theoremLatexIncludes()
         if theoremIncludes then

--- a/src/resources/filters/crossref/meta.lua
+++ b/src/resources/filters/crossref/meta.lua
@@ -5,6 +5,9 @@
 function crossrefMetaInject()
   return {
     Meta = function(meta)
+      local function as_latex(inlines)
+        return trim(pandoc.write(pandoc.Pandoc(inlines), "latex"))
+      end
       metaInjectLatex(meta, function(inject)
         
         inject(usePackage("caption"))
@@ -14,8 +17,8 @@ function crossrefMetaInject()
           maybeRenewCommand("contentsname", param("toc-title-document", "Table of contents")) ..
           maybeRenewCommand("listfigurename", listOfTitle("lof", "List of Figures")) ..
           maybeRenewCommand("listtablename", listOfTitle("lot", "List of Tables")) ..
-          maybeRenewCommand("figurename", titleString("fig", "Figure")) ..
-          maybeRenewCommand("tablename", titleString("tbl", "Table")) ..
+          maybeRenewCommand("figurename", as_latex(title("fig", "Figure"))) ..
+          maybeRenewCommand("tablename", as_latex(title("tbl", "Table"))) ..
           "}\n"
         )
       
@@ -23,7 +26,7 @@ function crossrefMetaInject()
           inject(
             "\\newcommand*\\listoflistings\\lstlistoflistings\n" ..
             "\\AtBeginDocument{%\n" ..
-            "\\renewcommand*\\lstlistlistingname{" .. listOfTitle("lol", "List of Listigs") .. "}\n" ..
+            "\\renewcommand*\\lstlistlistingname{" .. listOfTitle("lol", "List of Listings") .. "}\n" ..
             "}\n"
           )
         else
@@ -31,7 +34,7 @@ function crossrefMetaInject()
             usePackage("float") .. "\n" ..
             "\\floatstyle{ruled}\n" ..
             "\\@ifundefined{c@chapter}{\\newfloat{codelisting}{h}{lop}}{\\newfloat{codelisting}{h}{lop}[chapter]}\n" ..
-            "\\floatname{codelisting}{" .. titleString("lst", "Listing") .. "}\n"
+            "\\floatname{codelisting}{" .. as_latex(title("lst", "Listing")) .. "}\n"
           )
 
           inject(

--- a/src/resources/filters/crossref/meta.lua
+++ b/src/resources/filters/crossref/meta.lua
@@ -43,19 +43,21 @@ function crossrefMetaInject()
         end
 
         -- title-delim
-        local titleDelim = pandoc.utils.stringify(crossrefOption("title-delim"))
-        if titleDelim == ":" or titleDelim == "colon" then
-          inject("\\captionsetup{labelsep=colon}\n")
-        elseif titleDelim == "." or titleDelim == "period" then
-          inject("\\captionsetup{labelsep=period}\n")
-        elseif titleDelim == " " or titleDelim == "space" then
-          inject("\\captionsetup{labelsep=space}\n")
-        elseif titleDelim == "quad" then
-          inject("\\captionsetup{labelsep=quad}\n")
-        elseif titleDelim == "none" or titleDelim == "" then
-          inject("\\captionsetup{labelsep=none}\n")
-        else
-          fail("Invalid value for 'title-delim' option in PDF: " .. titleDelim .. ". The valid values are '', 'none', ':', 'colon', '.', 'period', ' ', 'space', and 'quad'")
+        if crossrefOption("title-delim") ~= nil then
+          local titleDelim = pandoc.utils.stringify(crossrefOption("title-delim"))
+          if titleDelim == ":" or titleDelim == "colon" then
+            inject("\\captionsetup{labelsep=colon}\n")
+          elseif titleDelim == "." or titleDelim == "period" then
+            inject("\\captionsetup{labelsep=period}\n")
+          elseif titleDelim == " " or titleDelim == "space" then
+            inject("\\captionsetup{labelsep=space}\n")
+          elseif titleDelim == "quad" then
+            inject("\\captionsetup{labelsep=quad}\n")
+          elseif titleDelim == "none" or titleDelim == "" then
+            inject("\\captionsetup{labelsep=none}\n")
+          else
+            fail("Invalid value for 'title-delim' option in PDF: " .. titleDelim .. ". The valid values are '', 'none', ':', 'colon', '.', 'period', ' ', 'space', and 'quad'")
+          end
         end
         
         local theoremIncludes = theoremLatexIncludes()


### PR DESCRIPTION
Closes #215.

- [x] allow markdown styles in *-title
- [x] title-delim in `pdf`