### PR TITLE
Add a try catch to prevent reading registry errors on windows

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -387,3 +387,4 @@
 - ([#7674](https://github.com/quarto-dev/quarto-cli/pull/7674)): Configure font paths for TinyTeX after installation so that `xetex` can find custom fonts correctly.
 - ([#7675](https://github.com/quarto-dev/quarto-cli/pull/7675)): On Windows, `quarto install tinytex` will install TinyTeX to the directory defined by the environment variable `ProgramData` when `APPDATA` is not a suitable location for TeX Live.
 - ([#8086](https://github.com/quarto-dev/quarto-cli/issues/8086)): Add support for indexing array metadata in `meta` shortcode.
+- ([#8245](https://github.com/quarto-dev/quarto-cli/issues/8245)): On Windows, prevent Quarto error due to access issue when trying to read codepage from registry.

--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -15,7 +15,7 @@ import { Command } from "cliffy/command/mod.ts";
 import { getenv } from "./env.ts";
 import { Args } from "flags/mod.ts";
 import { lines } from "./text.ts";
-import { error, getLogger, setup, warning } from "log/mod.ts";
+import { debug, error, getLogger, setup, warning } from "log/mod.ts";
 import { asErrorEx, InternalError } from "./lib/error.ts";
 
 export type LogLevel = "DEBUG" | "INFO" | "WARNING" | "ERROR";
@@ -334,6 +334,14 @@ export function warnOnce(msg: string) {
   }
 }
 const warnings: Record<string, boolean> = {};
+
+export function debugOnce(msg: string) {
+  if (!debugs[msg]) {
+    debugs[msg] = true;
+    debug(msg);
+  }
+}
+const debugs: Record<string, boolean> = {};
 
 function applyMsgOptions(msg: string, options: LogMessageOptions) {
   if (options.indent) {

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -6,7 +6,7 @@
 
 import { ProcessResult } from "./process-types.ts";
 import { execProcess } from "./process.ts";
-import { debug } from "log/mod.ts";
+import { debugOnce } from "./log.ts";
 
 export const kHKeyCurrentUser = "HKCU";
 export const kHKeyLocalMachine = "HKLM";
@@ -44,7 +44,7 @@ export async function registryReadString(
       stderr: "null",
     });
   } catch (e) {
-    debug(`Fail to read from registry: ${e}`);
+    debugOnce(`Fail to read from registry: ${e}`);
     return undefined;
   }
   if (result.success && result.stdout) {

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -1,11 +1,12 @@
 /*
-* registry.ts
-*
-* Copyright (C) 2020-2022 Posit Software, PBC
-*
-*/
+ * registry.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
 
+import { ProcessResult } from "./process-types.ts";
 import { execProcess } from "./process.ts";
+import { debug } from "log/mod.ts";
 
 export const kHKeyCurrentUser = "HKCU";
 export const kHKeyLocalMachine = "HKLM";
@@ -35,11 +36,17 @@ export async function registryReadString(
     "/v",
     value,
   ];
-  const result = await execProcess({
-    cmd,
-    stdout: "piped",
-    stderr: "null",
-  });
+  let result: ProcessResult;
+  try {
+    result = await execProcess({
+      cmd,
+      stdout: "piped",
+      stderr: "null",
+    });
+  } catch (e) {
+    debug(`Fail to read from registry: ${e}`);
+    return undefined;
+  }
   if (result.success && result.stdout) {
     const typePos = result.stdout?.indexOf(kTypeString);
     if (typePos !== -1) {


### PR DESCRIPTION
closes #8245

This adds a try-catch around all the registry reading calls to avoid Quarto not working if there is an issue in registry reading (like access denied somehow). 

I added a debug message, but I thought it was better to have it only thrown once when `QUARTO_LOG_LEVEL=DEBUG` so I added the `debugOnce()` wrapper for `debug()` like `warning()` and `error()`

It seems quite safe as we are just returning `undefined` in case of `execProcess()` error. 

