### PR TITLE
Correctly merged custom field-types in Listings with default

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -153,6 +153,7 @@
 - ([#7699](https://github.com/quarto-dev/quarto-cli/issues/7699)): Properly ignore non-HTML output for listings when project level renders render HTML and other formats (for example, a book of both HTML and PDF format)
 - ([#7290](https://github.com/quarto-dev/quarto-cli/issues/7290)): Add support for `feed:type` of `metadata`, which will use only explicitly provided description metadata when generating an RSS feed. Additionally, note that `partial` feed types will prefer to use an explicit description over the first paragraph, when a description is available.
 - Add support for programmatically filtering content from a listing using `include` or `exclude` with glob syntax to include or exclude specific items from the listing. See <https://github.com/quarto-dev/quarto-cli/commit/d415d9ca5b7cb59a8a4750dd3eeb60116b931bd6s>
+- ([#8197](https://github.com/quarto-dev/quarto-cli/issues/8197)): Custom `field-types` are now correctly merged with default values for website listings.
 
 ## Websites
 

--- a/src/project/types/website/listing/website-listing-read.ts
+++ b/src/project/types/website/listing/website-listing-read.ts
@@ -594,8 +594,8 @@ function hydrateListing(
 
   const listingHydrated: Listing = cloneDeep({
     fields: hydratedFields,
-    [kFieldDisplayNames]: {},
-    [kFieldTypes]: kDefaultFieldTypes,
+    [kFieldDisplayNames]: {}, // default values are merged later
+    [kFieldTypes]: {}, // default values are merged later
     [kFieldLinks]: defaultLinks,
     [kFieldSort]: defaultSort,
     [kFieldFilter]: hydratedFields,
@@ -660,7 +660,7 @@ function hydrateListing(
 
   // Merge column types
   listingHydrated[kFieldTypes] = {
-    ...listingHydrated[kFieldTypes],
+    ...kDefaultFieldTypes,
     ...listing[kFieldTypes] as Record<string, ColumnType>,
   };
 


### PR DESCRIPTION
Providing `field-types` in YAML was overriding the default values. Custom values need to be merged properly with the default values.

fix #8197 

@dragonstyle can we add some test for listings ? 

Feel free to tweak if you don't think this is the right way to fix
