### PR TITLE
1.3 xml fix

### DIFF
--- a/src/resources/filters/layout/docx.lua
+++ b/src/resources/filters/layout/docx.lua
@@ -47,11 +47,11 @@ end
 
 function docxAlign(align)
   if align == "left" then
-    return "start"
+    return "left"
   elseif align == "center" then
     return "center"
   elseif align == "right" then
-    return "end"
+    return "right"
   else
     return nil
   end

--- a/src/resources/filters/quarto-pre/callout.lua
+++ b/src/resources/filters/quarto-pre/callout.lua
@@ -674,6 +674,7 @@ function calloutDocxDefault(node, type, hasIcon)
 
   -- close the table
   local suffix = pandoc.List({pandoc.RawBlock("openxml", [[
+    <w:p/>
     </w:tc>
     </w:tr>
   </w:tbl>

--- a/src/resources/filters/quarto-pre/callout.lua
+++ b/src/resources/filters/quarto-pre/callout.lua
@@ -583,20 +583,23 @@ function calloutDocxDefault(node, type, hasIcon)
     <w:tbl>
     <w:tblPr>
       <w:tblStyle w:val="Table" />
-      <w:tblLook w:firstRow="0" w:lastRow="0" w:firstColumn="0" w:lastColumn="0" w:noHBand="0" w:noVBand="0" w:val="0000" />
+      <w:tblW w:type="pct" w:w="100%"/>
+      <w:tblInd w:w="164" w:type="dxa" />
       <w:tblBorders>  
-        <w:left w:val="single" w:sz="24" w:space="0" w:color="$color"/>  
-        <w:right w:val="single" w:sz="4" w:space="0" w:color="$color"/>  
         <w:top w:val="single" w:sz="4" w:space="0" w:color="$color"/>  
+        <w:left w:val="single" w:sz="24" w:space="0" w:color="$color"/>  
         <w:bottom w:val="single" w:sz="4" w:space="0" w:color="$color"/>  
+        <w:right w:val="single" w:sz="4" w:space="0" w:color="$color"/>  
       </w:tblBorders> 
       <w:tblCellMar>
         <w:left w:w="144" w:type="dxa" />
         <w:right w:w="144" w:type="dxa" />
       </w:tblCellMar>
-      <w:tblInd w:w="164" w:type="dxa" />
-      <w:tblW w:type="pct" w:w="100%"/>
+      <w:tblLook w:firstRow="0" w:lastRow="0" w:firstColumn="0" w:lastColumn="0" w:noHBand="0" w:noVBand="0" w:val="0000" />
     </w:tblPr>
+    <w:tblGrid>
+      <w:gridCol w:w="7920" />
+    </w:tblGrid>
     <w:tr>
       <w:trPr>
         <w:cantSplit/>
@@ -691,7 +694,7 @@ function calloutDocxSimple(node, type, hasIcon)
     <w:tbl>
     <w:tblPr>
       <w:tblStyle w:val="Table" />
-      <w:tblLook w:firstRow="0" w:lastRow="0" w:firstColumn="0" w:lastColumn="0" w:noHBand="0" w:noVBand="0" w:val="0000" />
+      <w:tblInd w:w="164" w:type="dxa" />
       <w:tblBorders>  
         <w:left w:val="single" w:sz="24" w:space="0" w:color="$color"/>  
       </w:tblBorders> 
@@ -699,8 +702,11 @@ function calloutDocxSimple(node, type, hasIcon)
         <w:left w:w="0" w:type="dxa" />
         <w:right w:w="0" w:type="dxa" />
       </w:tblCellMar>
-      <w:tblInd w:w="164" w:type="dxa" />
+      <w:tblLook w:firstRow="0" w:lastRow="0" w:firstColumn="0" w:lastColumn="0" w:noHBand="0" w:noVBand="0" w:val="0000" />
     </w:tblPr>
+    <w:tblGrid>
+      <w:gridCol w:w="7920" />
+    </w:tblGrid>
     <w:tr>
       <w:trPr>
         <w:cantSplit/>


### PR DESCRIPTION
## Description

Word was not able to open DOCX with nested tables due to the XML not conforming to its schema.

I used `docx-validator` and `OOXMLValidatorCLI`:
* tags need to be in the order defined in [wml.xsd](https://github.com/devoidfury/docx-validator/blob/main/schemas/ISO-IEC29500-4_2016/wml.xsd)
* some tags were missing (e.g. `tblGrid` is required)
* `OOXMLValidatorCLI` complained about using `start`/`end` in a Transitional  (as opposed to strict) schema. Pandoc only supports transitional  schema.

To fix nested tables apparently an empty paragraph needs to be inserted.

Tested by @vtraag (OP) and myself (using Office.com).

This doesn't mean that Quarto's output will now always pass the DOCX validator, but other problems can be fixed as they are found.

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog

(I couldn't find a separate changelog. I have written some commit messages though)