### PR TITLE
Project Create - Don’t Overwrite Supporting

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -98,5 +98,6 @@ All changes included in 1.5:
 - ([#8540](https://github.com/quarto-dev/quarto-cli/issues/8540)): Allow title to be specifed separately when creating a project
 - ([#8652](https://github.com/quarto-dev/quarto-cli/issues/8652)): Make code cell detection in IDE tooling consistent across editor modes.
 - ([#8779](https://github.com/quarto-dev/quarto-cli/issues/8779)): Resolve shortcode includes before engine and target determination.
+- ([#8873](https://github.com/quarto-dev/quarto-cli/issues/8873)): Don't overwrite supporting files when creating a project.
 - Add support for `{{< lipsum >}}` shortcode, which is useful for emitting placeholder text. Specify a specific number of paragraphs (`{{< lipsum 3 >}}`).
 - Increase v8's max heap size by default, to avoid out-of-memory errors when rendering large documents (also cf. https://github.com/denoland/deno/issues/18935).

--- a/src/project/project-create.ts
+++ b/src/project/project-create.ts
@@ -137,11 +137,12 @@ export async function projectCreate(options: ProjectCreateOptions) {
         dest = join(options.dir, supporting.to);
         displayName = supporting.to;
       }
-
-      ensureDirSync(dirname(dest));
-      copyTo(src, dest);
-      if (!options.quiet) {
-        info("- Created " + displayName, { indent: 2 });
+      if (!existsSync(dest)) {
+        ensureDirSync(dirname(dest));
+        copyTo(src, dest);
+        if (!options.quiet) {
+          info("- Created " + displayName, { indent: 2 });
+        }
       }
     }
   }


### PR DESCRIPTION
Don’t overwrite supporting files. Already doesn’t overwrite project or scaffolding files.

Fixes #8873
