### PR TITLE
Code annotations needs to take into account startFrom attributes for targetting annotated lines

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -183,6 +183,7 @@
 - Update observablehq's runtime to version 5.6.0.
 - ([#5215](https://github.com/quarto-dev/quarto-cli/issues/5215)): Report CORS requests as plain text when serving single-file previews.
 - ([#6267](https://github.com/quarto-dev/quarto-cli/issues/6267)): Fix error message when running in `file://`.
+- ([#7537](https://github.com/quarto-dev/quarto-cli/issues/7537)): Code annotations works better with OJS cells.
 
 ## Mermaid diagrams
 

--- a/src/resources/filters/quarto-pre/code-annotation.lua
+++ b/src/resources/filters/quarto-pre/code-annotation.lua
@@ -108,11 +108,11 @@ local function resolveCellAnnotes(codeBlockEl, processAnnotation)
     
     local outputs = pandoc.List({})
     local i = 1
+    local offset = codeBlockEl.attr.attributes['startFrom'] or 1
     for line in toLines(code) do
   
       -- Look and annotation
       local annoteNumber = annotationProvider.annotationNumber(line)
-
       if annoteNumber then
         -- Capture the annotation number and strip it
         local annoteId = toAnnoteId(annoteNumber)
@@ -120,7 +120,8 @@ local function resolveCellAnnotes(codeBlockEl, processAnnotation)
         if lineNumbers == nil then
           lineNumbers = pandoc.List({})
         end
-        lineNumbers:insert(i)
+        -- line numbers stored for targetting annotations line needs to take into account possible startFrom attribute
+        lineNumbers:insert(offset - 1 + i)
         annotations[annoteId] = lineNumbers
         outputs:insert(processAnnotation(line, annoteNumber, annotationProvider))
       else

--- a/tests/docs/smoke-all/code-annotations/code-annotations-offset.qmd
+++ b/tests/docs/smoke-all/code-annotations/code-annotations-offset.qmd
@@ -1,0 +1,24 @@
+---
+title: Hello World
+code-annotations: true
+format:
+  html: default
+_quarto:
+  tests: 
+    html:
+      ensureHtmlElements:
+        - 
+          - 'span[data-code-cell="annotated-cell-1"][data-code-lines="5"][data-code-annotation="1"]'
+          - 'span[data-code-cell="annotated-cell-1"][data-code-lines="7"][data-code-annotation="2"]'
+        - []
+---
+
+```{.r code-line-numbers="true" startFrom=5}
+1 + 1 # <1>
+2 + 2
+3 + 3 # <2>
+```
+
+1. displaying
+2. displaying
+


### PR DESCRIPTION
This fix an issue with OJS cell that does set `startFrom` attributes by default internally, which was preventing code annotation to work

closes #7537