### PR TITLE
css - do not add nested borders

### DIFF
--- a/src/resources/formats/html/_quarto-rules.scss
+++ b/src/resources/formats/html/_quarto-rules.scss
@@ -686,6 +686,12 @@ input[type="checkbox"] {
   margin-right: 0.5ch;
 }
 
+// don't nest borders
+// https://github.com/quarto-dev/quarto-cli/issues/8000
+.border .border {
+  border: inherit !important;
+}
+
 // Mermaid Theming
 // if none come from theme, we need these
 $body-color: #222 !default;


### PR DESCRIPTION
Closes #8000.

This is slightly broader than the narrowest possible fix, and doesn't address padding. I'm not sure if we want to improve on it or not. I'm on the fence.