### PR TITLE
Lua - maintain a single AST element when parsing HTML from RawBlock

### DIFF
--- a/src/resources/filters/normalize/parsehtml.lua
+++ b/src/resources/filters/normalize/parsehtml.lua
@@ -126,7 +126,7 @@ function parse_html_tables()
               blocks:insert(result)
             end
           end
-          return blocks
+          return pandoc.Div(blocks)
         end
       end
       return el

--- a/tests/docs/smoke-all/2024/01/24/8417.qmd
+++ b/tests/docs/smoke-all/2024/01/24/8417.qmd
@@ -12,11 +12,7 @@ filters:
 
 ```{r libraries}
 #| warning: false
-library(dplyr)
 library(gt)
-library(gtExtras)
-library(janitor)
-library(palmerpenguins)
 m <- mtcars[1:3,] |> 
   gt()
 i <- iris[1:3,] |> 

--- a/tests/docs/smoke-all/2024/01/24/8417.qmd
+++ b/tests/docs/smoke-all/2024/01/24/8417.qmd
@@ -1,0 +1,30 @@
+---
+pagetitle: "test"
+format:
+  html:
+    embed-resources: true
+execute:
+  echo: false
+filters:
+  - at: post-fold-code-and-lift-codeblocks-from-floats
+    path: 8417_test_ast.lua
+---
+
+```{r libraries}
+#| warning: false
+library(dplyr)
+library(gt)
+library(gtExtras)
+library(janitor)
+library(palmerpenguins)
+m <- mtcars[1:3,] |> 
+  gt()
+i <- iris[1:3,] |> 
+  gt()
+```
+
+```{r tables}
+#| layout: [[50, 50]]
+m
+i
+```

--- a/tests/docs/smoke-all/2024/01/24/8417_test_ast.lua
+++ b/tests/docs/smoke-all/2024/01/24/8417_test_ast.lua
@@ -1,0 +1,13 @@
+function Div(div)
+  if (div.classes:includes("cell") and div.attributes.layout ~= nil) then
+    local count = 0
+    quarto._quarto.ast.walk(div, {
+      Div = function(div)
+        if div.classes:includes("cell-output-display") then
+          count = count + #div.content
+        end
+      end
+    })
+    assert(count == 2)
+  end
+end


### PR DESCRIPTION
Closes #8417, maintaining a single output cell in the AST when parsing HTML from RawBlock.

This ensures that the number of cells available for layouts stays the same, regardless of the HTML table processing.