### PR TITLE
Reconfigure font paths after installing TinyTeX

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -268,3 +268,4 @@
 - ([#7131](https://github.com/quarto-dev/quarto-cli/issues/7131)): Fix typo in ISBN entry for JATS subarticle template (author: @jasonaris).
 - ([#3599](https://github.com/quarto-dev/quarto-cli/issues/3599), [#5870](https://github.com/quarto-dev/quarto-cli/issues/5870)): Fix hash issue causing unexpected render when `freeze` is activated on Windows but re-rendered on Linux (e.g. in Github Action).
 - ([#7252](https://github.com/quarto-dev/quarto-cli/issues/7252)): Improve handling with `tlmgr` of some mismatched LaTeX support files, associated with `expl3.sty` loading.
+- ([#7674](https://github.com/quarto-dev/quarto-cli/pull/7674)): Configure font paths for TinyTeX after installation so that `xetex` can find custom fonts correctly.

--- a/src/tools/impl/tinytex.ts
+++ b/src/tools/impl/tinytex.ts
@@ -312,6 +312,22 @@ async function afterInstall(context: InstallContext) {
       },
     );
 
+    // Reconfigure font paths for xetex (rstudio/tinytex#313)
+    await context.withSpinner(
+      { message: "Configuring font paths" },
+      async () => {
+        await exec(
+          tlmgrPath,
+          [
+            "postaction",
+            "install",
+            "script",
+            "xetex",
+          ],
+        );
+      },
+    );
+
     // Set the default repo to an https repo
     let restartRequired = false;
     const defaultRepo = textLiveRepo();


### PR DESCRIPTION
Apply the same fix to https://github.com/rstudio/tinytex/issues/313, i.e., run `tlmgr postaction install script xetex` after installation.

## Description

The same problem was reported at https://github.com/quarto-dev/quarto-cli/discussions/7630.

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] this PR closes #7673
- [x] updated the appropriate changelog
