### PR TITLE
Ignore search activation when focused element is content-editable

### DIFF
--- a/src/resources/projects/website/search/quarto-search.js
+++ b/src/resources/projects/website/search/quarto-search.js
@@ -393,7 +393,7 @@ window.document.addEventListener("DOMContentLoaded", function (_event) {
       return focusedEl.tagName.toLowerCase() === tag;
     });
 
-    if (kbds && kbds.includes(key) && !isFormElFocused) {
+    if (kbds && kbds.includes(key) && !isFormElFocused && focusedEl.isContentEditable) {
       event.preventDefault();
       window.quartoOpenSearch();
     }

--- a/src/resources/projects/website/search/quarto-search.js
+++ b/src/resources/projects/website/search/quarto-search.js
@@ -393,7 +393,7 @@ window.document.addEventListener("DOMContentLoaded", function (_event) {
       return focusedEl.tagName.toLowerCase() === tag;
     });
 
-    if (kbds && kbds.includes(key) && !isFormElFocused && focusedEl.isContentEditable) {
+    if (kbds && kbds.includes(key) && !isFormElFocused && !focusedEl.isContentEditable) {
       event.preventDefault();
       window.quartoOpenSearch();
     }


### PR DESCRIPTION

## Description

Avoids activating Quarto search when the focused element has `contenteditable="true"`, as is the case of the shinylive embedded editor.

You can see a reprex on https://wch.github.io/shiny_express_doc/. Type `s` or `f` into any of the code editors (or for fun type `from shiny ...` ).

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
