### PR TITLE
Project Includes - extensions

### DIFF
--- a/src/project/project-context.ts
+++ b/src/project/project-context.ts
@@ -153,10 +153,19 @@ export async function projectContext(
           projectConfig,
           dir,
         );
+
+        // resolve includes
+        const configSchema = await getProjectConfigSchema();
+        const includedMeta = await includedMetadata(
+          dir,
+          projectConfig,
+          configSchema,
+        );
+        const metadata = includedMeta.metadata;
+        projectConfig = mergeProjectMetadata(projectConfig, metadata);
       }
 
       // collect then merge configuration profiles
-      const configSchema = await getProjectConfigSchema();
       const result = await initializeProfileConfig(
         dir,
         projectConfig,


### PR DESCRIPTION
Currently, if an extension provides a `metadata-file`, we ignore that as it is resolved only for the main project above. This will actually perform that include resolution for the project extension as well.

