### PR TITLE
Update README.md with how to run quarto

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ cd quarto-cli
 ./configure.sh
 ```
 
+The `./configure.sh` script should add a symlink to `quarto` to your path. You can also run quarto by running `package/dist/bin/quarto`.
+
 To update to the latest development version, run `git pull` from the local repo directory:
 
 ```bash


### PR DESCRIPTION
If you can't run the newly built quarto (in my case, my already installed quarto was earlier in the path), make clear how to run the newly build quarto.

I found it a bit confusing how to run the freshly created `quarto`, when I didn't realise it got added to the path (and in my case I had a quarto earlier in my path anyway).