### PR TITLE
[gha] Add caching for Typst package to avoid downloading from remote 

### DIFF
--- a/.github/actions/cache-typst/action.yml
+++ b/.github/actions/cache-typst/action.yml
@@ -1,0 +1,32 @@
+name: "Cache Typst package"
+description: "Configures the caching for Typst packages"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Typst Cache path
+      run: |
+        case $RUNNER_OS in
+          "Linux")
+              echo "TYPST_CACHE=${XDG_CACHE_HOME:-~/.cache}/typst/packages/" >> $GITHUB_ENV
+              ;;
+          "macOS")
+              echo "TYPST_CACHE=~/Library/Caches/typst/packages/" >> $GITHUB_ENV
+              ;;
+          "Windows")
+              echo "TYPST_CACHE=$LOCALAPPDATA/typst/packages/" >> $GITHUB_ENV
+              ;;
+            *)
+              echo "$RUNNER_OS not supported"
+              exit 1
+              ;;
+        esac
+      shell: bash
+
+    - name: Cache Typst package folder
+      uses: actions/cache@v3
+      with:
+        path: ${{ env.TYPST_CACHE }}
+        key: ${{ runner.os }}-typst-1-${{ github.run_id }}
+        restore-keys: |
+          ${{ runner.os }}-typst-1-

--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -142,6 +142,9 @@ jobs:
         run: |
           quarto install tinytex
 
+      - name: Cache Typst packages
+        uses: ./.github/actions/cache-typst
+
       - name: Install Chrome
         uses: browser-actions/setup-chrome@latest
 


### PR DESCRIPTION
We are caching on GHA the typst packages downloaded. 

As documented at 
* https://typst.app/blog/2023/package-manager#how-packages-are-accessed
* https://github.com/typst/packages#downloads

the package are first search locally before downloading. 

So by caching and restoring at each run, we insure that no remote access will be done for typst packages. 

I did not put invalidation as it seems cache is quite low size, and also no easy way to invalidate the packages to cache. 

Maybe this `cache-typst` action could be put in `quarto-dev/quarto-actions` instead of here, as it seems it could be useful to others. It could even be a Marketplace action maybe 🤔  there was none doing that (but this is easy to setup though)

