### PR TITLE
Research/windows uniciode paths

### DIFF
--- a/src/command/render/filters.ts
+++ b/src/command/render/filters.ts
@@ -87,6 +87,7 @@ import { kJatsSubarticle } from "../../format/jats/format-jats-types.ts";
 import { shortUuid } from "../../core/uuid.ts";
 import { isServerShinyPython } from "../../core/render.ts";
 import { pythonExec } from "../../core/jupyter/exec.ts";
+import { encode as base64Encode } from "encoding/base64.ts";
 
 const kQuartoParams = "quarto-params";
 
@@ -682,7 +683,7 @@ function initFilterParams(dependenciesFile: string) {
       Deno.env.set("QUARTO_WIN_CODEPAGE", value);
     }
   }
-  Deno.env.set("QUARTO_FILTER_DEPENDENCY_FILE", dependenciesFile);
+  Deno.env.set("QUARTO_FILTER_DEPENDENCY_FILE", base64Encode(dependenciesFile));
   return params;
 }
 

--- a/src/resources/filters/modules/license.lua
+++ b/src/resources/filters/modules/license.lua
@@ -6,7 +6,7 @@
 -- restructured into the standard license
 -- format
 
-local constants = require("./constants")
+local constants = require("modules/constants")
 
 local function ccLicenseUrl(type, lang, version) 
   local langStr = 'en'

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -1493,7 +1493,7 @@ local function dependenciesFile()
   if dependenciesFile == nil then
     error('Missing expected dependency file environment variable QUARTO_FILTER_DEPENDENCY_FILE')
   else
-    return pandoc.utils.stringify(dependenciesFile)
+    return quarto.base64.decode(dependenciesFile)
   end
 end
 


### PR DESCRIPTION
- [x] LUA module loading
- [ ] To make LUA module loading work, we load the module for `license.lua` different, but this clearly has issues still
- [x] Installing TinyTex
- [ ] Known issue with python path handling - we are failing to initialize the logger in `log.py#19` likely due to incorrect path encoding
- [ ] Known issue can occur when attempting to read temp file path (this has been transient so I haven't pinned down when it happens yet)