### PR TITLE
Fix refs positionning using a div for PDF output 

### DIFF
--- a/src/resources/filters/main.lua
+++ b/src/resources/filters/main.lua
@@ -426,7 +426,9 @@ table.insert(quarto_filter_list, { name = "pre-render", filter = {} }) -- entry 
 tappend(quarto_filter_list, quarto_layout_filters)
 tappend(quarto_filter_list, quarto_post_filters)
 table.insert(quarto_filter_list, { name = "post-render", filter = {} }) -- entry point for user filters
+table.insert(quarto_filter_list, { name = "pre-finalize", filter = {} }) -- entry point for user filters
 tappend(quarto_filter_list, quarto_finalize_filters)
+table.insert(quarto_filter_list, { name = "post-finalize", filter = {} }) -- entry point for user filters
 
 -- now inject user-defined filters on appropriate positions
 inject_user_filters_at_entry_points(quarto_filter_list)

--- a/src/resources/filters/quarto-finalize/coalesceraw.lua
+++ b/src/resources/filters/quarto-finalize/coalesceraw.lua
@@ -22,7 +22,8 @@ function coalesce_raw()
       Div = function(div)
         -- only flatten out divs that have no classes or attributes
         -- (see https://github.com/quarto-dev/quarto-cli/issues/6936)
-        if #div.classes == 0 and #div.attributes == 0 then
+        -- or empty identifier (see https://github.com/quarto-dev/quarto-cli/issues/6867)
+        if #div.classes == 0 and #div.attributes == 0 and div.identifier == "" then
           return div.content
         end
       end

--- a/tests/docs/smoke-all/citations/biblatex-refs-position.qmd
+++ b/tests/docs/smoke-all/citations/biblatex-refs-position.qmd
@@ -1,0 +1,23 @@
+---
+title: Position citation
+bibliography: ref.bib
+cite-method: biblatex
+_quarto:
+  tests: 
+    latex:
+      ensureFileRegexMatches:
+        - ['\\subsection\{References\}[\s\S]+\\printbibliography\[heading=none\][\s\S]+\\subsection\{Appendix\}']
+        - []
+    pdf: null 
+---
+
+@Lovelace1842
+
+## References {#references}
+
+::: {#refs}
+:::
+
+## Appendix {#appendix}
+
+Blah.

--- a/tests/docs/smoke-all/citations/check-refs.lua
+++ b/tests/docs/smoke-all/citations/check-refs.lua
@@ -1,0 +1,23 @@
+--[[
+  This test that none of our Lua processing is removing the div of id refs which is used to hold the bibliography placement 
+  for Pandoc citeproc.
+--]]
+local ref_div_found = false
+
+Blocks = function(blocks)
+  blocks:walk({
+    Div = function(div)
+      if div.identifier == "refs" then
+        quarto.log.output(div)
+        ref_div_found = true
+      end
+    end
+  })
+end
+
+Pandoc = function(doc)
+  if not ref_div_found then
+    error("No div with identifier 'refs' found")
+    crash()
+  end
+end

--- a/tests/docs/smoke-all/citations/citeproc-refs-position.qmd
+++ b/tests/docs/smoke-all/citations/citeproc-refs-position.qmd
@@ -1,21 +1,6 @@
 ---
 title: Position citation
-references:
-- type: article-journal
-  id: Lovelace1842
-  author:
-  - family: Lovelace
-    given: Augusta Ada
-  issued:
-    date-parts:
-    - - 1842
-  title: >-
-    Sketch of the analytical engine invented by Charles Babbage, by LF Menabrea, 
-    officer of the military engineers, with notes upon the memoir by the translator
-  container-title: Taylor’s Scientific Memoirs
-  volume: 3
-  page: 666-731
-  language: en-GB
+bibliography: ref.bib
 format:
   html: default
   latex: default

--- a/tests/docs/smoke-all/citations/citeproc-refs-position.qmd
+++ b/tests/docs/smoke-all/citations/citeproc-refs-position.qmd
@@ -1,0 +1,36 @@
+---
+title: Position citation
+references:
+- type: article-journal
+  id: Lovelace1842
+  author:
+  - family: Lovelace
+    given: Augusta Ada
+  issued:
+    date-parts:
+    - - 1842
+  title: >-
+    Sketch of the analytical engine invented by Charles Babbage, by LF Menabrea, 
+    officer of the military engineers, with notes upon the memoir by the translator
+  container-title: Taylor’s Scientific Memoirs
+  volume: 3
+  page: 666-731
+  language: en-GB
+format:
+  html: default
+  pdf: default
+filters:
+  - at: post-finalize
+    path: check-refs.lua
+---
+
+@Lovelace1842
+
+## References {#references}
+
+::: {#refs}
+:::
+
+## Appendix {#appendix}
+
+Blah.

--- a/tests/docs/smoke-all/citations/citeproc-refs-position.qmd
+++ b/tests/docs/smoke-all/citations/citeproc-refs-position.qmd
@@ -18,10 +18,20 @@ references:
   language: en-GB
 format:
   html: default
-  pdf: default
+  latex: default
 filters:
   - at: post-finalize
     path: check-refs.lua
+_quarto:
+  tests: 
+    html:
+      ensureHtmlElements:
+        - ['#references div#refs.references div.csl-entry']
+        - []
+    latex:
+      ensureFileRegexMatches:
+        - ['\\subsection\{References\}[\s\S]+\\begin\{CSLReferences\}[\s\S]+\\subsection\{Appendix\}']
+        - []
 ---
 
 @Lovelace1842

--- a/tests/docs/smoke-all/citations/natbib-refs-position.qmd
+++ b/tests/docs/smoke-all/citations/natbib-refs-position.qmd
@@ -1,0 +1,23 @@
+---
+title: Position citation
+bibliography: ref.bib
+cite-method: natbib
+_quarto:
+  tests: 
+    latex:
+      ensureFileRegexMatches:
+        - ['\\subsection\{References\}[\s\S]+\\bibliography\{ref\.bib\}[\s\S]+\\subsection\{Appendix\}']
+        - []
+    pdf: null 
+---
+
+@Lovelace1842
+
+## References {#references}
+
+::: {#refs}
+:::
+
+## Appendix {#appendix}
+
+Blah.

--- a/tests/docs/smoke-all/citations/ref.bib
+++ b/tests/docs/smoke-all/citations/ref.bib
@@ -1,0 +1,11 @@
+@article{Lovelace1842,
+  author = {Lovelace, Augusta Ada},
+  title = {Sketch of the Analytical Engine Invented by {Charles}
+    {Babbage,} by {LF} {Menabrea,} Officer of the Military Engineers,
+    with Notes Upon the Memoir by the Translator},
+  journal = {TaylorÔÇÖs Scientific Memoirs},
+  volume = {3},
+  pages = {666-731},
+  date = {1842},
+  langid = {en-GB}
+}


### PR DESCRIPTION
This should fix #6867 

As discussed, this is a regression in 1.4 due to some change at #6620 regarding flattening the divs in `coalesce_raw()` at `src\resources\filters\quarto-finalize\coalesceraw.lua`

This PR complements the fix at #6952 by also checking for empty ids on the Div before doing the flattening. 

@cscheid is that too wide ? We could just disallow flattening for div with id `refs` if needed. I am not too sure why we would flatten in LaTeX all the div of the document - but you know better. 

Also I added some tests. For that, I thought about your Lua testing tricks. But it required to add and entry point at the very end . 
Is that ok ? 

Otherwise, classic test is to check inside output. 

To prevent regression, I also added some tests about the refs positioning feature for natbib and biblatex, which is a Quarto feature (https://quarto.org/docs/authoring/footnotes-and-citations.html#bibliography-generation) cc @dragonstyle I did not found any for this feature

