### PR TITLE
Fix a regression with detecting latex dependencies knit_meta in books

### DIFF
--- a/src/resources/rmd/execute.R
+++ b/src/resources/rmd/execute.R
@@ -574,7 +574,7 @@ is_pandoc_html_format <- function(format) {
 
 # check if pandoc$to is latex output
 is_pandoc_latex_output <- function(format) {
-  knitr:::is_latex_output() || is_pandoc_to_format(format, "pdf")
+  is_pandoc_to_format(format, c("latex", "beamer", "pdf"))
 }
 
 # check if pandoc$to is among markdown outputs

--- a/tests/docs/smoke-all/2024/02/22/8843/.gitignore
+++ b/tests/docs/smoke-all/2024/02/22/8843/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+/_book/

--- a/tests/docs/smoke-all/2024/02/22/8843/_quarto.yml
+++ b/tests/docs/smoke-all/2024/02/22/8843/_quarto.yml
@@ -1,0 +1,13 @@
+project:
+  type: book
+
+book:
+  title: "Latex-deps"
+  author: "Norah Jones"
+  date: "22/02/2024"
+  chapters:
+    - index.qmd
+
+format: pdf
+
+

--- a/tests/docs/smoke-all/2024/02/22/8843/index.qmd
+++ b/tests/docs/smoke-all/2024/02/22/8843/index.qmd
@@ -1,0 +1,17 @@
+---
+_quarto:
+  tests:
+    pdf: default
+---
+# Preface {.unnumbered}
+
+This is a Quarto book.
+
+To learn more about Quarto books visit <https://quarto.org/docs/books>.
+
+Add a table with latex dependencies
+
+```{r}
+library(flextable)
+flextable(head(mtcars))
+```


### PR DESCRIPTION
For books, we have a process of creating the includes for dependencies in a later step, after execution. 

https://github.com/quarto-dev/quarto-cli/blob/84ed763c591e08ee1ed1536e7891e7199c49025e/src/command/render/render.ts#L89-L93

https://github.com/quarto-dev/quarto-cli/blob/84ed763c591e08ee1ed1536e7891e7199c49025e/src/resources/rmd/execute.R#L204-L218

This step is done in R but outside of knitting and rendering context, which implies that knitr options should be assumed to be set. All required informations to create the dependencies from knit_meta are passed from TS to R directly.

https://github.com/quarto-dev/quarto-cli/blob/84ed763c591e08ee1ed1536e7891e7199c49025e/src/execute/rmd.ts#L158-L166

For other type of render, the dependencies from knit_meta are resolved to includes directly after the knitting process in same R session with same env has R Markdown rendering.

This fix a regression introduced in #7297 while trying to improve the dependencies insertion.

