### PR TITLE
Website Nav - use text for aria-label

### DIFF
--- a/src/project/types/book/book.ts
+++ b/src/project/types/book/book.ts
@@ -180,11 +180,12 @@ export const bookProjectType: ProjectType = {
   ) => {
     const chapterInfo = chapterInfoForInput(context, input);
     if (chapterInfo && number) {
-      return Promise.resolve(
-        numberChapterHtmlNav(text, chapterInfo),
-      );
+      return Promise.resolve({
+        text,
+        html: numberChapterHtmlNav(text, chapterInfo),
+      });
     } else {
-      return Promise.resolve(text);
+      return Promise.resolve({ html: text, text: text });
     }
   },
 

--- a/src/project/types/types.ts
+++ b/src/project/types/types.ts
@@ -66,7 +66,7 @@ export interface ProjectType {
     input: string,
     text: string,
     number: boolean,
-  ) => Promise<string>;
+  ) => Promise<{ html: string, text: string}>;
   incrementalRenderAll?: (
     context: ProjectContext,
     options: RenderOptions,

--- a/src/project/types/website/website-navigation.ts
+++ b/src/project/types/website/website-navigation.ts
@@ -1397,7 +1397,12 @@ function uniqueMenuId(navItem: NavigationItemObject) {
 }
 
 async function resolveItem<
-  T extends { href?: string; text?: string; icon?: string },
+  T extends {
+    href?: string;
+    text?: string;
+    icon?: string;
+    plainText?: string;
+  },
 >(
   project: ProjectContext,
   href: string,
@@ -1415,12 +1420,14 @@ async function resolveItem<
 
       const projType = projectType(project.config?.project?.[kProjectType]);
       if (projType.navItemText) {
-        inputItem.text = await projType.navItemText(
+        const navItemFormatted = await projType.navItemText(
           project,
           href,
           inputItem.text,
           number,
         );
+        inputItem.text = navItemFormatted.html;
+        inputItem.plainText = navItemFormatted.text;
       }
       return inputItem;
     } else if (looksLikeShortCode(href)) {

--- a/src/resources/projects/website/templates/nav-after-body-postamble.ejs
+++ b/src/resources/projects/website/templates/nav-after-body-postamble.ejs
@@ -4,7 +4,7 @@
 <nav class="page-navigation">
   <div class="nav-page nav-page-previous">
     <% if (nav.prevPage) { %>
-      <a  href="<%- nav.prevPage.href %>" class="pagination-link" aria-label="<%- nav.prevPage.text %>">
+      <a  href="<%- nav.prevPage.href %>" class="pagination-link" aria-label="<%- nav.prevPage.plainText || nav.prevPage.text %>">
         <i class="bi bi-arrow-left-short"></i> <span class="nav-page-text"><%= nav.prevPage.text %></span>
       </a>          
     <% } %>
@@ -13,7 +13,7 @@
 
   <div class="nav-page nav-page-next">
     <% if (nav.nextPage) { %>
-      <a  href="<%- nav.nextPage.href %>" class="pagination-link" aria-label="<%- nav.nextPage.text %>">
+      <a  href="<%- nav.nextPage.href %>" class="pagination-link" aria-label="<%- nav.nextPage.plainText || nav.nextPage.text %>">
         <span class="nav-page-text"><%= nav.nextPage.text %></span> <i class="bi bi-arrow-right-short"></i>
       </a>
     <% } %>


### PR DESCRIPTION
Books were injecting HTML tags into the nav item text, which would cause HTML tags to be embedded within the aria-label. Instead, use a plain text representation.

Fixes #8555

