### PR TITLE
Quarto email: ensure that lack of subject line is handled

### DIFF
--- a/src/resources/filters/quarto-post/email.lua
+++ b/src/resources/filters/quarto-post/email.lua
@@ -185,7 +185,7 @@ function generate_html_email_from_template(
   return html_str
 end
 
-local subject = nil
+local subject = ""
 local email_images = {}
 local image_tbl = {}
 local suppress_scheduled_email = false

--- a/tests/docs/email/email-no-subject.qmd
+++ b/tests/docs/email/email-no-subject.qmd
@@ -1,0 +1,22 @@
+---
+title: Email Test Document with No Subject Line
+author: Richard Iannone
+format: email
+---
+
+The report content. Anything that is here is not part of the email message.
+
+::: {.email}
+
+::: {.email-text}
+An optional text-only version of the email message..
+:::
+
+The HTML email content. Here you can add code cells, produce images, and write accompanying text.
+This content is not seen when viewing the rendered document on Connect (it's only
+seen when sending an email from the Connect document page). Emails from Connect
+can be sent manually, and they can also be scheduled.
+
+:::
+
+Any additional report content not part of the email message.

--- a/tests/smoke/render/render-email.test.ts
+++ b/tests/smoke/render/render-email.test.ts
@@ -35,6 +35,9 @@ testRender(docs("email/email.qmd"), "email", false, [fileExists(previewFile), va
 // Test basic attachment render, which will validate that attachment shows up in JSON
 testRender(docs("email/email-attach.qmd"), "email", false, [fileExists(previewFile), validJsonWithFields(jsonFile, {"rsc_email_subject": "The subject line.", "rsc_email_attachments": ["raw_data.csv"]})], cleanupCtx);
 
+// Test an email render that has no subject line, this verifies that `rsc_email_subject` key is present and the value is an empty string
+testRender(docs("email/email-no-subject.qmd"), "email", false, [fileExists(previewFile), validJsonWithFields(jsonFile, {"rsc_email_subject": ""})], cleanupCtx);
+
 // Render in a project with an output directory and confirm that everything ends up in the output directory
 testProjectRender(docs("email/project/email-attach.qmd"), "email", "_out", (outputDir: string) => {
   const verify: Verify[]= [];


### PR DESCRIPTION
This change to quarto email ensures that some subject line is passed to Connect. By initializing with an empty string and replacing that when a subject div is found, we can ensure that (1) there won't be an error on the quarto side, (2) the `rsc_email_subject` key in the `_metadata.json` file passed to Connect is populated either with an empty string (handled by Connect) or the user's subject line.

Added a test to render a qmd file (`format: email`) that excludes the subject div. Expectation is that the render is successful and that the `rsc_email_subject` key in the produced `_metadata.json` has a value of `""`.

Fixes: https://github.com/quarto-dev/quarto-cli/issues/8439