### PR TITLE
Use importlib.metadata to get the python module version

### DIFF
--- a/src/resources/capabilities/jupyter.py
+++ b/src/resources/capabilities/jupyter.py
@@ -1,6 +1,6 @@
 import sys
 import os
-import importlib
+from importlib.metadata import version
 
 sys.stdout.write('versionMajor: ' + str(sys.version_info.major))
 sys.stdout.write('\nversionMinor: ' + str(sys.version_info.minor))
@@ -16,8 +16,7 @@ sys.stdout.write('\nexecutable: "' + sys.executable.replace("\\", "/") + '"')
 def discover_package(pkg):
   sys.stdout.write('\n' + pkg + ': ')
   try:
-    imp = importlib.import_module(pkg)
-    sys.stdout.write(str(imp.__version__))
+    sys.stdout.write(version(pkg))
   except Exception:
     sys.stdout.write('null')
  


### PR DESCRIPTION
This is available since Python 3.8, oldest active version at date of this commit.

This is needed because `__version__` has been removed from jupyter_core 5.5.1 and quarto fails to find python.

fixes #7964 

I believe we should add somewhere that Quarto 1.4 now requires Python 3.8 as minimal version. We should probably make it clear about the EOL rule. 

Should it be in Changelog highlights or elsewhere ? 
