### PR TITLE
Embed - Properly emit cell yaml even with `echo` set

### DIFF
--- a/src/core/jupyter/jupyter.ts
+++ b/src/core/jupyter/jupyter.ts
@@ -1386,7 +1386,7 @@ async function mdFromCodeCell(
   const divBeginMd = divMd.join("").replace(/ $/, "").concat("}\n");
 
   // write code if appropriate
-  if (includeCode(cell, options)) {
+  if (includeCode(cell, options) || options.preserveCodeCellYaml) {
     const fenced = echoFenced(cell, options);
     const ticks = "`".repeat(
       Math.max(countTicks(cell.source) + 1, fenced ? 4 : 3),

--- a/tests/docs/embed/qmd-embed/index.qmd
+++ b/tests/docs/embed/qmd-embed/index.qmd
@@ -1,0 +1,7 @@
+---
+title: "Hi"
+---
+
+{{< embed notebook.qmd#fig-index-plot >}}
+
+{{< embed notebook2.qmd#fig-polar echo=true >}}

--- a/tests/docs/embed/qmd-embed/notebook.qmd
+++ b/tests/docs/embed/qmd-embed/notebook.qmd
@@ -1,0 +1,23 @@
+---
+title: "Quarto MWE"
+format: html
+---
+
+```{python}
+#| echo: false 
+#| label: fig-index-plot
+#| fig-cap: "A plot of the sine function"
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+r = np.arange(0, 2, 0.01)
+theta = 2 * np.pi * r
+fig, ax = plt.subplots(
+  subplot_kw = {'projection': 'polar'} 
+)
+ax.plot(theta, r)
+ax.set_rticks([0.5, 1, 1.5, 2])
+ax.grid(True)
+plt.show()
+```

--- a/tests/docs/embed/qmd-embed/notebook2.qmd
+++ b/tests/docs/embed/qmd-embed/notebook2.qmd
@@ -1,0 +1,24 @@
+---
+title: "matplotlib demo"
+format: html
+---
+
+For a demonstration of a line plot on a polar axis, see @fig-polar.
+
+```{python}
+#| label: fig-polar
+#| fig-cap: "A line plot on a polar axis"
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+r = np.arange(0, 2, 0.01)
+theta = 2 * np.pi * r
+fig, ax = plt.subplots(
+  subplot_kw = {'projection': 'polar'} 
+)
+ax.plot(theta, r)
+ax.set_rticks([0.5, 1, 1.5, 2])
+ax.grid(True)
+plt.show()
+```

--- a/tests/smoke/embed/render-embed.test.ts
+++ b/tests/smoke/embed/render-embed.test.ts
@@ -4,7 +4,7 @@
 * Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
-import { dirname, join } from "path/mod.ts";
+import { dirname, extname, join } from "path/mod.ts";
 import { docs, outputForInput } from "../../utils.ts";
 import {
   ensureFileRegexMatches,
@@ -13,6 +13,7 @@ import {
   noErrorsOrWarnings,
 } from "../../verify.ts";
 import { testRender } from "../render/render.ts";
+import { walkSync } from "fs/mod.ts";
 
 const format = "html";
 const input = docs("embed/embed-qmd.qmd");
@@ -102,3 +103,35 @@ testRender(ipynbInput, format, false, [
     return Promise.resolve();
   },
 });
+
+// Test different echo settings (bug 8472)
+const docInput = docs("embed/qmd-embed/index.qmd");
+const docOutput = outputForInput(docInput, "html");
+testRender(docInput, "html", false, [
+  noErrorsOrWarnings,
+  ensureHtmlElements(docOutput.outputPath, [
+    // Make sure the embeds produce expected output
+    "#fig-polar",
+    "#fig-index-plot",
+    // Make sure notebook links are present
+    "a.quarto-notebook-link",
+    ".quarto-alternate-notebooks a",
+  ]),
+  // Ensure the captions look good
+  ensureFileRegexMatches(docOutput.outputPath, [
+    /Figure.*1:/,
+    /Figure.*2:/,
+  ]),
+], {
+  teardown: () => {
+    // Only qmds should be left in this directory
+    const dir = join(Deno.cwd(), dirname(docInput));
+
+    const cleanup = ["notebook.embed_files", "notebook.embed-preview.html", "notebook2.embed_files", "notebook2.embed-preview.html"];
+    cleanup.forEach((path) => {
+      Deno.removeSync(join(dir, path), {recursive: true});
+    })
+    return Promise.resolve();
+  },
+});
+


### PR DESCRIPTION
We rely upon cell yaml when embedding from a qmd -> ipynb, so be sure we emit it even when `echo: false` is set in the QMD

Fixes #8472

