### PR TITLE
Error with helpful message when publishing to Github pages and no `gh-pages` branch

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -207,6 +207,7 @@
 
 - ([#5436](https://github.com/quarto-dev/quarto-cli/issues/5436)): Add support for publishing to Posit Cloud.
 - ([#5220](https://github.com/quarto-dev/quarto-cli/issues/5220)): Properly respect `output-dir` when publishin individual files in a default Quarto project
+- ([#4498](https://github.com/quarto-dev/quarto-cli/issues/4498)): Better error when `quarto publish gh-pages` fails because `gh-pages` branch does not exist on `origin` remote.
 
 ## Video (and Audio)
 

--- a/src/publish/gh-pages/gh-pages.ts
+++ b/src/publish/gh-pages/gh-pages.ts
@@ -96,6 +96,10 @@ async function publishRecord(
       id: "gh-pages",
       url: ghContext.siteUrl || ghContext.originUrl,
     };
+  } else {
+    throwUnableToPublish(
+      'the remote origin does not have a branch named "gh-pages". Use first `quarto publish gh-pages` locally to initialize the remote repository for publishing.',
+    );
   }
 }
 


### PR DESCRIPTION
This 
* fixes #4498 
* fixes quarto-ext/manuscript-template-rstudio#1 

`gh-pages` needs to be existing when publishing with `--no-prompt`. This could happen when initialiazing a new repo on CI without calling `quarto publish gh-pages` first locally, or creating the `gh-pages` branch manually.

This PR adds an error in the function that checks for it to have a more helpful error 