### PR TITLE
Patch Footnotes when in margin to support multiple paragraph

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -66,6 +66,7 @@
 - ([#6990](https://github.com/quarto-dev/quarto-cli/issues/6990)): Fix an issue where underscore in `filename` code cell attribute were not escaped.
 - ([#7175](https://github.com/quarto-dev/quarto-cli/issues/7175)): Fix an issue with code annotations when more than one digit is used for annotation number.
 - ([#7267](https://github.com/quarto-dev/quarto-cli/issues/7267)): Fix issue with longtable environments interfering with the `table` counter.
+- ([#7534](https://github.com/quarto-dev/quarto-cli/issues/7534)): Fix issue with multiple paragraph footnotes when using `reference-location: margin`.
 
 ## Docusaurus Format
 

--- a/src/resources/filters/quarto-post/latex.lua
+++ b/src/resources/filters/quarto-post/latex.lua
@@ -376,7 +376,14 @@ function render_latex()
       end
       
       return pandoc.Div(calloutContents)
-    end    
+    end,
+    Note = function(n)
+      if marginReferences() then
+        -- This is to support multiple paragraphs in footnotes in margin as sidenotes CTAN has some issue (quarto-dev/quarto-cli#7534)
+        n.content = pandoc.Para(pandoc.utils.blocks_to_inlines(n.content, {pandoc.RawInline('latex', '\n\\endgraf\n')}))
+        return n
+      end
+    end
   }
 end
 

--- a/tests/docs/smoke-all/2023/11/13/7534.qmd
+++ b/tests/docs/smoke-all/2023/11/13/7534.qmd
@@ -1,0 +1,17 @@
+---
+title: multiple paragraph in footnotes (#7534)
+reference-location: margin
+_quarto:
+  tests:
+    pdf: null
+    latex:
+      ensureFileRegexMatches:
+        - ['The first paragraph\.[\s\S]+\\endgraf[\s\S]+The second paragraph']
+        - []
+---
+
+Some text.[^note] Some more text.
+
+[^note]: The first paragraph.   
+    
+    The second paragraph.


### PR DESCRIPTION
As it seems sidenotes CTAN package has an issue and does not handle it correctly, unless using a specific syntax

Fix #7534 

@cscheid this is what you were thinking ? 