### PR TITLE
Use %ProgramData% to install TinyTeX when %APPDATA% is not suitable for TeX Live

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -268,3 +268,4 @@
 - ([#7131](https://github.com/quarto-dev/quarto-cli/issues/7131)): Fix typo in ISBN entry for JATS subarticle template (author: @jasonaris).
 - ([#3599](https://github.com/quarto-dev/quarto-cli/issues/3599), [#5870](https://github.com/quarto-dev/quarto-cli/issues/5870)): Fix hash issue causing unexpected render when `freeze` is activated on Windows but re-rendered on Linux (e.g. in Github Action).
 - ([#7252](https://github.com/quarto-dev/quarto-cli/issues/7252)): Improve handling with `tlmgr` of some mismatched LaTeX support files, associated with `expl3.sty` loading.
+- ([#7675](https://github.com/quarto-dev/quarto-cli/pull/7675)): On Windows, `quarto install tinytex` will install TinyTeX to the directory defined by the environment variable `ProgramData` when `APPDATA` is not a suitable location for TeX Live.

--- a/src/tools/impl/tinytex-info.ts
+++ b/src/tools/impl/tinytex-info.ts
@@ -23,7 +23,12 @@ export function hasTinyTex(): boolean {
 export function tinyTexInstallDir(): string | undefined {
   switch (Deno.build.os) {
     case "windows":
-      return expandPath(join(getenv("APPDATA", undefined), "TinyTeX"));
+      let appDir = getenv("APPDATA", undefined);
+      // use ProgramData if APPDATA is not set or contains spaces or non-ASCII characters
+      if (!appDir || !appDir.match(/^[!-~]+$/)) {
+        appDir = getenv("ProgramData", undefined);
+      }
+      return expandPath(join(appDir, "TinyTeX"));
     case "linux":
       return expandPath("~/.TinyTeX");
     case "darwin":


### PR DESCRIPTION
Fixes #7620.

When `%APPDATA%` contains spaces, TeX Live may not work (https://github.com/rstudio/tinytex/issues/420). When it contains non-ASCII characters, TeX Live will not work for sure.

More info: https://yihui.org/en/2023/11/tinytex-path/