### PR TITLE
Follow up tweak on Deno.removeSync issues 

### DIFF
--- a/src/command/render/cleanup.ts
+++ b/src/command/render/cleanup.ts
@@ -1,9 +1,8 @@
 /*
-* renderCleanup.ts
-*
-* Copyright (C) 2020-2022 Posit Software, PBC
-*
-*/
+ * renderCleanup.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
 
 import { existsSync } from "fs/mod.ts";
 import { dirname, extname, isAbsolute, join } from "../../deno_ral/path.ts";
@@ -14,6 +13,7 @@ import {
   normalizePath,
   removeIfEmptyDir,
   removeIfExists,
+  safeRemoveSync,
 } from "../../core/path.ts";
 import { figuresDir, inputFilesDir } from "../../core/render.ts";
 
@@ -90,7 +90,7 @@ export function renderCleanup(
     // clean supporting
     ld.uniq(supporting).forEach((path) => {
       if (existsSync(path)) {
-        Deno.removeSync(path, { recursive: true });
+        safeRemoveSync(path, { recursive: true });
       }
     });
   }

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -50,7 +50,7 @@ export function safeRemoveSync(
   try {
     Deno.removeSync(file, options);
   } catch (e) {
-    if (existsSync(file) || !(e instanceof Deno.errors.NotFound)) {
+    if (existsSync(file)) {
       throw e;
     }
   }

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -50,7 +50,9 @@ export function safeRemoveSync(
   try {
     Deno.removeSync(file, options);
   } catch (e) {
-    if (existsSync(file)) throw e;
+    if (existsSync(file) || !(e instanceof Deno.errors.NotFound)) {
+      throw e;
+    }
   }
 }
 


### PR DESCRIPTION
This is follow up on https://github.com/quarto-dev/quarto-cli/issues/4614 and https://github.com/quarto-dev/quarto-cli/pull/7921

It seems there is another place where removing the `mediabag` is possibly throwing a Deno error while it works. 

See https://github.com/quarto-dev/quarto-cli/issues/4614#issuecomment-1864404082

Again narrow fix where the errors shared comes from. There are other occurence of `Deno.removeSync` but I left them open