### PR TITLE
use chapter names in cross-chapter book references when `number-sections: false`

### DIFF
--- a/src/project/types/book/book-chapters.ts
+++ b/src/project/types/book/book-chapters.ts
@@ -1,3 +1,9 @@
+/*
+ * book-chapters.ts
+ *
+ * Copyright (C) 2020-2023 Posit Software, PBC
+ */
+
 import * as ld from "../../../core/lodash.ts";
 
 import { PandocAttr } from "../../../core/pandoc/types.ts";
@@ -133,22 +139,28 @@ export function formatChapterTitle(
     }
   };
 
-  if (info) {
-    if (info.appendix) {
-      const crossref = format.metadata?.crossref as Metadata;
-      const title = crossref?.[kCrossrefAppendixTitle] ||
-        format.language[kCrossrefApxPrefix] || "Appendix";
-      const delim = crossref?.[kCrossrefAppendixDelim] !== undefined
-        ? crossref?.[kCrossrefAppendixDelim]
-        : " —";
-      return withIdSpan(`${title} ${info.labelPrefix}${delim} ${label}`);
+  if (!info) {
+    return withIdSpan(label);
+  }
+
+  if (info.appendix) {
+    const crossref = format.metadata?.crossref as Metadata;
+    const title = crossref?.[kCrossrefAppendixTitle] ||
+      format.language[kCrossrefApxPrefix] || "Appendix";
+    const delim = crossref?.[kCrossrefAppendixDelim] !== undefined
+      ? crossref?.[kCrossrefAppendixDelim]
+      : " —";
+    return withIdSpan(`${title} ${info.labelPrefix}${delim} ${label}`);
+  } else {
+    if (format.pandoc[kNumberSections] === false) {
+      return withIdSpan(
+        `[${label}]{.chapter-title}`,
+      );
     } else {
       return withIdSpan(
         `[${info.labelPrefix}]{.chapter-number}\u00A0 [${label}]{.chapter-title}`,
       );
     }
-  } else {
-    return withIdSpan(label);
   }
 }
 

--- a/src/resources/filters/crossref/index.lua
+++ b/src/resources/filters/crossref/index.lua
@@ -99,7 +99,7 @@ function writeIndex()
         if isQmdInput() then
           writeKeysIndex(indexFile)
         else
-          writeFullIndex(indexFile)
+          writeFullIndex(indexFile, doc)
         end   
       end
     end
@@ -108,11 +108,7 @@ end
 
 local function index_caption(v)
   if #v.caption > 0 then
-    if pandoc.utils.type(v.caption[1]) == "Inline" then
-      return inlinesToString(pandoc.Inlines({v.caption[1]}))
-    else
-      return inlinesToString(pandoc.Inlines(v.caption[1].content))
-    end
+    return inlinesToString(quarto.utils.as_inlines(v.caption))
   else
     return ""
   end
@@ -144,7 +140,7 @@ function writeKeysIndex(indexFile)
 end
 
 
-function writeFullIndex(indexFile)
+function writeFullIndex(indexFile, doc)
   -- create an index data structure to serialize for this file 
   local index = {
     entries = pandoc.List(),
@@ -184,7 +180,8 @@ function writeFullIndex(indexFile)
         order = {
           number = 1,
           section = crossref.index.numberOffset
-        }
+        },
+        caption = pandoc.utils.stringify(doc.meta.title)
       }
       index.entries:insert(chapterEntry)
     end


### PR DESCRIPTION
(cc @hadley)

This fixes the bug in rendering https://design.tidyverse.org/important-args-first.html:

<table>
<tr>
<td>Before
</td>
<td>After
</td>
</tr>
<tr>
<td>
<img width="773" alt="image" src="https://github.com/quarto-dev/quarto-cli/assets/285675/0422c4b2-ee07-4f9d-ba49-1760bfc878e8">
</td>
<td>
<img width="788" alt="image" src="https://github.com/quarto-dev/quarto-cli/assets/285675/852dec16-5017-4956-9a5a-7a86e8fd177c">
</td>
</tr>
</table>

You'll note that we lose the markup in the title, with `...` being rendered as "...". I might be able to improve that in the future, but this bugfix is pretty necessary.