### PR TITLE
[internal] index file should be invalidate when input file is newer

### DIFF
--- a/src/project/project-index.ts
+++ b/src/project/project-index.ts
@@ -218,6 +218,7 @@ function readInputTargetIndexIfStillCurrent(projectDir: string, input: string) {
       if (inputMod > indexMod) {
         inputTargetIndexCacheMetrics.invalidations++;
         inputTargetIndexCache.delete(indexFile);
+        return undefined;
       }
 
       if (inputTargetIndexCache.has(indexFile)) {


### PR DESCRIPTION
If the input file is newer that the index file stored, then we should consider it outdated

this way is will be rewritten with newer content. cc @dragonstyle as we discussed

# Context 

Found while looking at #8016

The index file is read from local storage as a cache, but I notice that a complete unrelated version of my `index.qmd` was internally loaded while debugging. This is because we were finding the .qmd was newer but re-reading the existing (wrong) index file which leads the futher processing below to use an unrelated content to my real `index.qmd`

https://github.com/quarto-dev/quarto-cli/blob/bac63d8e1a477184b7e962253fccbd88134f2a16/src/project/project-index.ts#L136-L143

https://github.com/quarto-dev/quarto-cli/blob/bac63d8e1a477184b7e962253fccbd88134f2a16/src/project/project-config.ts#L97-L115

This PR makes sure we return `undefined` to make clear that no index file is found because `stale`. it will then be rewritten. 

This is there since several month, I am surprised we were not bitten by that, but I am pretty sure something is not right. I believe this is fixed is the right one but unsure. 

The new logic since performance fix (#5245) is more complex than the previous one which was 
https://github.com/quarto-dev/quarto-cli/blob/9f61990d374f15a1ac95bd17a531d8d0ec8a98bf/src/project/project-index.ts#L182-L198

So hopefully I got it right