### PR TITLE
Add support for OCaml code annotations

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -270,6 +270,7 @@
 - ([#6385](https://github.com/quarto-dev/quarto-cli/issues/6385)): Add support for code annotation in fenced code cells
 - ([#7056](https://github.com/quarto-dev/quarto-cli/issues/7056)): Only make content of the hover annotation scrollable if it necessary
 - ([#7435](https://github.com/quarto-dev/quarto-cli/issues/7435)): Use `#` as a fallback comment character for unknown languages
+- Add support for OCaml code annotations
 
 ## Author and Affiliations
 

--- a/src/core/jupyter/jupyter.ts
+++ b/src/core/jupyter/jupyter.ts
@@ -1174,6 +1174,7 @@ const kLangCommentChars: Record<string, string | string[]> = {
   dot: "//",
   mermaid: "%%",
   apl: "⍝",
+  ocaml: ["(*", "*)"],
 };
 
 function cleanJupyterOutputDisplayData(

--- a/src/core/lib/partition-cell-options.ts
+++ b/src/core/lib/partition-cell-options.ts
@@ -352,6 +352,7 @@ export const kLangCommentChars: Record<string, string | [string, string]> = {
   dot: "//",
   ojs: "//",
   apl: "⍝",
+  ocaml: ["(*", "*)"],
 };
 
 function escapeRegExp(str: string) {

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -22606,7 +22606,8 @@ var require_yaml_intelligence_resources = __commonJS({
         dot: "//",
         ojs: "//",
         apl: "\u235D",
-        mermaid: "%%"
+        mermaid: "%%",
+        ocaml: ["(*", "*)"]
       },
       "handlers/mermaid/schema.yml": {
         _internalId: 180595,
@@ -31785,7 +31786,8 @@ var kLangCommentChars = {
   haskell: "--",
   dot: "//",
   ojs: "//",
-  apl: "\u235D"
+  apl: "\u235D",
+  ocaml: ["(*", "*)"]
 };
 function escapeRegExp(str2) {
   return str2.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -22607,7 +22607,8 @@ try {
           dot: "//",
           ojs: "//",
           apl: "\u235D",
-          mermaid: "%%"
+          mermaid: "%%",
+          ocaml: ["(*", "*)"]
         },
         "handlers/mermaid/schema.yml": {
           _internalId: 180595,
@@ -31799,7 +31800,8 @@ ${tidyverseInfo(
     haskell: "--",
     dot: "//",
     ojs: "//",
-    apl: "\u235D"
+    apl: "\u235D",
+    ocaml: ["(*", "*)"]
   };
   function escapeRegExp(str2) {
     return str2.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -15578,7 +15578,8 @@
     "dot": "//",
     "ojs": "//",
     "apl": "⍝",
-    "mermaid": "%%"
+    "mermaid": "%%",
+    "ocaml": ["(*", "*)"]
   },
   "handlers/mermaid/schema.yml": {
     "_internalId": 180595,

--- a/src/resources/filters/modules/constants.lua
+++ b/src/resources/filters/modules/constants.lua
@@ -124,7 +124,8 @@ local kLangCommentChars = {
   html = { "<!--", "-->"},
   markdown = {"<!--", "-->"},
   gap = { "#" },
-  dockerfile = { "#" }
+  dockerfile = { "#" },
+  ocaml = { "(*", "*)"}
 }
 local kDefaultCodeAnnotationComment =  {"#"}
 

--- a/src/resources/jupyter/notebook.py
+++ b/src/resources/jupyter/notebook.py
@@ -681,7 +681,8 @@ def nb_language_comment_chars(lang):
       asy = "//",
       haskell = "--",
       dot = "//",
-      apl = "⍝"
+      apl = "⍝",
+      ocaml = ["(*", "*)"]
    )
    if lang in langs:
       chars = langs[lang]

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -955,7 +955,8 @@ engine_comment_chars <- function(engine) {
     asy = "//",
     haskell = "--",
     dot = "//",
-    apl = "\u235D"
+    apl = "\u235D",
+    ocaml = c("(*", "*)")
   )
   comment_chars[[engine]] %||% "#"
 }


### PR DESCRIPTION
## Description

OCaml doesn't have line comments.
The comment chars are `(*` and `*)`, which work like `/*` and `*/` in C.

There is quite a lot of duplication here, but I think I updated all the places that define comment characters.

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).

I don't think this is necessary for this small change: there is only way to define comment chars in OCaml and that is by adding the lines I've added here, which are more like data than code.

- [ ] referenced the GitHub issue this PR closes
- [x] updated the appropriate changelog
