### PR TITLE
Don't show cell-output-display div when `output: asis`

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -216,6 +216,7 @@
 - ([#7002](https://github.com/quarto-dev/quarto-cli/issues/7002)): `layout-valign` is correctly forwarded to HTML to tweak vertical figure layout alignment for computational figures.
 - ([#5994](https://github.com/quarto-dev/quarto-cli/issues/5994)): Options like `include` or `echo` for `ojs` or `mermaid` cells are now correctly handled with knitr engine.
 - ([#4869](https://github.com/quarto-dev/quarto-cli/issues/4869)): `sql` cell output has now correct Quarto treatment so that specific features like `column: margin` works.
+- ([#7600](https://github.com/quarto-dev/quarto-cli/issues/7600)): `output: asis` now correctly don't emit `.cell-output-display` div around cell outputs of class `knit_asis`.
 
 ## OJS engine
 

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -672,6 +672,7 @@ knitr_plot_hook <- function(format) {
       
       # result = "asis" specific
       if (identical(options[["results"]], "asis")) return(md)
+      
       # enclose in output div 
       output_div(md, NULL, classes)
     }

--- a/src/resources/rmd/patch.R
+++ b/src/resources/rmd/patch.R
@@ -111,6 +111,9 @@ wrap_asis_output <- function(options, x) {
     x <- paste0("`````{=html}\n", x, "\n`````")
   }
   
+  # If asis output, don't include the output div
+  if (identical(options[["results"]], "asis")) return(x)
+
   output_div(x, output_label_placeholder(options), classes, attrs)
 }
 


### PR DESCRIPTION
Follow up on #4703 and trying to solve #7600

Currently, we do still add 
```` markdown
::: {.cell-output-display}
````
when outputing `knit_asis` class content

Opening this PR to see how this simple change is impacted our tests - I feel this is a little change that could have side effect, especially because in our R knitr code `output: asis` means `results: asis` and both are not decoupled. 

Though this change match our doc (https://quarto.org/docs/computations/execution-options.html#raw-output)
> When output: asis is specified none of Quarto’s standard enclosing divs will be included.

However, I can see too that `output: asis` as the lowest priority if other options are provided. 
https://github.com/quarto-dev/quarto-cli/blob/f38a30e63607a6cfec3a770ca8c0a70e865f7b4d/src/resources/rmd/hooks.R#L400-L416

This change a bit what we discussed, especially regarding #7607 
 
