### PR TITLE
Website: Support announcement bar

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -4,6 +4,10 @@ All changes included in 1.5:
 
 - ([#8118](https://github.com/quarto-dev/quarto-cli/issues/8118)): Add support for `body-classes` to add classes to the document body.
 
+## Website
+
+- ([#8294](https://github.com/quarto-dev/quarto-cli/issues/8294)): Add support for website announcements, using the `announcement` key under `website`.
+
 ## Other Fixes
 
 - ([#8119](https://github.com/quarto-dev/quarto-cli/issues/8119)): More intelligently detect when ejs templates are modified during development, improving quality of life during preview.

--- a/src/project/types/website/website-config.ts
+++ b/src/project/types/website/website-config.ts
@@ -73,7 +73,8 @@ type WebsiteConfigKey =
   | "comments"
   | "other-links"
   | "code-links"
-  | "reader-mode";
+  | "reader-mode"
+  | "announcement";
 
 export function websiteConfigBoolean(
   name: WebsiteConfigKey,

--- a/src/project/types/website/website-constants.ts
+++ b/src/project/types/website/website-constants.ts
@@ -35,6 +35,8 @@ export const kMarginFooter = "margin-footer";
 export const kBodyHeader = "body-header";
 export const kBodyFooter = "body-footer";
 
+export const kAnnouncement = "announcement";
+
 export const kContents = "contents";
 
 export const kTwitterCard = "twitter-card";

--- a/src/project/types/website/website-navigation-md.ts
+++ b/src/project/types/website/website-navigation-md.ts
@@ -21,13 +21,13 @@ import {
   BodyDecorators,
   flattenItems,
   Navigation,
+  NavigationAnnouncement,
   NavigationPagination,
   PageMargin,
 } from "./website-shared.ts";
 import { removeChapterNumber } from "./website-utils.ts";
 import { MarkdownPipelineHandler } from "../../../core/markdown-pipeline.ts";
 import { safeExistsSync } from "../../../core/path.ts";
-import { md5Hash } from "../../../core/hash.ts";
 
 const kSidebarTitleId = "quarto-int-sidebar-title";
 const kNavbarTitleId = "quarto-int-navbar-title";
@@ -47,6 +47,7 @@ export interface NavigationPipelineContext {
   bodyDecorators?: BodyDecorators;
   breadCrumbs?: SidebarItem[];
   pageNavigation: NavigationPagination;
+  announcement?: NavigationAnnouncement;
 }
 
 export function navigationMarkdownHandlers(context: NavigationPipelineContext) {
@@ -62,6 +63,7 @@ export function navigationMarkdownHandlers(context: NavigationPipelineContext) {
     marginHeaderFooterHandler(context),
     bodyHeaderFooterHandler(context),
     breadCrumbHandler(context),
+    announcementHandler(context),
   ];
 }
 
@@ -219,6 +221,25 @@ const breadCrumbHandler = (context: NavigationPipelineContext) => {
         if (renderedEl) {
           breadCrumbEl.innerHTML = renderedEl.innerHTML;
         }
+      }
+    },
+  };
+};
+
+const announcementHandler = (context: NavigationPipelineContext) => {
+  return {
+    getUnrendered() {
+      if (context.announcement?.content) {
+        return { blocks: { announcement: context.announcement.content } };
+      }
+    },
+    processRendered(rendered: Record<string, Element>, doc: Document) {
+      const announceEl = doc.querySelector(
+        "#quarto-announcement .quarto-announcement-content",
+      );
+      if (announceEl) {
+        const renderedEl = rendered["announcement"];
+        announceEl.innerHTML = renderedEl.innerHTML;
       }
     },
   };

--- a/src/project/types/website/website-navigation.ts
+++ b/src/project/types/website/website-navigation.ts
@@ -378,6 +378,7 @@ export async function websiteNavigationExtras(
     pageNavigation,
     bodyDecorators: navigation.bodyDecorators,
     breadCrumbs: navigation.breadCrumbs,
+    announcement: navigation.announcement,
   });
   const markdownPipeline = createMarkdownPipeline(
     "quarto-navigation-envelope",

--- a/src/project/types/website/website-navigation.ts
+++ b/src/project/types/website/website-navigation.ts
@@ -158,6 +158,7 @@ export async function initWebsiteNavigation(project: ProjectContext) {
     footer,
     pageMargin,
     bodyDecorators,
+    announcement,
   } = websiteNavigationConfig(
     project,
   );
@@ -191,6 +192,7 @@ export async function initWebsiteNavigation(project: ProjectContext) {
   navigation.bodyDecorators = bodyDecorators;
 
   navigation.pageMargin = pageMargin;
+  navigation.announcement = announcement;
 }
 
 export async function websiteNoThemeExtras(
@@ -295,6 +297,7 @@ export async function websiteNavigationExtras(
       true,
       project.config,
     ),
+    announcement: navigation.announcement,
   };
 
   // Determine the previous and next page

--- a/src/project/types/website/website-shared.ts
+++ b/src/project/types/website/website-shared.ts
@@ -23,6 +23,7 @@ import {
   SidebarItem,
 } from "../../types.ts";
 import {
+  kAnnouncement,
   kBodyFooter,
   kBodyHeader,
   kMarginFooter,
@@ -42,6 +43,7 @@ import {
 import { cookieConsentEnabled } from "./website-analytics.ts";
 import { Format, FormatExtras } from "../../../config/types.ts";
 import { kPageTitle, kTitle, kTitlePrefix } from "../../../config/constants.ts";
+import { md5Hash } from "../../../core/hash.ts";
 export { type NavigationFooter } from "../../types.ts";
 
 export interface Navigation {
@@ -52,6 +54,7 @@ export interface Navigation {
   pageMargin?: PageMargin;
   bodyDecorators?: BodyDecorators;
   breadCrumbs?: SidebarItem[];
+  announcement?: NavigationAnnouncement;
 }
 
 export interface NavigationPagination {
@@ -67,6 +70,14 @@ export interface PageMargin {
 export interface BodyDecorators {
   header?: string[];
   footer?: string[];
+}
+
+export interface NavigationAnnouncement {
+  id: string;
+  content: string;
+  dismissable: boolean;
+  type: string;
+  icon?: string;
 }
 
 export function computePageTitle(
@@ -202,6 +213,27 @@ export function websiteNavigationConfig(project: ProjectContext) {
     bodyDecorators.footer = bodyFooterVal;
   }
 
+  // parse the announcement for this website
+  const announcementRaw = websiteConfig(kAnnouncement, project.config);
+  let announcement: NavigationAnnouncement | undefined;
+  if (typeof announcementRaw === "string") {
+    announcement = {
+      id: md5Hash(announcementRaw),
+      icon: undefined,
+      dismissable: true,
+      content: announcementRaw,
+      type: "primary",
+    };
+  } else if (announcementRaw && !Array.isArray(announcementRaw)) {
+    announcement = {
+      id: md5Hash(announcementRaw.content as string),
+      icon: announcementRaw.icon as string | undefined,
+      dismissable: announcementRaw.dismissable !== false,
+      content: announcementRaw.content as string,
+      type: announcementRaw.type as string | undefined || "primary",
+    };
+  }
+
   // return
   return {
     navbar,
@@ -210,6 +242,7 @@ export function websiteNavigationConfig(project: ProjectContext) {
     footer,
     pageMargin,
     bodyDecorators,
+    announcement,
   };
 }
 

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -9353,6 +9353,45 @@ var require_yaml_intelligence_resources = __commonJS({
                 ],
                 description: "Enable Google Analytics for this website"
               },
+              announcement: {
+                anyOf: [
+                  "string",
+                  {
+                    object: {
+                      properties: {
+                        content: {
+                          schema: "string",
+                          description: "The content of the announcement"
+                        },
+                        dismissable: {
+                          schema: "boolean",
+                          description: "Whether this announcement may be dismissed by the user."
+                        },
+                        icon: {
+                          schema: "string",
+                          description: "The icon to display in the annoucement"
+                        },
+                        type: {
+                          schema: {
+                            enum: [
+                              "primary",
+                              "secondary",
+                              "success",
+                              "danger",
+                              "warning",
+                              "info",
+                              "light",
+                              "dark"
+                            ]
+                          },
+                          description: "The type of announcement. Affects the appearance of the announcement."
+                        }
+                      }
+                    }
+                  }
+                ],
+                description: "Provides an announcement displayed at the top of the page."
+              },
               "cookie-consent": {
                 anyOf: [
                   {
@@ -19576,6 +19615,11 @@ var require_yaml_intelligence_resources = __commonJS({
           short: "The version number of Google Analytics to use.",
           long: "The version number of Google Analytics to use."
         },
+        "Provides an announcement displayed at the top of the page.",
+        "The content of the announcement",
+        "Whether this announcement may be dismissed by the user.",
+        "The icon to display in the annoucement",
+        "The type of announcement. Affects the appearance of the\nannouncement.",
         {
           short: "Request cookie consent before enabling scripts that set cookies",
           long: 'Quarto includes the ability to request cookie consent before enabling\nscripts that set cookies, using <a href="https://www.cookieconsent.com/">Cookie Consent</a>.\nThe user\u2019s cookie preferences will automatically control Google\nAnalytics (if enabled) and can be used to control custom scripts you add\nas well. For more information see <a href="https://quarto.org/docs/websites/website-tools.html#custom-scripts-and-cookie-consent">Custom\nScripts and Cookie Consent</a>.'
@@ -19711,6 +19755,11 @@ var require_yaml_intelligence_resources = __commonJS({
           short: "The version number of Google Analytics to use.",
           long: "The version number of Google Analytics to use."
         },
+        "Provides an announcement displayed at the top of the page.",
+        "The content of the announcement",
+        "Whether this announcement may be dismissed by the user.",
+        "The icon to display in the annoucement",
+        "The type of announcement. Affects the appearance of the\nannouncement.",
         {
           short: "Request cookie consent before enabling scripts that set cookies",
           long: 'Quarto includes the ability to request cookie consent before enabling\nscripts that set cookies, using <a href="https://www.cookieconsent.com/">Cookie Consent</a>.\nThe user\u2019s cookie preferences will automatically control Google\nAnalytics (if enabled) and can be used to control custom scripts you add\nas well. For more information see <a href="https://quarto.org/docs/websites/website-tools.html#custom-scripts-and-cookie-consent">Custom\nScripts and Cookie Consent</a>.'
@@ -21455,6 +21504,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "The light theme name, theme scss file, or a mix of both.",
         "The dark theme name, theme scss file, or a mix of both.",
         "The dark theme name, theme scss file, or a mix of both.",
+        "Classes to apply to the body of the document.",
         "Disables the built in html features like theming, anchor sections,\ncode block behavior, and more.",
         "Enables inclusion of Pandoc default CSS for this document.",
         "One or more CSS style sheets.",
@@ -21885,6 +21935,11 @@ var require_yaml_intelligence_resources = __commonJS({
           short: "The version number of Google Analytics to use.",
           long: "The version number of Google Analytics to use."
         },
+        "Provides an announcement displayed at the top of the page.",
+        "The content of the announcement",
+        "Whether this announcement may be dismissed by the user.",
+        "The icon to display in the annoucement",
+        "The type of announcement. Affects the appearance of the\nannouncement.",
         {
           short: "Request cookie consent before enabling scripts that set cookies",
           long: 'Quarto includes the ability to request cookie consent before enabling\nscripts that set cookies, using <a href="https://www.cookieconsent.com/">Cookie Consent</a>.\nThe user\u2019s cookie preferences will automatically control Google\nAnalytics (if enabled) and can be used to control custom scripts you add\nas well. For more information see <a href="https://quarto.org/docs/websites/website-tools.html#custom-scripts-and-cookie-consent">Custom\nScripts and Cookie Consent</a>.'
@@ -22204,6 +22259,11 @@ var require_yaml_intelligence_resources = __commonJS({
           short: "The version number of Google Analytics to use.",
           long: "The version number of Google Analytics to use."
         },
+        "Provides an announcement displayed at the top of the page.",
+        "The content of the announcement",
+        "Whether this announcement may be dismissed by the user.",
+        "The icon to display in the annoucement",
+        "The type of announcement. Affects the appearance of the\nannouncement.",
         {
           short: "Request cookie consent before enabling scripts that set cookies",
           long: 'Quarto includes the ability to request cookie consent before enabling\nscripts that set cookies, using <a href="https://www.cookieconsent.com/">Cookie Consent</a>.\nThe user\u2019s cookie preferences will automatically control Google\nAnalytics (if enabled) and can be used to control custom scripts you add\nas well. For more information see <a href="https://quarto.org/docs/websites/website-tools.html#custom-scripts-and-cookie-consent">Custom\nScripts and Cookie Consent</a>.'
@@ -22471,8 +22531,7 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
         "Manuscript configuration",
-        "internal-schema-hack",
-        "Classes to apply to the body of the document."
+        "internal-schema-hack"
       ],
       "schema/external-schemas.yml": [
         {
@@ -22701,12 +22760,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 180863,
+        _internalId: 181057,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 180855,
+            _internalId: 181049,
             type: "enum",
             enum: [
               "png",
@@ -22722,7 +22781,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 180862,
+            _internalId: 181056,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -9354,6 +9354,45 @@ try {
                   ],
                   description: "Enable Google Analytics for this website"
                 },
+                announcement: {
+                  anyOf: [
+                    "string",
+                    {
+                      object: {
+                        properties: {
+                          content: {
+                            schema: "string",
+                            description: "The content of the announcement"
+                          },
+                          dismissable: {
+                            schema: "boolean",
+                            description: "Whether this announcement may be dismissed by the user."
+                          },
+                          icon: {
+                            schema: "string",
+                            description: "The icon to display in the annoucement"
+                          },
+                          type: {
+                            schema: {
+                              enum: [
+                                "primary",
+                                "secondary",
+                                "success",
+                                "danger",
+                                "warning",
+                                "info",
+                                "light",
+                                "dark"
+                              ]
+                            },
+                            description: "The type of announcement. Affects the appearance of the announcement."
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  description: "Provides an announcement displayed at the top of the page."
+                },
                 "cookie-consent": {
                   anyOf: [
                     {
@@ -19577,6 +19616,11 @@ try {
             short: "The version number of Google Analytics to use.",
             long: "The version number of Google Analytics to use."
           },
+          "Provides an announcement displayed at the top of the page.",
+          "The content of the announcement",
+          "Whether this announcement may be dismissed by the user.",
+          "The icon to display in the annoucement",
+          "The type of announcement. Affects the appearance of the\nannouncement.",
           {
             short: "Request cookie consent before enabling scripts that set cookies",
             long: 'Quarto includes the ability to request cookie consent before enabling\nscripts that set cookies, using <a href="https://www.cookieconsent.com/">Cookie Consent</a>.\nThe user\u2019s cookie preferences will automatically control Google\nAnalytics (if enabled) and can be used to control custom scripts you add\nas well. For more information see <a href="https://quarto.org/docs/websites/website-tools.html#custom-scripts-and-cookie-consent">Custom\nScripts and Cookie Consent</a>.'
@@ -19712,6 +19756,11 @@ try {
             short: "The version number of Google Analytics to use.",
             long: "The version number of Google Analytics to use."
           },
+          "Provides an announcement displayed at the top of the page.",
+          "The content of the announcement",
+          "Whether this announcement may be dismissed by the user.",
+          "The icon to display in the annoucement",
+          "The type of announcement. Affects the appearance of the\nannouncement.",
           {
             short: "Request cookie consent before enabling scripts that set cookies",
             long: 'Quarto includes the ability to request cookie consent before enabling\nscripts that set cookies, using <a href="https://www.cookieconsent.com/">Cookie Consent</a>.\nThe user\u2019s cookie preferences will automatically control Google\nAnalytics (if enabled) and can be used to control custom scripts you add\nas well. For more information see <a href="https://quarto.org/docs/websites/website-tools.html#custom-scripts-and-cookie-consent">Custom\nScripts and Cookie Consent</a>.'
@@ -21456,6 +21505,7 @@ try {
           "The light theme name, theme scss file, or a mix of both.",
           "The dark theme name, theme scss file, or a mix of both.",
           "The dark theme name, theme scss file, or a mix of both.",
+          "Classes to apply to the body of the document.",
           "Disables the built in html features like theming, anchor sections,\ncode block behavior, and more.",
           "Enables inclusion of Pandoc default CSS for this document.",
           "One or more CSS style sheets.",
@@ -21886,6 +21936,11 @@ try {
             short: "The version number of Google Analytics to use.",
             long: "The version number of Google Analytics to use."
           },
+          "Provides an announcement displayed at the top of the page.",
+          "The content of the announcement",
+          "Whether this announcement may be dismissed by the user.",
+          "The icon to display in the annoucement",
+          "The type of announcement. Affects the appearance of the\nannouncement.",
           {
             short: "Request cookie consent before enabling scripts that set cookies",
             long: 'Quarto includes the ability to request cookie consent before enabling\nscripts that set cookies, using <a href="https://www.cookieconsent.com/">Cookie Consent</a>.\nThe user\u2019s cookie preferences will automatically control Google\nAnalytics (if enabled) and can be used to control custom scripts you add\nas well. For more information see <a href="https://quarto.org/docs/websites/website-tools.html#custom-scripts-and-cookie-consent">Custom\nScripts and Cookie Consent</a>.'
@@ -22205,6 +22260,11 @@ try {
             short: "The version number of Google Analytics to use.",
             long: "The version number of Google Analytics to use."
           },
+          "Provides an announcement displayed at the top of the page.",
+          "The content of the announcement",
+          "Whether this announcement may be dismissed by the user.",
+          "The icon to display in the annoucement",
+          "The type of announcement. Affects the appearance of the\nannouncement.",
           {
             short: "Request cookie consent before enabling scripts that set cookies",
             long: 'Quarto includes the ability to request cookie consent before enabling\nscripts that set cookies, using <a href="https://www.cookieconsent.com/">Cookie Consent</a>.\nThe user\u2019s cookie preferences will automatically control Google\nAnalytics (if enabled) and can be used to control custom scripts you add\nas well. For more information see <a href="https://quarto.org/docs/websites/website-tools.html#custom-scripts-and-cookie-consent">Custom\nScripts and Cookie Consent</a>.'
@@ -22472,8 +22532,7 @@ try {
           },
           "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
           "Manuscript configuration",
-          "internal-schema-hack",
-          "Classes to apply to the body of the document."
+          "internal-schema-hack"
         ],
         "schema/external-schemas.yml": [
           {
@@ -22702,12 +22761,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 180863,
+          _internalId: 181057,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 180855,
+              _internalId: 181049,
               type: "enum",
               enum: [
                 "png",
@@ -22723,7 +22782,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 180862,
+              _internalId: 181056,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -2325,6 +2325,45 @@
             ],
             "description": "Enable Google Analytics for this website"
           },
+          "announcement": {
+            "anyOf": [
+              "string",
+              {
+                "object": {
+                  "properties": {
+                    "content": {
+                      "schema": "string",
+                      "description": "The content of the announcement"
+                    },
+                    "dismissable": {
+                      "schema": "boolean",
+                      "description": "Whether this announcement may be dismissed by the user."
+                    },
+                    "icon": {
+                      "schema": "string",
+                      "description": "The icon to display in the annoucement"
+                    },
+                    "type": {
+                      "schema": {
+                        "enum": [
+                          "primary",
+                          "secondary",
+                          "success",
+                          "danger",
+                          "warning",
+                          "info",
+                          "light",
+                          "dark"
+                        ]
+                      },
+                      "description": "The type of announcement. Affects the appearance of the announcement."
+                    }
+                  }
+                }
+              }
+            ],
+            "description": "Provides an announcement displayed at the top of the page."
+          },
           "cookie-consent": {
             "anyOf": [
               {
@@ -12548,6 +12587,11 @@
       "short": "The version number of Google Analytics to use.",
       "long": "The version number of Google Analytics to use."
     },
+    "Provides an announcement displayed at the top of the page.",
+    "The content of the announcement",
+    "Whether this announcement may be dismissed by the user.",
+    "The icon to display in the annoucement",
+    "The type of announcement. Affects the appearance of the\nannouncement.",
     {
       "short": "Request cookie consent before enabling scripts that set cookies",
       "long": "Quarto includes the ability to request cookie consent before enabling\nscripts that set cookies, using <a href=\"https://www.cookieconsent.com/\">Cookie Consent</a>.\nThe user’s cookie preferences will automatically control Google\nAnalytics (if enabled) and can be used to control custom scripts you add\nas well. For more information see <a href=\"https://quarto.org/docs/websites/website-tools.html#custom-scripts-and-cookie-consent\">Custom\nScripts and Cookie Consent</a>."
@@ -12683,6 +12727,11 @@
       "short": "The version number of Google Analytics to use.",
       "long": "The version number of Google Analytics to use."
     },
+    "Provides an announcement displayed at the top of the page.",
+    "The content of the announcement",
+    "Whether this announcement may be dismissed by the user.",
+    "The icon to display in the annoucement",
+    "The type of announcement. Affects the appearance of the\nannouncement.",
     {
       "short": "Request cookie consent before enabling scripts that set cookies",
       "long": "Quarto includes the ability to request cookie consent before enabling\nscripts that set cookies, using <a href=\"https://www.cookieconsent.com/\">Cookie Consent</a>.\nThe user’s cookie preferences will automatically control Google\nAnalytics (if enabled) and can be used to control custom scripts you add\nas well. For more information see <a href=\"https://quarto.org/docs/websites/website-tools.html#custom-scripts-and-cookie-consent\">Custom\nScripts and Cookie Consent</a>."
@@ -14427,6 +14476,7 @@
     "The light theme name, theme scss file, or a mix of both.",
     "The dark theme name, theme scss file, or a mix of both.",
     "The dark theme name, theme scss file, or a mix of both.",
+    "Classes to apply to the body of the document.",
     "Disables the built in html features like theming, anchor sections,\ncode block behavior, and more.",
     "Enables inclusion of Pandoc default CSS for this document.",
     "One or more CSS style sheets.",
@@ -14857,6 +14907,11 @@
       "short": "The version number of Google Analytics to use.",
       "long": "The version number of Google Analytics to use."
     },
+    "Provides an announcement displayed at the top of the page.",
+    "The content of the announcement",
+    "Whether this announcement may be dismissed by the user.",
+    "The icon to display in the annoucement",
+    "The type of announcement. Affects the appearance of the\nannouncement.",
     {
       "short": "Request cookie consent before enabling scripts that set cookies",
       "long": "Quarto includes the ability to request cookie consent before enabling\nscripts that set cookies, using <a href=\"https://www.cookieconsent.com/\">Cookie Consent</a>.\nThe user’s cookie preferences will automatically control Google\nAnalytics (if enabled) and can be used to control custom scripts you add\nas well. For more information see <a href=\"https://quarto.org/docs/websites/website-tools.html#custom-scripts-and-cookie-consent\">Custom\nScripts and Cookie Consent</a>."
@@ -15176,6 +15231,11 @@
       "short": "The version number of Google Analytics to use.",
       "long": "The version number of Google Analytics to use."
     },
+    "Provides an announcement displayed at the top of the page.",
+    "The content of the announcement",
+    "Whether this announcement may be dismissed by the user.",
+    "The icon to display in the annoucement",
+    "The type of announcement. Affects the appearance of the\nannouncement.",
     {
       "short": "Request cookie consent before enabling scripts that set cookies",
       "long": "Quarto includes the ability to request cookie consent before enabling\nscripts that set cookies, using <a href=\"https://www.cookieconsent.com/\">Cookie Consent</a>.\nThe user’s cookie preferences will automatically control Google\nAnalytics (if enabled) and can be used to control custom scripts you add\nas well. For more information see <a href=\"https://quarto.org/docs/websites/website-tools.html#custom-scripts-and-cookie-consent\">Custom\nScripts and Cookie Consent</a>."
@@ -15443,8 +15503,7 @@
     },
     "Disambiguating year suffix in author-date styles (e.g.&nbsp;“a” in “Doe,\n1999a”).",
     "Manuscript configuration",
-    "internal-schema-hack",
-    "Classes to apply to the body of the document."
+    "internal-schema-hack"
   ],
   "schema/external-schemas.yml": [
     {
@@ -15673,12 +15732,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 180863,
+    "_internalId": 181057,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 180855,
+        "_internalId": 181049,
         "type": "enum",
         "enum": [
           "png",
@@ -15694,7 +15753,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 180862,
+        "_internalId": 181056,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/projects/website/navigation/quarto-nav.js
+++ b/src/resources/projects/website/navigation/quarto-nav.js
@@ -5,8 +5,44 @@ const headroomChanged = new CustomEvent("quarto-hrChanged", {
   composed: false,
 });
 
+const announceDismiss = () => {
+  const annEl = window.document.getElementById("quarto-announcement");
+  if (annEl) {
+    annEl.remove();
+
+    const annId = annEl.getAttribute("data-announcement-id");
+    window.localStorage.setItem(`quarto-announce-${annId}`, "true");
+  }
+};
+
+const announceRegister = () => {
+  const annEl = window.document.getElementById("quarto-announcement");
+  if (annEl) {
+    const annId = annEl.getAttribute("data-announcement-id");
+    const isDismissed =
+      window.localStorage.getItem(`quarto-announce-${annId}`) || false;
+    if (isDismissed) {
+      announceDismiss();
+      return;
+    } else {
+      annEl.classList.remove("hidden");
+    }
+
+    const actionEl = annEl.querySelector(".quarto-announcement-action");
+    if (actionEl) {
+      actionEl.addEventListener("click", function (e) {
+        e.preventDefault();
+        // Hide the bar immediately
+        announceDismiss();
+      });
+    }
+  }
+};
+
 window.document.addEventListener("DOMContentLoaded", function () {
   let init = false;
+
+  announceRegister();
 
   // Manage the back to top button, if one is present.
   let lastScrollTop = window.pageYOffset || document.documentElement.scrollTop;

--- a/src/resources/projects/website/navigation/quarto-nav.scss
+++ b/src/resources/projects/website/navigation/quarto-nav.scss
@@ -951,3 +951,25 @@ body .nav-footer {
   padding: 0.4rem 0.8rem;
   transform: translate(-50%, 0);
 }
+
+/* announcement bar */
+#quarto-announcement {
+  padding: 0.5em;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0;
+  font-size: 0.9em;
+
+  .quarto-announcement-content {
+    margin-right: auto;
+    p {
+      margin-bottom: 0;
+    }
+  }
+  .quarto-announcement-icon {
+    margin-right: 0.5em;
+  }
+  .quarto-announcement-action {
+    cursor: pointer;
+  }
+}

--- a/src/resources/projects/website/templates/nav-before-body.ejs
+++ b/src/resources/projects/website/templates/nav-before-body.ejs
@@ -5,15 +5,20 @@ const navbarTocRight = nav['toc-location'] === "right" || nav['toc-location'] ==
 %>
 
 
+
 <% /* Container that holds search results (when using the non-floating style.) */ %>
 <div id="quarto-search-results"></div>
 
   
   <% /* The header will hold the navbar (if present) and/or a container for the collapsed sidebar */ %>
-  <% if (nav.navbar || nav.sidebar) { %>  
+  <% if (nav.navbar || nav.sidebar || nav.announcement) { %>  
   <header id="quarto-header" class="headroom fixed-top">
 
-  <% if (nav.navbar) { %>  
+    <% if (nav.announcement) { %>
+      <div id="quarto-announcement" data-announcement-id="<%- nav.announcement.id %>" class="alert alert-<%- nav.announcement.type %> hidden"><% if (nav.announcement.icon) { %><i class="bi bi-<%- nav.announcement.icon %> quarto-announcement-icon"></i><% } %><div class="quarto-announcement-content"><%= nav.announcement.content %></div><% if (nav.announcement.dismissable) { %><i class="bi bi-x-lg quarto-announcement-action"></i><% } %></div>
+    <% } %>
+
+    <% if (nav.navbar) { %>  
     <nav class="navbar navbar-expand<%- nav.navbar["collapse-below"] %> <%- nav.navbar.background === "none" || nav.navbar.background === "body" ? "border-bottom" : "" %>" data-bs-theme="dark">
       <div class="navbar-container container-fluid">
       <% partial('navbrand.ejs', {

--- a/src/resources/schema/definitions.yml
+++ b/src/resources/schema/definitions.yml
@@ -737,6 +737,36 @@
 
                       This is automatically detected based upon the `tracking-id`, but you may specify it.
         description: "Enable Google Analytics for this website"
+      announcement:
+        anyOf:
+          - string
+          - object:
+              properties:
+                content:
+                  schema: string
+                  description: "The content of the announcement"
+                dismissable:
+                  schema: boolean
+                  description: "Whether this announcement may be dismissed by the user."
+                icon:
+                  schema: string
+                  description: "The icon to display in the annoucement"
+                type:
+                  schema:
+                    enum:
+                      [
+                        primary,
+                        secondary,
+                        success,
+                        danger,
+                        warning,
+                        info,
+                        light,
+                        dark,
+                      ]
+                  description: "The type of announcement. Affects the appearance of the announcement."
+
+        description: Provides an announcement displayed at the top of the page.
       cookie-consent:
         anyOf:
           - enum: [express, implied]

--- a/src/resources/types/schema-types.ts
+++ b/src/resources/types/schema-types.ts
@@ -435,6 +435,20 @@ The user’s cookie preferences will automatically control Google Analytics (if 
     | TwitterCardConfig /* Publish twitter card metadata */;
   "other-links"?: OtherLinks;
   "code-links"?: boolean | CodeLinksSchema;
+  announcement?: string | {
+    content?: string;
+    dismissable?: boolean;
+    icon?: string;
+    type?:
+      | "primary"
+      | "secondary"
+      | "success"
+      | "danger"
+      | "warning"
+      | "info"
+      | "light"
+      | "dark";
+  } /* Provides an announcement displayed at the top of the page. */;
   comments?: Comments;
   description?: string /* Website description */;
   favicon?: string /* The path to the favicon for this website */;


### PR DESCRIPTION
Add support for a website announcement bar. 

![Screenshot 2024-01-16 at 3 18 59 PM](https://github.com/quarto-dev/quarto-cli/assets/261654/8f38f43d-03ee-488a-bb5b-c7c081cd739d)

Specify under the `website` key, in simplest form as:

```yaml
website:
  announcement: "This is the announcement content"
```

or with all properties as:

```yaml
website: 
  announcement: 
    icon: info-circle
    dismissable: true
    content: "**Alert** - this is some information that you should pay attention to"
    type: primary
```

**content**
The content of the announcement (markdown allowed)

**icon**
A bootswatch icon to be displayed on the left side of the alert. No icon is shown by default.

**dismissable**
A boolean indicating whether the announcement can be dismissed. Defaults to true. If true, an 'X' will appear on the right side and the user may click this to dismiss the announcement. The announcement dismissal will be stored in local storage (based upon the text of the announcement, so if the announcement text changes, the announcement will be shown again).

**type**
The type of the announcement (which corresponds to types of alerts in bootstrap). Affects the color of the alert, primarily. Defaults to `primary`



Fixes #7517