### PR TITLE
[GHA] Directly commit to main the update version.txt file

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -35,14 +35,18 @@ jobs:
           read_version=$(cat version.txt)
           version=$(echo $read_version | grep -o '[[:digit:]]*\.[[:digit:]]*' | head -1)
           build_number=$(($(echo $read_version | grep -o '[[:digit:]]*' | tail -1)+1))
+          version_full=$version.$build_number
           echo "version=$version" >> $GITHUB_OUTPUT
-          echo "version_full=$version.$build_number">> $GITHUB_OUTPUT
+          echo "version_full=$version_full">> $GITHUB_OUTPUT
+          echo "**Full Changelog**: https://github.com/cderv/quarto-cli/compare/v${read_version}...v${version_full}" > "release_note.md"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
           name: News
-          path: ./news/changelog-${{steps.read-version.outputs.version}}.md
+          path: |
+            ./news/changelog-${{steps.read-version.outputs.version}}.md
+            ./release_note.md
 
       - name: Update version.txt
         run: |
@@ -432,7 +436,7 @@ jobs:
       - name: Rename news
         run: |
           ls -la ./News
-          mv ./News/changelog-${{needs.configure.outputs.version_base}}.md ./News/changelog.md
+          mv ./News/news/changelog-${{needs.configure.outputs.version_base}}.md ./News/news/changelog.md
 
       - name: Generate Checksums
         id: generate_checksum
@@ -486,7 +490,7 @@ jobs:
           tag_name: ${{needs.configure.outputs.tag_name}}
           target_commitish: ${{ needs.configure.outputs.version_commit }}
           name: ${{needs.configure.outputs.tag_name}}
-          generate_release_notes: true
+          body_path: ./News/release_note.md
           draft: false
           prerelease: ${{ inputs.pre-release }}
           files: |
@@ -500,7 +504,7 @@ jobs:
             ./Windows Zip/quarto-${{needs.configure.outputs.version}}-win.zip
             ./Mac Installer/quarto-${{needs.configure.outputs.version}}-macos.pkg
             ./Mac Zip/quarto-${{needs.configure.outputs.version}}-macos.tar.gz
-            ./News/changelog.md
+            ./News/news/changelog.md
             quarto-${{needs.configure.outputs.version}}-checksums.txt
 
   docker-push:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -14,11 +14,6 @@ on:
         required: false
         type: boolean
         default: true
-      draft:
-        description: "Draft"
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   configure:
@@ -496,7 +491,7 @@ jobs:
           target_commitish: ${{ needs.configure.outputs.version_commit }}
           name: ${{needs.configure.outputs.tag_name}}
           generate_release_notes: true
-          draft: ${{ inputs.draft }}
+          draft: false
           prerelease: ${{ inputs.pre-release }}
           files: |
             ./Source/quarto-${{needs.configure.outputs.version}}.tar.gz

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -27,8 +27,7 @@ jobs:
       version: ${{steps.config.outputs.version}}.${{ steps.config.outputs.build_number}}
       version_base: ${{steps.config.outputs.version}}
       tag_name: v${{steps.config.outputs.version}}.${{ steps.config.outputs.build_number }}
-      release: v${{steps.config.outputs.version}}.${{ steps.config.outputs.build_number }}
-      changes: ${{ steps.config.outputs.changes }}
+      version_commit: ${{ steps.version_commit.outputs.commit_long_sha }}
     if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository == 'quarto-dev/quarto-cli')
     steps:
       - name: Install libc6-div
@@ -43,19 +42,9 @@ jobs:
         run: |
           source ./configuration
 
-          CHANGES=
-          # CHANGES=$(git log $(git describe --tags --abbrev=0)..HEAD --oneline)
-          # Escape \n, \r to preserve multiline variable
-          # See https://github.community/t/set-output-truncates-multiline-strings/16852/2
-          # CHANGES="${CHANGES//'%'/'%25'}"
-          # CHANGES="${CHANGES//$'\n'/'%0A'}"
-          # CHANGES="${CHANGES//$'\r'/'%0D'}"
-          # echo "changes=$CHANGES" >> $GITHUB_OUTPUT
-
           QUARTO_BUILD_NUMBER=$(($QUARTO_BUILD_RUN_OFFSET + $GITHUB_RUN_NUMBER))
 
           echo "version=$QUARTO_VERSION" >> $GITHUB_OUTPUT
-          echo "changes=$CHANGES" >> $GITHUB_OUTPUT
           echo "build_number=$QUARTO_BUILD_NUMBER" >> $GITHUB_OUTPUT
 
       - name: Upload Artifact
@@ -64,12 +53,28 @@ jobs:
           name: News
           path: ./news/changelog-${{steps.config.outputs.version}}.md
 
+      - name: Update version.txt
+        run: |
+          echo ${{steps.config.outputs.version}}.${{steps.config.outputs.build_number}} > version.txt
+
+      - uses: EndBug/add-and-commit@v9
+        if: ${{ inputs.publish-release }}
+        id: version_commit
+        with:
+          add: "version.txt"
+          tag: v${{steps.config.outputs.version}}.${{ steps.config.outputs.build_number }}
+          message: "Update version.txt"
+          fetch: true
+          default_author: github_actions
+
   make-source-tarball:
     runs-on: ubuntu-latest
     needs: [configure]
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.configure.outputs.version_commit }}
 
       - name: Make Tarball
         run: |
@@ -432,7 +437,7 @@ jobs:
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v3
-        
+
       - name: Rename news
         run: |
           ls -la ./News
@@ -488,9 +493,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{needs.configure.outputs.tag_name}}
-          name: ${{needs.configure.outputs.release}}
-          body: |
-            ${{ needs.configure.outputs.changes }}
+          target_commitish: ${{ needs.configure.outputs.version_commit }}
+          name: ${{needs.configure.outputs.tag_name}}
+          generate_release_notes: true
           draft: ${{ inputs.draft }}
           prerelease: ${{ inputs.pre-release }}
           files: |

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,9 +19,9 @@ jobs:
   configure:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{steps.config.outputs.version}}.${{ steps.config.outputs.build_number}}
-      version_base: ${{steps.config.outputs.version}}
-      tag_name: v${{steps.config.outputs.version}}.${{ steps.config.outputs.build_number }}
+      version: ${{ steps.read-version.outputs.version_full }}
+      version_base: ${{ steps.read-version.outputs.version }}
+      tag_name: v${{ steps.read-version.outputs.version_full }}
       version_commit: ${{ steps.version_commit.outputs.commit_long_sha }}
     if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository == 'quarto-dev/quarto-cli')
     steps:
@@ -29,32 +29,31 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: config
-        id: config
+      - name: Get previous version
+        id: read-version
         run: |
-          source ./configuration
-
-          QUARTO_BUILD_NUMBER=$(($QUARTO_BUILD_RUN_OFFSET + $GITHUB_RUN_NUMBER))
-
-          echo "version=$QUARTO_VERSION" >> $GITHUB_OUTPUT
-          echo "build_number=$QUARTO_BUILD_NUMBER" >> $GITHUB_OUTPUT
+          read_version=$(cat version.txt)
+          version=$(echo $read_version | grep -o '[[:digit:]]*\.[[:digit:]]*' | head -1)
+          build_number=$(($(echo $read_version | grep -o '[[:digit:]]*' | tail -1)+1))
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "version_full=$version.$build_number">> $GITHUB_OUTPUT
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
           name: News
-          path: ./news/changelog-${{steps.config.outputs.version}}.md
+          path: ./news/changelog-${{steps.read-version.outputs.version}}.md
 
       - name: Update version.txt
         run: |
-          echo ${{steps.config.outputs.version}}.${{steps.config.outputs.build_number}} > version.txt
+          echo ${{ steps.read-version.outputs.version_full }} > version.txt
 
       - uses: EndBug/add-and-commit@1bad3abcf0d6ec49a5857d124b0bfb52dc7bb081
         if: ${{ inputs.publish-release }}
         id: version_commit
         with:
           add: "version.txt"
-          tag: v${{steps.config.outputs.version}}.${{ steps.config.outputs.build_number }}
+          tag: v${{ steps.read-version.outputs.version_full }}
           message: "Update version.txt"
           fetch: true
           default_author: github_actions

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -38,7 +38,10 @@ jobs:
           version_full=$version.$build_number
           echo "version=$version" >> $GITHUB_OUTPUT
           echo "version_full=$version_full">> $GITHUB_OUTPUT
-          echo "**Full Changelog**: https://github.com/cderv/quarto-cli/compare/v${read_version}...v${version_full}" > "release_note.md"
+          echo "**Changelog since last release**: https://github.com/${GITHUB_REPOSITORY}/compare/v${read_version}...v${version_full}" > "release_note.md"
+          echo -e "\n\nFull ${version} changelog up to this version:\n" >> "release_note.md"
+          echo -e "  * View: https://github.com/cderv/quarto-cli/blob/v${version_full}/news/changelog-${version}.md\n" >> "release_note.md"
+          echo -e "  * Download: https://github.com/${GITHUB_REPOSITORY}/releases/download/v${version_full}/changelog.md\n" >> "release_note.md"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -90,6 +90,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.configure.outputs.version_commit }}
 
       - name: Configure
         run: |
@@ -122,6 +124,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.configure.outputs.version_commit }}
 
       - name: Configure
         run: |
@@ -154,6 +158,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.configure.outputs.version_commit }}
 
       - name: Configure
         run: |
@@ -197,6 +203,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.configure.outputs.version_commit }}
 
       - name: Configure
         run: |
@@ -226,6 +234,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.configure.outputs.version_commit }}
 
       - name: Configure
         run: |
@@ -278,6 +288,8 @@ jobs:
           rustup.exe default 1.63.0
 
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.configure.outputs.version_commit }}
 
       - name: Configure
         run: |
@@ -337,6 +349,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.configure.outputs.version_commit }}
 
       - name: Configure
         run: |

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -25,9 +25,6 @@ jobs:
       version_commit: ${{ steps.version_commit.outputs.commit_long_sha }}
     if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository == 'quarto-dev/quarto-cli')
     steps:
-      - name: Install libc6-div
-        run: sudo apt-get install libc6-dev
-
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -534,6 +534,7 @@ jobs:
         make-installer-deb,
         make-installer-arm64-deb,
         make-installer-win,
+        make-installer-mac,
         make-tarball-rhel,
         make-arm64-tarball,
         make-tarball,
@@ -541,7 +542,7 @@ jobs:
         test-zip-win,
         test-zip-mac,
         test-tarball-linux,
-        publish-release,
+        publish-release
       ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           echo ${{steps.config.outputs.version}}.${{steps.config.outputs.build_number}} > version.txt
 
-      - uses: EndBug/add-and-commit@v9
+      - uses: EndBug/add-and-commit@1bad3abcf0d6ec49a5857d124b0bfb52dc7bb081
         if: ${{ inputs.publish-release }}
         id: version_commit
         with:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,6 +15,10 @@ on:
         type: boolean
         default: true
 
+concurrency:
+  # make publishing release concurrent (but others trigger not)
+  group: building-releases-${{ inputs.publish-release && 'prerelease' || github.run_id }}
+
 jobs:
   configure:
     runs-on: ubuntu-latest
@@ -542,7 +546,7 @@ jobs:
         test-zip-win,
         test-zip-mac,
         test-tarball-linux,
-        publish-release
+        publish-release,
       ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -23,6 +23,8 @@ jobs:
       version_base: ${{ steps.read-version.outputs.version }}
       tag_name: v${{ steps.read-version.outputs.version_full }}
       version_commit: ${{ steps.version_commit.outputs.commit_long_sha }}
+      pushed: ${{ steps.version_commit.outputs.pushed }}
+      tag_pushed: ${{ steps.version_commit.outputs.tag_pushed }}
     if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository == 'quarto-dev/quarto-cli')
     steps:
       - uses: actions/checkout@v3
@@ -523,6 +525,43 @@ jobs:
             ./Mac Zip/quarto-${{needs.configure.outputs.version}}-macos.tar.gz
             ./News/news/changelog.md
             quarto-${{needs.configure.outputs.version}}-checksums.txt
+
+  cleanup-when-failure:
+    if: ${{ failure() && inputs.publish-release }}
+    needs:
+      [
+        configure,
+        make-installer-deb,
+        make-installer-arm64-deb,
+        make-installer-win,
+        make-tarball-rhel,
+        make-arm64-tarball,
+        make-tarball,
+        make-source-tarball,
+        test-zip-win,
+        test-zip-mac,
+        test-tarball-linux,
+        publish-release,
+      ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Revert commit of version.txt
+        if: ${{ needs.configure.outputs.pushed }}
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git pull origin $GITHUB_REF_NAME
+          git revert -n ${{ needs.configure.outputs.version_commit }}
+          git add 'version.txt'
+          git commit -m 'Revert version.txt update (${{ needs.configure.outputs.version_commit }})' -m 'Publishing release has failed.'
+          git push origin $GITHUB_REF_NAME
+
+      - name: Deleted created tag
+        if: ${{ needs.configure.outputs.tag_pushed }}
+        run: |
+          git push --delete origin ${{ needs.configure.outputs.tag_name }}
 
   docker-push:
     if: ${{ inputs.publish-release }}

--- a/configuration
+++ b/configuration
@@ -59,7 +59,6 @@ export ALGOLIA_SEARCH_INSIGHTS_JS=2.0.3
 # Quarto Info Version
 export QUARTO_VERSION=1.4
 export QUARTO_NAME=Quarto
-export QUARTO_BUILD_RUN_OFFSET=-2030
 
 # Folder names. These are not the same as paths (those variable names end in _PATH).
 #     See set_package_paths .sh and .bat for these in context of full paths.


### PR DESCRIPTION
This PR solves the problem of update `version.txt` each time we do a pre-release 

Challenges are: 

* `version.txt` leaves in main - This requires a commit to main **after we trigger a pre-release**
* Release process failure needs to be handled correctly 
	 * Commit and tag done needs to be correctly reverted if needed
	 * `pip install` should work, even if done during the release process window (~15min)

This PR does the following: 

* `version.txt` is commited to main at start of release with a tag creation 
* release publishing happens - it takes roughly 15 minutes
	* if success: a new github release is created
	* if failure: **a revert commit of the version.txt + tag deletion is done** 
	
During those 15 minutes, the repo has a version.txt that points to no Github release really. Tag does exists, but no Github release with assets yet. As a failsafe mode if someone install from main during this time: 
	* setup.py tries to download the version from `version.txt`
	* if error - meaning no existence of release and assets - `setup.py` will look for previous commit in history of `version.txt` calling Git command and look the content - this release must exists and is used. 

## Other things this PR does : 

* No more draft PR mode - checkbox is removed
	* 	Draft PR are not really used in our workflow, and this would not be easy to handle with `version.txt`
	* Unchecking `pre-release` when doing manual run will do the same thing: Build everything - just not publish. Which it seems we really needed

* Pre-release description has been updated to a new message with more links and information about the content than just the last commit message. 


I tested all this in my fork so it is working as expected - unless I missed some specificity of this repo. Though I'll be reactive to fix if problems next time we try to do a pre-release. 

