### PR TITLE
Website Listing - file paths

### DIFF
--- a/src/project/types/website/listing/website-listing-read.ts
+++ b/src/project/types/website/listing/website-listing-read.ts
@@ -1003,6 +1003,13 @@ async function listItemFromMeta(
           ...(fileListing.item || {}),
           ...listingItem,
         };
+        // If the file itself provides a path (e.g. it is an input with an
+        // output path), that should be used rather than the path in the metadata
+        // which was literally just used to get the path to the file that
+        // we're now reading.
+        if (fileListing.item.path) {
+          listingItem.path = fileListing.item.path;
+        }
         source = ListingItemSource.metadataDocument;
       }
     }

--- a/src/project/types/website/website-navigation.ts
+++ b/src/project/types/website/website-navigation.ts
@@ -288,6 +288,10 @@ export async function websiteNavigationExtras(
   const target = await resolveInputTarget(project, inputRelative);
   const href = target?.outputHref || inputFileHref(inputRelative);
   const sidebar = sidebarForHref(href, format);
+  // if the sidebar has a title and no id generate the id
+  if (sidebar && sidebar.title && !sidebar.id) {
+    sidebar.id = asHtmlId(sidebar.title);
+  }
 
   // Forward the draft mode, if present
   const draftMode = projectDraftMode(project);
@@ -1003,11 +1007,6 @@ async function sidebarsEjsData(project: ProjectContext, sidebars: Sidebar[]) {
 
 async function sidebarEjsData(project: ProjectContext, sidebar: Sidebar) {
   sidebar = ld.cloneDeep(sidebar);
-
-  // if the sidebar has a title and no id generate the id
-  if (sidebar.title && !sidebar.id) {
-    sidebar.id = asHtmlId(sidebar.title);
-  }
 
   // ensure title and search are present
   sidebar.title = sidebarTitle(sidebar, project) as string | undefined;


### PR DESCRIPTION
This bug was occurring when we read a file path from YAML. We then see if that file path points to an input file (e.g. a qmd file), in which case we then actually read the QMD file as if it were an item in the listing, using it’s metadata. The `path`, however should be replaced with the resolve path to the input, but we were just keeping the original path from the raw metadata.

We _should_ do this for other fields, so the metadata has the final say, but path should be treated specially.