### PR TITLE
use explicit path to sysctl

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -29,5 +29,6 @@
 ## Other Fixes
 
 - ([#8119](https://github.com/quarto-dev/quarto-cli/issues/8119)): More intelligently detect when ejs templates are modified during development, improving quality of life during preview.
+- ([#8177](https://github.com/quarto-dev/quarto-cli/issues/8177)): Use an explicit path to `sysctl` when detecting MacOS architecture. (author: @kevinushey)
 - Add support for `{{< lipsum >}}` shortcode, which is useful for emitting placeholder text. Specify a specific number of paragraphs (`{{< lipsum 3 >}}`).
 - Increase v8's max heap size by default, to avoid out-of-memory errors when rendering large documents (also cf. https://github.com/denoland/deno/issues/18935).

--- a/package/scripts/common/quarto
+++ b/package/scripts/common/quarto
@@ -126,7 +126,7 @@ fi
 if [[ $OSTYPE == 'darwin'* ]]; then
   # We cannot use uname to determine the _machine_ architecture:
   # https://github.com/quarto-dev/quarto-cli/issues/2420#issuecomment-1245768732
-  FULLARCH="$(sysctl machdep.cpu.brand_string)"
+  FULLARCH="$(/usr/sbin/sysctl machdep.cpu.brand_string)"
   
   if [[ $FULLARCH == *"Intel"* ]]; then
     ARCH_DIR=x86_64

--- a/package/scripts/macos/pkg/postinstall
+++ b/package/scripts/macos/pkg/postinstall
@@ -29,7 +29,7 @@ ln -fs $2/share/man/quarto.man /usr/local/man/quarto.1
 fi
 
 ## Detect the current architecture and create symlink
-FULLARCH="$(sysctl machdep.cpu.brand_string)"
+FULLARCH="$(/usr/sbin/sysctl machdep.cpu.brand_string)"
   if [[ $FULLARCH == *"Intel"* ]]; then
   ARCH_DIR=x86_64
 else


### PR DESCRIPTION
Some RStudio users have reported issues with the way running `sysctl`, presumedly because `/usr/sbin` is not on the PATH when quarto is being run. This is rather unexpected, but I think it makes sense for quarto to defend against this?

Related: https://github.com/rstudio/rstudio/issues/13993