### PR TITLE
Website - Check title before overwriting with rendered

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -4,6 +4,10 @@ All changes included in 1.5:
 
 - ([#8118](https://github.com/quarto-dev/quarto-cli/issues/8118)): Add support for `body-classes` to add classes to the document body.
 
+## Website
+
+- ([#7318](https://github.com/quarto-dev/quarto-cli/issues/7318)): Don't improperly overwrite page titles
+
 ## Other Fixes
 
 - ([#8119](https://github.com/quarto-dev/quarto-cli/issues/8119)): More intelligently detect when ejs templates are modified during development, improving quality of life during preview.

--- a/src/project/types/website/website-meta.ts
+++ b/src/project/types/website/website-meta.ts
@@ -432,10 +432,12 @@ const kOgTitle = "quarto-ogcardtitle";
 const kOgDesc = "quarto-ogcardddesc";
 const kMetaSideNameId = "quarto-metasitename";
 function metaMarkdownPipeline(format: Format, extras: FormatExtras) {
+  const resolvedTitle = computePageTitle(format);
+
   const titleMetaHandler = {
     getUnrendered() {
       const inlines: Record<string, string> = {};
-      const resolvedTitle = computePageTitle(format);
+
       if (resolvedTitle !== undefined) {
         inlines[kMetaTitleId] = resolvedTitle;
       }
@@ -455,7 +457,7 @@ function metaMarkdownPipeline(format: Format, extras: FormatExtras) {
         const el = doc.querySelector(
           `head title`,
         );
-        if (el) {
+        if (el && el.innerText === resolvedTitle) {
           if (format.pandoc[kNumberSections] === false) {
             // Remove chapter numbers if not numbered
             const numberEl = renderedEl.querySelector("span.chapter-number");


### PR DESCRIPTION
Note that I confirmed that shortcodes will still render properly and behave in a sane fashion as expected.

Fixes #7318

