### PR TITLE
feat: add documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,41 @@
+name: Documentation issue
+description: Report issues on quarto.org, give documentation feedback, or suggest documentation improvements
+labels: ["documentation", "triaged-to"]
+assignees:
+  - cwickham
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Welcome to the quarto GitHub repository!
+
+        We are always happy to hear feedback from our users.
+
+        When reporting an issue with the documentation, please consider adding a link to the page you are referring to and a screenshot of the issue.
+
+        If you want to report a bug, please use the [Bug Reports GitHub Issues](https://github.com/quarto-dev/quarto-cli/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml).
+        If you want to ask for a feature, please use the [Feature Requests GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/feature-requests).
+        If you want to ask for help, please use the [Q&A GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/q-a).
+
+        Thank you for using Quarto!
+
+  - type: dropdown
+    id: type-documentation
+    attributes:
+      label: What would you like to do?
+      options:
+        - Report an issue on quarto.org
+        - Give feedback or suggest an improvement
+      default: 0
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: Describe the issue, give feedback or suggest an improvement.
+      placeholder: Please describe your issue/feedback/improvement here. For issues on quarto.org, include a link to the page you are referring to and a screenshot of the issue.
+
+  - type: markdown
+    attributes:
+      value: "_Thanks for submitting this bug report, feedback or improvement suggestion!_"


### PR DESCRIPTION
This PR adds a documentation issue template to help retrieve those "independently" of bug report and feature requests.

<img width="1500" alt="image" src="https://github.com/quarto-dev/quarto-cli/assets/8896044/cc076600-cf0b-479a-98f4-4b0df561f793">


PS: @cderv I don't think the CI should be triggered on changes to `.github` (and similar directories).