### PR TITLE
Fix issue with #raw usage in typst and our custom redefinition

### DIFF
--- a/src/resources/formats/typst/pandoc/quarto/definitions.typ
+++ b/src/resources/formats/typst/pandoc/quarto/definitions.typ
@@ -23,13 +23,12 @@
 
 // Some quarto-specific definitions.
 
-#show raw: it => {
-  if it.block {
-    block(fill: luma(230), width: 100%, inset: 8pt, radius: 2pt, it)
-  } else {
-    it
-  }
-}
+#show raw.where(block: true): block.with(
+    fill: luma(230), 
+    width: 100%, 
+    inset: 8pt, 
+    radius: 2pt
+  )
 
 #let block_with_new_content(old_block, new_content) = {
   let d = (:)

--- a/tests/docs/smoke-all/2023/11/24/typst-code.qmd
+++ b/tests/docs/smoke-all/2023/11/24/typst-code.qmd
@@ -1,0 +1,20 @@
+---
+format: typst
+---
+
+This is an inline code `x + 1`
+
+And this is a code block
+
+```
+1 + 1 
+```
+
+Now with lang attributes
+```r
+1 + 1
+```
+
+also inline `<div>`{.html}
+
+This is also suppose to work `#raw("x + y")`{=typst}


### PR DESCRIPTION
This closes https://github.com/quarto-dev/quarto-cli/issues/7688

It only changes the way we redefine the #raw output when there is a block. I followed Typst doc on this by applying the change only when block is set. 

https://typst.app/docs/reference/text/raw/#parameters-block

it also adds a regression test