### PR TITLE
Correctly place the error about gh-pages being required for github pages deployment

### DIFF
--- a/src/command/publish/deployment.ts
+++ b/src/command/publish/deployment.ts
@@ -26,6 +26,7 @@ import {
   publishRecordIdentifier,
   readAccountsPublishedTo,
 } from "../../publish/common/data.ts";
+import { kGhpages } from "../../publish/gh-pages/gh-pages.ts";
 
 export async function resolveDeployment(
   options: PublishOptions,
@@ -84,7 +85,7 @@ export async function resolveDeployment(
         }
       } else {
         return await chooseDeployment(deployments);
-      } 
+      }
     } else if (deployments.length === 1) {
       return deployments[0];
     } else {
@@ -95,7 +96,12 @@ export async function resolveDeployment(
   } else if (!options.prompt) {
     // if we get this far then an existing deployment has not been chosen,
     // if --no-prompt is specified then this is an error state
-    if (!options.prompt) {
+    if (providerFilter === kGhpages) {
+      // special case for gh-pages where no _publish.yml is required but a gh-pages branch is
+      throw new Error(
+        `Unable to publish to GitHub Pages (the remote origin does not have a branch named "gh-pages". Use first \`quarto publish gh-pages\` locally to initialize the remote repository for publishing.)`,
+      );
+    } else {
       throw new Error(
         `No _publish.yml file available (_publish.yml specifying a destination required for non-interactive publish)`,
       );

--- a/src/publish/gh-pages/gh-pages.ts
+++ b/src/publish/gh-pages/gh-pages.ts
@@ -96,10 +96,6 @@ async function publishRecord(
       id: "gh-pages",
       url: ghContext.siteUrl || ghContext.originUrl,
     };
-  } else {
-    throwUnableToPublish(
-      'the remote origin does not have a branch named "gh-pages". Use first `quarto publish gh-pages` locally to initialize the remote repository for publishing.',
-    );
   }
 }
 


### PR DESCRIPTION
This adapt commit 69cc07b29c893fe29c9c553442bae81255715bd4 (#8161) to fix #8221

It happened that we do check publish record  for each provider supported when no deployment target is provided in `quarto render`. And for Github Pages, the publish record is in fact the `gh-pages` branch existence as we do not seem to create a `_publish.yml` in that case.
