### PR TITLE
chore: add example in plain text of qa discussion template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/feature-requests.yml
+++ b/.github/DISCUSSION_TEMPLATE/feature-requests.yml
@@ -1,4 +1,5 @@
 title: "The (missing) feature you want to discuss"
+labels: "enhancement"
 body:
   - type: markdown
     attributes:

--- a/.github/DISCUSSION_TEMPLATE/feature-requests.yml
+++ b/.github/DISCUSSION_TEMPLATE/feature-requests.yml
@@ -1,5 +1,5 @@
 title: "The (missing) feature you want to discuss"
-labels: "enhancement"
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -9,8 +9,37 @@ body:
         After checking, if you are not sure if your question has already been asked, please create a new discussion.
         We look forward to hearing from you.
 
-        Finally, try to describe the best you can what you want to achieve or what is your issue, especially by providing a complete self-contained reproducible example (as demonstrated in the below form).
+        Finally, try to describe the best you can what you want to achieve or what is your issue, especially by providing a complete self-contained reproducible example (consider reading our ["Bug Reports" guide](https://quarto.org/bug-reports.html)).
         This will help us to understand your question and answer it.
+
+        `````md
+        ````qmd
+        ---
+        title: "Reproducible Quarto Document"
+        format: html
+        engine: jupyter
+        ---
+
+        This is a reproducible Quarto document using `format: html`.
+        It is written in Markdown and contains embedded Python code.
+        When you run the code, it will produce a message.
+
+        ```{python}
+        print("Hello, world!")
+        ```
+
+        ![A placeholder image](https://placehold.co/600x400.png)
+
+        The end.
+        ````
+        `````
+
+        You can add some additional information that can help us to help you:
+
+        - What Quarto version are you using?  
+          You can find the version of Quarto you used by running `quarto --version` in your terminal.
+        - What operating system are you using?  
+          Linux Ubuntu 20.04, macOS 11.2.3, Windows 10, _etc._
 
         _Thank you for opening this discussion either to ask for help or to report a possible bug!_
   - type: textarea


### PR DESCRIPTION
This PR adds a small reproducible example snippet as plain text in addition to the placeholder which is actually nit very visible.
It also adds a default labels for Feature Request discussion, namely "enhancement" (mostly for convenience, when creating issues from discussions).

<img width="779" alt="image" src="https://github.com/quarto-dev/quarto-cli/assets/8896044/25e3e9c1-c610-4f2b-bc6d-43f554248fc6">
