### PR TITLE
chore: remove greater/lower symbols in discussion template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/feature-requests.yml
+++ b/.github/DISCUSSION_TEMPLATE/feature-requests.yml
@@ -1,7 +1,7 @@
-title: "<The (missing) feature you want to discuss>"
+title: "The (missing) feature you want to discuss"
 body:
   - type: markdown
-    attributes: 
+    attributes:
       value: |
         First, please check [Quarto Issues](https://github.com/quarto-dev/quarto-cli/issues) and [Feature Requests GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/feature-requests) to see if your feature request has already been discussed.
         If it has, please consider adding a comment to the existing discussion instead of creating a new one.

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,7 +1,7 @@
-title: "<Your question in one sentence (e.g., How do I preview documents with Quarto?)>"
+title: "Your question in one sentence (e.g., How do I preview documents with Quarto?)"
 body:
   - type: markdown
-    attributes: 
+    attributes:
       value: |
         First, please check [Quarto Issues](https://github.com/quarto-dev/quarto-cli/issues) and [Q&A GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/q-a) first to see if your question has already been asked.
         If it has, please consider adding a comment to the existing discussion instead of creating a new one.
@@ -18,27 +18,27 @@ body:
       label: Description
       description: Start your question/report!
       placeholder: |
-          You can include Quarto document code which includes code blocks like this:
+        You can include Quarto document code which includes code blocks like this:
 
-          ````qmd
-          ---
-          title: "Hello Quarto!"
-          format: html
-          ---
+        ````qmd
+        ---
+        title: "Hello Quarto!"
+        format: html
+        ---
 
-          ```py
-          print("Hello Quarto!")
-          ```
-          ````
+        ```py
+        print("Hello Quarto!")
+        ```
+        ````
 
-          ---
+        ---
 
-          ### Additional information that can help us to help you
+        ### Additional information that can help us to help you
 
-          - What Quarto version are you using?  
-            You can find the version of Quarto you used by running `quarto --version` in your terminal.
-          - What operating system are you using?  
-            Linux Ubuntu 20.04, macOS 11.2.3, Windows 10, _etc._
+        - What Quarto version are you using?  
+          You can find the version of Quarto you used by running `quarto --version` in your terminal.
+        - What operating system are you using?  
+          Linux Ubuntu 20.04, macOS 11.2.3, Windows 10, _etc._
     validations:
       required: true
   - type: markdown

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,7 +1,7 @@
-title: "<The item you want to talk about>"
+title: "The item you want to talk about"
 body:
   - type: markdown
-    attributes: 
+    attributes:
       value: |
         If you want to ask for a feature, please use the [Feature Requests GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/feature-requests).
         If you want to ask for help, please use the [Q&A GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/q-a).


### PR DESCRIPTION
This is a really minor PR to get rid of `<>` symbols in default title field.
These `<>` symbols were sometimes not removed by users which causes the whole thing to be read as HTML tag thus hide the content from screen readers, especially on GitHub mobile.