### PR TITLE
Extensions - Properly copy project resources from extensions

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -4,6 +4,10 @@ All changes included in 1.5:
 
 - ([#8118](https://github.com/quarto-dev/quarto-cli/issues/8118)): Add support for `body-classes` to add classes to the document body.
 
+## Extensions
+
+- ([#8385](https://github.com/quarto-dev/quarto-cli/issues/8385)): Properly copy project resources when extensions are installed at project level.
+
 ## Other Fixes
 
 - ([#8119](https://github.com/quarto-dev/quarto-cli/issues/8119)): More intelligently detect when ejs templates are modified during development, improving quality of life during preview.

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -140,7 +140,10 @@ export function createExtensionContext(): ExtensionContext {
 // _extensions/confluence/logo.png
 // will be copied and resolved to:
 // site_lib/quarto-contrib/quarto-project/confluence/logo.png
-export function projectExtensionPathResolver(libDir: string) {
+export function projectExtensionPathResolver(
+  libDir: string,
+  projectDir: string,
+) {
   return (href: string, projectOffset: string) => {
     const projectRelativeHref = relative(projectOffset, href);
 
@@ -150,7 +153,11 @@ export function projectExtensionPathResolver(libDir: string) {
         `${libDir}/quarto-contrib/quarto-project/`,
       );
 
-      copyResourceFile(".", projectRelativeHref, projectTargetHref);
+      copyResourceFile(
+        projectDir,
+        join(projectDir, projectRelativeHref),
+        join(projectDir, projectTargetHref),
+      );
       return join(projectOffset, projectTargetHref);
     }
 

--- a/src/project/types/website/website.ts
+++ b/src/project/types/website/website.ts
@@ -194,6 +194,7 @@ export const websiteProjectType: ProjectType = {
           project,
           projectExtensionPathResolver(
             project.config?.project[kProjectLibDir] || "",
+            project.dir,
           ),
         ),
       ]);


### PR DESCRIPTION
Frequently, the render is happening from within the project directory, so the previous implementation would work. But if rendering from within a subfolder, that wouldn’t work - this fixes that.

Fixes #8385
