### PR TITLE
Enable Manuscript reference page

### DIFF
--- a/src/resources/schema/project.yml
+++ b/src/resources/schema/project.yml
@@ -67,7 +67,9 @@
 - name: manuscript
   description: Manuscript configuration
   schema:
-    ref: manuscript-schema
+    object:
+      super:
+        - resolveRef: manuscript-schema
 
 - name: type
   hidden: true


### PR DESCRIPTION
@dragonstyle this change gets the reference page infrastructure in quarto-web to work for manuscript projects, but I don't understand if it has larger consequences.

See https://github.com/quarto-dev/quarto-web/pull/952 for PR that adds reference page to quarto-web.