### PR TITLE
`quarto use` support for non-empty directories

### DIFF
--- a/src/command/use/commands/template.ts
+++ b/src/command/use/commands/template.ts
@@ -23,6 +23,7 @@ import { createTempContext } from "../../../core/temp.ts";
 import {
   completeInstallation,
   confirmInstallation,
+  copyExtensions,
 } from "../../../extension/install.ts";
 import { kExtensionDir } from "../../../extension/constants.ts";
 import { InternalError } from "../../../core/lib/error.ts";
@@ -153,7 +154,13 @@ async function useTemplate(
     if (installExtensions) {
       installedExtensions.push(...templateExtensions);
       await withSpinner({ message: "Installing extensions..." }, async () => {
-        await completeInstallation(stagedDir, outputDirectory);
+        // Copy the extensions into a substaging directory
+        // this will ensure that they are namespaced properly
+        const subStagedDir = tempContext.createDir();
+        await copyExtensions(source, stagedDir, subStagedDir);
+
+        // Now complete installation from this sub-staged directory
+        await completeInstallation(subStagedDir, outputDirectory);
       });
     }
 

--- a/tests/smoke/use/template.test.ts
+++ b/tests/smoke/use/template.test.ts
@@ -1,0 +1,60 @@
+import { testQuartoCmd } from "../../test.ts";
+import { directoryContainsOnlyAllowedPaths, fileExists, folderExists, noErrorsOrWarnings, printsMessage } from "../../verify.ts";
+import { join } from "path/mod.ts";
+import { ensureDirSync } from "fs/mod.ts";
+
+const tempDir = Deno.makeTempDirSync();
+
+const templateFolder = "article";
+const workingDir = join(tempDir, templateFolder);
+const extensionsDir = join(workingDir, "_extensions");
+ensureDirSync(workingDir);
+testQuartoCmd(
+  "use",
+  ["template", "quarto-journals/jasa", "--no-prompt"],
+  [noErrorsOrWarnings, fileExists(`${templateFolder}.qmd`), folderExists(extensionsDir)],
+  {
+    setup: () => {
+      return Promise.resolve();
+    },
+    cwd: () => {
+      return workingDir;
+    },
+    teardown: () => {
+      try {
+       Deno.removeSync(workingDir, {recursive: true});
+      } catch {
+
+      }
+       return Promise.resolve();
+    }
+  }
+)
+
+const nonEmptyTemplateFolder = "notempty";
+const nonEmptyFileName = `${nonEmptyTemplateFolder}.qmd`;
+const nonEmptyWorkingDir = join(tempDir, nonEmptyTemplateFolder);
+ensureDirSync(nonEmptyWorkingDir);
+
+testQuartoCmd(
+  "use",
+  ["template", "quarto-journals/jasa", "--no-prompt"],
+  [printsMessage("ERROR", /directory isn't empty/), directoryContainsOnlyAllowedPaths(nonEmptyWorkingDir, [nonEmptyFileName])],
+  {
+    setup: () => {
+      Deno.writeTextFileSync(join(nonEmptyWorkingDir, nonEmptyFileName), "Just making a non-empty file!");
+      return Promise.resolve();
+    },
+    cwd: () => {
+      return nonEmptyWorkingDir;
+    },
+    teardown: () => {
+      try {
+       Deno.removeSync(nonEmptyWorkingDir, {recursive: true});
+      } catch {
+        
+      }
+       return Promise.resolve();
+    }
+  }
+)

--- a/tests/verify.ts
+++ b/tests/verify.ts
@@ -4,10 +4,10 @@
  * Copyright (C) 2020-2022 Posit Software, PBC
  */
 
-import { existsSync } from "fs/mod.ts";
+import { existsSync, walkSync} from "fs/mod.ts";
 import { DOMParser, NodeList } from "../src/core/deno-dom.ts";
 import { assert } from "testing/asserts.ts";
-import { join } from "path/mod.ts";
+import { join, relative } from "path/mod.ts";
 import { parseXmlDocument } from "slimdom";
 import xpath from "fontoxpath";
 import * as ld from "../src/core/lodash.ts";
@@ -138,6 +138,34 @@ export const fileExists = (file: string): Verify => {
     },
   };
 };
+
+export const directoryContainsOnlyAllowedPaths = (dir: string, paths: string[]): Verify => {
+  return {
+    name: `Ensure only has ${paths.length} paths in folder`,
+    verify: (_output: ExecuteOutput[]) => {
+
+      for (const walk of walkSync(dir)) {
+        const path = relative(dir, walk.path);
+        if (path !== "") {
+          assert(paths.includes(path), `Unexpected path ${path} encountered.`); 
+  
+        }
+      }    
+      return Promise.resolve();
+    },
+  };
+}
+
+export const folderExists = (path: string): Verify => {
+  return {
+    name: `Folder ${path} exists`,
+    verify: (_output: ExecuteOutput[]) => {
+      verifyPath(path);
+      assert(Deno.statSync(path).isDirectory, `Path ${path} isn't a folder`);
+      return Promise.resolve();
+    },
+  }; 
+}
 
 export const validJsonFileExists = (file: string): Verify => {
   return {


### PR DESCRIPTION
Add for executing the `quarto use` command in non-empty directories. This requires some additional improvements to the overall installation process as outlined below. (Fixes #8595)

### When prompting is enabled
- The user may always elect to install into the current directory
- If the user selects the current directory, its folder name will be used as the name for the main `qmd` (e.g. a folder named my-article will contain the file my-article.qmd once the template has been used).
- The user may still elect to use a subdirectory
- The use command will now explicitly use extension installation to compare any existing extensions with extensions provided by the template. The user is presented with an option to accept the extension changes or exit.
- The use command will now prompt before overwriting a conflicting file. If there are no file conflicts, it will not prompt.

### When prompting is not enabled
- If prompting is not allowed (e.g. in CI), `quarto use` will error when attempting to use a template in a non-empty directory. It the responsibility of the calling script to ensure that the working directory for `quarto use` is empty.

### Tests
This PR adds tests that verify
- basic unprompted installation works as expected
- unprompted non-empty installation throws an error

### Example Session

The following example shell session uses two different templates in the same working directory:

```bash
charlesteague@MacBook-Pro journal-article % quarto use template quarto-journals/jasa

Quarto templates may execute code when documents are rendered. If you do not
trust the authors of the template, we recommend that you do not install or
use the template.
 ? Do you trust the authors of this template (Y/n) › Yes
 ? Create a subdirectory for template? (y/N) › No
[✓] Downloading
[✓] Unzipping

The template requires the following changes to extensions:
Journal of the American Statistical Association   [Install]   0.10.1 (formats)
 ? Would you like to continue (Y/n) › Yes

Preparing template files...

[✓] Copying
[✓] Installing extensions...
[✓] Copying files...

Extensions installed:
 - Journal of the American Statistical Association

Files created:
 - agsm.bst
 - bibliography.bib
 - fig1.pdf
 - journal-article.qmd
charlesteague@MacBook-Pro journal-article % quarto use template quarto-journals/jss

Quarto templates may execute code when documents are rendered. If you do not
trust the authors of the template, we recommend that you do not install or
use the template.
 ? Do you trust the authors of this template (Y/n) › Yes
 ? Create a subdirectory for template? (Y/n) › No
[✓] Downloading
[✓] Unzipping

The template requires the following changes to extensions:
Journal of Statistical Software Format   [Install]   0.9.4 (formats)
 ? Would you like to continue (Y/n) › Yes

Preparing template files...
 ? Overwrite file bibliography.bib? (y/n) › No
 ? Overwrite file journal-article.qmd? (y/n) › No

[✓] Copying
[✓] Installing extensions...
[✓] Copying files...

Extensions installed:
 - Journal of Statistical Software Format

Files created:
 - article-visualization.pdf
charlesteague@MacBook-Pro journal-article %
```