### PR TITLE
[GHA] Auto update: Handle the case of new minor / major version creation

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -77,7 +77,7 @@ jobs:
         if: ${{ inputs.publish-release }}
         id: version_commit
         with:
-          add: "version.txt"
+          add: '["version.txt", "news/changelog-${{steps.read-version.outputs.version}}.md"]'
           tag: v${{ steps.read-version.outputs.version_full }}
           message: "Update version.txt"
           fetch: true
@@ -570,8 +570,9 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git pull origin $GITHUB_REF_NAME
+          git stash -u
           git revert -n ${{ needs.configure.outputs.version_commit }}
-          git add 'version.txt'
+          git add .
           git commit -m 'Revert version.txt update (${{ needs.configure.outputs.version_commit }})' -m 'Publishing release has failed.'
           git push origin $GITHUB_REF_NAME
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -38,9 +38,21 @@ jobs:
       - name: Get previous version
         id: read-version
         run: |
+          source ./configuration
           read_version=$(cat version.txt)
           version=$(echo $read_version | grep -o '[[:digit:]]*\.[[:digit:]]*' | head -1)
-          build_number=$(($(echo $read_version | grep -o '[[:digit:]]*' | tail -1)+1))
+          if [ "$version" == "$QUARTO_VERSION" ]; then
+            ## This should be the case only when we do a new patch release or for next pre-release to build.
+            build_number=$(($(echo $read_version | grep -o '[[:digit:]]*' | tail -1)+1))
+          else
+            ## This should be the case only when we do a new major/minor release, for next pre-release to build.
+            version=$QUARTO_VERSION
+            build_number=0
+            news="news/changelog-${version}.md"
+            if [ ! -f "$news" ]; then
+              echo -e "All changes included in ${version}:\n\n" > $news
+            fi
+          fi
           version_full=$version.$build_number
           echo "version=$version" >> $GITHUB_OUTPUT
           echo "version_full=$version_full">> $GITHUB_OUTPUT

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -543,7 +543,7 @@ jobs:
             quarto-${{needs.configure.outputs.version}}-checksums.txt
 
   cleanup-when-failure:
-    if: ${{ failure() && inputs.publish-release }}
+    if: ${{ (failure() || cancelled()) && inputs.publish-release }}
     needs:
       [
         configure,


### PR DESCRIPTION
This complements previous #7557 by handling the case of a new minor release. 

We are in 1.4 - when doing 1.4 release, we'll build 1.5. In that `./configuration` will be updated for  `QUARTO_VERSION` env var. So we check that; 

* If the value is the same as in `version.txt`, we are still in the same release
* If not, then this is a new minor release
	* 	We reset the build number to `0` so that it will be `1.5.0`
	*  We create new changelog file `changelog-1.5.md` with a default content, which is committed 

If a failure happens in this process, both files will be revert (the whole commit)

I believe this will do it - right @dragonstyle ? 

Also this PR adds support for correctly revert any commit and tag if a cancellation happens. 

