### PR TITLE
support caption-location in custom crossrefs, use it correctly

### DIFF
--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -12251,6 +12251,15 @@ var require_yaml_intelligence_resources = __commonJS({
                               string: {
                                 description: 'The description of the crossreferenceable object to be used in the title of the "list of" command. If unspecified, the field `name` is used.'
                               }
+                            },
+                            "caption-location": {
+                              enum: [
+                                "top",
+                                "bottom",
+                                "margin"
+                              ],
+                              default: "bottom",
+                              description: "The location of the caption relative to the crossreferenceable content."
                             }
                           }
                         }
@@ -20605,6 +20614,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "In LaTeX output, the name of the custom environment to be used.",
         "In LaTeX output, the extension of the auxiliary file used by LaTeX to\ncollect names to be used in the custom \u201Clist of\u201D command. If omitted, a\nstring with prefix <code>lo</code> and suffix with the value of\n<code>ref-type</code> is used.",
         "The description of the crossreferenceable object to be used in the\ntitle of the \u201Clist of\u201D command. If unspecified, the field\n<code>name</code> is used.",
+        "The location of the caption relative to the crossreferenceable\ncontent.",
         "Use top level sections (H1) in this document as chapters.",
         "The delimiter used between the prefix and the caption.",
         "The title prefix used for figure captions.",
@@ -20806,6 +20816,10 @@ var require_yaml_intelligence_resources = __commonJS({
         {
           short: "The math font options for use with <code>xelatex</code> or\n<code>lualatex</code>.",
           long: 'The math font options for use with <code>xelatex</code> or\n<code>lualatex</code> allowing any options available through <a href="https://ctan.org/pkg/fontspec"><code>fontspec</code></a>.'
+        },
+        {
+          short: "Adds additional directories to search for fonts when compiling with\nTypst.",
+          long: "Locally, Typst uses installed system fonts. In addition, some custom\npath can be specified to add directories that should be scanned for\nfonts. Setting this configuration will take precedence over any path set\nin TYPST_FONT_PATHS environment variable."
         },
         {
           short: "The CJK font options for use with <code>xelatex</code> or\n<code>lualatex</code>.",
@@ -21289,10 +21303,6 @@ var require_yaml_intelligence_resources = __commonJS({
         {
           short: "The mode to use when previewing this document.",
           long: "The mode to use when previewing this document. To disable any special\npreviewing features, pass <code>raw</code> as the preview-mode."
-        },
-        {
-          short: "Adds additional directories to search for fonts when compiling with\nTypst.",
-          long: "Locally, Typst uses installed system fonts. In addition, some custom\npath can be specified to add directories that should be scanned for\nfonts. Setting this configuration will take precedence over any path set\nin TYPST_FONT_PATHS environment variable."
         },
         {
           short: "Adds the necessary setup to the document preamble to generate PDF/A\nof the type specified.",
@@ -22245,11 +22255,7 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
         "Manuscript configuration",
-        "internal-schema-hack",
-        {
-          short: "Adds additional directories to search for fonts when compiling with\nTypst.",
-          long: "Locally, Typst uses installed system fonts. In addition, some custom\npath can be specified to add directories that should be scanned for\nfonts. Setting this configuration will take precedence over any path set\nin TYPST_FONT_PATHS environment variable."
-        }
+        "internal-schema-hack"
       ],
       "schema/external-schemas.yml": [
         {
@@ -22473,12 +22479,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 178550,
+        _internalId: 178763,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 178542,
+            _internalId: 178755,
             type: "enum",
             enum: [
               "png",
@@ -22494,7 +22500,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 178549,
+            _internalId: 178762,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -12252,6 +12252,15 @@ try {
                                 string: {
                                   description: 'The description of the crossreferenceable object to be used in the title of the "list of" command. If unspecified, the field `name` is used.'
                                 }
+                              },
+                              "caption-location": {
+                                enum: [
+                                  "top",
+                                  "bottom",
+                                  "margin"
+                                ],
+                                default: "bottom",
+                                description: "The location of the caption relative to the crossreferenceable content."
                               }
                             }
                           }
@@ -20606,6 +20615,7 @@ try {
           "In LaTeX output, the name of the custom environment to be used.",
           "In LaTeX output, the extension of the auxiliary file used by LaTeX to\ncollect names to be used in the custom \u201Clist of\u201D command. If omitted, a\nstring with prefix <code>lo</code> and suffix with the value of\n<code>ref-type</code> is used.",
           "The description of the crossreferenceable object to be used in the\ntitle of the \u201Clist of\u201D command. If unspecified, the field\n<code>name</code> is used.",
+          "The location of the caption relative to the crossreferenceable\ncontent.",
           "Use top level sections (H1) in this document as chapters.",
           "The delimiter used between the prefix and the caption.",
           "The title prefix used for figure captions.",
@@ -20807,6 +20817,10 @@ try {
           {
             short: "The math font options for use with <code>xelatex</code> or\n<code>lualatex</code>.",
             long: 'The math font options for use with <code>xelatex</code> or\n<code>lualatex</code> allowing any options available through <a href="https://ctan.org/pkg/fontspec"><code>fontspec</code></a>.'
+          },
+          {
+            short: "Adds additional directories to search for fonts when compiling with\nTypst.",
+            long: "Locally, Typst uses installed system fonts. In addition, some custom\npath can be specified to add directories that should be scanned for\nfonts. Setting this configuration will take precedence over any path set\nin TYPST_FONT_PATHS environment variable."
           },
           {
             short: "The CJK font options for use with <code>xelatex</code> or\n<code>lualatex</code>.",
@@ -21290,10 +21304,6 @@ try {
           {
             short: "The mode to use when previewing this document.",
             long: "The mode to use when previewing this document. To disable any special\npreviewing features, pass <code>raw</code> as the preview-mode."
-          },
-          {
-            short: "Adds additional directories to search for fonts when compiling with\nTypst.",
-            long: "Locally, Typst uses installed system fonts. In addition, some custom\npath can be specified to add directories that should be scanned for\nfonts. Setting this configuration will take precedence over any path set\nin TYPST_FONT_PATHS environment variable."
           },
           {
             short: "Adds the necessary setup to the document preamble to generate PDF/A\nof the type specified.",
@@ -22246,11 +22256,7 @@ try {
           },
           "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
           "Manuscript configuration",
-          "internal-schema-hack",
-          {
-            short: "Adds additional directories to search for fonts when compiling with\nTypst.",
-            long: "Locally, Typst uses installed system fonts. In addition, some custom\npath can be specified to add directories that should be scanned for\nfonts. Setting this configuration will take precedence over any path set\nin TYPST_FONT_PATHS environment variable."
-          }
+          "internal-schema-hack"
         ],
         "schema/external-schemas.yml": [
           {
@@ -22474,12 +22480,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 178550,
+          _internalId: 178763,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 178542,
+              _internalId: 178755,
               type: "enum",
               enum: [
                 "png",
@@ -22495,7 +22501,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 178549,
+              _internalId: 178762,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -5223,6 +5223,15 @@
                           "string": {
                             "description": "The description of the crossreferenceable object to be used in the title of the \"list of\" command. If unspecified, the field `name` is used."
                           }
+                        },
+                        "caption-location": {
+                          "enum": [
+                            "top",
+                            "bottom",
+                            "margin"
+                          ],
+                          "default": "bottom",
+                          "description": "The location of the caption relative to the crossreferenceable content."
                         }
                       }
                     }
@@ -13577,6 +13586,7 @@
     "In LaTeX output, the name of the custom environment to be used.",
     "In LaTeX output, the extension of the auxiliary file used by LaTeX to\ncollect names to be used in the custom “list of” command. If omitted, a\nstring with prefix <code>lo</code> and suffix with the value of\n<code>ref-type</code> is used.",
     "The description of the crossreferenceable object to be used in the\ntitle of the “list of” command. If unspecified, the field\n<code>name</code> is used.",
+    "The location of the caption relative to the crossreferenceable\ncontent.",
     "Use top level sections (H1) in this document as chapters.",
     "The delimiter used between the prefix and the caption.",
     "The title prefix used for figure captions.",
@@ -13778,6 +13788,10 @@
     {
       "short": "The math font options for use with <code>xelatex</code> or\n<code>lualatex</code>.",
       "long": "The math font options for use with <code>xelatex</code> or\n<code>lualatex</code> allowing any options available through <a href=\"https://ctan.org/pkg/fontspec\"><code>fontspec</code></a>."
+    },
+    {
+      "short": "Adds additional directories to search for fonts when compiling with\nTypst.",
+      "long": "Locally, Typst uses installed system fonts. In addition, some custom\npath can be specified to add directories that should be scanned for\nfonts. Setting this configuration will take precedence over any path set\nin TYPST_FONT_PATHS environment variable."
     },
     {
       "short": "The CJK font options for use with <code>xelatex</code> or\n<code>lualatex</code>.",
@@ -14261,10 +14275,6 @@
     {
       "short": "The mode to use when previewing this document.",
       "long": "The mode to use when previewing this document. To disable any special\npreviewing features, pass <code>raw</code> as the preview-mode."
-    },
-    {
-      "short": "Adds additional directories to search for fonts when compiling with\nTypst.",
-      "long": "Locally, Typst uses installed system fonts. In addition, some custom\npath can be specified to add directories that should be scanned for\nfonts. Setting this configuration will take precedence over any path set\nin TYPST_FONT_PATHS environment variable."
     },
     {
       "short": "Adds the necessary setup to the document preamble to generate PDF/A\nof the type specified.",
@@ -15217,11 +15227,7 @@
     },
     "Disambiguating year suffix in author-date styles (e.g.&nbsp;“a” in “Doe,\n1999a”).",
     "Manuscript configuration",
-    "internal-schema-hack",
-    {
-      "short": "Adds additional directories to search for fonts when compiling with\nTypst.",
-      "long": "Locally, Typst uses installed system fonts. In addition, some custom\npath can be specified to add directories that should be scanned for\nfonts. Setting this configuration will take precedence over any path set\nin TYPST_FONT_PATHS environment variable."
-    }
+    "internal-schema-hack"
   ],
   "schema/external-schemas.yml": [
     {
@@ -15445,12 +15451,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 178550,
+    "_internalId": 178763,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 178542,
+        "_internalId": 178755,
         "type": "enum",
         "enum": [
           "png",
@@ -15466,7 +15472,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 178549,
+        "_internalId": 178762,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/filters/crossref/custom.lua
+++ b/src/resources/filters/crossref/custom.lua
@@ -19,7 +19,7 @@ function initialize_custom_crossref_categories(meta)
     -- luacov: enable
   end
   local keys = {
-    ["default-caption-location"] = function(v) return pandoc.utils.stringify(v) end,
+    ["caption-location"] = function(v) return pandoc.utils.stringify(v) end,
     ["kind"] = function(v) return pandoc.utils.stringify(v) end,
     ["name"] = function(v) return pandoc.utils.stringify(v) end,
     ["prefix"] = function(v) return pandoc.utils.stringify(v) end,
@@ -30,7 +30,7 @@ function initialize_custom_crossref_categories(meta)
     ["space-before-numbering"] = function(v) return v end,
   }
   local obj_mapping = {
-    ["default-caption-location"] = "default_caption_location",
+    ["caption-location"] = "caption_location",
     ["latex-env"] = "latex_env",
     ["latex-list-of-file-extension"] = "latex_list_of_file_extension",
     ["latex-list-of-description"] = "latex_list_of_description",
@@ -44,8 +44,8 @@ function initialize_custom_crossref_categories(meta)
         entry[key] = xform(v[key])
       end
     end
-    if entry["default-caption-location"] == nil then
-      entry["default-caption-location"] = "bottom"
+    if entry["caption-location"] == nil then
+      entry["caption-location"] = "bottom"
     end
     -- slightly inefficient because we recompute the indices at
     -- every call, but should be totally ok for the number of categories
@@ -71,13 +71,11 @@ function initialize_custom_crossref_categories(meta)
         local ref_type = entry["ref-type"]
         local list_of_name = entry["latex-list-of-file-extension"] or ("lo" .. ref_type)
         local list_of_description = entry["latex-list-of-description"] or name
+        local cap_location = entry["caption-location"] or "bottom"
         local space_before_numbering = entry["space-before-numbering"]
         if space_before_numbering == nil then
           space_before_numbering = true
         end
-
-        -- FIXME do we need different "lop" extensions for each category?
-        -- we should be able to test this by creating a document with listings and diagrams
         
         inject(
         usePackage("float") .. "\n" ..
@@ -85,6 +83,10 @@ function initialize_custom_crossref_categories(meta)
         "\\@ifundefined{c@chapter}{\\newfloat{" .. env_name .. "}{h}{" .. list_of_name .. "}}{\\newfloat{" .. env_name .. "}{h}{" .. list_of_name .. "}[chapter]}\n" ..
         "\\floatname{".. env_name .. "}{" .. as_latex(title(ref_type, env_prefix)) .. "}\n"
         )
+
+        if cap_location == "top" then
+          inject("\\floatstyle{plaintop}\n\\restylefloat{" .. env_name .. "}\n")
+        end
 
         -- FIXME this is a bit of hack for the case of custom categories with
         -- space-before-numbering: false

--- a/src/resources/filters/customnodes/floatreftarget.lua
+++ b/src/resources/filters/customnodes/floatreftarget.lua
@@ -59,7 +59,7 @@ function cap_location(float_or_layout)
     float_or_layout.attributes['cap-location'] or
     option_as_string(qualified_key) or
     option_as_string('cap-location') or
-    crossref.categories.by_ref_type[ref].default_caption_location)
+    crossref.categories.by_ref_type[ref].caption_location)
 
   if result ~= "margin" and result ~= "top" and result ~= "bottom" then
     -- luacov: disable

--- a/src/resources/filters/layout/pandoc3_figure.lua
+++ b/src/resources/filters/layout/pandoc3_figure.lua
@@ -138,7 +138,7 @@ function render_pandoc3_figure()
           content = figure.content[1],
           caption = figure.caption.long[1],
           kind = "quarto-float-fig",
-          caption_location = crossref.categories.by_ref_type["fig"].default_caption_location,
+          caption_location = crossref.categories.by_ref_type["fig"].caption_location,
           supplement = "Figure",
         })
       end

--- a/src/resources/filters/mainstateinit.lua
+++ b/src/resources/filters/mainstateinit.lua
@@ -32,7 +32,7 @@ crossref = {
   categories = {
     all = {
       {
-        default_caption_location = "bottom",
+        caption_location = "bottom",
         kind = "float",
         name = "Figure",
         prefix = "Figure",
@@ -40,7 +40,7 @@ crossref = {
         ref_type = "fig",
       },
       {
-        default_caption_location = "top",
+        caption_location = "top",
         kind = "float",
         name = "Table",
         prefix = "Table",
@@ -48,7 +48,7 @@ crossref = {
         ref_type = "tbl",
       },
       {
-        default_caption_location = "top",
+        caption_location = "top",
         kind = "float",
         name = "Listing",
         prefix = "Listing",

--- a/src/resources/schema/document-crossref.yml
+++ b/src/resources/schema/document-crossref.yml
@@ -38,6 +38,10 @@
                     latex-list-of-description:
                       string:
                         description: The description of the crossreferenceable object to be used in the title of the "list of" command. If unspecified, the field `name` is used.
+                    caption-location:
+                      enum: [top, bottom, margin]
+                      default: bottom
+                      description: The location of the caption relative to the crossreferenceable content.
 
             chapters:
               boolean:


### PR DESCRIPTION
Will close #7625.

NB: it also consolidates the configuration of caption location information in the custom crossrefs YAMl to `caption-location`, instead of `default-caption-location` or `cap-location`. This is good for a couple of reasons, the most important being that in LaTeX, the float package doesn't allow flexibility in defining the caption location on a per-call basis. So it really is just `caption-location` instead of _default_-`caption-location`.