### PR TITLE
Listing - don’t insert listings by id if that id isn’t present

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -152,6 +152,7 @@
 - ([#7345](https://github.com/quarto-dev/quarto-cli/issues/7345)): Improve display of categories in a table style listing
 - ([#7699](https://github.com/quarto-dev/quarto-cli/issues/7699)): Properly ignore non-HTML output for listings when project level renders render HTML and other formats (for example, a book of both HTML and PDF format)
 - ([#7290](https://github.com/quarto-dev/quarto-cli/issues/7290)): Add support for `feed:type` of `metadata`, which will use only explicitly provided description metadata when generating an RSS feed. Additionally, note that `partial` feed types will prefer to use an explicit description over the first paragraph, when a description is available.
+- ([#8088](https://github.com/quarto-dev/quarto-cli/issues/8088)): [Behavior Change] Do not insert a listing into a page if the listing is targeting an `id` and an element with the `id` isn’t present in the document.
 - Add support for programmatically filtering content from a listing using `include` or `exclude` with glob syntax to include or exclude specific items from the listing. See <https://github.com/quarto-dev/quarto-cli/commit/d415d9ca5b7cb59a8a4750dd3eeb60116b931bd6s>
 
 ## Websites

--- a/src/project/types/website/listing/website-listing-read.ts
+++ b/src/project/types/website/listing/website-listing-read.ts
@@ -1235,7 +1235,13 @@ function listingForMetadata(
   // special behavior
 
   // Use the userId or our synthesized Id
-  listing.id = meta.id as string || synthId();
+  if (meta.id) {
+    listing.id = meta.id as string;
+    listing.autoId = false;
+  } else {
+    listing.id = synthId();
+    listing.autoId = true;
+  }
 
   // Set the sort to our resolve listing (if the user has provided it)
   // If the user hasn't provided a sort, the list will be unsorted
@@ -1331,6 +1337,7 @@ function listingForType(
 ): ListingDehydrated {
   const listing: ListingDehydrated = {
     id: kDefaultId,
+    autoId: true,
     type: type,
     contents: kDefaultContentsGlob,
   };

--- a/src/project/types/website/listing/website-listing-shared.ts
+++ b/src/project/types/website/listing/website-listing-shared.ts
@@ -131,6 +131,7 @@ export interface ListingDehydrated extends Record<string, unknown> {
   id: string;
   type: ListingType;
   contents: Array<string | Metadata>; // globs (or items)
+  autoId: boolean;
 }
 
 export type CategoryStyle =

--- a/src/project/types/website/listing/website-listing-template.ts
+++ b/src/project/types/website/listing/website-listing-template.ts
@@ -95,7 +95,7 @@ export function templateMarkdownHandler(
             // For file modified specifically, include the time portion
             const includeTime = field === kFieldFileModified;
 
-            const date = typeof (dateRaw) === "string"
+            const date = typeof dateRaw === "string"
               ? parsePandocDate(dateRaw as string)
               : dateRaw as Date;
             if (date) {
@@ -219,7 +219,8 @@ export function templateMarkdownHandler(
       // See if there is a target div already in the page
       // This will match our default page layout
       let listingEl = doc.querySelector(`div[id='${listing.id}']`);
-      if (listingEl === null) {
+      if (listingEl === null && listing.autoId) {
+        // This was an automatically provisioned id, just insert this item
         // No target div, cook one up
         const content = doc.querySelector("#quarto-content main.content");
         listingEl = doc.createElement("div");
@@ -255,7 +256,7 @@ export function templateMarkdownHandler(
       }
 
       const renderedEl = rendered[pipelineId(listing.id)];
-      if (renderedEl) {
+      if (renderedEl && listingEl) {
         listingEl.innerHTML = renderedEl.innerHTML;
       }
     },


### PR DESCRIPTION
In older versions of Quarto, we would always insert all listings (including listings which specify an `id` that they should target) whether or not an element with `id` was present to insert the listing into.

This change makes it so we will not insert a listing into a page if the listing is targeting an `id`  and an element with the `id` isn’t present in the document. This is required to support things like conditional targets for listings - the conditionality removes the target, but the post-processor isn’t aware of that and so was always just appending all the listings with missing targets.

I considered throwing in this case, but that defeats the conditional target specific to the reported issue.

Fixes #8088

