### PR TITLE
Attributes are passed through in Title when using empty heading

### DIFF
--- a/src/core/pandoc/pandoc-partition.ts
+++ b/src/core/pandoc/pandoc-partition.ts
@@ -18,7 +18,7 @@ export function firstHeadingFromMarkdown(markdown: string): string | undefined {
   return partitioned.headingText;
 }
 
-const kPandocTitleRegex = /^\#{1,}\s(.*)\s\{(.*)\}$/;
+const kPandocTitleRegex = /^\#{1,}\s(?:(.*)\s)?\{(.*)\}$/;
 const kRemoveHeadingRegex = /^#{1,}\s*/;
 
 export function parsePandocTitle(title: string) {

--- a/tests/docs/smoke-all/2023/12/22/jupyter-no-title-empty-header.qmd
+++ b/tests/docs/smoke-all/2023/12/22/jupyter-no-title-empty-header.qmd
@@ -1,0 +1,23 @@
+---
+format: html
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - []
+        - ['\{\.empty-header\}']
+    revealjs:
+      ensureFileRegexMatches:
+        - []
+        - ['\{\.empty-header\}']
+---
+
+## {.empty-header}
+
+Content
+
+## Python slide
+
+```{python}
+1 + 1
+```


### PR DESCRIPTION
Related to #8012 report (solves part of it)

We should consider empty headers with attributes when matching against Pandoc Title regex

Dummy example 

````markdown
---
format: html           
---

## {.empty-header}

Content

## Python slide

```{python}
1 + 1
```
````

![image](https://github.com/quarto-dev/quarto-cli/assets/6791940/433ae927-0b8a-47a8-ac6b-e90e88c08e80)


It context of revealjs, this is a problem has empty headers can have a meaning (creating a new section without title) 

````markdown
---
format: revealjs           
---

## {.empty-header}

Content

## Python slide

```{python}
1 + 1
```
````

![image](https://github.com/quarto-dev/quarto-cli/assets/6791940/0d37dd61-0f53-4e53-bd6b-72c141657e47)
