### PR TITLE
For reference in margin, process list and tables after callouts

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -60,6 +60,7 @@
 - Ensure that code annotation buttons are not selectable text.
 - ([#7364](https://github.com/quarto-dev/quarto-cli/discussions/7364)): Restore support for `layout-align` attribute in panels
 - ([#8032](https://github.com/quarto-dev/quarto-cli/issues/8032)): Fix layout issue when margin footnotes are contained on a list item inside a callout.
+- ([#7153](https://github.com/quarto-dev/quarto-cli/issues/7153)): Fix layout issue when margin footnotes are contained in a blockquote.
 
 ## Appendix
 

--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -59,6 +59,7 @@
 - ([#7542](https://github.com/quarto-dev/quarto-cli/discussions/7542)): Title block will properly present author affiliations when there is a mix of authors with affiliations and authors without affiliations
 - Ensure that code annotation buttons are not selectable text.
 - ([#7364](https://github.com/quarto-dev/quarto-cli/discussions/7364)): Restore support for `layout-align` attribute in panels
+- ([#8032](https://github.com/quarto-dev/quarto-cli/issues/8032)): Fix layout issue when margin footnotes are contained on a list item inside a callout.
 
 ## Appendix
 

--- a/src/format/html/format-html-bootstrap.ts
+++ b/src/format/html/format-html-bootstrap.ts
@@ -1736,20 +1736,6 @@ const marginContainerForEl = (el: Element, doc: Document) => {
     return el.previousElementSibling;
   }
 
-  // Check for a list or table
-  const list = findOutermostParentElOfType(el, ["OL", "UL", "TABLE"]);
-  if (list) {
-    if (list.nextElementSibling && isContainer(list.nextElementSibling)) {
-      return list.nextElementSibling;
-    } else {
-      const container = createMarginContainer(doc);
-      if (list.parentNode) {
-        list.parentNode.insertBefore(container, list.nextElementSibling);
-      }
-      return container;
-    }
-  }
-
   // Find the callout parent and create a container for the callout there
   // Walks up the parent stack until a callout element is found
   const findCalloutEl = (el: Element): Element | undefined => {
@@ -1769,6 +1755,20 @@ const marginContainerForEl = (el: Element, doc: Document) => {
       calloutEl.nextElementSibling,
     );
     return container;
+  }
+
+  // Check for a list or table
+  const list = findOutermostParentElOfType(el, ["OL", "UL", "TABLE"]);
+  if (list) {
+    if (list.nextElementSibling && isContainer(list.nextElementSibling)) {
+      return list.nextElementSibling;
+    } else {
+      const container = createMarginContainer(doc);
+      if (list.parentNode) {
+        list.parentNode.insertBefore(container, list.nextElementSibling);
+      }
+      return container;
+    }
   }
 
   // Deal with a paragraph

--- a/src/format/html/format-html-bootstrap.ts
+++ b/src/format/html/format-html-bootstrap.ts
@@ -1773,7 +1773,7 @@ const marginContainerForEl = (el: Element, doc: Document) => {
 
   // Deal with a paragraph
   const parentEl = el.parentElement;
-  const cantContainBlockTags = ["P"];
+  const cantContainBlockTags = ["P", "BLOCKQUOTE"];
   if (parentEl && cantContainBlockTags.includes(parentEl.tagName)) {
     // See if this para has a parent div with a container
     if (

--- a/tests/docs/smoke-all/article-layout/margin-location/reference-location-margin.qmd
+++ b/tests/docs/smoke-all/article-layout/margin-location/reference-location-margin.qmd
@@ -5,7 +5,7 @@ _quarto:
   tests:
     html:
       ensureHtmlElements:
-        - ['#callout div.callout + div.column-margin']
+        - ['#callout div.callout + div.column-margin', '#blockquote blockquote + div.column-margin']
         - []
 ---
 
@@ -21,3 +21,9 @@ Callout with numbered list
 :::
 
 [^3]: Sidenote for numbered list inside callout
+
+## Inside blockquote {#blockquote}
+
+> text [^note]
+
+[^note]: Footnote.

--- a/tests/docs/smoke-all/article-layout/margin-location/reference-location-margin.qmd
+++ b/tests/docs/smoke-all/article-layout/margin-location/reference-location-margin.qmd
@@ -1,0 +1,23 @@
+---
+format: html
+reference-location: margin
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ['#callout div.callout + div.column-margin']
+        - []
+---
+
+## Inside callout {#callout}
+
+:::{.callout-tip}
+
+Callout with numbered list
+
+1. blah 2 [^3]
+2. blah 3
+
+:::
+
+[^3]: Sidenote for numbered list inside callout


### PR DESCRIPTION
Fix #8032

I believe we need to process callout first before any other processing. As we were processing list before, the margin element was added inside the callout and not after. 

This fixes #7153 too. I believe blockquote should be treaded like a paragraph
