### PR TITLE
Adding translations for tools-share and tools-download in spanish and brazilian portuguese

### DIFF
--- a/src/resources/language/_language-es.yml
+++ b/src/resources/language/_language-es.yml
@@ -51,6 +51,9 @@ code-tools-hide-all-code: "Ocultar todo el código"
 code-tools-view-source: "Ver el código fuente"
 code-tools-source-code: "Ejecutar el código"
 
+tools-share: "Compartir"
+tools-download: "Descargar"
+
 copy-button-tooltip: "Copiar al portapapeles"
 copy-button-tooltip-success: "Copiado"
 

--- a/src/resources/language/_language-pt-BR.yml
+++ b/src/resources/language/_language-pt-BR.yml
@@ -50,6 +50,9 @@ code-tools-hide-all-code: "Esconder o código"
 code-tools-view-source: "Ver o código fonte"
 code-tools-source-code: "Código fonte"
 
+tools-share: "Compartilhar"
+tools-download: "Baixar"
+
 copy-button-tooltip: "Copiar para a área de transferência"
 copy-button-tooltip-success: "Copiada"
 


### PR DESCRIPTION
## Description

Adding translations for `tools-share` and `tools-download` in spanish (es) and brazilian portuguese (pt-BR) taking into account the changes made in #8169 by fixing #8145

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
