### PR TITLE
Add a safe version for removeSync

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -370,3 +370,4 @@
 - ([#7675](https://github.com/quarto-dev/quarto-cli/pull/7675)): On Windows, `quarto install tinytex` will install TinyTeX to the directory defined by the environment variable `ProgramData` when `APPDATA` is not a suitable location for TeX Live.
 - ([#4673](https://github.com/quarto-dev/quarto-cli/issues/4673)): Quarto now report in check and error message if **rmarkdown** R package minimal requirement (>= 2.3) is not fullfilled, and it will ask to update the package.
 - ([#7793](https://github.com/quarto-dev/quarto-cli/issues/7793)): When a project render list includes only negative globs, use those to filter out the default render list.
+- ([#4614](https://github.com/quarto-dev/quarto-cli/issues/4614)): Correctly remove empty mediabag directory in remote drives.

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -45,6 +45,17 @@ export function safeRemoveIfExists(file: string) {
   }
 }
 
+export function safeRemoveSync(
+  file: string,
+  options: Deno.RemoveOptions = {},
+) {
+  try {
+    Deno.removeSync(file, options);
+  } catch (e) {
+    if (existsSync(file)) throw e;
+  }
+}
+
 export function removeIfEmptyDir(dir: string): boolean {
   if (existsSync(dir)) {
     let empty = true;
@@ -53,7 +64,7 @@ export function removeIfEmptyDir(dir: string): boolean {
       break;
     }
     if (empty) {
-      Deno.removeSync(dir, { recursive: true });
+      safeRemoveSync(dir, { recursive: true });
       return true;
     }
     return false;


### PR DESCRIPTION
This PR fixes #4614

It is based on new behavior found for Deno and detailed in 
* https://github.com/denoland/deno/issues/18996#issuecomment-1856266913

This Deno issue is the real issue, but it seems removal does happen even if Deno throws an error. 

So this implements a workaround. 

I am not Deno export, so happy to have feedback @cscheid and @dragonstyle 

If you think this is not good and a deno fix shoud be prefered, let's wait. But my test with Google Drive disk shows that document renders and so #4614 is indeed fixed. 

I just replaced the `Deno.removeSync()` from the initial error, but this safe version could be used for each `Deno.removeSync()` call I believe. 

What do you think ? 