### PR TITLE
Show failed metadata filename in error

### DIFF
--- a/src/project/project-shared.ts
+++ b/src/project/project-shared.ts
@@ -293,7 +293,7 @@ export async function directoryMetadataForInputFile(
       // There is a metadata file, read it and merge it
       // Note that we need to convert paths that are relative
       // to the metadata file to be relative to input
-      const errMsg = "Directory metadata validation failed.";
+      const errMsg = "Directory metadata validation failed for " + file + ".";
       const yaml = ((await readAndValidateYamlFromFile(
         file,
         frontMatterSchema,


### PR DESCRIPTION
When parsing a _metadata.yml fails, the current error starts:

```
Preparing to preview
ERROR: Directory metadata validation failed.

(line 1, column 1) YAML value is missing.
```

I accidentally made an empty `_metadata.yml`, and didn't realise what the problematic file was. This PR improves the error to include the file which failed, like this:

```
> quarto preview --port 8888
Preparing to preview
ERROR: Directory metadata validation failed for /home/caj/files/web/quarto-site/group-book/_metadata.yml.

(line 1, column 1) YAML value is missing.
```

I'm not sure if there is a better way to do this, open to suggestions.