### PR TITLE
parsermd qmd typo fixes

### DIFF
--- a/tests/docs/smoke-all/confluence/confluence-smoke-test.qmd
+++ b/tests/docs/smoke-all/confluence/confluence-smoke-test.qmd
@@ -568,7 +568,7 @@ While the examples above illustrate laying out figures, it's important to note t
 -   Item X
 -   Item Y
 -   Item Z
-    :::
+:::
 
 Note that headings are automatically combined with the block that follows them, so this markdown has a total of 2 columns to lay out. Here's an example of a paragraph next to a bullet list (without headings):
 


### PR DESCRIPTION
## Description

This pull requests fixes two small typos I've found while testing [parsermd](https://github.com/rundel/parsermd) against  qmd documents in the `tests/` directory.  

## Checklist

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog

I don't believe any of the above are applicable here
