### PR TITLE
Avoid applying quarto-figure CSS inside html widgets outputs

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -30,6 +30,10 @@ All changes included in 1.5:
 - ([#4802](https://github.com/quarto-dev/quarto-cli/issues/4802)): Change name of temporary input notebook to avoid accidental overwriting.
 - ([#8433](https://github.com/quarto-dev/quarto-cli/issues/8433)): Escape jupyter widget states that contain `</script>` so they can be embedded in HTML documents.
 
+## Knitr
+
+- ([#7843](https://github.com/quarto-dev/quarto-cli/issues/7843)): fix an issue with Quarto figure specific css rules applying inside HTML widgets output.
+
 ## Website Listings
 
 - ([#8147](https://github.com/quarto-dev/quarto-cli/issues/8147)): Ensure that listings don't include the contents of the output directory

--- a/src/resources/formats/html/_quarto-rules.scss
+++ b/src/resources/formats/html/_quarto-rules.scss
@@ -112,15 +112,18 @@ figure .quarto-layout-row figure figcaption {
   margin-bottom: 0;
 }
 .quarto-figure-left > figure > p,
-.quarto-figure-left > figure > div /* for mermaid and dot diagrams */ {
+/* for mermaid and dot diagrams, excluding impact on htmlwidget output */ 
+.quarto-figure-left > figure > div:not(.html-widget, :nth-child(1):not(.html-widget)) {
   text-align: left;
 }
 .quarto-figure-center > figure > p,
-.quarto-figure-center > figure > div /* for mermaid and dot diagrams */ {
+/* for mermaid and dot diagrams, excluding impact on htmlwidget output */ 
+.quarto-figure-center > figure > div:not(.html-widget, :nth-child(1):not(.html-widget)) {
   text-align: center;
 }
 .quarto-figure-right > figure > p,
-.quarto-figure-right > figure > div /* for mermaid and dot diagrams */ {
+/* for mermaid and dot diagrams, excluding impact on htmlwidget output */ 
+.quarto-figure-right > figure > div:not(.html-widget, :nth-child(1):not(.html-widget)) {
   text-align: right;
 }
 


### PR DESCRIPTION
This PR add some `:not()` selectors on the quarto-figure div CSS rule so that it does not apply on div inside html widgets elements.

I did use this 
````
div:not(.html-widget, :nth-child(1):not(.html-widget))
````
with `:nth_child(1)`  because it seems we do add some specific div like this 
````html
<div aria-describedby="fig-leaflet-caption-0ceaefa1-69ba-4598-a22c-09a6ac19f8ca">
````
and in fact the CSS rules we have apply on it directly. So I did not test this one, but the child of it. For security I also added the `div.html-widget` part though. 

@cscheid I see from comment that theses rules are for mermaid and dot 
````css
.quarto-figure-left > figure > div /* for mermaid and dot diagrams */ {
````

another fix would be to make them more selective toward their mermaid or dot target if they are only for those cases. 
Maybe you remember the precise context ? 

Hard to add test on this, so I did not but I manually tested and this works. 

