### PR TITLE
typst theorems

### DIFF
--- a/dev-docs/feature-format-matrix/qmd-files/crossref/block/theorem/document.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/crossref/block/theorem/document.qmd
@@ -1,0 +1,34 @@
+---
+format:
+  html:
+    quality: 2
+  pdf:
+    quality: 2
+  typst:
+    quality: 2
+  dashboard:
+    quality: 1
+  markdown:
+    quality: 2
+  docx:
+    quality: 1
+  pptx:
+    quality: 1
+  ipynb:
+    quality: 0
+    comment: "Renders as HTML prefixed with # on empty line"
+
+---
+
+::: {#thm-line}
+
+## Line
+
+The equation of any straight line, called a linear equation, can be written as:
+
+$$
+y = mx + b
+$$
+:::
+
+See @thm-line.

--- a/src/resources/filters/customnodes/theorem.lua
+++ b/src/resources/filters/customnodes/theorem.lua
@@ -99,7 +99,8 @@ local function ensure_typst_theorems(reftype)
   if not letted_typst_theorem[reftype] then
     letted_typst_theorem[reftype] = true
     local theorem_type = theorem_types[reftype]
-    quarto.doc.include_text("in-header", "#let " .. theorem_type.env .. " = thmbox(\"" .. theorem_type.env .. "\", \"" .. theorem_type.title .. "\", fill: rgb(\"#eeffee\"))")
+    quarto.doc.include_text("in-header", "#let " .. theorem_type.env .. " = thmbox(\"" ..
+     theorem_type.env .. "\", \"" .. theorem_type.title .. "\")")
   end
 end
 
@@ -160,11 +161,9 @@ end, function(thm)
     if name then
       tappend(callthm.content, name)
     end
-    quarto.log.output(el.content)
     callthm.content:insert(pandoc.RawInline("typst", "\")["))
     tappend(callthm.content, quarto.utils.as_inlines(el.content))
     callthm.content:insert(pandoc.RawInline("typst", "] <" .. el.attr.identifier .. ">"))
-    quarto.log.output(callthm.content)
     return callthm
 
   else

--- a/src/resources/filters/customnodes/theorem.lua
+++ b/src/resources/filters/customnodes/theorem.lua
@@ -88,6 +88,22 @@ _quarto.ast.add_handler({
   end
 })
 
+local included_typst_theorems = false
+local letted_typst_theorem = {}
+local function ensure_typst_theorems(reftype)
+  if not included_typst_theorems then
+    included_typst_theorems = true
+    quarto.doc.include_text("in-header", "#import \"@preview/ctheorems:1.1.0\": *")
+    quarto.doc.include_text("in-header", "#show: thmrules")
+  end
+  if not letted_typst_theorem[reftype] then
+    letted_typst_theorem[reftype] = true
+    local theorem_type = theorem_types[reftype]
+    quarto.doc.include_text("in-header", "#let " .. theorem_type.env .. " = thmbox(\"" .. theorem_type.env .. "\", \"" .. theorem_type.title .. "\", fill: rgb(\"#eeffee\"))")
+  end
+end
+
+
 _quarto.ast.add_renderer("Theorem", function()
   return true 
 end, function(thm)
@@ -136,7 +152,21 @@ end, function(thm)
     -- JATS XML theorem
     local lbl = captionPrefix({}, type, theorem_type, order)
     el = jatsTheorem(el, lbl, name)          
-    
+
+  elseif _quarto.format.isTypstOutput() then
+    ensure_typst_theorems(type)
+    -- el.content:insert(1, pandoc.RawInline("typst", "#" .. theorem_type.env .. "(\"" .. thm.name .. "\")["))
+    local callthm = pandoc.Para(pandoc.RawInline("typst", "#" .. theorem_type.env .. "(\""))
+    if name then
+      tappend(callthm.content, name)
+    end
+    quarto.log.output(el.content)
+    callthm.content:insert(pandoc.RawInline("typst", "\")["))
+    tappend(callthm.content, quarto.utils.as_inlines(el.content))
+    callthm.content:insert(pandoc.RawInline("typst", "] <" .. el.attr.identifier .. ">"))
+    quarto.log.output(callthm.content)
+    return callthm
+
   else
     -- create caption prefix
     local captionPrefix = captionPrefix(name, type, theorem_type, order)

--- a/tests/docs/smoke-all/crossrefs/theorem/lemma-1.qmd
+++ b/tests/docs/smoke-all/crossrefs/theorem/lemma-1.qmd
@@ -1,5 +1,7 @@
 ---
-keep-typ: true
+format:
+  typst:
+    output-ext: typ
 _quarto:
   tests:
     html:

--- a/tests/docs/smoke-all/crossrefs/theorem/lemma-1.qmd
+++ b/tests/docs/smoke-all/crossrefs/theorem/lemma-1.qmd
@@ -1,0 +1,44 @@
+---
+keep-typ: true
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - 
+          - "a.quarto-xref"
+        - []
+    latex:
+      ensureFileRegexMatches:
+        -
+          - "hypertarget{lem-line}"
+          - "label{lem-line}"
+          - "Lemma~\\\\ref\\{lem-line\\}"
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        - 
+          - "<lem-line>"
+          - "@lem-line"
+          - "#lemma\\(\"Line\"\\)"
+        - []
+    markdown:
+      ensureFileRegexMatches:
+        -
+          - "\\[Lemma 1\\]\\(#lem-line\\)\\{.quarto-xref\\}"
+          - '\[\*\*Lemma 1 \(Line\)\*\*\]\{.theorem-title\}'
+    
+
+---
+
+::: {#lem-line}
+
+## Line
+
+The equation of any straight line, called a linear equation, can be written as:
+
+$$
+y = mx + b
+$$
+:::
+
+See @lem-line.

--- a/tests/docs/smoke-all/crossrefs/theorem/theorem-1.qmd
+++ b/tests/docs/smoke-all/crossrefs/theorem/theorem-1.qmd
@@ -1,5 +1,7 @@
 ---
-keep-typ: true
+format:
+  typst:
+    output-ext: typ
 _quarto:
   tests:
     html:

--- a/tests/docs/smoke-all/crossrefs/theorem/theorem-1.qmd
+++ b/tests/docs/smoke-all/crossrefs/theorem/theorem-1.qmd
@@ -1,0 +1,44 @@
+---
+keep-typ: true
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - 
+          - "a.quarto-xref"
+        - []
+    latex:
+      ensureFileRegexMatches:
+        -
+          - "hypertarget{thm-line}"
+          - "label{thm-line}"
+          - "Theorem~\\\\ref\\{thm-line\\}"
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        - 
+          - "<thm-line>"
+          - "@thm-line"
+          - "#theorem\\(\"Line\"\\)"
+        - []
+    markdown:
+      ensureFileRegexMatches:
+        -
+          - "\\[Theorem 1\\]\\(#thm-line\\)\\{.quarto-xref\\}"
+          - '\[\*\*Theorem 1 \(Line\)\*\*\]\{.theorem-title\}'
+    
+
+---
+
+::: {#thm-line}
+
+## Line
+
+The equation of any straight line, called a linear equation, can be written as:
+
+$$
+y = mx + b
+$$
+:::
+
+See @thm-line.


### PR DESCRIPTION
Here are typst theorems, along with tests for a few formats and a row in the feature-format matrix.

It was easier to use the [typst-theorems](https://github.com/sahasatvik/typst-theorems) extension than to simplify the feature wrapper. 

The light green background color is from their example and hardcoded here... haven't looked at how to add new parameters and defaults.

<img width="559" alt="image" src="https://github.com/quarto-dev/quarto-cli/assets/1366709/32f0b1c4-ebfe-4ba7-ae03-a0e1a22fabbc">


Seems like black magic getting the newlines to work out right in pandoc (and typst may be more sensitive to these). Hoping I will understand blocks and inlines better over time.