### PR TITLE
Add light / dark configuration for giscus in reference long description

### DIFF
--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -8654,11 +8654,18 @@ var require_yaml_intelligence_resources = __commonJS({
                                 "light",
                                 "light_high_contrast",
                                 "light_protanopia",
+                                "light_tritanopia",
                                 "dark",
                                 "dark_high_contrast",
                                 "dark_protanopia",
+                                "dark_tritanopia",
                                 "dark_dimmed",
                                 "transparent_dark",
+                                "cobalt",
+                                "purple_dark",
+                                "noborder_light",
+                                "noborder_dark",
+                                "noborder_gray",
                                 "preferred_color_scheme"
                               ]
                             },
@@ -8680,7 +8687,10 @@ var require_yaml_intelligence_resources = __commonJS({
                               }
                             }
                           ],
-                          description: "The giscus theme to use when displaying comments."
+                          description: {
+                            short: "The giscus theme to use when displaying comments.",
+                            long: "The giscus theme to use when displaying comments. Light and dark themes are supported. If a single theme is provided by name, it will be used as light and dark theme. To use different themes, use `light` and `dark` key: \n\n```yaml\nwebsite:\n  comments:\n    giscus:\n      light: light # giscus theme used for light website theme\n      dark: dark_dimmed # giscus theme used for dark website theme\n```\n"
+                          }
                         },
                         language: {
                           string: {
@@ -19372,7 +19382,10 @@ var require_yaml_intelligence_resources = __commonJS({
         "Display reactions for the discussion\u2019s main post before the\ncomments.",
         "Specify <code>loading: lazy</code> to defer loading comments until\nthe user scrolls near the comments container.",
         "Place the comment input box above or below the comments.",
-        "The giscus theme to use when displaying comments.",
+        {
+          short: "The giscus theme to use when displaying comments.",
+          long: "The giscus theme to use when displaying comments. Light and dark\nthemes are supported. If a single theme is provided by name, it will be\nused as light and dark theme. To use different themes, use\n<code>light</code> and <code>dark</code> key:"
+        },
         "The light theme name.",
         "The dark theme name.",
         "The language that should be used when displaying the commenting\ninterface.",
@@ -19579,6 +19592,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "The responsive breakpoint below which the navbar will collapse into a\nmenu (<code>sm</code>, <code>md</code>, <code>lg</code> (default),\n<code>xl</code>, <code>xxl</code>).",
         "List of items for the left side of the navbar.",
         "List of items for the right side of the navbar.",
+        "The position of the collapsed navbar toggle when in responsive\nmode",
         "Side navigation options",
         "The identifier for this sidebar.",
         "The sidebar title. Uses the project title if none is specified.",
@@ -19713,6 +19727,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "The responsive breakpoint below which the navbar will collapse into a\nmenu (<code>sm</code>, <code>md</code>, <code>lg</code> (default),\n<code>xl</code>, <code>xxl</code>).",
         "List of items for the left side of the navbar.",
         "List of items for the right side of the navbar.",
+        "The position of the collapsed navbar toggle when in responsive\nmode",
         "Side navigation options",
         "The identifier for this sidebar.",
         "The sidebar title. Uses the project title if none is specified.",
@@ -21885,6 +21900,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "The responsive breakpoint below which the navbar will collapse into a\nmenu (<code>sm</code>, <code>md</code>, <code>lg</code> (default),\n<code>xl</code>, <code>xxl</code>).",
         "List of items for the left side of the navbar.",
         "List of items for the right side of the navbar.",
+        "The position of the collapsed navbar toggle when in responsive\nmode",
         "Side navigation options",
         "The identifier for this sidebar.",
         "The sidebar title. Uses the project title if none is specified.",
@@ -22203,6 +22219,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "The responsive breakpoint below which the navbar will collapse into a\nmenu (<code>sm</code>, <code>md</code>, <code>lg</code> (default),\n<code>xl</code>, <code>xxl</code>).",
         "List of items for the left side of the navbar.",
         "List of items for the right side of the navbar.",
+        "The position of the collapsed navbar toggle when in responsive\nmode",
         "Side navigation options",
         "The identifier for this sidebar.",
         "The sidebar title. Uses the project title if none is specified.",
@@ -22639,15 +22656,16 @@ var require_yaml_intelligence_resources = __commonJS({
           "(*",
           "*)"
         ],
+        rust: "//",
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 180612,
+        _internalId: 180617,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 180604,
+            _internalId: 180609,
             type: "enum",
             enum: [
               "png",
@@ -22663,7 +22681,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 180611,
+            _internalId: 180616,
             type: "anyOf",
             anyOf: [
               {
@@ -31819,7 +31837,8 @@ var kLangCommentChars = {
   dot: "//",
   ojs: "//",
   apl: "\u235D",
-  ocaml: ["(*", "*)"]
+  ocaml: ["(*", "*)"],
+  rust: "//"
 };
 function escapeRegExp(str2) {
   return str2.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -8655,11 +8655,18 @@ try {
                                   "light",
                                   "light_high_contrast",
                                   "light_protanopia",
+                                  "light_tritanopia",
                                   "dark",
                                   "dark_high_contrast",
                                   "dark_protanopia",
+                                  "dark_tritanopia",
                                   "dark_dimmed",
                                   "transparent_dark",
+                                  "cobalt",
+                                  "purple_dark",
+                                  "noborder_light",
+                                  "noborder_dark",
+                                  "noborder_gray",
                                   "preferred_color_scheme"
                                 ]
                               },
@@ -8681,7 +8688,10 @@ try {
                                 }
                               }
                             ],
-                            description: "The giscus theme to use when displaying comments."
+                            description: {
+                              short: "The giscus theme to use when displaying comments.",
+                              long: "The giscus theme to use when displaying comments. Light and dark themes are supported. If a single theme is provided by name, it will be used as light and dark theme. To use different themes, use `light` and `dark` key: \n\n```yaml\nwebsite:\n  comments:\n    giscus:\n      light: light # giscus theme used for light website theme\n      dark: dark_dimmed # giscus theme used for dark website theme\n```\n"
+                            }
                           },
                           language: {
                             string: {
@@ -19373,7 +19383,10 @@ try {
           "Display reactions for the discussion\u2019s main post before the\ncomments.",
           "Specify <code>loading: lazy</code> to defer loading comments until\nthe user scrolls near the comments container.",
           "Place the comment input box above or below the comments.",
-          "The giscus theme to use when displaying comments.",
+          {
+            short: "The giscus theme to use when displaying comments.",
+            long: "The giscus theme to use when displaying comments. Light and dark\nthemes are supported. If a single theme is provided by name, it will be\nused as light and dark theme. To use different themes, use\n<code>light</code> and <code>dark</code> key:"
+          },
           "The light theme name.",
           "The dark theme name.",
           "The language that should be used when displaying the commenting\ninterface.",
@@ -19580,6 +19593,7 @@ try {
           "The responsive breakpoint below which the navbar will collapse into a\nmenu (<code>sm</code>, <code>md</code>, <code>lg</code> (default),\n<code>xl</code>, <code>xxl</code>).",
           "List of items for the left side of the navbar.",
           "List of items for the right side of the navbar.",
+          "The position of the collapsed navbar toggle when in responsive\nmode",
           "Side navigation options",
           "The identifier for this sidebar.",
           "The sidebar title. Uses the project title if none is specified.",
@@ -19714,6 +19728,7 @@ try {
           "The responsive breakpoint below which the navbar will collapse into a\nmenu (<code>sm</code>, <code>md</code>, <code>lg</code> (default),\n<code>xl</code>, <code>xxl</code>).",
           "List of items for the left side of the navbar.",
           "List of items for the right side of the navbar.",
+          "The position of the collapsed navbar toggle when in responsive\nmode",
           "Side navigation options",
           "The identifier for this sidebar.",
           "The sidebar title. Uses the project title if none is specified.",
@@ -21886,6 +21901,7 @@ try {
           "The responsive breakpoint below which the navbar will collapse into a\nmenu (<code>sm</code>, <code>md</code>, <code>lg</code> (default),\n<code>xl</code>, <code>xxl</code>).",
           "List of items for the left side of the navbar.",
           "List of items for the right side of the navbar.",
+          "The position of the collapsed navbar toggle when in responsive\nmode",
           "Side navigation options",
           "The identifier for this sidebar.",
           "The sidebar title. Uses the project title if none is specified.",
@@ -22204,6 +22220,7 @@ try {
           "The responsive breakpoint below which the navbar will collapse into a\nmenu (<code>sm</code>, <code>md</code>, <code>lg</code> (default),\n<code>xl</code>, <code>xxl</code>).",
           "List of items for the left side of the navbar.",
           "List of items for the right side of the navbar.",
+          "The position of the collapsed navbar toggle when in responsive\nmode",
           "Side navigation options",
           "The identifier for this sidebar.",
           "The sidebar title. Uses the project title if none is specified.",
@@ -22640,15 +22657,16 @@ try {
             "(*",
             "*)"
           ],
+          rust: "//",
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 180612,
+          _internalId: 180617,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 180604,
+              _internalId: 180609,
               type: "enum",
               enum: [
                 "png",
@@ -22664,7 +22682,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 180611,
+              _internalId: 180616,
               type: "anyOf",
               anyOf: [
                 {
@@ -31833,7 +31851,8 @@ ${tidyverseInfo(
     dot: "//",
     ojs: "//",
     apl: "\u235D",
-    ocaml: ["(*", "*)"]
+    ocaml: ["(*", "*)"],
+    rust: "//"
   };
   function escapeRegExp(str2) {
     return str2.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -1626,11 +1626,18 @@
                             "light",
                             "light_high_contrast",
                             "light_protanopia",
+                            "light_tritanopia",
                             "dark",
                             "dark_high_contrast",
                             "dark_protanopia",
+                            "dark_tritanopia",
                             "dark_dimmed",
                             "transparent_dark",
+                            "cobalt",
+                            "purple_dark",
+                            "noborder_light",
+                            "noborder_dark",
+                            "noborder_gray",
                             "preferred_color_scheme"
                           ]
                         },
@@ -1652,7 +1659,10 @@
                           }
                         }
                       ],
-                      "description": "The giscus theme to use when displaying comments."
+                      "description": {
+                        "short": "The giscus theme to use when displaying comments.",
+                        "long": "The giscus theme to use when displaying comments. Light and dark themes are supported. If a single theme is provided by name, it will be used as light and dark theme. To use different themes, use `light` and `dark` key: \n\n```yaml\nwebsite:\n  comments:\n    giscus:\n      light: light # giscus theme used for light website theme\n      dark: dark_dimmed # giscus theme used for dark website theme\n```\n"
+                      }
                     },
                     "language": {
                       "string": {
@@ -12344,7 +12354,10 @@
     "Display reactions for the discussion’s main post before the\ncomments.",
     "Specify <code>loading: lazy</code> to defer loading comments until\nthe user scrolls near the comments container.",
     "Place the comment input box above or below the comments.",
-    "The giscus theme to use when displaying comments.",
+    {
+      "short": "The giscus theme to use when displaying comments.",
+      "long": "The giscus theme to use when displaying comments. Light and dark\nthemes are supported. If a single theme is provided by name, it will be\nused as light and dark theme. To use different themes, use\n<code>light</code> and <code>dark</code> key:"
+    },
     "The light theme name.",
     "The dark theme name.",
     "The language that should be used when displaying the commenting\ninterface.",
@@ -12551,6 +12564,7 @@
     "The responsive breakpoint below which the navbar will collapse into a\nmenu (<code>sm</code>, <code>md</code>, <code>lg</code> (default),\n<code>xl</code>, <code>xxl</code>).",
     "List of items for the left side of the navbar.",
     "List of items for the right side of the navbar.",
+    "The position of the collapsed navbar toggle when in responsive\nmode",
     "Side navigation options",
     "The identifier for this sidebar.",
     "The sidebar title. Uses the project title if none is specified.",
@@ -12685,6 +12699,7 @@
     "The responsive breakpoint below which the navbar will collapse into a\nmenu (<code>sm</code>, <code>md</code>, <code>lg</code> (default),\n<code>xl</code>, <code>xxl</code>).",
     "List of items for the left side of the navbar.",
     "List of items for the right side of the navbar.",
+    "The position of the collapsed navbar toggle when in responsive\nmode",
     "Side navigation options",
     "The identifier for this sidebar.",
     "The sidebar title. Uses the project title if none is specified.",
@@ -14857,6 +14872,7 @@
     "The responsive breakpoint below which the navbar will collapse into a\nmenu (<code>sm</code>, <code>md</code>, <code>lg</code> (default),\n<code>xl</code>, <code>xxl</code>).",
     "List of items for the left side of the navbar.",
     "List of items for the right side of the navbar.",
+    "The position of the collapsed navbar toggle when in responsive\nmode",
     "Side navigation options",
     "The identifier for this sidebar.",
     "The sidebar title. Uses the project title if none is specified.",
@@ -15175,6 +15191,7 @@
     "The responsive breakpoint below which the navbar will collapse into a\nmenu (<code>sm</code>, <code>md</code>, <code>lg</code> (default),\n<code>xl</code>, <code>xxl</code>).",
     "List of items for the left side of the navbar.",
     "List of items for the right side of the navbar.",
+    "The position of the collapsed navbar toggle when in responsive\nmode",
     "Side navigation options",
     "The identifier for this sidebar.",
     "The sidebar title. Uses the project title if none is specified.",
@@ -15611,15 +15628,16 @@
       "(*",
       "*)"
     ],
+    "rust": "//",
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 180612,
+    "_internalId": 180617,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 180604,
+        "_internalId": 180609,
         "type": "enum",
         "enum": [
           "png",
@@ -15635,7 +15653,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 180611,
+        "_internalId": 180616,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/schema/definitions.yml
+++ b/src/resources/schema/definitions.yml
@@ -274,11 +274,18 @@
                           light,
                           light_high_contrast,
                           light_protanopia,
+                          light_tritanopia,
                           dark,
                           dark_high_contrast,
                           dark_protanopia,
+                          dark_tritanopia,
                           dark_dimmed,
                           transparent_dark,
+                          cobalt,
+                          purple_dark,
+                          noborder_light,
+                          noborder_dark,
+                          noborder_gray,
                           preferred_color_scheme,
                         ]
                     - object:

--- a/src/resources/schema/definitions.yml
+++ b/src/resources/schema/definitions.yml
@@ -291,7 +291,18 @@
                             string:
                               description: The dark theme name.
 
-                  description: The giscus theme to use when displaying comments.
+                  description:
+                    short: The giscus theme to use when displaying comments.
+                    long: |
+                      The giscus theme to use when displaying comments. Light and dark themes are supported. If a single theme is provided by name, it will be used as light and dark theme. To use different themes, use `light` and `dark` key: 
+
+                      ```yaml
+                      website:
+                        comments:
+                          giscus:
+                            light: light # giscus theme used for light website theme
+                            dark: dark_dimmed # giscus theme used for dark website theme
+                      ```
                 language:
                   string:
                     description: The language that should be used when displaying the commenting interface.

--- a/src/resources/types/schema-types.ts
+++ b/src/resources/types/schema-types.ts
@@ -134,17 +134,32 @@ the discussions feature must be enabled. */;
         | "light"
         | "light_high_contrast"
         | "light_protanopia"
+        | "light_tritanopia"
         | "dark"
         | "dark_high_contrast"
         | "dark_protanopia"
+        | "dark_tritanopia"
         | "dark_dimmed"
         | "transparent_dark"
+        | "cobalt"
+        | "purple_dark"
+        | "noborder_light"
+        | "noborder_dark"
+        | "noborder_gray"
         | "preferred_color_scheme"
       )
       | {
         dark?: string /* The dark theme name. */;
         light?: string; /* The light theme name. */
-      }; /* The giscus theme to use when displaying comments. */
+      }; /* The giscus theme to use when displaying comments. Light and dark themes are supported. If a single theme is provided by name, it will be used as light and dark theme. To use different themes, use `light` and `dark` key:
+
+```yaml
+website:
+  comments:
+    giscus:
+      light: light # giscus theme used for light website theme
+      dark: dark_dimmed # giscus theme used for dark website theme
+``` */
   };
   hypothesis?: boolean | {
     "client-url"?:


### PR DESCRIPTION
closes #8306

One thing though: 

- I would like to split the enum or at least add the enum for auto completion in each key `light` and `dark` in 
````yaml
  comments:
    giscus:
      repo: quarto-dev/quarto-web
      theme:
        light: light_tritanopia
        dark: dark_tritanopia
````

is this possibly without repeating the enum ? Or should I just repeat ? 

