### PR TITLE
Correctly normalize to forward slash the path when creating tar.gz for Posit Connect deploys

### DIFF
--- a/src/publish/common/bundle.ts
+++ b/src/publish/common/bundle.ts
@@ -13,6 +13,7 @@ import { Tar } from "archive/tar.ts";
 import { PublishFiles } from "../provider-types.ts";
 import { TempContext } from "../../core/temp-types.ts";
 import { md5HashBytes } from "../../core/hash.ts";
+import { pathWithForwardSlashes } from "../../core/path.ts";
 
 interface ManifestMetadata {
   appmode: string;
@@ -97,7 +98,9 @@ export async function createBundle(
   const tarFiles = [...files.files, "manifest.json"];
 
   for (const tarFile of tarFiles) {
-    await tar.append(tarFile, { filePath: join(stageDir, tarFile) });
+    await tar.append(pathWithForwardSlashes(tarFile), {
+      filePath: join(stageDir, tarFile),
+    });
   }
 
   // write to temp file


### PR DESCRIPTION

`std/archive/tar.ts` will create folders based on file paths used, but it requires using `/` and not `\` in path. This is a problem on Windows, where the path separator is `\`. This commit adds a check to normalize the path to use `/` instead of `\` when creating the tar.gz file for Connect deploys.

fixes #8749

Opening as a PR as I want to be sure the `manifest.json` file needs also normalizing or not. 

Test shows it works with only this fix. 

@cscheid as this impact Posit connect deploys, and this is quite scoped, could we target this for our next path release of 1.4 ? 