### PR TITLE
Improve/perf capture file opens

### DIFF
--- a/src/core/performance/metrics.ts
+++ b/src/core/performance/metrics.ts
@@ -6,9 +6,33 @@
 
 import { inputTargetIndexCacheMetrics } from "../../project/project-index.ts";
 
+type FileReadRecord = {
+  path: string;
+  stack: string;
+};
+
+let fileReads: FileReadRecord[] | undefined = undefined;
+
+export function captureFileReads() {
+  fileReads = [];
+
+  const originalReadTextFileSync = Deno.readTextFileSync;
+
+  Deno.readTextFileSync = function (path: string | URL) {
+    try {
+      throw new Error("File read");
+    } catch (e) {
+      const stack = e.stack!.split("\n").slice(2);
+      fileReads!.push({ path: String(path), stack });
+    }
+    return originalReadTextFileSync(path);
+  };
+}
+
 export function quartoPerformanceMetrics() {
   return {
     inputTargetIndexCache: inputTargetIndexCacheMetrics,
+    fileReads,
   };
 }
 

--- a/src/quarto.ts
+++ b/src/quarto.ts
@@ -13,13 +13,7 @@ import {
 } from "cliffy/command/mod.ts";
 
 import { commands } from "./command/command.ts";
-import {
-  appendLogOptions,
-  cleanupLogger,
-  initializeLogger,
-  logError,
-  logOptions,
-} from "./core/log.ts";
+import { appendLogOptions } from "./core/log.ts";
 import { debug } from "log/mod.ts";
 
 import { cleanupSessionTempDir, initSessionTempDir } from "./core/temp.ts";
@@ -36,9 +30,8 @@ import {
   reconfigureQuarto,
 } from "./core/devconfig.ts";
 import { typstBinaryPath } from "./core/typst.ts";
-import { exitWithCleanup, onCleanup } from "./core/cleanup.ts";
+import { onCleanup } from "./core/cleanup.ts";
 
-import { parse } from "flags/mod.ts";
 import { runScript } from "./command/run/run.ts";
 
 // ensures run handlers are registered


### PR DESCRIPTION
Adds the ability to set QUARTO_CAPTURE_PERFORMANCE_METRICS on the environment.

Currently, this will:

- patch Deno.readTextFileSync to catch the stack trace and collect it
- print Deno's performance metrics together with whatever we captured

It's a simple thing but I already noticed a bad duplication of effort in our code base that would case Quarto to traverse the entire project multiple times per render (duplicate creation of extension contexts which meant no caching).

