### PR TITLE
lua - treat prefix as 'fig' if prefix exists but has not been declared as crossref

### DIFF
--- a/src/resources/filters/customnodes/floatreftarget.lua
+++ b/src/resources/filters/customnodes/floatreftarget.lua
@@ -115,7 +115,7 @@ function cap_location(float_or_layout)
     ref = refType(float_or_layout.attributes["ref-parent"] or "")
   end
   -- last resort, pretend we're a figure
-  if ref == nil then
+  if ref == nil or crossref.categories.by_ref_type[ref] == nil then
     ref = "fig"
   end
   local qualified_key = ref .. '-cap-location'

--- a/tests/docs/smoke-all/2024/01/11/8234.qmd
+++ b/tests/docs/smoke-all/2024/01/11/8234.qmd
@@ -1,0 +1,5 @@
+---
+title: baddd
+---
+
+![Data science project model](https://placeholder.co/400){#data-science-model fig-align="center"}


### PR DESCRIPTION
This closes #8234.