### PR TITLE
Improve default in create project when no-prompt 

### DIFF
--- a/src/command/create/artifacts/project.ts
+++ b/src/command/create/artifacts/project.ts
@@ -25,6 +25,7 @@ import { join } from "path/mod.ts";
 
 // ensures project types are registered
 import "../../../project/types/register.ts";
+import { warning } from "log/mod.ts";
 
 const kProjectTypes = projectTypes();
 const kProjectTypeAliases = projectTypeAliases();
@@ -120,11 +121,17 @@ function finalizeOptions(createContext: CreateContext) {
   const typeStr = createContext.options[kType] as string || "default";
   // Resolve the type and template
   const resolved = resolveTemplate(typeStr);
-  const name = createContext.options.name;
   const directory = join(
     createContext.cwd,
     createContext.options[kSubdirectory] as string,
   );
+  let name = createContext.options.name;
+  if (!name) {
+    name = defaultName(createContext.options[kSubdirectory], typeStr);
+    warning(
+      `No 'title' for project provided in \`quarto create project\`. Using '${name}' as default.`,
+    );
+  }
   const template = resolved.template
     ? `${resolved.type}:${resolved.template}`
     : resolved.type;
@@ -179,9 +186,10 @@ function nextPrompt(
       name: "name",
       message: "Title",
       type: Input,
-      default: createOptions.options[kSubdirectory] !== "."
-        ? createOptions.options[kSubdirectory]
-        : createOptions.options[kType],
+      default: defaultName(
+        createOptions.options[kSubdirectory],
+        createOptions.options[kType],
+      ),
     };
   }
 }
@@ -238,4 +246,9 @@ async function createArtifact(
       ? ["index.qmd", "_quarto.yml"]
       : ["_quarto.yml"],
   };
+}
+
+// choose a default name if none provided in the createContext
+function defaultName(subdirectory, type) {
+  return subdirectory !== "." ? subdirectory : type;
 }

--- a/src/command/create/artifacts/project.ts
+++ b/src/command/create/artifacts/project.ts
@@ -193,8 +193,8 @@ function nextPrompt(
       message: "Title",
       type: Input,
       default: defaultName(
-        createOptions.options[kSubdirectory],
-        createOptions.options[kType],
+        createOptions.options[kSubdirectory] as string,
+        createOptions.options[kType] as string,
       ),
     };
   }
@@ -255,6 +255,6 @@ async function createArtifact(
 }
 
 // choose a default name if none provided in the createContext
-function defaultName(subdirectory, type) {
+function defaultName(subdirectory: string, type: string) {
   return subdirectory !== "." ? subdirectory : type;
 }

--- a/src/command/create/artifacts/project.ts
+++ b/src/command/create/artifacts/project.ts
@@ -127,13 +127,10 @@ function finalizeOptions(createContext: CreateContext) {
       "A directory is required for project creation with \`quarto create project\`",
     );
   }
-  const directory = join(
-    createContext.cwd,
-    createContext.options[kSubdirectory] as string,
-  );
+  const directory = join(createContext.cwd, subdirectory);
   let name = createContext.options.name;
   if (!name) {
-    name = defaultName(createContext.options[kSubdirectory], typeStr);
+    name = defaultName(subdirectory, typeStr);
     warning(
       `No 'title' for project provided in \`quarto create project\`. Using '${name}' as default.`,
     );

--- a/src/command/create/artifacts/project.ts
+++ b/src/command/create/artifacts/project.ts
@@ -121,6 +121,12 @@ function finalizeOptions(createContext: CreateContext) {
   const typeStr = createContext.options[kType] as string || "default";
   // Resolve the type and template
   const resolved = resolveTemplate(typeStr);
+  const subdirectory = createContext.options[kSubdirectory] as string;
+  if (!subdirectory) {
+    throw new Error(
+      "A directory is required for project creation with \`quarto create project\`",
+    );
+  }
   const directory = join(
     createContext.cwd,
     createContext.options[kSubdirectory] as string,


### PR DESCRIPTION
This PR improve user experience fro 
````bash
quarto create project <type> <directory> <title> --no-prompt
````

This will now error like this 
````powershell
> quarto create project --no-prompt
ERROR: A directory is required for project creation with `quarto create project`
````

and passing no title will use the directory name 
````powershell
> quarto create project default test-project --no-prompt --no-open
WARNING: No 'title' for project provided in `quarto create project`. Using 'test-project' as default.
Creating project at C:\Users\chris\AppData\Local\Temp\RtmpCyCVMf\file7824480e6a30\test-project:
  - Created _quarto.yml
  - Created test-project.qmd
````

with a warning to indicate the non provided argument 

If that is ok, then I'll try to add test creation with `--no-prompt`

I have some in Quarto R package and this is how I found this in the first place. 

fixes #8809 