### PR TITLE
patch knitr to know about OJS chunk and its comment character so opti…

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -198,6 +198,7 @@
 - ([#6775](https://github.com/quarto-dev/quarto-cli/pull/6775)): Avoid duplicating special internal `tools:quarto` R environment used for making `ojs_define()` accessible during knitting.
 - ([#6792](https://github.com/quarto-dev/quarto-cli/issues/6792)): `fig-asp` provided at YAML config level now correctly work to set `fig.asp` chunk option in **knitr**.
 - ([#7002](https://github.com/quarto-dev/quarto-cli/issues/7002)): `layout-valign` is correctly forwarded to HTML to tweak vertical figure layout alignment for computational figures.
+- ([#5994](https://github.com/quarto-dev/quarto-cli/issues/5994)): Options like `include` or `echo` for `ojs` or `mermaid` cells are now correctly handled with knitr engine.
 
 ## OJS engine
 

--- a/src/resources/rmd/execute.R
+++ b/src/resources/rmd/execute.R
@@ -55,6 +55,7 @@ execute <- function(input, format, tempDir, libDir, dependencies, cwd, params, r
   knitr::knit_engines$set(ojs = function(options) {
     knitr:::one_string(c(
       "```{ojs}",
+      options$yaml.code,
       options$code,
       "```"
     ))

--- a/src/resources/rmd/patch.R
+++ b/src/resources/rmd/patch.R
@@ -270,8 +270,10 @@ assignInNamespace("valid_path", valid_path, ns = "knitr")
 
 
 # add special language comment options support in knitr
-knitr_comment_chars <- knitr:::comment_chars
-knitr_comment_chars$ojs <- "//"
-knitr_comment_chars$mermaid <- "%%"
-knitr_comment_chars$dot <- "//"
-assignInNamespace("comment_chars", knitr_comment_chars, ns = "knitr")
+if (knitr_has_yaml_chunk_options()) {
+  knitr_comment_chars <- knitr:::comment_chars
+  knitr_comment_chars$ojs <- "//"
+  knitr_comment_chars$mermaid <- "%%"
+  knitr_comment_chars$dot <- "//"
+  assignInNamespace("comment_chars", knitr_comment_chars, ns = "knitr")
+}

--- a/src/resources/rmd/patch.R
+++ b/src/resources/rmd/patch.R
@@ -270,7 +270,10 @@ assignInNamespace("valid_path", valid_path, ns = "knitr")
 
 
 # add special language comment options support in knitr
-if (knitr_has_yaml_chunk_options()) {
+# it was added in 1.46 but we need to support older version too
+# https://github.com/quarto-dev/quarto-cli/pull/7799
+# FIXME: can be cleaned when knitr 1.45 is considered too old
+if (knitr_has_yaml_chunk_options() && utils::packageVersion("knitr") <= "1.45") {
   knitr_comment_chars <- knitr:::comment_chars
   knitr_comment_chars$ojs <- "//"
   knitr_comment_chars$mermaid <- "%%"

--- a/src/resources/rmd/patch.R
+++ b/src/resources/rmd/patch.R
@@ -268,3 +268,8 @@ valid_path = function(prefix, label) {
 }
 assignInNamespace("valid_path", valid_path, ns = "knitr")
 
+
+# add OJS comment option support in knitr
+knitr_comment_chars <- knitr:::comment_chars
+knitr_comment_chars$ojs <- "//"
+assignInNamespace("comment_chars", knitr_comment_chars, ns = "knitr")

--- a/src/resources/rmd/patch.R
+++ b/src/resources/rmd/patch.R
@@ -269,7 +269,9 @@ valid_path = function(prefix, label) {
 assignInNamespace("valid_path", valid_path, ns = "knitr")
 
 
-# add OJS comment option support in knitr
+# add special language comment options support in knitr
 knitr_comment_chars <- knitr:::comment_chars
 knitr_comment_chars$ojs <- "//"
+knitr_comment_chars$mermaid <- "%%"
+knitr_comment_chars$dot <- "//"
 assignInNamespace("comment_chars", knitr_comment_chars, ns = "knitr")

--- a/tests/docs/smoke-all/2023/12/05/knitr-handled-language-cell-options.qmd
+++ b/tests/docs/smoke-all/2023/12/05/knitr-handled-language-cell-options.qmd
@@ -1,0 +1,53 @@
+---
+format: html
+engine: knitr
+execute:
+  include: false
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ["#ojs div#ojs-cell-1", "#mermaid pre.mermaid", "#dot svg"]
+        - []
+      ensureFileRegexMatches:
+        - [] 
+        - []
+---
+
+## OJS
+
+```{ojs}
+//| include: true
+1 + 1
+```
+
+## MERMAID
+```{mermaid}
+%%| include: true
+flowchart LR
+  A[Hard edge] --> B(Round edge)
+  B --> C{Decision}
+  C --> D[Result one]
+  C --> E[Result two]
+```
+
+## DOT
+```{dot}
+//| include: true
+graph G {
+  layout=neato
+  run -- intr;
+  intr -- runbl;
+  runbl -- run;
+  run -- kernel;
+  kernel -- zombie;
+  kernel -- sleep;
+  kernel -- runmem;
+  sleep -- swap;
+  swap -- runswap;
+  runswap -- new;
+  runswap -- runmem;
+  new -- runmem;
+  sleep -- runmem;
+}
+```


### PR DESCRIPTION
and its comment character so options are parsed

closes https://github.com/quarto-dev/quarto-cli/issues/5994

@cscheid that would be the scoped way to handle a patch that does work no matter the knitr version. 

The issue is the same of all special engines so this include fix for mermaid. dot was working because already known by **knitr**

I believe this is safe to do that, and indeed is the right way to do it for current special engine implementation. 

Notice that OJS and mermaid / dot (`handledLanguages`) gets exactly the same treatment, but `ojs` is not part of `handledLanguages`, so we get two passes. I can refactor, but leaving this way makes it clear we do have different meaning for `ojs` and `mermaid` / `dot` (and possibly more later). 

