### PR TITLE
Lua: scaffold parse_md_in_html_rawblocks so it works inside combineFilters

### DIFF
--- a/src/resources/filters/common/pandoc.lua
+++ b/src/resources/filters/common/pandoc.lua
@@ -51,6 +51,14 @@ function combineFilters(filters)
         for _, fn in ipairs(fns) do
           local result = fn(current)
           if result ~= nil then
+            if (pandoc.utils.type(result) ~= pandoc.utils.type(current) or
+                result.t ~= current.t) then
+              -- luacov: disable
+              quarto.log.info("combineFilters: expected " .. (current.t or pandoc.utils.type(current)) .. " got " .. (result.t or pandoc.utils.type(result)))
+              quarto.log.info("Exiting filter early. (This is a potential bug in Quarto.)")
+              return result
+              -- luacov: enable
+            end
             -- if there is a result from this function
             -- update the current value with the result
             current = result

--- a/src/resources/filters/customnodes/callout.lua
+++ b/src/resources/filters/customnodes/callout.lua
@@ -119,7 +119,7 @@ function docx_callout_and_table_fixup()
     Blocks = function(blocks)
       local lastWasCallout = false
       local lastWasTableOrFigure = false
-      local newBlocks = pandoc.List()
+      local newBlocks = pandoc.Blocks({})
       for i,el in ipairs(blocks) do 
         -- determine what this block is
         local isCallout = is_custom_node(el, "Callout")

--- a/src/resources/filters/normalize/extractquartodom.lua
+++ b/src/resources/filters/normalize/extractquartodom.lua
@@ -14,16 +14,16 @@ function parse_md_in_html_rawblocks()
   return {
     Div = function(div)
       if div.attributes.qmd ~= nil or div.attributes["qmd-base64"] ~= nil then
-        return process_quarto_markdown_input_element(div)
+        return make_scaffold(pandoc.Div, process_quarto_markdown_input_element(div))
       end
     end,
     Span = function(span)
       if span.attributes.qmd ~= nil or span.attributes["qmd-base64"] ~= nil then
-        local blocks = process_quarto_markdown_input_element(span)
-        if #blocks < 1 then
-          return pandoc.Span({})
+        local inlines = quarto.utils.as_inlines(process_quarto_markdown_input_element(span))
+        if #inlines < 1 then
+          return make_scaffold(pandoc.Span, {})
         end
-        return blocks[1].content
+        return make_scaffold(pandoc.Span, inlines)
       end
     end
   }

--- a/src/resources/filters/quarto-finalize/descaffold.lua
+++ b/src/resources/filters/quarto-finalize/descaffold.lua
@@ -15,3 +15,7 @@ function descaffold()
     end
   }
 end
+
+function make_scaffold(ctor, node)
+  return ctor(node or {}, pandoc.Attr("", {"quarto-scaffold", "hidden"}, {}))
+end


### PR DESCRIPTION
This closes #7501.

In addition to the fix, I added a check and internal error in the combineFilters() function itself, so that if we use it wrongly again in the future, the error will be easier to track down.