### PR TITLE
fix `mdx-code-block` special code block for docusaurus

### DIFF
--- a/src/resources/extensions/quarto/docusaurus/docusaurus.lua
+++ b/src/resources/extensions/quarto/docusaurus/docusaurus.lua
@@ -53,7 +53,8 @@ end
 -- into raw commamark to pass through via dangerouslySetInnerHTML
 local function RawBlock(el)
   if el.format == 'mdx' then
-    return pandoc.CodeBlock(el.text, pandoc.Attr("", {"mdx-code-block"}))
+    -- special mdx-code-block is not handled if whitespace is present after backtrick (#8333)
+    return pandoc.RawBlock("markdown", "````mdx-code-block\n" .. el.text .. "\n````")
   elseif el.format == 'html' then
     -- track the raw html vars (we'll insert them at the top later on as
     -- mdx requires all exports be declared together)

--- a/tests/docs/smoke-all/2023/04/27/5316.qmd
+++ b/tests/docs/smoke-all/2023/04/27/5316.qmd
@@ -7,7 +7,7 @@ _quarto:
   tests:
     docusaurus-md:
       ensureFileRegexMatches:
-        - ["[^\\]]``` *python", "[^\\]]``` *mdx-code-block"]
+        - ["[^\\]]``` *python", "[^\\]]````mdx-code-block"]
         - ["[^\\]]``` *text"]
 ---
 


### PR DESCRIPTION
It is not handled by docusaurus if there is whitespace after backtick like pandoc is creating from CodeBlock

This fixes #8333 

Though from discussion there, it could also be an issue in docusaurus itself that they should fix as it is breaking from V2 to V3 
and it does not seem they mention this change as known  (cc @eitsupi) 

Their checker (https://github.com/slorber/docusaurus-mdx-checker) does not warn on the produced file with a space also 

So opening as draft to keep this if we decide to merge it


