### PR TITLE
lua,meta - resolve int keys as ints

### DIFF
--- a/src/resources/filters/quarto-pre/options.lua
+++ b/src/resources/filters/quarto-pre/options.lua
@@ -40,11 +40,13 @@ end
 
 function parseOption(name, options, def) 
   local keys = split(name, ".")
+  quarto.log.output(keys)
   local value = nil
   for i, key in ipairs(keys) do
     if value == nil then
       value = readOption(options, key, nil)
     else
+      key = tonumber(key) or key
       value = value[key]
     end
 

--- a/tests/docs/smoke-all/2024/01/03/issue-8086.qmd
+++ b/tests/docs/smoke-all/2024/01/03/issue-8086.qmd
@@ -1,0 +1,19 @@
+---
+title: issue-8086
+testkey:
+  - "value 1"
+  - "value 2"
+testkey2:
+  testkey: testvalue
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - 
+          - "testvalue"
+          - "value 1"
+---
+
+{{< meta testkey.1 >}}
+
+{{< meta testkey2.testkey >}}


### PR DESCRIPTION
Closes #8086.

This "resolves" the issue by allowing meta arrays to be indexed. The syntax is a bit clunky, but the regression test includes a minimal example:

```
---
title: issue-8086
testkey:
  - "value 1"
  - "value 2"
testkey2:
  testkey: testvalue
_quarto:
  tests:
    html:
      ensureFileRegexMatches:
        - 
          - "testvalue"
          - "value 1"
---

{{< meta testkey.1 >}}

{{< meta testkey2.testkey >}}
```