### PR TITLE
Improve `page-footer` behavior at small sizes

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -6,6 +6,7 @@ All changes included in 1.5:
 
 ## Website
 
+- ([#8267](https://github.com/quarto-dev/quarto-cli/issues/8267)): Improve responsive layout of `page-footer`
 - ([#8294](https://github.com/quarto-dev/quarto-cli/issues/8294)): Add support for website announcements, using the `announcement` key under `website`.
 
 ## Other Fixes

--- a/src/resources/projects/website/navigation/quarto-nav.scss
+++ b/src/resources/projects/website/navigation/quarto-nav.scss
@@ -872,26 +872,46 @@ body .nav-footer {
   padding-right: 0.6em;
 }
 .nav-footer-left {
-  flex: 1 1 0px;
-  text-align: left;
+  @include media-breakpoint-up(md) {
+    flex: 1 1 0px;
+  }
+  @include media-breakpoint-down(sm) {
+    margin-bottom: 1em;
+    text-align: left;
+  }
+  @include media-breakpoint-down(sm) {
+    margin-bottom: 1em;
+  }
 }
 .nav-footer-right {
-  flex: 1 1 0px;
-  text-align: right;
+  @include media-breakpoint-up(md) {
+    flex: 1 1 0px;
+    text-align: right;
+  }
+  @include media-breakpoint-down(sm) {
+    margin-bottom: 1em;
+  }
 }
 
 .nav-footer-center {
-  flex: 1 1 0px;
-  min-height: 3em;
+  @include media-breakpoint-up(md) {
+    flex: 1 1 0px;
+  }
   text-align: center;
+  min-height: 3em;
   .footer-items {
     justify-content: center;
+  }
+  @include media-breakpoint-down(md) {
+    margin-bottom: 1em;
+    flex: 100%;
   }
 }
 
 @include media-breakpoint-down(md) {
   .nav-footer-center {
     margin-top: 3em;
+    order: 10;
   }
 }
 


### PR DESCRIPTION
fixes #8267

Allow page-left, right, and center to collapse into a single column.

