### PR TITLE
Fixes escaping bugs

### DIFF
--- a/src/resources/filters/customnodes/shortcodes.lua
+++ b/src/resources/filters/customnodes/shortcodes.lua
@@ -285,7 +285,12 @@ function shortcodes_filter()
         Link = function(el)
           el.target = code_shortcode:match(el.target)
           return el
-        end
+        end,
+        Span = function(el)
+          if el.classes:includes("quarto-shortcode__-escaped") then
+            return pandoc.Str(el.attributes["data-value"])
+          end
+        end,
        })
       return doc
     end

--- a/src/resources/filters/modules/patterns.lua
+++ b/src/resources/filters/modules/patterns.lua
@@ -13,7 +13,7 @@ local html_table = tag(html_table_tag_name)
 local html_table_caption = tag("[Cc][Aa][Pp][Tt][Ii][Oo][Nn]")
 local html_paged_table = "<script data[-]pagedtable[-]source type=\"application/json\">"
 local html_gt_table = "<table class=\"gt_table\">"
-local engine_escape = "{({+([^}]+)}+)}"
+local engine_escape = "{({+([^<}]+)}+)}"
 local shortcode = "{{+<[^>]+>}+}"
 local latex_label = "(\\label{([^}]+)})"
 local latex_caption = "(\\caption{([^}]+)})"

--- a/src/resources/filters/quarto-pre/engine-escape.lua
+++ b/src/resources/filters/quarto-pre/engine-escape.lua
@@ -24,6 +24,10 @@ function engine_escape()
         end
         return "```" .. engine 
       end)
+
+      -- handles escaped inline code cells within a code block
+      el.text = el.text:gsub("(`+)" .. patterns.engine_escape, "%1%2")
+
       return el
     end,
 

--- a/tests/docs/smoke-all/2024/01/22/8389.md.snapshot
+++ b/tests/docs/smoke-all/2024/01/22/8389.md.snapshot
@@ -1,0 +1,26 @@
+---
+_quarto: {}
+foo: bar
+toc-title: Table of contents
+---
+
+    This doesn't unescape and should: `{r} 1.2`
+    This evaluates: 1.2
+    bar
+    In a phrase: bar
+    With quotes: `bar`
+    {{< meta foo >}}
+    In a phrase: {{< meta foo >}}
+    With quotes: `{{< meta foo >}}`
+
+`bar` There's no more bug here.
+
+`{{< meta foo >}}` There's no more bug here.
+
+{{< meta foo >}} Hello?
+
+bar Hello?
+
+Hello, `{{< meta foo >}}`, `bar`.
+
+`` `{{< meta foo >}}` ``, `` `bar` ``.

--- a/tests/docs/smoke-all/2024/01/22/8389.qmd
+++ b/tests/docs/smoke-all/2024/01/22/8389.qmd
@@ -1,0 +1,32 @@
+---
+engine: knitr
+format: markdown
+foo: bar
+_quarto:
+  tests:
+    markdown:
+      ensureSnapshotMatches: true
+---
+
+```
+This doesn't unescape and should: `{{r}} 1.2`
+This evaluates: `{r} 1.2`
+{{< meta foo >}}
+In a phrase: {{< meta foo >}}
+With quotes: `{{< meta foo >}}`
+{{{< meta foo >}}}
+In a phrase: {{{< meta foo >}}}
+With quotes: `{{{< meta foo >}}}`
+```
+
+`{{< meta foo >}}` There's no more bug here.
+
+`{{{< meta foo >}}}` There's no more bug here.
+
+{{{< meta foo >}}} Hello?
+
+{{< meta foo >}} Hello?
+
+Hello, `{{{< meta foo >}}}`, `{{< meta foo >}}`.
+
+`` `{{{< meta foo >}}}` ``, `` `{{< meta foo >}}` ``.


### PR DESCRIPTION
Closes #8389.

The obscure-but-real regression on a "naked" escaped shortcode makes it so that we (very narrowly) think this is a 1.4 fix.