### PR TITLE
Add annotations for GAP (www.gap-system.org)

### DIFF
--- a/src/resources/filters/modules/constants.lua
+++ b/src/resources/filters/modules/constants.lua
@@ -122,7 +122,8 @@ local kLangCommentChars = {
   elm = { "#" },
   vhdl = { "--"},
   html = { "<!--", "-->"},
-  markdown = {"<!--", "-->"}
+  markdown = {"<!--", "-->"},
+  gap = { "#" }
 }
 
 return {

--- a/src/resources/filters/quarto-pre/engine-escape.lua
+++ b/src/resources/filters/quarto-pre/engine-escape.lua
@@ -85,6 +85,7 @@ local kHighlightClasses = {
   "fortranfixed",
   "fortranfree",
   "fsharp",
+  "gap",
   "gcc",
   "glsl",
   "gnuassembler",


### PR DESCRIPTION
## Description

This add annotation support for the 'GAP' programming language (www.gap-system.org). It is a language designed for discrete maths.

I hope this isn't big enough to need contributor agreement, mainly because I don't current have printer access, but I can probably sort that out if required. I'd also be happy for someone to throw this away and do the same thing if required (GAP uses '#' as comment marker).
