### PR TITLE
lua,latex - Don't process rawhtml when a crossref category is mismatched

### DIFF
--- a/src/resources/filters/quarto-pre/parsefiguredivs.lua
+++ b/src/resources/filters/quarto-pre/parsefiguredivs.lua
@@ -656,7 +656,9 @@ function parse_floatreftargets()
       -- knitr can emit a label that starts with "tab:"
       -- we don't handle those as floats
       local ref = refType(identifier)
-      if ref == nil then
+      -- https://github.com/quarto-dev/quarto-cli/issues/8841#issuecomment-1959667121
+      if ref ~= "tbl" then
+        warn("Raw LaTeX table found with non-tbl label: " .. identifier .. "\nWon't be able to cross-reference this table using Quarto's native crossref system.")
         return nil
       end
 

--- a/tests/docs/smoke-all/2024/02/22/8841-b.qmd
+++ b/tests/docs/smoke-all/2024/02/22/8841-b.qmd
@@ -1,0 +1,22 @@
+---
+title: "Table test"
+format: latex
+_quarto:
+  tests:
+    latex:
+      ensureFileRegexMatches:
+        - ["\\\\begin{table}\\[ht\\]"]
+        - []
+---
+
+```{=latex}
+\begin{table}[ht]
+\begin{tabular}{ll}
+foo & bar
+\end{tabular}
+\caption{label has dash: problem}
+\label{has-dash}
+\end{table}
+```
+
+See \ref{has-dash}.


### PR DESCRIPTION
Closes #8841.