### PR TITLE
fix issue in books when `page-footer` is a link

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -24,6 +24,10 @@ All changes included in 1.5:
 - ([#8544](https://github.com/quarto-dev/quarto-cli/issues/8544)): Fix about page layout when using an `id` to provide contents.
 - ([#8588](https://github.com/quarto-dev/quarto-cli/issues/8588)): Fix display of `bread-crumbs` on pages with banner style title blocks.
 
+## Book
+
+- ([#8737](https://github.com/quarto-dev/quarto-cli/issues/8737)): Fix issue in `page-footer` when url are used in `href` for book's configuration.
+
 ## OJS
 
 - ([#8327](https://github.com/quarto-dev/quarto-cli/issues/8327)): Issue error messages on console so they're visible in the case of hidden OJS cells.

--- a/src/project/types/book/book-config.ts
+++ b/src/project/types/book/book-config.ts
@@ -124,6 +124,7 @@ import {
 } from "../../../resources/types/schema-types.ts";
 import { projectType } from "../project-types.ts";
 import { BookRenderItem, BookRenderItemType } from "./book-types.ts";
+import { isAbsoluteRef } from "../../../core/http.ts";
 
 export async function bookProjectConfig(
   project: ProjectContext,
@@ -255,7 +256,7 @@ export async function bookProjectConfig(
       for (const item of region) {
         if (typeof item !== "string") {
           const navItem = item as NavigationItemObject;
-          if (navItem.href) {
+          if (navItem.href && !isAbsoluteRef(navItem.href)) {
             footerFiles.push(navItem.href);
           }
         }

--- a/tests/docs/smoke-all/book/page-footer/.gitignore
+++ b/tests/docs/smoke-all/book/page-footer/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+/_book/

--- a/tests/docs/smoke-all/book/page-footer/_quarto.yml
+++ b/tests/docs/smoke-all/book/page-footer/_quarto.yml
@@ -1,0 +1,28 @@
+project:
+  type: book
+
+book:
+  title: "Testing Page Footer"
+  author: "Norah Jones"
+  date: "22/02/2024"
+  chapters:
+    - index.qmd
+    - intro.qmd
+    - summary.qmd
+    - references.qmd
+  page-footer:
+    left:
+      - text: Quarto
+        href: https://quarto.org
+    right: "Some text"
+    center:
+      - text: "Licence"
+        href: license.qmd
+
+bibliography: references.bib
+
+format:
+  html:
+    theme: cosmo
+  pdf:
+    documentclass: scrreprt

--- a/tests/docs/smoke-all/book/page-footer/index.qmd
+++ b/tests/docs/smoke-all/book/page-footer/index.qmd
@@ -1,0 +1,17 @@
+---
+_quarto:
+  tests:
+    html: 
+      ensureHtmlElements:
+        - 
+          - 'footer.footer div.nav-footer-left a.nav-link[href="https://quarto.org"]'
+          - 'footer.footer div.nav-footer-center a.nav-link[href$="license.html"]'
+          - 'footer.footer div.nav-footer-right p'
+        - []
+---
+
+# Preface {.unnumbered}
+
+This is a Quarto book.
+
+To learn more about Quarto books visit <https://quarto.org/docs/books>.

--- a/tests/docs/smoke-all/book/page-footer/intro.qmd
+++ b/tests/docs/smoke-all/book/page-footer/intro.qmd
@@ -1,0 +1,5 @@
+# Introduction
+
+This is a book created from markdown and executable code.
+
+See @knuth84 for additional discussion of literate programming.

--- a/tests/docs/smoke-all/book/page-footer/license.qmd
+++ b/tests/docs/smoke-all/book/page-footer/license.qmd
@@ -1,0 +1,5 @@
+---
+title: Licence for this project
+---
+
+License content file

--- a/tests/docs/smoke-all/book/page-footer/references.bib
+++ b/tests/docs/smoke-all/book/page-footer/references.bib
@@ -1,0 +1,19 @@
+@article{knuth84,
+  author = {Knuth, Donald E.},
+  title = {Literate Programming},
+  year = {1984},
+  issue_date = {May 1984},
+  publisher = {Oxford University Press, Inc.},
+  address = {USA},
+  volume = {27},
+  number = {2},
+  issn = {0010-4620},
+  url = {https://doi.org/10.1093/comjnl/27.2.97},
+  doi = {10.1093/comjnl/27.2.97},
+  journal = {Comput. J.},
+  month = may,
+  pages = {97–111},
+  numpages = {15}
+}
+
+

--- a/tests/docs/smoke-all/book/page-footer/references.qmd
+++ b/tests/docs/smoke-all/book/page-footer/references.qmd
@@ -1,0 +1,4 @@
+# References {.unnumbered}
+
+::: {#refs}
+:::

--- a/tests/docs/smoke-all/book/page-footer/summary.qmd
+++ b/tests/docs/smoke-all/book/page-footer/summary.qmd
@@ -1,0 +1,3 @@
+# Summary
+
+In summary, this book has no content whatsoever.


### PR DESCRIPTION
Change has been made in 90e04f46d1e9c0a80c761f2ef005819f7ba4f860 following discussion in #3441 to allow `href` being a .qmd file to be rendered.

Though when `href` is a link, it made Windows fails because our globExpanson on Linux knows to ignore https:// one, and on Windows it doesn't. Deno behavior for `expandGlobSync` - see discussion in issue #8737)

fixes #8737
