### PR TITLE
Improved EJS caching

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -1,3 +1,5 @@
 All changes included in 1.5:
 
+## Other Fixes
 
+- ([#8119](https://github.com/quarto-dev/quarto-cli/issues/8119)): More intelligently detect when ejs templates are modified during development, improving quality of life during preview.


### PR DESCRIPTION
In Quarto 1.4, we cache the EJS templates for the life of the process. This is usually find, but while developing custom templates using preview, this means that the preview server must be terminated to reload changes in custom templates.

Instead, use the modified time as a simple check to invalidate the cache.  Cleanup the typing while in there.

Fixes #8119
