### PR TITLE
Docusaurus: reactPreamble not rendering

### DIFF
--- a/src/resources/extensions/quarto/docusaurus/_extension.yml
+++ b/src/resources/extensions/quarto/docusaurus/_extension.yml
@@ -30,7 +30,7 @@ contributes:
       fig-height: 5
       html-math-method: webtex
       filters:
-        - at: post-quarto
+        - at: post-render
           path: docusaurus.lua
         - at: post-finalize
           path: docusaurus_citeproc.lua

--- a/src/resources/extensions/quarto/docusaurus/docusaurus.lua
+++ b/src/resources/extensions/quarto/docusaurus/docusaurus.lua
@@ -6,6 +6,14 @@ local rawHtmlVars = pandoc.List()
 
 local code_block = require('docusaurus_utils').code_block
 
+local reactPreamble = pandoc.List()
+
+local function addPreamble(preamble)
+  if not reactPreamble:includes(preamble) then
+    reactPreamble:insert(preamble)
+  end
+end
+
 local function Pandoc(doc)
   -- insert exports at the top if we have them
   if #rawHtmlVars > 0 then
@@ -16,6 +24,12 @@ local function Pandoc(doc)
       )
     )
     doc.blocks:insert(1, pandoc.RawBlock("markdown", exports .. "\n"))
+  end
+
+  -- insert react preamble if we have it
+  if #reactPreamble > 0 then
+    local preamble = table.concat(reactPreamble, "\n")
+    doc.blocks:insert(1, pandoc.RawBlock("markdown", preamble .. "\n"))
   end
 
   return doc
@@ -60,14 +74,6 @@ end
 
 local function CodeBlock(el)
   return code_block(el, el.attr.attributes["filename"])
-end
-
-local reactPreamble = pandoc.List()
-
-local function addPreamble(preamble)
-  if not reactPreamble:includes(preamble) then
-    reactPreamble:insert(preamble)
-  end
 end
 
 local function jsx(content)

--- a/tests/docs/smoke-all/2024/01/16/8289.qmd
+++ b/tests/docs/smoke-all/2024/01/16/8289.qmd
@@ -1,0 +1,26 @@
+---
+title: foo
+format: docusaurus-md
+_quarto:
+  tests:
+    docusaurus-md:
+      ensureFileRegexMatches:
+        - ["import Tabs"]
+        - []
+---
+
+:::{.panel-tabset}
+
+## Not work
+
+```{.python filename="Python"}
+print("bar")
+```
+
+## Work
+
+```{.python}
+print("bar")
+```
+
+:::

--- a/tests/docs/smoke-all/crossrefs/float/hugo/hugo-float-numbering-1.qmd
+++ b/tests/docs/smoke-all/crossrefs/float/hugo/hugo-float-numbering-1.qmd
@@ -10,9 +10,9 @@ _quarto:
     hugo-md:
       ensureFileRegexMatches:
         - 
-          - "Figure&nbsp;x: Elephant"
-          - "Table&nbsp;A: My Caption"
-          - "Figure&nbsp;y: Famous Elephants"
+          - "Figure x: Elephant" # NB: there's a non-breaking space in there
+          - "Table A: My Caption" # same
+          - "Figure y: Famous Elephants" # same
           - "\\(i\\) Surus"
           - "\\(ii\\) Abbas"
 ---

--- a/tests/docs/smoke-all/crossrefs/float/hugo/hugo-float-options-1.qmd
+++ b/tests/docs/smoke-all/crossrefs/float/hugo/hugo-float-options-1.qmd
@@ -11,9 +11,9 @@ _quarto:
     hugo-md:
       ensureFileRegexMatches:
         - 
-          - "Figure&nbsp;1— Elephant"
-          - "See T.&nbsp;1."
-          - "See F.&nbsp;1."
+          - "Figure 1— Elephant" # NB there's a non-breaking space here
+          - "See T\\. 1\\." # NB same as above
+          - "See F\\. 1" # NB same as above
         -
           - "<a href=\"#tbl-letters\" class=\"quarto-xref\">" # ref-hyperlink: false
 ---

--- a/tests/docs/smoke-all/crossrefs/float/hugo/hugo-knitr-table-captions-1.qmd
+++ b/tests/docs/smoke-all/crossrefs/float/hugo/hugo-knitr-table-captions-1.qmd
@@ -12,7 +12,7 @@ _quarto:
           - "<div id=\"tbl-pressure\">"
           - "\\(a\\) Cars"
           - "\\(b\\) Pressure"
-          - "Table 1: Tables"
+          - "Table 1: Tables" # NB there's a non-breaking space here 
         - []
 ---
 

--- a/tests/docs/smoke-all/crossrefs/float/hugo/rawtablecaption.qmd
+++ b/tests/docs/smoke-all/crossrefs/float/hugo/rawtablecaption.qmd
@@ -7,7 +7,7 @@ _quarto:
       ensureFileRegexMatches:
         - 
           - "<div id=\"tbl-1\">"
-          - "Table 1: This is a caption."
+          - "Table 1: This is a caption." # NB there's a non-breaking space here 
           - "<a href=\"#tbl-1\" class=\"quarto-xref\">"
         - []
 ---


### PR DESCRIPTION
Closes #8289. This PR:

- Fixes filter so that `reactPreamble` is rendered to output
- removes `_quarto` from preserved yaml block so that smoke tests are properly run
