### PR TITLE
Fix support in books for url in `bibliogrpahy` field

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -27,6 +27,7 @@ All changes included in 1.5:
 ## Book
 
 - ([#8737](https://github.com/quarto-dev/quarto-cli/issues/8737)): Fix issue in `page-footer` when url are used in `href` for book's configuration.
+- ([#8814](https://github.com/quarto-dev/quarto-cli/issues/8814)): Fix issue with `bibliography` field using urls in book's configuration.
 
 ## OJS
 

--- a/src/project/types/book/book-bibliography.ts
+++ b/src/project/types/book/book-bibliography.ts
@@ -40,6 +40,7 @@ import { WebsiteProjectOutputFile } from "../website/website.ts";
 import { bookMultiFileHtmlOutputs } from "./book-extension.ts";
 import { ProjectOutputFile } from "../types.ts";
 import { projectType } from "../project-types.ts";
+import { isAbsoluteRef } from "../../../core/http.ts";
 
 export async function bookBibliography(
   outputFiles: ProjectOutputFile[],
@@ -76,7 +77,11 @@ export async function bookBibliography(
     const firstFileDir = dirname(inputfile.file);
     bibliographyPaths.push(
       ...bibliography.map((file) =>
-        isAbsolute(file) ? file : join(firstFileDir, file)
+        // we don't want to process already absolute path or url
+        // (Pandoc supports fetching bibliography from the web)
+        isAbsolute(file) || isAbsoluteRef(file)
+          ? file
+          : join(firstFileDir, file)
       ),
     );
 

--- a/tests/docs/smoke-all/2024/02/22/8814/.gitignore
+++ b/tests/docs/smoke-all/2024/02/22/8814/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+/_book/

--- a/tests/docs/smoke-all/2024/02/22/8814/_quarto.yml
+++ b/tests/docs/smoke-all/2024/02/22/8814/_quarto.yml
@@ -1,0 +1,25 @@
+project:
+  type: book
+
+book:
+  title: "Url-bib"
+  author: "Norah Jones"
+  date: "22/02/2024"
+  chapters:
+    - index.qmd
+    - intro.qmd
+    - summary.qmd
+    - references.qmd
+
+bibliography: 
+  - references.bib
+  - https://raw.githubusercontent.com/quarto-dev/quarto-cli/main/tests/docs/biblio/biblio.bib
+
+format:
+  html:
+    theme: cosmo
+  pdf:
+    documentclass: scrreprt
+
+
+

--- a/tests/docs/smoke-all/2024/02/22/8814/index.qmd
+++ b/tests/docs/smoke-all/2024/02/22/8814/index.qmd
@@ -1,0 +1,5 @@
+# Preface {.unnumbered}
+
+This is a Quarto book.
+
+To learn more about Quarto books visit <https://quarto.org/docs/books>.

--- a/tests/docs/smoke-all/2024/02/22/8814/intro.qmd
+++ b/tests/docs/smoke-all/2024/02/22/8814/intro.qmd
@@ -1,0 +1,17 @@
+---
+_quarto:
+  html:
+    ensureHtmlElement:
+    - 
+      - 'span.citation[data-cites="knuth84"]'
+      - 'span.citation[data-cites="Blei09"]'
+  pdf: default
+---
+
+# Introduction
+
+This is a book created from markdown and executable code.
+
+See @knuth84 for additional discussion of literate programming.
+
+and @Blei09 Is pretty sweet.

--- a/tests/docs/smoke-all/2024/02/22/8814/references.bib
+++ b/tests/docs/smoke-all/2024/02/22/8814/references.bib
@@ -1,0 +1,19 @@
+@article{knuth84,
+  author = {Knuth, Donald E.},
+  title = {Literate Programming},
+  year = {1984},
+  issue_date = {May 1984},
+  publisher = {Oxford University Press, Inc.},
+  address = {USA},
+  volume = {27},
+  number = {2},
+  issn = {0010-4620},
+  url = {https://doi.org/10.1093/comjnl/27.2.97},
+  doi = {10.1093/comjnl/27.2.97},
+  journal = {Comput. J.},
+  month = may,
+  pages = {97–111},
+  numpages = {15}
+}
+
+

--- a/tests/docs/smoke-all/2024/02/22/8814/references.qmd
+++ b/tests/docs/smoke-all/2024/02/22/8814/references.qmd
@@ -1,0 +1,14 @@
+---
+_quarto:
+  html:
+    ensureHtmlElement:
+    - 
+      - 'div#ref-Blei09'
+      - 'div#ref-knuth84'
+  pdf: default
+---
+
+# References {.unnumbered}
+
+::: {#refs}
+:::

--- a/tests/docs/smoke-all/2024/02/22/8814/summary.qmd
+++ b/tests/docs/smoke-all/2024/02/22/8814/summary.qmd
@@ -1,0 +1,3 @@
+# Summary
+
+In summary, this book has no content whatsoever.


### PR DESCRIPTION
For book we do a pre-processing of the `bibliography` field to generate ourselfs the bibliography output. This processing now accounts for a url path used in addition of relative or absolute path.

fixes #8814
