### PR TITLE
Lua - don't forward classes from image to floats or figures

### DIFF
--- a/src/resources/filters/layout/html.lua
+++ b/src/resources/filters/layout/html.lua
@@ -171,7 +171,13 @@ function renderHtmlFigure(el, render)
   end
 
   -- create figure div
-  local figureDiv = pandoc.Div({}, pandoc.Attr(el.identifier, el.classes, figureAttr))
+  local figureDiv = pandoc.Div({}, pandoc.Attr(el.identifier, {}, figureAttr))
+  figureDiv.classes = el.classes:filter(function(str) 
+    if str:match("quarto%-figure.*") then
+      return true
+    end
+    return false
+  end)
 
   -- remove identifier (it is now on the div)
   el.identifier = ""

--- a/src/resources/filters/layout/pandoc3_figure.lua
+++ b/src/resources/filters/layout/pandoc3_figure.lua
@@ -50,8 +50,10 @@ function render_pandoc3_figure()
       image.caption = quarto.utils.as_inlines(figure.caption.long)
     end
     -- TODO need to find all correct classes to forward
-    if figure.classes:includes("margin-caption") then
-      image.classes:insert("margin-caption")
+    for i, v in pairs(figure.classes) do
+      if v:match("^margin%-") or v:match("^quarto%-") or v:match("^column%-") then
+        image.classes:insert(v)
+      end
     end
     return htmlImageFigure(image)
   end

--- a/tests/docs/smoke-all/2024/01/05/issue-8000.qmd
+++ b/tests/docs/smoke-all/2024/01/05/issue-8000.qmd
@@ -1,0 +1,38 @@
+---
+title: issue-8000
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - 
+          - "div#fig-2.border"
+        -
+          - "div#fig-1.border"
+          - "div#fig-3.border"
+          - "#scaffold div.border"
+---
+
+::: {#scaffold}
+
+![An _image_ with border](https://placeholder.co/400){.border fig-alt="And alt text."}
+
+:::
+
+![An _image_ with border](https://placeholder.co/400){#fig-1 .border fig-alt="And alt text."}
+
+
+::: {#fig-2 .border}
+
+![](https://placeholder.co/400)
+
+A _figure_ with border.
+
+:::
+
+::: {#fig-3}
+
+![](https://placeholder.co/400){.border}
+
+An image with border again.
+
+:::


### PR DESCRIPTION
This closes #8000.

The proper fix for the bug is for floats to not get the image classes, unless explicitly asked for. This also restores the behavior from 1.3.