### PR TITLE
Add execprocess debug messages

### DIFF
--- a/src/core/process.ts
+++ b/src/core/process.ts
@@ -6,7 +6,7 @@
 
 import { MuxAsyncIterator, pooledMap } from "async/mod.ts";
 import { iterateReader } from "streams/mod.ts";
-import { info } from "log/mod.ts";
+import { debug, info } from "log/mod.ts";
 import { onCleanup } from "./cleanup.ts";
 import { ProcessResult } from "./process-types.ts";
 
@@ -43,6 +43,7 @@ export async function execProcess(
     // If the caller asked for stdout/stderr to be directed to the rid of an open
     // file, just allow that to happen. Otherwise, specify piped and we will implement
     // the proper behavior for inherit, etc....
+    debug(`[execProcess] ${options.cmd.join(" ")}`);
     const process = Deno.run({
       ...options,
       stdin: stdin !== undefined ? "piped" : options.stdin,
@@ -159,6 +160,8 @@ export async function execProcess(
     process.close();
 
     processList.delete(thisProcessId);
+
+    debug(`[execProcess] Success: ${status.success}, code: ${status.code}`);
 
     return {
       success: status.success,


### PR DESCRIPTION
Sample:

```bash
$ quarto render --log-level debug 2>&1 | grep -i "\[execProcess\]"
[execProcess] which git
[execProcess] Success: true, code: 0
[execProcess] git rev-parse
[execProcess] Success: false, code: 128
[execProcess] /Users/cool-user/dev/package/dist/bin/tools/x86_64/dart-sass/sass /var/folders/xd/yz194wns70n2zknfrt5l0v0m0000gr/T/quarto-session1d948518/2783de1a/df54678c.scss /var/folders/xd/yz194wns70n2zknfrt5l0v0m0000gr/T/quarto-session1d948518/2783de1a/sass/aaecd917b9d237aa39e15a02e860d546.css --style compressed --quiet --load-path=/Users/cool-user/dev/src/resources/formats/html/bootstrap/dist/scss --load-path=/Users/cool-user/dev/src/resources/formats/html/bslib/bslib-scss
[execProcess] Success: true, code: 0
[execProcess] /Users/cool-user/dev/package/dist/bin/tools/x86_64/pandoc +RTS -K512m -RTS --defaults /var/folders/xd/yz194wns70n2zknfrt5l0v0m0000gr/T/quarto-session1d948518/2783de1a/quarto-defaultsc3b64472.yml /var/folders/xd/yz194wns70n2zknfrt5l0v0m0000gr/T/quarto-session1d948518/2783de1a/quarto-input031a71f4.md --metadata-file /var/folders/xd/yz194wns70n2zknfrt5l0v0m0000gr/T/quarto-session1d948518/2783de1a/quarto-metadatab4990235.yml --verbose --trace --data-dir /Users/cool-user/dev/src/resources/pandoc/datadir
[execProcess] Success: true, code: 0
[execProcess] /Users/cool-user/dev/package/dist/bin/tools/x86_64/pandoc +RTS -K512m -RTS --defaults /var/folders/xd/yz194wns70n2zknfrt5l0v0m0000gr/T/quarto-session1d948518/2783de1a/quarto-defaults02c7c01d.yml /var/folders/xd/yz194wns70n2zknfrt5l0v0m0000gr/T/quarto-session1d948518/2783de1a/quarto-input34b0ec5e.md --metadata-file /var/folders/xd/yz194wns70n2zknfrt5l0v0m0000gr/T/quarto-session1d948518/2783de1a/quarto-metadata58c5ecb6.yml --verbose --trace --data-dir /Users/cool-user/dev/src/resources/pandoc/datadir
[execProcess] Success: true, code: 0
[execProcess] /Users/cool-user/dev/package/dist/bin/tools/x86_64/pandoc +RTS -K512m -RTS --defaults /var/folders/xd/yz194wns70n2zknfrt5l0v0m0000gr/T/quarto-session1d948518/2783de1a/quarto-defaults7a10b4d5.yml /var/folders/xd/yz194wns70n2zknfrt5l0v0m0000gr/T/quarto-session1d948518/2783de1a/quarto-input6f9be3d9.md --metadata-file /var/folders/xd/yz194wns70n2zknfrt5l0v0m0000gr/T/quarto-session1d948518/2783de1a/quarto-metadata0f427806.yml --verbose --trace --data-dir /Users/cool-user/dev/src/resources/pandoc/datadir
[execProcess] Success: true, code: 0
[execProcess] /Users/cool-user/dev/package/dist/bin/tools/x86_64/pandoc +RTS -K512m -RTS --defaults /var/folders/xd/yz194wns70n2zknfrt5l0v0m0000gr/T/quarto-session1d948518/2783de1a/quarto-defaults262b5efb.yml /var/folders/xd/yz194wns70n2zknfrt5l0v0m0000gr/T/quarto-session1d948518/2783de1a/quarto-inputa845f63d.md --metadata-file /var/folders/xd/yz194wns70n2zknfrt5l0v0m0000gr/T/quarto-session1d948518/2783de1a/quarto-metadataa01728da.yml --verbose --trace --data-dir /Users/cool-user/dev/src/resources/pandoc/datadir
[execProcess] Success: true, code: 0
```