### PR TITLE
lua,latex - do not crash with empty floats

### DIFF
--- a/src/resources/filters/customnodes/floatreftarget.lua
+++ b/src/resources/filters/customnodes/floatreftarget.lua
@@ -294,6 +294,11 @@ end, function(float)
   local capLoc = cap_location(float)
   local caption_cmd_name = latexCaptionEnv(float)
 
+  if float.content == nil then
+    warn("FloatRefTarget with no content: " .. float.identifier)
+    return pandoc.Div({})
+  end
+
   if float.parent_id then
     if caption_cmd_name == kSideCaptionEnv then
       fail_and_ask_for_bugreport("Subcaptions for side captions are unimplemented.")

--- a/tests/docs/smoke-all/2024/02/13/empty-floats.qmd
+++ b/tests/docs/smoke-all/2024/02/13/empty-floats.qmd
@@ -1,0 +1,23 @@
+---
+title: "empty floats"
+format: latex
+_quarto:
+  tests:
+    latex:
+      verifyNoErrors: true
+---
+
+:::{#fig-1}
+
+:::{.content-hidden when-format="latex"}
+![A sub-caption](an-image.png){#fig-1-1}
+:::
+
+:::{.content-hidden when-format="latex"}
+![A sub-caption](an-image.png){#fig-1-2}
+:::
+
+A caption.
+:::
+
+


### PR DESCRIPTION
In some cases we might end up with empty floats in our pipeline ([conditional content](https://github.com/quarto-dev/quarto-cli/issues/6123#issuecomment-1942846884) likely being the most common). Let's emit a warning in this case instead of crashing.

