### PR TITLE
Google Scholar Meta - Improve robustness of CSL date parsing

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -7,12 +7,9 @@ All changes included in 1.5:
 
 ## Website
 
+- ([#8108](https://github.com/quarto-dev/quarto-cli/issues/8108)): Individual pages can suppress breadcrumbs using `bread-crumbs: false`
 - ([#8267](https://github.com/quarto-dev/quarto-cli/issues/8267)): Improve responsive layout of `page-footer`
 - ([#8294](https://github.com/quarto-dev/quarto-cli/issues/8294)): Add support for website announcements, using the `announcement` key under `website`.
-
-## Website
-
-- ([#8108](https://github.com/quarto-dev/quarto-cli/issues/8108)): Individual pages can suppress breadcrumbs using `bread-crumbs: false`
 
 ## Manuscripts
 
@@ -25,6 +22,7 @@ All changes included in 1.5:
 ## Website
 
 - ([#7318](https://github.com/quarto-dev/quarto-cli/issues/7318)): Don't improperly overwrite page titles
+- ([#8426](https://github.com/quarto-dev/quarto-cli/issues/8426)): Ignore invalid dates for references when generating Google Scholar data.
 
 ## Other Fixes
 

--- a/src/core/csl.ts
+++ b/src/core/csl.ts
@@ -165,7 +165,7 @@ export function suggestId(author: CSLName[], date?: CSLDate) {
 // See https://www.loc.gov/standards/datetime/
 // Currently omits time component so this isn't truly level 0
 export function cslDateToEDTFDate(date: CSLDate) {
-  if (date["date-parts"]) {
+  if (date["date-parts"] && date["date-parts"].length > 0) {
     const paddedParts = date["date-parts"][0].map((part) => {
       const partStr = part?.toString();
       if (partStr?.length === 1) {

--- a/src/format/html/format-html-meta.ts
+++ b/src/format/html/format-html-meta.ts
@@ -136,16 +136,21 @@ function googleScholarMeta(
 
   if (csl.issued) {
     const edtfIssued = cslDateToEDTFDate(csl.issued);
-    write("citation_publication_date", edtfIssued);
-    write("citation_cover_date", edtfIssued);
+    if (edtfIssued) {
+      write("citation_publication_date", edtfIssued);
+      write("citation_cover_date", edtfIssued);
+    }
     const parts = csl.issued["date-parts"];
-    if (parts) {
+    if (parts && parts.length > 0) {
       write("citation_year", parts[0][0]);
     }
   }
 
   if (csl["available-date"]) {
-    write("citation_online_date", cslDateToEDTFDate(csl["available-date"]));
+    const edtfAvailable = cslDateToEDTFDate(csl["available-date"]);
+    if (edtfAvailable) {
+      write("citation_online_date", edtfAvailable);
+    }
   }
 
   if (csl.URL) {

--- a/tests/docs/smoke-all/2024/01/24/8362.qmd
+++ b/tests/docs/smoke-all/2024/01/24/8362.qmd
@@ -1,0 +1,15 @@
+---
+title: Hello World
+format: html
+bibliography: bad.bib
+google-scholar: true
+nocite: |
+  @*
+---
+
+## Hello.
+
+### References
+
+::: {#refs}
+:::

--- a/tests/docs/smoke-all/2024/01/24/bad.bib
+++ b/tests/docs/smoke-all/2024/01/24/bad.bib
@@ -1,0 +1,24 @@
+
+@article{guo2020,
+	title = {The origin, transmission and clinical therapies on coronavirus disease 2019 (COVID-19) outbreak {\textendash} an update on the status of our research.},
+	author = {{Guo}, {Yan-Rong} and {Cao}, {Qing-Dong} and {Hong}, {Zhong-Si} and {Tan}, {Yuan-Yang} and {Chen}, {Shou-Deng} and {Jin}, {Hong-Jun} and {Tan}, {Kai-Sen} and {Wang}, {De-Yun} and {Yan}, {Yan}},
+	year = {2020},
+	month = {12},
+	date = {2020-12},
+	journal = {Military Medical Research},
+	pages = {11},
+	volume = {7},
+	number = {1},
+	doi = {10.1186/s40779-020-00240-0},
+	url = {https://mmrjournal.biomedcentral.com/articles/10.1186/s40779-020-00240-0},
+	langid = {en}
+}
+
+
+@book{hootsteinWearingFourPairs2012,
+  title = {Wearing Four Pairs of Shoes: {{The}} Roles of e-Learning Facilitators},
+  author = {Hootstein, Ed},
+  year = {August 16, 2012 2002},
+  publisher = {{American Society for Training and Development}},
+  abstract = {The emergence of e-learning comes at a time when education and training are undergoing important transformations. The teacher-centered model that has dominated instruction for centuries is slowly giving way to a learner-centered model with instructors in the roles of facilitators or "guides on the side." E-learning is no exception. But e-learning's use doesn't preclude facilitators' responsibilities for structuring learning experiences. The effectiveness and success of e-learning programs are dependent on facilitators' roles in delivering and managing instruction. One of the leading conceptualizers in the field of distance learning, Zane Berge, broke down an instructor's role in computer conferencing into four separate parts. I propose a similar model, in which an e-learning facilitator "wears four pairs of shoes"{\textendash}acting as instructor, social director, program manager, and technical assistant.}
+}


### PR DESCRIPTION
Improve robustness of CSL date parsing when rendering google scholar metadata

When we render to CSLJSON using pandoc and an invalid date is present, the CSL date is an empty array rather than undefined, so we need to be aware of this.

Fixes #8362