### PR TITLE
Improve fixupStreams output merging logic

### DIFF
--- a/src/core/jupyter/jupyter-fixups.ts
+++ b/src/core/jupyter/jupyter-fixups.ts
@@ -40,17 +40,17 @@ export function fixupStreams(nb: JupyterNotebook): JupyterNotebook {
 
         // join the outputs if match is found
         if (indices.length > 1) {
-          const streams = indices.map((index) => cell.outputs[index]);
-        const joinedText = streams.map((output) => output.text ?? []).flat();
-        const newOutput: JupyterOutput = {
-          output_type: "stream",
-          name: thisOutput.name,
-          text: joinedText,
-        };
+          const streams = indices.map((index) => cell.outputs![index]);
+          const joinedText = streams.map((output) => output.text ?? []).flat();
+          const newOutput: JupyterOutput = {
+            output_type: "stream",
+            name: thisOutput.name,
+            text: joinedText,
+          };
           cell.outputs[i1] = newOutput;
           cell.outputs = cell.outputs.filter(
             (output, j) => i1 === j || !indices.includes(j)
-        );
+          );
         }
       }
       i1++;


### PR DESCRIPTION
## Description

This PR is a proposed bugfix for https://github.com/quarto-dev/quarto-cli/issues/8473

Minimal reproducible repo is at https://github.com/loneguardian/quarto-cli-issue-8473

This PR:

* Improve the logic of `fixupStreams()` so that it only groups adjacent stream outputs, instead of all stream outputs.

Referring to the original intended fix for #4968:

* I am unsure whether this PR will cause regression
* I am guessing it is unlikely to cause regression.

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md). [In progress]
- [x] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog [not sure which file]
