### PR TITLE
break line after template partial to work around apparent EOF line chomping from Pandoc

### DIFF
--- a/src/resources/formats/pdf/pandoc/template.tex
+++ b/src/resources/formats/pdf/pandoc/template.tex
@@ -371,6 +371,7 @@ $title.tex()$
 
 \begin{document}
 $before-body.tex()$
+
 $for(include-before)$
 $include-before$
 


### PR DESCRIPTION
This closes #7293.
