### PR TITLE
[knitr] Update pdf cropping detection to latest knitr version and allow opt out using `crop: false` chunk option

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -218,6 +218,7 @@
 - ([#5994](https://github.com/quarto-dev/quarto-cli/issues/5994)): Options like `include` or `echo` for `ojs` or `mermaid` cells are now correctly handled with knitr engine.
 - ([#4869](https://github.com/quarto-dev/quarto-cli/issues/4869)): `sql` cell output has now correct Quarto treatment so that specific features like `column: margin` works.
 - ([#7600](https://github.com/quarto-dev/quarto-cli/issues/7600)): `output: asis` now correctly don't emit `.cell-output-display` div around cell outputs of class `knit_asis`.
+- ([#7877](https://github.com/quarto-dev/quarto-cli/issues/7877)): `crop: false` chunk options allows to opt out (per chunk or globally) automatic cropping in PDF when `pdfcrop` and `ghostscript` are detected. This complements knitr's way `crop: null`.
 
 ## OJS engine
 

--- a/src/resources/rmd/execute.R
+++ b/src/resources/rmd/execute.R
@@ -689,11 +689,13 @@ apply_responsive_patch <- function(format) {
 
 # from rmarkdown 
 # https://github.com/rstudio/rmarkdown/blob/0951a2fea7e317f77d27969c25f3194ead38805e/R/util.R#L318-L331
-has_crop_tools <- function (warn = TRUE) {
-  if (packageVersion("rmarkdown") >= "2.8") {
-    return(rmarkdown:::has_crop_tools(warn))
+has_crop_tools <- function(warn = TRUE) {
+  if (packageVersion("knitr") >= "1.44") {
+    return(knitr:::has_crop_tools(warn))
   }
-  # for older version we do inline the function
+  # for older version we do inline the function from rmarkdown
+  # but it does not have the knitr improvment for windows 
+  # https://github.com/yihui/knitr/issues/2246
   tools <- c(
     pdfcrop = unname(rmarkdown:::find_program("pdfcrop")),
     ghostscript = unname(tools::find_gs_cmd())

--- a/src/resources/rmd/execute.R
+++ b/src/resources/rmd/execute.R
@@ -321,7 +321,11 @@ knitr_options <- function(format, resourceDir, handledLanguages) {
   if (opts_chunk$dev == 'pdf') {
     opts_chunk$dev.args <- list(pdf = list(useDingbats = FALSE))
     if (has_crop_tools(FALSE)) {
-      knit_hooks$crop <- knitr::hook_pdfcrop
+      knit_hooks$crop <- function(before, options, envir) {
+        if (isTRUE(options$crop)) {
+          knitr::hook_pdfcrop(before, options, envir)
+        }
+      }
       opts_chunk$crop <- TRUE
     }
   }


### PR DESCRIPTION
This PR 

* fix https://github.com/quarto-dev/quarto-cli/issues/5734
* fix https://github.com/quarto-dev/quarto-cli/issues/5981

It update our R code to use the latest fix from https://github.com/yihui/knitr/issues/2246 (when recent version of knitr is used) 

and it adds support to use `crop: false` chunk option to opt out cropping feature in PDF. 

Either at chunk level 

````
```{r}
#| crop: false
library(ggplot2)
ggplot() + theme(plot.margin = margin(t=2,b=2,unit='cm')) # wide margins to see the effect (or lack thereof)
```
````

or globally 

````yaml
knitr:
  opts_chunk: 
    crop: false
````

The usual **knitr** way is `crop: null` but this is less known and easy to remember

````yaml
knitr:
  opts_chunk: 
    crop: null
````

and 
````markdown
```{r}
#| crop: null
library(ggplot2)
ggplot() + theme(plot.margin = margin(t=2,b=2,unit='cm')) # wide margins to see the effect (or lack thereof)
```
````