### PR TITLE
Resolve user paths before mergin template partials

### DIFF
--- a/src/command/render/pandoc.ts
+++ b/src/command/render/pandoc.ts
@@ -155,6 +155,7 @@ import {
   cleanTemplatePartialMetadata,
   kTemplatePartials,
   readPartials,
+  resolveTemplatePartialPaths,
   stageTemplate,
 } from "./template.ts";
 import {
@@ -517,6 +518,12 @@ export async function runPandoc(
 
     // merge metadata
     if (extras.metadata || extras.metadataOverride) {
+      // before we merge metadata, ensure that partials are proper paths
+      resolveTemplatePartialPaths(
+        options.format.metadata,
+        cwd,
+        options.project,
+      );
       options.format.metadata = {
         ...mergeConfigs(
           extras.metadata || {},


### PR DESCRIPTION
Since we are merging absolute paths to format resources into the partials provided by the user, we need to resolve the user paths into absolute paths before we merge them. This will allow us to to use project semantics for resolving the path - (e.g. `/` prefix path).

