### PR TITLE
Dashboard - correct title from code cell

### DIFF
--- a/src/resources/filters/quarto-post/dashboard.lua
+++ b/src/resources/filters/quarto-post/dashboard.lua
@@ -328,11 +328,11 @@ function render_dashboard()
                   local prefixLen = pandoc.text.len(titlePrefix)
 
                   local strValue = codeBlockEl.text
-                  if pandoc.text.len(strValue) > prefixLen then
+                  if pandoc.text.len(strValue) > prefixLen and strValue:match('^title=') then                    
                     options['title'] = trim(pandoc.text.sub(codeBlockEl.text, prefixLen + 1))
+                    cardContent = tslice(cardContent, 2)
                   end
                 end
-                cardContent = tslice(cardContent, 2)
               end
             end
 

--- a/tests/docs/smoke-all/dashboard/bugs/8552.qmd
+++ b/tests/docs/smoke-all/dashboard/bugs/8552.qmd
@@ -1,0 +1,17 @@
+---
+title: "Untitled"
+format: dashboard
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - 
+          - <code>\[1\] 0\.6</code>
+        - [] 
+---
+
+```{r}
+0.6
+2 + 2
+```
+


### PR DESCRIPTION
We should check to see if the `title` prefix is present.

Fixes #8552

