### PR TITLE
within citations, if page is undefined do not make it a string

### DIFF
--- a/src/quarto-core/attribution/document.ts
+++ b/src/quarto-core/attribution/document.ts
@@ -394,7 +394,7 @@ export function documentCSL(
 
   // Process keywords
   const kwString = citationMetadata.keyword;
-  if (kwString && typeof (kwString) === "string") {
+  if (kwString && typeof kwString === "string") {
     extras.keywords = kwString.split(",");
   } else if (inputMetadata.keywords) {
     const kw = inputMetadata.keywords;
@@ -465,7 +465,9 @@ function synthesizeCitationUrl(
 function pages(citationMetadata: Metadata): PageRange {
   let firstPage = citationMetadata[kFirstPage];
   let lastPage = citationMetadata[kLastPage];
-  let pages = `${citationMetadata[kPage] as string}`; // Force pages to string in case user writes `page: 7`
+  let pages = citationMetadata[kPage]
+    ? `${citationMetadata[kPage] as string}` // Force pages to string in case user writes `page: 7`
+    : undefined;
   if (pages && pages.includes("-")) {
     const pagesSplit = pages.split("-");
     if (!firstPage) {


### PR DESCRIPTION
This would have the side effect of having the undefined field shows in output

Fixes #7638 following change in 2e7ba02abf92f3ef01d3fb9fdbc8e1734c10f8be

cc @dragonstyle 