### PR TITLE
Website About - fix layout

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -16,6 +16,7 @@ All changes included in 1.5:
 - ([#8267](https://github.com/quarto-dev/quarto-cli/issues/8267)): Improve responsive layout of `page-footer`
 - ([#8294](https://github.com/quarto-dev/quarto-cli/issues/8294)): Add support for website announcements, using the `announcement` key under `website`.
 - ([#8426](https://github.com/quarto-dev/quarto-cli/issues/8426)): Ignore invalid dates for references when generating Google Scholar data.
+- ([#8544](https://github.com/quarto-dev/quarto-cli/issues/8544)): Fix about page layout when using an `id` to provide contents.
 - ([#8588](https://github.com/quarto-dev/quarto-cli/issues/8588)): Fix display of `bread-crumbs` on pages with banner style title blocks.
 
 ## OJS

--- a/src/resources/projects/website/about/about.scss
+++ b/src/resources/projects/website/about/about.scss
@@ -62,6 +62,7 @@ div.quarto-about-jolla {
   align-items: center;
   margin-top: 10%;
   padding-bottom: 1em;
+  grid-row: content-top/content-bottom;
 
   .about-image {
     object-fit: cover;
@@ -106,6 +107,7 @@ div.quarto-about-solana {
   flex-direction: column;
   padding-top: 3em !important;
   padding-bottom: 1em;
+  grid-row: content-top/content-bottom;
 
   .about-entity {
     display: flex !important;
@@ -169,6 +171,7 @@ div.quarto-about-trestles {
   flex-direction: row;
   padding-top: 3em !important;
   padding-bottom: 1em;
+  grid-row: content-top/content-bottom;
 
   @include media-breakpoint-down(lg) {
     flex-direction: column;
@@ -224,6 +227,8 @@ div.quarto-about-trestles {
 // Marquee
 div.quarto-about-marquee {
   padding-bottom: 1em;
+  grid-row: content-top/content-bottom;
+
   .about-contents {
     display: flex;
     flex-direction: column;
@@ -259,6 +264,7 @@ div.quarto-about-broadside {
   display: flex;
   flex-direction: column;
   padding-bottom: 1em;
+  grid-row: content-top/content-bottom;
 
   .about-main {
     display: flex !important;

--- a/src/resources/projects/website/about/broadside.ejs.html
+++ b/src/resources/projects/website/about/broadside.ejs.html
@@ -1,4 +1,4 @@
-<div class="quarto-about-broadside column-page content">
+<div class="quarto-about-broadside column-page">
   <div class="about-main">
     <div
       class="about-entity"

--- a/src/resources/projects/website/about/jolla.ejs.html
+++ b/src/resources/projects/website/about/jolla.ejs.html
@@ -1,4 +1,4 @@
-<div class="quarto-about-jolla content">
+<div class="quarto-about-jolla">
   <% partial('_image.ejs.html', { about, imgOpts: {} }) %> <%= about.title %><%=
   about.body %> <% if (about.links) { %>
   <hr class="about-sep" />

--- a/src/resources/projects/website/about/marquee.ejs.html
+++ b/src/resources/projects/website/about/marquee.ejs.html
@@ -1,4 +1,4 @@
-<div class="quarto-about-marquee content">
+<div class="quarto-about-marquee">
   <div class="about-image-container">
     <% partial('_image.ejs.html', { about, imgOpts: {} }) %>
   </div>

--- a/src/resources/projects/website/about/solana.ejs.html
+++ b/src/resources/projects/website/about/solana.ejs.html
@@ -1,4 +1,4 @@
-<div class="quarto-about-solana column-body content">
+<div class="quarto-about-solana column-body">
   <div class="about-entity">
     <div class="entity-contents">
       <%= about.title %> <% partial('_links.ejs.html', { about }) %>

--- a/src/resources/projects/website/about/trestles.ejs.html
+++ b/src/resources/projects/website/about/trestles.ejs.html
@@ -1,4 +1,4 @@
-<div class="quarto-about-trestles content">
+<div class="quarto-about-trestles">
   <div class="about-entity">
     <% partial('_image.ejs.html', { about, imgOpts: {} }) %><%= about.title %>
     <% partial('_links.ejs.html', { about }) %>


### PR DESCRIPTION
The `content` class applies a flex order as well which repositions the contents of the div, which isn’t desirable. Just apply the column directly instead.

Fixes #8544

