### PR TITLE
makes all deb package content owned by the root user

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Make Tarball
         run: |
-          tar -zcvf  quarto-${{needs.configure.outputs.version}}.tar.gz *
+          tar --owner=root --group=root -zcvf  quarto-${{needs.configure.outputs.version}}.tar.gz *
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
@@ -125,7 +125,7 @@ jobs:
         run: |
           pushd package/
           mv pkg-working quarto-${{needs.configure.outputs.version}}
-          tar -cvf  quarto-${{needs.configure.outputs.version}}-linux-amd64.tar quarto-${{needs.configure.outputs.version}}
+          tar --owner=root --group=root -cvf  quarto-${{needs.configure.outputs.version}}-linux-amd64.tar quarto-${{needs.configure.outputs.version}}
           gzip quarto-${{needs.configure.outputs.version}}-linux-amd64.tar
           mv quarto-${{needs.configure.outputs.version}} pkg-working
           popd
@@ -159,7 +159,7 @@ jobs:
         run: |
           pushd package/
           mv pkg-working quarto-${{needs.configure.outputs.version}}
-          tar -cvf  quarto-${{needs.configure.outputs.version}}-linux-arm64.tar quarto-${{needs.configure.outputs.version}}
+          tar --owner=root --group=root -cvf  quarto-${{needs.configure.outputs.version}}-linux-arm64.tar quarto-${{needs.configure.outputs.version}}
           gzip quarto-${{needs.configure.outputs.version}}-linux-arm64.tar
           mv quarto-${{needs.configure.outputs.version}} pkg-working
           popd
@@ -204,7 +204,7 @@ jobs:
         run: |
           pushd package/
           mv pkg-working quarto-${{needs.configure.outputs.version}}
-          tar -cvf  quarto-${{needs.configure.outputs.version}}-linux-rhel7-amd64.tar quarto-${{needs.configure.outputs.version}}
+          tar --owner=root --group=root -cvf  quarto-${{needs.configure.outputs.version}}-linux-rhel7-amd64.tar quarto-${{needs.configure.outputs.version}}
           gzip quarto-${{needs.configure.outputs.version}}-linux-rhel7-amd64.tar
           mv quarto-${{needs.configure.outputs.version}} pkg-working
           popd
@@ -289,7 +289,7 @@ jobs:
           tar -zxf quarto-${{needs.configure.outputs.version}}-linux-amd64.tar.gz
           echo "$GITHUB_WORKSPACE/quarto-${{needs.configure.outputs.version}}/bin" >> $GITHUB_PATH
       - run: |
-          ls -R
+          ls -lR
           echo $PATH
           quarto check
           quarto --paths

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -289,6 +289,7 @@ jobs:
           tar -zxf quarto-${{needs.configure.outputs.version}}-linux-amd64.tar.gz
           echo "$GITHUB_WORKSPACE/quarto-${{needs.configure.outputs.version}}/bin" >> $GITHUB_PATH
       - run: |
+          tar -tzvf quarto-${{needs.configure.outputs.version}}-linux-amd64.tar.gz | head
           ls -lR
           echo $PATH
           quarto check
@@ -438,7 +439,8 @@ jobs:
       - run: |
           tar -zxf quarto-${{needs.configure.outputs.version}}-macos.tar.gz
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
-      - run: ls -R
+      - run: tar -tzvf ${{needs.configure.outputs.version}}-macos.tar.gz | head
+      - run: ls -lR
       - run: echo $PATH
       - run: |
           quarto check

--- a/package/src/linux/installer.ts
+++ b/package/src/linux/installer.ts
@@ -128,6 +128,7 @@ export async function makeInstallerDeb(
     "gzip",
     "-z",
     "9",
+    "--root-owner-group",
     "--build",
     workingDir,
     join(configuration.directoryInfo.out, packageName),


### PR DESCRIPTION
fixes #8898

When we create the bundle for debian, we were missing the flag `--root-owner-group` which makes sure to remove the owner and group for the CI environment. 

From man page: https://man7.org/linux/man-pages/man1/dpkg-deb.1.html
> --root-owner-group
           Set the owner and group for each entry in the filesystem tree
           data to root with id 0 (since dpkg 1.19.0).

and these blog post 
* https://www.internalpointers.com/post/build-binary-deb-package-practical-guide
	> The --root-owner-group flag makes all deb package content owned by the root user, which is the standard way to go. Without such flag, all files and folders would be owned by your user, which might not exist in the system the deb package would be installed to.

Should this be backported so that next v1.4 release patch also benefit from it ? 

(cc @dragonstyle)