### PR TITLE
Add missing --no-prompt check in quarto use binder

### DIFF
--- a/src/command/use/commands/binder/binder.ts
+++ b/src/command/use/commands/binder/binder.ts
@@ -152,7 +152,7 @@ export const useBinderCommand = new Command()
         info(
           "\nNo files which provide dependencies were discovered. If you continue, no dependencies will be restored when running this project with Binder.\n\nLearn more at:\nhttps://www.quarto.org/docs/prerelease/1.4/binder.html#dependencies\n",
         );
-        const proceed = await Confirm.prompt({
+        const proceed = !options.prompt || await Confirm.prompt({
           message: "Do you want to continue?",
           default: true,
         });


### PR DESCRIPTION
This really 1.4 missing feature for new `quarto use binder` https://quarto.org/docs/projects/binder.html

but maybe too late to merge. I let you decide. It seems small enough though...