### PR TITLE
Improve title snipping in notebooks for revealjs

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -19,6 +19,7 @@ All changes included in 1.6:
 - Remove wrong `sourceMappingUrl` entry in SASS built css.
 - ([#7715](https://github.com/quarto-dev/quarto-cli/issues/7715)): Revealjs don't support anymore special Pandoc syntax making BulletList in Blockquotes become incremental list. This was confusing and unexpected behavior. Supported syntax for incremental list is documented at <https://quarto.org/docs/presentations/revealjs/#incremental-lists>.
 - ([#9742](https://github.com/quarto-dev/quarto-cli/issues/9742)): Links to cross-referenced images correctly works.
+- ([#8012](https://github.com/quarto-dev/quarto-cli/issues/8012)): Don't perform notebook title fixup with `format: revealjs` as this would create a new undesired title slide.
 
 ## `typst` Format
 

--- a/src/core/jupyter/jupyter-fixups.ts
+++ b/src/core/jupyter/jupyter-fixups.ts
@@ -166,7 +166,7 @@ export function fixupFrontMatter(nb: JupyterNotebook): JupyterNotebook {
 
   // if we have front matter and a title then we are done
   const yaml = partitioned ? readYamlFromMarkdown(partitioned.yaml) : undefined;
-  if (yaml?.title) {
+  if (yaml?.title || yaml?.format?.["revealjs"]) {
     return nb;
   }
 

--- a/src/core/jupyter/jupyter-fixups.ts
+++ b/src/core/jupyter/jupyter-fixups.ts
@@ -164,9 +164,15 @@ export function fixupFrontMatter(nb: JupyterNotebook): JupyterNotebook {
     }
   });
 
-  // if we have front matter and a title then we are done
   const yaml = partitioned ? readYamlFromMarkdown(partitioned.yaml) : undefined;
-  if (yaml?.title || yaml?.format?.["revealjs"]) {
+  if (
+    // if we have front matter and a title then we are done
+    yaml?.title ||
+    // if we have front matter and it has revealjs as a format then we are done too
+    (yaml?.format !== null &&
+      (yaml?.format === "revealjs" ||
+        (typeof yaml?.format === "object" && "revealjs" in yaml?.format)))
+  ) {
     return nb;
   }
 

--- a/tests/docs/smoke-all/2024/09/03/revealjs-title-snipping-jupyter.qmd
+++ b/tests/docs/smoke-all/2024/09/03/revealjs-title-snipping-jupyter.qmd
@@ -1,0 +1,24 @@
+---
+format: revealjs
+_quarto:
+  tests:
+    revealjs:
+      ensureHtmlElements:
+        - ['div.slides > section#custom:first-child']
+        - []
+      ensureFileRegexMatches:
+        - [] 
+        - []
+---
+
+## My Title slide {#custom .center}
+
+Some content
+
+
+## Python slide
+
+```{python}
+print(2+2)
+```
+


### PR DESCRIPTION
fixes #8012

Doing a title snipping when `engine: jupyter` is a bit too much for `revealjs` format because this will create a new title slide whereas when no `title` is provided, it should be considered custom first slide per our doc: https://quarto.org/docs/presentations/revealjs/index.html#title-slide

So I suggest we do not strip in Revealjs format. 

Just asking for review because I don't fully understand why we do this stripping. 

Does it sounds good ? 

We also use the function for stripping at 
https://github.com/quarto-dev/quarto-cli/blob/9f0c42f4485a178dea5b26830bc7556aee7ca11c/src/core/pandoc/pandoc-partition.ts#L49-L58

So I need to check if we need also some support there... 🤔 

it seems used for special cases like embed feature 	and some unused function 