### PR TITLE
Adapt the footer text color when slide has dark-background

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -70,7 +70,7 @@
 - ([#7366](https://github.com/quarto-dev/quarto-cli/issues/7366)): `smaller: true` now applies correctly on nested slides.
 - ([#7394](https://github.com/quarto-dev/quarto-cli/issues/7394)): Fix issue with mermaid diagrams in revealjs slides when `output-location: fragment`.
 - ([#4988](https://github.com/quarto-dev/quarto-cli/issues/4988)): targets for links on numbered code lines are removed, as revealjs doesn't support them because navigation is done by slide only.
-- ([#4156](https://github.com/quarto-dev/quarto-cli/issues/4156)): footer text on slide with dark background have now an adapted text muted color based on `$dark-bg-text-color`.
+- ([#4156](https://github.com/quarto-dev/quarto-cli/issues/4156)): footer and slide number text on slide with dark background have now an adapted text muted color based on `$dark-bg-text-color`.
 
 ## PDF Format
 

--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -70,6 +70,7 @@
 - ([#7366](https://github.com/quarto-dev/quarto-cli/issues/7366)): `smaller: true` now applies correctly on nested slides.
 - ([#7394](https://github.com/quarto-dev/quarto-cli/issues/7394)): Fix issue with mermaid diagrams in revealjs slides when `output-location: fragment`.
 - ([#4988](https://github.com/quarto-dev/quarto-cli/issues/4988)): targets for links on numbered code lines are removed, as revealjs doesn't support them because navigation is done by slide only.
+- ([#4156](https://github.com/quarto-dev/quarto-cli/issues/4156)): footer text on slide with dark background have now an adapted text muted color based on `$dark-bg-text-color`.
 
 ## PDF Format
 

--- a/src/resources/formats/revealjs/plugins/support/support.js
+++ b/src/resources/formats/revealjs/plugins/support/support.js
@@ -113,6 +113,13 @@ window.QuartoSupport = function () {
 
   // add footer text
   function addFooter(deck) {
+    const toggleDarkBackground = function(el, onDarkBackground) {
+      if (onDarkBackground) {
+        el.classList.add('has-dark-background')
+      } else {
+        el.classList.remove('has-dark-background')
+      }
+    }
     const revealParent = deck.getRevealElement();
     const defaultFooterDiv = document.querySelector(".footer-default");
     if (defaultFooterDiv) {
@@ -127,13 +134,16 @@ window.QuartoSupport = function () {
             prevSlideFooter.remove();
           }
           const currentSlideFooter = ev.currentSlide.querySelector(".footer");
+          const onDarkBackground = Reveal.getSlideBackground(ev.indexh, ev.indexv).classList.contains('has-dark-background')
           if (currentSlideFooter) {
             defaultFooterDiv.style.display = "none";
             const slideFooter = currentSlideFooter.cloneNode(true);
             handleLinkClickEvents(deck, slideFooter);
             deck.getRevealElement().appendChild(slideFooter);
+            toggleDarkBackground(slideFooter, onDarkBackground)
           } else {
             defaultFooterDiv.style.display = "block";
+            toggleDarkBackground(defaultFooterDiv, onDarkBackground)
           }
         });
       }

--- a/src/resources/formats/revealjs/plugins/support/support.js
+++ b/src/resources/formats/revealjs/plugins/support/support.js
@@ -4,6 +4,20 @@ window.QuartoSupport = function () {
     return /print-pdf/gi.test(window.location.search);
   }
 
+  // helper for theme toggling
+  function toggleBackgroundTheme(el, onDarkBackground, onLightBackground) {
+    if (onDarkBackground) {
+      el.classList.add('has-dark-background')
+    } else {
+      el.classList.remove('has-dark-background')
+    }
+    if (onLightBackground) {
+      el.classList.add('has-light-background')
+    } else {
+      el.classList.remove('has-light-background')
+    }
+  }
+
   // implement controlsAudo
   function controlsAuto(deck) {
     const config = deck.getConfig();
@@ -111,20 +125,19 @@ window.QuartoSupport = function () {
     }
   }
 
-  // add footer text
-  function addFooter(deck) {
-    const toggleBackgroundTheme = function(el, onDarkBackground, onLightBackground) {
-      if (onDarkBackground) {
-        el.classList.add('has-dark-background')
-      } else {
-        el.classList.remove('has-dark-background')
-      }
-      if (onLightBackground) {
-        el.classList.add('has-light-background')
-      } else {
-        el.classList.remove('has-light-background')
-      }
-    }
+  // tweak slide-number element
+  function tweakSlideNumber(deck) {
+    deck.on("slidechanged", function (ev) {
+      const revealParent = deck.getRevealElement();
+      const slideNumberEl = revealParent.querySelector(".slide-number");
+      const onDarkBackground = Reveal.getSlideBackground(ev.indexh, ev.indexv).classList.contains('has-dark-background');
+      const onLightBackground = Reveal.getSlideBackground(ev.indexh, ev.indexv).classList.contains('has-light-background');
+      toggleBackgroundTheme(slideNumberEl, onDarkBackground, onLightBackground);
+    })
+  }
+
+   // add footer text
+   function addFooter(deck) {
     const revealParent = deck.getRevealElement();
     const defaultFooterDiv = document.querySelector(".footer-default");
     if (defaultFooterDiv) {
@@ -296,6 +309,7 @@ window.QuartoSupport = function () {
       fixupForPrint(deck);
       applyGlobalStyles(deck);
       addLogoImage(deck);
+      tweakSlideNumber(deck);
       addFooter(deck);
       addChalkboardButtons(deck);
       handleTabbyClicks();

--- a/src/resources/formats/revealjs/plugins/support/support.js
+++ b/src/resources/formats/revealjs/plugins/support/support.js
@@ -113,11 +113,16 @@ window.QuartoSupport = function () {
 
   // add footer text
   function addFooter(deck) {
-    const toggleDarkBackground = function(el, onDarkBackground) {
+    const toggleBackgroundTheme = function(el, onDarkBackground, onLightBackground) {
       if (onDarkBackground) {
         el.classList.add('has-dark-background')
       } else {
         el.classList.remove('has-dark-background')
+      }
+      if (onLightBackground) {
+        el.classList.add('has-light-background')
+      } else {
+        el.classList.remove('has-light-background')
       }
     }
     const revealParent = deck.getRevealElement();
@@ -135,15 +140,16 @@ window.QuartoSupport = function () {
           }
           const currentSlideFooter = ev.currentSlide.querySelector(".footer");
           const onDarkBackground = Reveal.getSlideBackground(ev.indexh, ev.indexv).classList.contains('has-dark-background')
+          const onLightBackground = Reveal.getSlideBackground(ev.indexh, ev.indexv).classList.contains('has-light-background')
           if (currentSlideFooter) {
             defaultFooterDiv.style.display = "none";
             const slideFooter = currentSlideFooter.cloneNode(true);
             handleLinkClickEvents(deck, slideFooter);
             deck.getRevealElement().appendChild(slideFooter);
-            toggleDarkBackground(slideFooter, onDarkBackground)
+            toggleBackgroundTheme(slideFooter, onDarkBackground, onLightBackground)
           } else {
             defaultFooterDiv.style.display = "block";
-            toggleDarkBackground(defaultFooterDiv, onDarkBackground)
+            toggleBackgroundTheme(defaultFooterDiv, onDarkBackground, onLightBackground)
           }
         });
       }

--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -443,6 +443,14 @@ $panel-sidebar-padding: 0.5em;
 
 .reveal .slide-number {
   color: $text-muted;
+
+  &.has-dark-background {
+    color: sass-color.scale($dark-bg-text-color, $whiteness: 30%);
+  }
+
+  &.has-light-background {
+    color: sass-color.scale($light-bg-text-color, $whiteness: 30%);
+  }
 }
 
 // handle caption for figures

--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -419,10 +419,18 @@ $panel-sidebar-padding: 0.5em;
 
 .reveal .footer {
   color: $text-muted;
-}
 
-.reveal .footer a {
-  color: $linkColor;
+  a {
+    color: $linkColor;
+  }
+
+  &.has-dark-background {
+    color: darken($dark-bg-text-color, 20%);
+
+    a {
+      color: darken($dark-bg-link-color, 20%);
+    }
+  }
 }
 
 .reveal .slide-number {

--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -425,10 +425,18 @@ $panel-sidebar-padding: 0.5em;
   }
 
   &.has-dark-background {
-    color: darken($dark-bg-text-color, 20%);
+    color: sass-color.scale($dark-bg-text-color, $whiteness: 30%);
 
     a {
-      color: darken($dark-bg-link-color, 20%);
+      color: sass-color.scale($dark-bg-link-color, $whiteness: 30%);
+    }
+  }
+
+  &.has-light-background {
+    color: sass-color.scale($light-bg-text-color, $whiteness: 30%);
+
+    a {
+      color: sass-color.scale($light-bg-link-color, $whiteness: 30%);
     }
   }
 }


### PR DESCRIPTION
closes #4156 

This PR is a proposal so that colors of footer and slide numbers are adapted when on light / dark slides when dark / light background is used. 

Check this PR by checking out the branch and then 

## Dark theme, light slide 

````markdown
---
title: Footers
format: 
  revealjs: 
    incremental: true
    slide-number: true
    theme: dark
---

# Custom footer {background-color="lightblue"}

Something on a red background

::: footer
Amazing custom footer thing [QUarto](https://quarto.org)
:::

````

![image](https://github.com/quarto-dev/quarto-cli/assets/6791940/e97d682b-3b24-42e3-ab38-e2b357376537)


## Dark slide on light theme
 
````markdown
---
title: Footers
format: 
  revealjs: 
    incremental: true
    slide-number: true
    theme: dark
---

# Custom footer {background-color="lightblue"}

Something on a red background

::: footer
Amazing custom footer thing [QUarto](https://quarto.org)
:::

````

![image](https://github.com/quarto-dev/quarto-cli/assets/6791940/00be6d78-f794-419d-8fb5-4091991da5c7)


Only limitation - the tweak happens when the slide changes, so when going to slide directly using a direct url, the color may not be adjusted yet before any slide is changed. 

@dragonstyle I know you looked into that. What do you think about this solution ? 