### PR TITLE
Lua - pass Inlines to inlinesToString in columns-preprocess

### DIFF
--- a/src/resources/filters/layout/columns-preprocess.lua
+++ b/src/resources/filters/layout/columns-preprocess.lua
@@ -259,7 +259,7 @@ function columnOption(key)
   if value == nil or #value < 1 then
     return {}
   else
-    return {'column-' .. inlinesToString(value[1])}
+    return {'column-' .. inlinesToString(quarto.utils.as_inlines(value[1]))}
   end
 end
 

--- a/tests/docs/smoke-all/2024/02/01/8536.qmd
+++ b/tests/docs/smoke-all/2024/02/01/8536.qmd
@@ -1,0 +1,16 @@
+---
+title: "Screen inset"
+format: 
+  html:
+    column: screen-inset-right
+editor_options: 
+  chunk_output_type: console
+---
+
+## Plot
+
+```{r}
+data(iris)
+
+plot(Sepal.Length ~ Sepal.Width, data = iris)
+```


### PR DESCRIPTION
Closes #8536.

We'll backport this narrow regression fix to 1.4, and I'll add a separate issue for us to do a code review over all calls to inlinesToString. We now have `quarto.utils.as_inlines`, which we should be using possibly even in the body of `inlinesToString`, so that it is fundamentally more robust.