### PR TITLE
[typst] For floatRefTarget of type listing, we force a left centering

### DIFF
--- a/src/resources/filters/customnodes/floatreftarget.lua
+++ b/src/resources/filters/customnodes/floatreftarget.lua
@@ -866,6 +866,7 @@ end, function(float)
   local kind
   local supplement = ""
   local numbering = ""
+  local content = float.content
 
   if float.parent_id then
     kind = "quarto-subfloat-" .. ref
@@ -878,11 +879,17 @@ end, function(float)
 
   local caption_location = cap_location(float)
 
-  -- FIXME: Listings shouldn't emit centered blocks. I don't know how to disable that right now.
   -- FIXME: custom numbering doesn't work yet
+  
+  if (ref == "lst") then
+    -- FIXME: 
+    -- Listings shouldn't emit centered blocks. 
+    -- We don't know how to disable that right now using #show rules for #figures in template.
+    content = { pandoc.RawBlock("typst", "#set align(left)"), content }
+  end
 
   return make_typst_figure {
-    content = float.content,
+    content = content,
     caption_location = caption_location,
     caption = float.caption_long,
     kind = kind,

--- a/tests/docs/smoke-all/crossrefs/float/typst/typst-float-caption-formatting-1.qmd
+++ b/tests/docs/smoke-all/crossrefs/float/typst/typst-float-caption-formatting-1.qmd
@@ -8,6 +8,7 @@ _quarto:
       ensureTypstFileRegexMatches:
         - 
           - "Customers #emph\\[query\\]"
+          - '#figure\(\[[\s]+#set align\(left\)' # FIXME: change if we manage center in typst's template
 
 ---
 


### PR DESCRIPTION
For the figure body i.e the codeblock

Closes #7959

I did not find a way to do that using `#show` despite several tries. I may not fully understand how typst work though... 

It seems we can modify the alignment for the `figure.body` from an existing figure. It would require to redefine from scratch `#figure` for this `kind`

```typst
#show figure.where(kind: "quarto-float-lst"): fig => {
	(...)
}
````

but this would require to manage all type of condition, and not sure `fig.caption(placement: ..)` define in figure would still apply. 

Anyhow, it seemed easy enough to do it like this for the time being. Unless this is not something you want us to do (inserting raw typst like this)