### PR TITLE
perf - create a single extension context

### DIFF
--- a/src/command/preview/cmd.ts
+++ b/src/command/preview/cmd.ts
@@ -391,7 +391,11 @@ export const previewCommand = new Command()
     // see if we are serving a project or a file
     if (Deno.statSync(file).isDirectory) {
       // project preview
-      await serveProject(projectTarget, flags, args, {
+      const renderOptions = {
+        services: renderServices(notebookContext()),
+        flags,
+      };
+      await serveProject(projectTarget, renderOptions, args, {
         port: options.port,
         host: options.host,
         browser: (options.browser === false || options.browse === false)

--- a/src/command/render/project.ts
+++ b/src/command/render/project.ts
@@ -294,7 +294,7 @@ export async function renderProject(
     context = await projectContextForDirectory(
       context.dir,
       context.notebookContext,
-      projectRenderConfig.options.flags,
+      projectRenderConfig.options,
     );
 
     // Validate that certain project properties haven't been mutated

--- a/src/command/render/render-shared.ts
+++ b/src/command/render/render-shared.ts
@@ -18,10 +18,6 @@ import { renderProject } from "./project.ts";
 import { renderFiles } from "./render-files.ts";
 import { resourceFilesFromRenderedFile } from "./resources.ts";
 import { RenderFlags, RenderOptions, RenderResult } from "./types.ts";
-import {
-  fileExecutionEngine,
-  fileExecutionEngineAndTarget,
-} from "../../execute/engine.ts";
 
 import {
   isProjectInputFile,
@@ -49,12 +45,12 @@ export async function render(
   const nbContext = notebookContext();
 
   // determine target context/files
-  let context = await projectContext(path, nbContext, options.flags);
+  let context = await projectContext(path, nbContext, options);
 
   // if there is no project parent and an output-dir was passed, then force a project
   if (!context && options.flags?.outputDir) {
     // recompute context
-    context = await projectContextForDirectory(path, nbContext, options.flags);
+    context = await projectContextForDirectory(path, nbContext, options);
 
     // force clean as --output-dir implies fully overwrite the target
     options.forceClean = options.flags.clean !== false;

--- a/src/core/performance/metrics.ts
+++ b/src/core/performance/metrics.ts
@@ -6,9 +6,33 @@
 
 import { inputTargetIndexCacheMetrics } from "../../project/project-index.ts";
 
+type FileReadRecord = {
+  path: string;
+  stack: string;
+};
+
+let fileReads: FileReadRecord[] | undefined = undefined;
+
+export function captureFileReads() {
+  fileReads = [];
+
+  const originalReadTextFileSync = Deno.readTextFileSync;
+
+  Deno.readTextFileSync = function (path: string | URL) {
+    try {
+      throw new Error("File read");
+    } catch (e) {
+      const stack = e.stack!.split("\n").slice(2);
+      fileReads!.push({ path: String(path), stack });
+    }
+    return originalReadTextFileSync(path);
+  };
+}
+
 export function quartoPerformanceMetrics() {
   return {
     inputTargetIndexCache: inputTargetIndexCacheMetrics,
+    fileReads,
   };
 }
 

--- a/src/project/project-context.ts
+++ b/src/project/project-context.ts
@@ -69,7 +69,11 @@ import {
   projectResolveFullMarkdownForFile,
   projectVarsFile,
 } from "./project-shared.ts";
-import { RenderFlags, RenderServices } from "../command/render/types.ts";
+import {
+  RenderFlags,
+  RenderOptions,
+  RenderServices,
+} from "../command/render/types.ts";
 import { kWebsite } from "./types/website/website-constants.ts";
 
 import { readAndValidateYamlFromFile } from "../core/schema/validated-yaml.ts";
@@ -95,16 +99,18 @@ import { MappedString } from "../core/mapped-text.ts";
 export async function projectContext(
   path: string,
   notebookContext: NotebookContext,
-  flags?: RenderFlags,
+  renderOptions?: RenderOptions,
   force = false,
 ): Promise<ProjectContext | undefined> {
+  const flags = renderOptions?.flags;
   let dir = normalizePath(
     Deno.statSync(path).isDirectory ? path : dirname(path),
   );
   const originalDir = dir;
 
-  // create a shared extension context
-  const extensionContext = createExtensionContext();
+  // create an extension context if one doesn't exist
+  const extensionContext = renderOptions?.services.extension ||
+    createExtensionContext();
 
   // first pass uses the config file resolve
   const configSchema = await getProjectConfigSchema();
@@ -636,9 +642,9 @@ async function resolveLanguageTranslations(
 export function projectContextForDirectory(
   path: string,
   notebookContext: NotebookContext,
-  flags?: RenderFlags,
+  renderOptions?: RenderOptions,
 ): Promise<ProjectContext> {
-  return projectContext(path, notebookContext, flags, true) as Promise<
+  return projectContext(path, notebookContext, renderOptions, true) as Promise<
     ProjectContext
   >;
 }

--- a/src/project/serve/serve.ts
+++ b/src/project/serve/serve.ts
@@ -82,7 +82,11 @@ import { htmlResourceResolverPostprocessor } from "../../project/types/website/w
 import { inputFilesDir } from "../../core/render.ts";
 import { kResources, kTargetFormat } from "../../config/constants.ts";
 import { resourcesFromMetadata } from "../../command/render/resources.ts";
-import { RenderFlags, RenderResult } from "../../command/render/types.ts";
+import {
+  RenderFlags,
+  RenderOptions,
+  RenderResult,
+} from "../../command/render/types.ts";
 import {
   kPdfJsInitialPath,
   pdfJsBaseDir,
@@ -124,18 +128,23 @@ export const kRenderDefault = "default";
 
 export async function serveProject(
   target: string | ProjectContext,
-  flags: RenderFlags,
+  renderOptions: RenderOptions,
   pandocArgs: string[],
   options: ServeOptions,
   noServe: boolean,
 ) {
   let project: ProjectContext | undefined;
-  const nbContext = notebookContext();
+  let flags = renderOptions.flags;
+  const nbContext = renderOptions.services.notebook;
   if (typeof target === "string") {
     if (target === ".") {
       target = Deno.cwd();
     }
-    project = await projectContext(target, nbContext, flags);
+    project = await projectContext(
+      target,
+      nbContext,
+      renderOptions,
+    );
     if (!project || !project?.config) {
       throw new Error(`${target} is not a project`);
     }
@@ -301,7 +310,7 @@ export async function serveProject(
     project,
     extensionDirs,
     resourceFiles,
-    flags,
+    { ...renderOptions, flags },
     pandocArgs,
     options,
     !pdfOutput, // we don't render on reload for pdf output

--- a/src/project/serve/watch.ts
+++ b/src/project/serve/watch.ts
@@ -25,7 +25,7 @@ import { projectContext } from "../../project/project-context.ts";
 
 import { ProjectWatcher, ServeOptions } from "./types.ts";
 import { httpDevServer } from "../../core/http-devserver.ts";
-import { RenderFlags } from "../../command/render/types.ts";
+import { RenderOptions } from "../../command/render/types.ts";
 import { renderProject } from "../../command/render/project.ts";
 import { render } from "../../command/render/render-shared.ts";
 import { renderServices } from "../../command/render/render-services.ts";
@@ -53,7 +53,7 @@ export function watchProject(
   project: ProjectContext,
   extensionDirs: string[],
   resourceFiles: string[],
-  flags: RenderFlags,
+  renderOptions: RenderOptions,
   pandocArgs: string[],
   options: ServeOptions,
   renderingOnReload: boolean,
@@ -61,9 +61,11 @@ export function watchProject(
   stopServer: VoidFunction,
 ): Promise<ProjectWatcher> {
   const nbContext = notebookContext();
+  const flags = renderOptions.flags;
   // helper to refresh project config
   const refreshProjectConfig = async () => {
-    project = (await projectContext(project.dir, nbContext, flags, false))!;
+    project =
+      (await projectContext(project.dir, nbContext, renderOptions, false))!;
   };
 
   // See if we're in draft mode

--- a/src/quarto.ts
+++ b/src/quarto.ts
@@ -13,13 +13,7 @@ import {
 } from "cliffy/command/mod.ts";
 
 import { commands } from "./command/command.ts";
-import {
-  appendLogOptions,
-  cleanupLogger,
-  initializeLogger,
-  logError,
-  logOptions,
-} from "./core/log.ts";
+import { appendLogOptions } from "./core/log.ts";
 import { debug } from "log/mod.ts";
 
 import { cleanupSessionTempDir, initSessionTempDir } from "./core/temp.ts";
@@ -36,9 +30,8 @@ import {
   reconfigureQuarto,
 } from "./core/devconfig.ts";
 import { typstBinaryPath } from "./core/typst.ts";
-import { exitWithCleanup, onCleanup } from "./core/cleanup.ts";
+import { onCleanup } from "./core/cleanup.ts";
 
-import { parse } from "flags/mod.ts";
 import { runScript } from "./command/run/run.ts";
 
 // ensures run handlers are registered


### PR DESCRIPTION
Using #8820, I noticed that we were sometimes creating multiple extension contexts. This PR moves that object creation further up the stack and reuses RenderOptions whenever possible.

This reduces the amount of traversal that Quarto does in the file system.