### PR TITLE
Remove `keep-yaml` from reference doc as no more used

### DIFF
--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -16248,17 +16248,6 @@ var require_yaml_intelligence_resources = __commonJS({
           description: "Specify whether to use `atx` (`#`-prefixed) or\n`setext` (underlined) headings for level 1 and 2\nheadings (`atx` or `setext`).\n"
         },
         {
-          name: "keep-yaml",
-          tags: {
-            formats: [
-              "$markdown-all"
-            ]
-          },
-          schema: "boolean",
-          default: false,
-          description: "Preserve the original YAML front matter in rendered markdown"
-        },
-        {
           name: "ipynb-output",
           tags: {
             formats: [
@@ -19812,7 +19801,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "A list of input documents that should be treated as drafts",
         {
           short: "How to handle drafts that are encountered.",
-          long: "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to."
+          long: "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to (default)."
         },
         "Book title",
         "Description metadata for HTML version of book",
@@ -19958,7 +19947,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "A list of input documents that should be treated as drafts",
         {
           short: "How to handle drafts that are encountered.",
-          long: "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to."
+          long: "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to (default)."
         },
         "Book subtitle",
         "Author or authors of the book",
@@ -22153,7 +22142,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "A list of input documents that should be treated as drafts",
         {
           short: "How to handle drafts that are encountered.",
-          long: "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to."
+          long: "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to (default)."
         },
         "Book subtitle",
         "Author or authors of the book",
@@ -22483,7 +22472,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "A list of input documents that should be treated as drafts",
         {
           short: "How to handle drafts that are encountered.",
-          long: "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to."
+          long: "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to (default)."
         },
         "Book subtitle",
         "Author or authors of the book",
@@ -22880,12 +22869,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 182026,
+        _internalId: 182024,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 182018,
+            _internalId: 182016,
             type: "enum",
             enum: [
               "png",
@@ -22901,7 +22890,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 182025,
+            _internalId: 182023,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -16249,17 +16249,6 @@ try {
             description: "Specify whether to use `atx` (`#`-prefixed) or\n`setext` (underlined) headings for level 1 and 2\nheadings (`atx` or `setext`).\n"
           },
           {
-            name: "keep-yaml",
-            tags: {
-              formats: [
-                "$markdown-all"
-              ]
-            },
-            schema: "boolean",
-            default: false,
-            description: "Preserve the original YAML front matter in rendered markdown"
-          },
-          {
             name: "ipynb-output",
             tags: {
               formats: [
@@ -19813,7 +19802,7 @@ try {
           "A list of input documents that should be treated as drafts",
           {
             short: "How to handle drafts that are encountered.",
-            long: "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to."
+            long: "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to (default)."
           },
           "Book title",
           "Description metadata for HTML version of book",
@@ -19959,7 +19948,7 @@ try {
           "A list of input documents that should be treated as drafts",
           {
             short: "How to handle drafts that are encountered.",
-            long: "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to."
+            long: "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to (default)."
           },
           "Book subtitle",
           "Author or authors of the book",
@@ -22154,7 +22143,7 @@ try {
           "A list of input documents that should be treated as drafts",
           {
             short: "How to handle drafts that are encountered.",
-            long: "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to."
+            long: "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to (default)."
           },
           "Book subtitle",
           "Author or authors of the book",
@@ -22484,7 +22473,7 @@ try {
           "A list of input documents that should be treated as drafts",
           {
             short: "How to handle drafts that are encountered.",
-            long: "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to."
+            long: "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to (default)."
           },
           "Book subtitle",
           "Author or authors of the book",
@@ -22881,12 +22870,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 182026,
+          _internalId: 182024,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 182018,
+              _internalId: 182016,
               type: "enum",
               enum: [
                 "png",
@@ -22902,7 +22891,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 182025,
+              _internalId: 182023,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -9220,17 +9220,6 @@
       "description": "Specify whether to use `atx` (`#`-prefixed) or\n`setext` (underlined) headings for level 1 and 2\nheadings (`atx` or `setext`).\n"
     },
     {
-      "name": "keep-yaml",
-      "tags": {
-        "formats": [
-          "$markdown-all"
-        ]
-      },
-      "schema": "boolean",
-      "default": false,
-      "description": "Preserve the original YAML front matter in rendered markdown"
-    },
-    {
       "name": "ipynb-output",
       "tags": {
         "formats": [
@@ -12784,7 +12773,7 @@
     "A list of input documents that should be treated as drafts",
     {
       "short": "How to handle drafts that are encountered.",
-      "long": "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to."
+      "long": "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to (default)."
     },
     "Book title",
     "Description metadata for HTML version of book",
@@ -12930,7 +12919,7 @@
     "A list of input documents that should be treated as drafts",
     {
       "short": "How to handle drafts that are encountered.",
-      "long": "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to."
+      "long": "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to (default)."
     },
     "Book subtitle",
     "Author or authors of the book",
@@ -15125,7 +15114,7 @@
     "A list of input documents that should be treated as drafts",
     {
       "short": "How to handle drafts that are encountered.",
-      "long": "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to."
+      "long": "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to (default)."
     },
     "Book subtitle",
     "Author or authors of the book",
@@ -15455,7 +15444,7 @@
     "A list of input documents that should be treated as drafts",
     {
       "short": "How to handle drafts that are encountered.",
-      "long": "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to."
+      "long": "How to handle drafts that are encountered.\n<code>visible</code> - the draft will visible and fully available\n<code>unlinked</code> - the draft will be rendered, but will not appear\nin navigation, search, or listings. <code>gone</code> - the draft will\nhave no content and will not be linked to (default)."
     },
     "Book subtitle",
     "Author or authors of the book",
@@ -15852,12 +15841,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 182026,
+    "_internalId": 182024,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 182018,
+        "_internalId": 182016,
         "type": "enum",
         "enum": [
           "png",
@@ -15873,7 +15862,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 182025,
+        "_internalId": 182023,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/schema/document-options.yml
+++ b/src/resources/schema/document-options.yml
@@ -285,13 +285,6 @@
     `setext` (underlined) headings for level 1 and 2
     headings (`atx` or `setext`).
 
-- name: keep-yaml
-  tags:
-    formats: [$markdown-all]
-  schema: boolean
-  default: false
-  description: "Preserve the original YAML front matter in rendered markdown"
-
 - name: ipynb-output
   tags:
     formats: [ipynb]


### PR DESCRIPTION
As discussed in #4210, `keep-yaml` as a user option was removed in a7f26f0 and is not more available since  v1.2.160

No more occurrence in our code except for the doc: https://github.com/search?q=repo%3Aquarto-dev%2Fquarto-cli+keep-yaml&type=code

closes #4210

@dragonstyle @cscheid is it safe to remove a field from all JS files like that? 

