### PR TITLE
Scope `has_annotations()` to its related function 

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -248,6 +248,7 @@
 - ([#4869](https://github.com/quarto-dev/quarto-cli/issues/4869)): `sql` cell output has now correct Quarto treatment so that specific features like `column: margin` works.
 - ([#7600](https://github.com/quarto-dev/quarto-cli/issues/7600)): `output: asis` now correctly don't emit `.cell-output-display` div around cell outputs of class `knit_asis`.
 - ([#7877](https://github.com/quarto-dev/quarto-cli/issues/7877)): `crop: false` chunk options allows to opt out (per chunk or globally) automatic cropping in PDF when `pdfcrop` and `ghostscript` are detected. This complements knitr's way `crop: null`.
+- ([#7943](https://github.com/quarto-dev/quarto-cli/issues/7943)): Internal Quarto R function should not leak to user's global environment.
 
 ## OJS engine
 


### PR DESCRIPTION
so that it does not appear in the user's global R environment.

Closes #7943 