### PR TITLE
Correctly match options of the form --option=arg

### DIFF
--- a/src/command/render/flags.ts
+++ b/src/command/render/flags.ts
@@ -42,6 +42,10 @@ export async function parseRenderFlags(args: string[]) {
   const argsStack = [...args];
   let arg = argsStack.shift();
   while (arg !== undefined) {
+    const equalSignIndex = arg.indexOf("=");
+    if(arg.startsWith("--") && equalSignIndex > 0) {
+      arg = arg.slice(0, equalSignIndex);
+    }
     switch (arg) {
       case "-t":
       case "--to":


### PR DESCRIPTION
## Description

Please describe your PR here.

https://github.com/quarto-dev/quarto-cli/commit/2de8e5f6b36174a63d934b57be8720d8ff086529 , which fixed #7868 , introduced a different issue because it meant command line options like `--katex=filename` now aren't picked up as a flag (as it just looks for `--katex`.

I thought I could write a PR to show the issue faster than explaining it :) I have tested this by adding some console.logs, but aren't sure how to test it generally, or if this is the right fix (it isn't using the explicitly recently added list of things not to split = from, for example). I'm happy for this to be closed and replaced, if a better fix exists.

## Checklist

I have (if applicable):

- [x ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md). (just emailed)
- [ ] referenced the GitHub issue this PR closes (could make a new one)
- [ ] updated the appropriate changelog (not sure it needs a changelog as it fixes a bug from yesterday?)
