### PR TITLE
Lua - escape unicode characters around LPEG library

### DIFF
--- a/src/resources/filters/customnodes/shortcodes.lua
+++ b/src/resources/filters/customnodes/shortcodes.lua
@@ -225,8 +225,6 @@ function shortcodes_filter()
       end
       local result = callShortcodeHandler(handler, shortcode_struct)
       return pandoc.utils.stringify(result) 
-    
-      -- return "<<<" .. table.concat(lst, " ") .. ">>>"
     end, 
   })
   local filter
@@ -265,7 +263,7 @@ function shortcodes_filter()
       return
     end
 
-    el.text = code_shortcode:match(el.text)
+    el.text = shortcode_lpeg.wrap_lpeg_match(code_shortcode, el.text)
     return el
   end
 
@@ -284,11 +282,11 @@ function shortcodes_filter()
         Shortcode = inline_handler,
         RawInline = code_handler,
         Image = function(el)
-          el.src = code_shortcode:match(el.src)
+          el.src = shortcode_lpeg.wrap_lpeg_match(code_shortcode, el.src)
           return el
         end,
         Link = function(el)
-          el.target = code_shortcode:match(el.target)
+          el.target = shortcode_lpeg.wrap_lpeg_match(code_shortcode, el.target)
           return el
         end,
         Span = function(el)

--- a/src/resources/pandoc/datadir/readqmd.lua
+++ b/src/resources/pandoc/datadir/readqmd.lua
@@ -126,8 +126,7 @@ end
 
 local function readqmd(txt, opts)
   txt, tags = escape_invalid_tags(txt)
-  txt = md_shortcode.md_shortcode:match(txt)
-
+  txt = md_shortcode.parse_md_shortcode(txt)
   local flavor = {
     format = "markdown",
     extensions = {},
@@ -150,7 +149,7 @@ local function readqmd(txt, opts)
 
   local unshortcode_text = function (c)
     if c.text:match("data%-is%-shortcode%=%\"1%\"") then
-      c.text = md_shortcode.unshortcode:match(c.text)
+      c.text = md_shortcode.unparse_md_shortcode(c.text)
     end
     return c
   end
@@ -159,7 +158,7 @@ local function readqmd(txt, opts)
     CodeBlock = function (cb)
       cb.classes = cb.classes:map(restore_invalid_tags)
       if cb.text:match("data%-is%-shortcode%=%\"1%\"") then
-        cb.text = md_shortcode.unshortcode:match(cb.text)
+        cb.text = md_shortcode.unparse_md_shortcode(cb.text)
       end
       cb.text = unescape_invalid_tags(cb.text, tags)
       return cb
@@ -169,13 +168,13 @@ local function readqmd(txt, opts)
     RawBlock = unshortcode_text,
     Link = function (l)
       if l.target:match("data%-is%-shortcode%=%%221%%22") then
-        l.target = md_shortcode.unshortcode:match(urldecode(l.target))
+        l.target = md_shortcode.unparse_md_shortcode(urldecode(l.target))
         return l
       end
     end,
     Image = function (i)
       if i.src:match("data%-is%-shortcode%=%%221%%22") then
-        i.src = md_shortcode.unshortcode:match(urldecode(i.src))
+        i.src = md_shortcode.unparse_md_shortcode(urldecode(i.src))
         return i
       end
     end,

--- a/tests/docs/smoke-all/2024/01/29/8485.qmd
+++ b/tests/docs/smoke-all/2024/01/29/8485.qmd
@@ -1,0 +1,9 @@
+---
+title: issue-8485
+format: html
+classe_rugosità: value
+---
+
+this shortcode will raise a encoding error on 1.4.549
+
+{{< meta classe_rugosità >}}


### PR DESCRIPTION
Lua's LPEG library is not unicode-aware, and we use it to parse shortcodes in front of Pandoc. If the codepoints are not escaped to plain ASCII, then Lua's LPEG will truncate code points and emit bad UTF-8.

Closes #8485.