### PR TITLE
Bugfix/docusaurus

### DIFF
--- a/dev-docs/feature-format-matrix/.gitignore
+++ b/dev-docs/feature-format-matrix/.gitignore
@@ -1,0 +1,7 @@
+**/*_files
+index.html
+index_files
+qmd-files/**/*.html
+qmd-files/**/*.pdf
+qmd-files/**/*.md
+qmd-files/**/*.mdx

--- a/dev-docs/feature-format-matrix/_tabulator.qmd
+++ b/dev-docs/feature-format-matrix/_tabulator.qmd
@@ -26,7 +26,8 @@ var table = new Tabulator("#features-formats-table", {
         {title:"HTML", field: "html", formatter: "html"},
         {title:"Markdown", field: "markdown", formatter: "html"},
         {title:"PDF", field: "pdf", formatter: "html"},
-        {title:"Docx", field: "docx", formatter: "html"}
+        {title:"Docx", field: "docx", formatter: "html"},
+        {title:"Docusaurus", field: "docusaurus", formatter: "html"}
     ],
 });
 </script>

--- a/dev-docs/feature-format-matrix/qmd-files/callout/docusaurus.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/callout/docusaurus.qmd
@@ -1,0 +1,18 @@
+---
+title: Callouts
+format: docusaurus-md
+_quarto:
+  tests:
+    docusaurus-md:
+      ensureFileRegexMatches:
+        - [":::note\\[A small note\\]"]
+        - []
+---
+
+::: {.callout-note}
+
+## A small note
+
+You should note that this is a note.
+
+:::

--- a/dev-docs/feature-format-matrix/qmd-files/code-folding/docusaurus.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/code-folding/docusaurus.qmd
@@ -1,0 +1,10 @@
+---
+title: Code fold
+format: 
+  docusaurus-md:
+    code-fold: true
+---
+
+```{r}
+1 + 2
+```

--- a/dev-docs/feature-format-matrix/qmd-files/code-line-numbers/docusaurus.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/code-line-numbers/docusaurus.qmd
@@ -1,0 +1,21 @@
+---
+title: "Plot Test"
+format: docusaurus-md
+code-line-numbers: true
+knitr:
+  opts_chunk: 
+      eval: false
+---
+
+# with line number comment {#with-numbering}
+
+```{r}
+1 + 2
+```
+
+# no line number comment {#no-numbering}
+
+```{r}
+#| code-line-numbers: false
+1 + 2
+```

--- a/dev-docs/feature-format-matrix/qmd-files/crossref/custom/docusaurus.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/crossref/custom/docusaurus.qmd
@@ -1,0 +1,26 @@
+---
+title: Custom crossreferenceable elements
+format: docusaurus-md
+crossref:
+  custom:
+    - kind: float
+      key: dia
+      reference-prefix: Diagram
+      latex-env: diagram
+      latex-list-of-file-extension: lod
+---
+
+::: {#dia-1}
+
+```{mermaid}
+flowchart LR
+  A[Hard edge] --> B(Round edge)
+  B --> C{Decision}
+  C --> D[Result one]
+  C --> E[Result two]
+```
+
+A Mermaid diagram with a caption.
+:::
+
+See @dia-1.

--- a/dev-docs/feature-format-matrix/qmd-files/crossref/float/caption-location-bottom/docusaurus.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/crossref/float/caption-location-bottom/docusaurus.qmd
@@ -1,0 +1,15 @@
+---
+format:
+  docusaurus-md:
+    cap-location: bottom
+---
+
+::: {#tbl-1}
+
+|foo|bar|
+|---|---|
+|v1 |v2 |
+
+This is the table caption.
+
+:::

--- a/dev-docs/feature-format-matrix/qmd-files/crossref/float/caption-location-top/docusaurus.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/crossref/float/caption-location-top/docusaurus.qmd
@@ -1,0 +1,9 @@
+---
+format:
+  docusaurus-md:
+    cap-location: top
+---
+
+![This is the caption](image.jpg){#fig-1}
+
+See @fig-1.

--- a/dev-docs/feature-format-matrix/qmd-files/crossref/float/code-listing/docusaurus.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/crossref/float/code-listing/docusaurus.qmd
@@ -1,0 +1,11 @@
+---
+format: docusaurus-md
+---
+
+## Crossreferenceable Code Listings
+
+```{#lst-customers .sql lst-cap="Customers Query"}
+SELECT * FROM Customers
+```
+
+Then we query the customers database (@lst-customers).

--- a/dev-docs/feature-format-matrix/qmd-files/crossref/float/custom/docusaurus.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/crossref/float/custom/docusaurus.qmd
@@ -1,0 +1,23 @@
+---
+title: Custom crossrefs
+crossref:
+  custom:
+    - kind: float
+      key: dia
+      reference-prefix: Diagram
+---
+
+::: {#dia-1}
+
+```{mermaid}
+flowchart LR
+  A[Hard edge] --> B(Round edge)
+  B --> C{Decision}
+  C --> D[Result one]
+  C --> E[Result two]
+```
+
+A Mermaid diagram with a caption.
+:::
+
+See @dia-1.

--- a/dev-docs/feature-format-matrix/qmd-files/crossref/float/figure/docusaurus.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/crossref/float/figure/docusaurus.qmd
@@ -1,0 +1,8 @@
+---
+title: Cross-referenceable Figures
+format: docusaurus-md
+---
+
+![This is the caption](https://placeholder.co/400){#fig-1}
+
+See @fig-1.

--- a/dev-docs/feature-format-matrix/qmd-files/math/docusaurus.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/math/docusaurus.qmd
@@ -1,0 +1,14 @@
+---
+title: Equations
+_quarto:
+  tests:
+    docusaurus-md:
+      ensureFileRegexMatches:
+        - ["^[$][$]", "^price = \\hat"]
+---
+
+$$
+price = \hat{\beta}_0 + \hat{\beta}_1 \times area + \epsilon
+$$
+
+Inline equations as well: $e = mc^2$.

--- a/dev-docs/feature-format-matrix/qmd-files/mermaid/docusaurus.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/mermaid/docusaurus.qmd
@@ -1,0 +1,14 @@
+---
+title: Mermaid
+format: docusaurus-md
+---
+
+This works, but emits a fairly-wonky markdown and doesn't use Javascript rendering.
+
+```{mermaid}
+flowchart LR
+  A[Hard edge] --> B(Round edge)
+  B --> C{Decision}
+  C --> D[Result one]
+  C --> E[Result two]
+```

--- a/src/resources/extensions/quarto/docusaurus/_extension.yml
+++ b/src/resources/extensions/quarto/docusaurus/_extension.yml
@@ -30,6 +30,8 @@ contributes:
       fig-height: 5
       html-math-method: webtex
       filters:
+        - at: layout-cites
+          path: docusaurus_code_blocks.lua # we need to run this before the code blocks are rendered
         - at: post-render
           path: docusaurus.lua
         - at: post-finalize

--- a/src/resources/extensions/quarto/docusaurus/docusaurus_code_blocks.lua
+++ b/src/resources/extensions/quarto/docusaurus/docusaurus_code_blocks.lua
@@ -1,0 +1,14 @@
+-- docusaurus_code_blocks.lua
+-- Copyright (C) 2024 Posit Software, PBC
+
+local code_block = require('docusaurus_utils').code_block
+
+return {
+  traverse = "topdown",
+  DecoratedCodeBlock = function(el)
+    return nil, false -- defer to the custom renderer later in the pipeline
+  end,
+  CodeBlock = function(el)
+    return code_block(el, el.attr.attributes["filename"])
+  end,
+}

--- a/src/resources/filters/customnodes/floatreftarget.lua
+++ b/src/resources/filters/customnodes/floatreftarget.lua
@@ -138,6 +138,9 @@ function cap_location(float_or_layout)
   return result
 end
 
+-- we need to expose this function for use in the docusaurus renderer
+quarto.doc.crossref.cap_location = cap_location
+
 local function get_node_from_float_and_type(float, type, filter_base)
   -- this explicit check appears necessary for the case where
   -- float.content is directly the node we want, and not a container that
@@ -208,6 +211,11 @@ function decorate_caption_with_crossref(float)
   end
   return float
 end
+
+-- we need to expose this function for use in the docusaurus renderer,
+-- which is technically an extension that doesn't have access to the
+-- internal filters namespace
+quarto.doc.crossref.decorate_caption_with_crossref = decorate_caption_with_crossref
 
 function full_caption_prefix(float, subfloat)
   if not param("enable-crossref", true) then

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -2062,7 +2062,8 @@ quarto = {
     end,
 
     output_file = outputFile(),
-    input_file = inputFile()
+    input_file = inputFile(),
+    crossref = {}
   },
   project = {
    directory = projectDirectory(),

--- a/tests/docs/smoke-all/2024/01/18/docusaurus/callouts.qmd
+++ b/tests/docs/smoke-all/2024/01/18/docusaurus/callouts.qmd
@@ -1,0 +1,18 @@
+---
+title: Callouts
+format: docusaurus-md
+_quarto:
+  tests:
+    docusaurus-md:
+      ensureFileRegexMatches:
+        - [":::note\\[A small note\\]"]
+        - []
+---
+
+::: {.callout-note}
+
+## A small note
+
+You should note that this is a note.
+
+:::

--- a/tests/docs/smoke-all/2024/01/18/docusaurus/equations.mdx.snapshot
+++ b/tests/docs/smoke-all/2024/01/18/docusaurus/equations.mdx.snapshot
@@ -1,0 +1,13 @@
+---
+title: Equations
+format: docusaurus-md
+---
+
+
+
+
+$$
+price = \hat{\beta}_0 + \hat{\beta}_1 \times area + \epsilon
+$$
+
+Inline equations as well: $e = mc^2$.

--- a/tests/docs/smoke-all/2024/01/18/docusaurus/equations.qmd
+++ b/tests/docs/smoke-all/2024/01/18/docusaurus/equations.qmd
@@ -1,0 +1,16 @@
+---
+title: Equations
+format: docusaurus-md
+_quarto:
+  tests:
+    docusaurus-md:
+      ensureFileRegexMatches:
+        - ["\\$\\$", "price = \\\\hat", "\\$e = mc\\^2\\$"]
+      ensureSnapshotMatches: true
+---
+
+$$
+price = \hat{\beta}_0 + \hat{\beta}_1 \times area + \epsilon
+$$
+
+Inline equations as well: $e = mc^2$.

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -24,6 +24,7 @@ import {
   ensureOdtXpath,
   ensurePptxRegexMatches,
   ensureTypstFileRegexMatches,
+  ensureSnapshotMatches,
   fileExists,
   noErrors,
   noErrorsOrWarnings,
@@ -96,6 +97,7 @@ function resolveTestSpecs(
     ensureOdtXpath,
     ensureJatsXpath,
     ensurePptxRegexMatches,
+    ensureSnapshotMatches
   };
 
   for (const [format, testObj] of Object.entries(specs)) {
@@ -130,7 +132,11 @@ function resolveTestSpecs(
               }
             }
           } else if (verifyMap[key]) {
-            verifyFns.push(verifyMap[key](outputFile.outputPath, ...value));
+            if (typeof value === "object") {
+              verifyFns.push(verifyMap[key](outputFile.outputPath, ...value));
+            } else {
+              verifyFns.push(verifyMap[key](outputFile.outputPath, value));
+            }
           }
         }
       }

--- a/tests/verify.ts
+++ b/tests/verify.ts
@@ -229,6 +229,22 @@ export const ensureHtmlElements = (
   };
 };
 
+export const ensureSnapshotMatches = (
+  file: string,
+): Verify => {
+  return {
+    name: "Inspecting Snapshot",
+    verify: async (_output: ExecuteOutput[]) => {
+      const output = await Deno.readTextFile(file);
+      const snapshot = await Deno.readTextFile(file + ".snapshot");
+        assert(
+          output === snapshot || output.replace(/\r\n/g, "\n") === snapshot.replace(/\r\n/g, "\n"),
+          `Snapshot ${file}.snapshot doesn't match output`,
+        );
+    },
+  };
+}
+
 export const ensureFileRegexMatches = (
   file: string,
   matchesUntyped: (string | RegExp)[],


### PR DESCRIPTION
This fixes a number of docusaurus rendering bugs.

- crossreferenceable Figures
- crossreferenceable Tables
- custom crossreferenceable elements (like Diagrams, etc)
- Figure and Table reftargets with custom content in them (Tables with image content, Images with raw content, etc)
- callouts
- code folding
- caption location control
- ...

Things we won't fix here:

- OJS support