### PR TITLE
Add `pdf-engine-opts` to YAML schema

### DIFF
--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -16085,6 +16085,23 @@ var require_yaml_intelligence_resources = __commonJS({
           }
         },
         {
+          name: "pdf-engine-opts",
+          tags: {
+            formats: [
+              "$pdf-all",
+              "ms",
+              "context"
+            ]
+          },
+          schema: {
+            arrayOf: "string"
+          },
+          description: {
+            short: "Pass multiple command-line arguments to the `pdf-engine`.",
+            long: "Use the given strings passed as a array as command-line arguments to the pdf-engine.\nThis is an alternative to `pdf-engine-opt` for passing multiple options.\n"
+          }
+        },
+        {
           name: "beamerarticle",
           schema: "boolean",
           tags: {
@@ -22675,7 +22692,11 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
         "Manuscript configuration",
-        "internal-schema-hack"
+        "internal-schema-hack",
+        {
+          short: "Pass multiple command-line arguments to the\n<code>pdf-engine</code>.",
+          long: "Use the given strings passed as a array as command-line arguments to\nthe pdf-engine. This is an alternative to <code>pdf-engine-opt</code>\nfor passing multiple options."
+        }
       ],
       "schema/external-schemas.yml": [
         {
@@ -22904,12 +22925,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 177508,
+        _internalId: 181894,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 177500,
+            _internalId: 181886,
             type: "enum",
             enum: [
               "png",
@@ -22925,7 +22946,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 177507,
+            _internalId: 181893,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -21671,6 +21671,10 @@ var require_yaml_intelligence_resources = __commonJS({
           short: "Use the given string as a command-line argument to the\n<code>pdf-engine</code>.",
           long: "Use the given string as a command-line argument to the pdf-engine.\nFor example, to use a persistent directory foo for latexmk\u2019s auxiliary\nfiles, use <code>pdf-engine-opt: -outdir=foo</code>. Note that no check\nfor duplicate options is done."
         },
+        {
+          short: "Pass multiple command-line arguments to the\n<code>pdf-engine</code>.",
+          long: "Use the given strings passed as a array as command-line arguments to\nthe pdf-engine. This is an alternative to <code>pdf-engine-opt</code>\nfor passing multiple options."
+        },
         "Whether to produce a Beamer article from this presentation.",
         "Add an extra Beamer option using <code>\\setbeameroption{}</code>.",
         "The aspect ratio for this presentation.",
@@ -22692,11 +22696,7 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
         "Manuscript configuration",
-        "internal-schema-hack",
-        {
-          short: "Pass multiple command-line arguments to the\n<code>pdf-engine</code>.",
-          long: "Use the given strings passed as a array as command-line arguments to\nthe pdf-engine. This is an alternative to <code>pdf-engine-opt</code>\nfor passing multiple options."
-        }
+        "internal-schema-hack"
       ],
       "schema/external-schemas.yml": [
         {
@@ -22925,12 +22925,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 181894,
+        _internalId: 182250,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 181886,
+            _internalId: 182242,
             type: "enum",
             enum: [
               "png",
@@ -22946,7 +22946,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 181893,
+            _internalId: 182249,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -16086,6 +16086,23 @@ try {
             }
           },
           {
+            name: "pdf-engine-opts",
+            tags: {
+              formats: [
+                "$pdf-all",
+                "ms",
+                "context"
+              ]
+            },
+            schema: {
+              arrayOf: "string"
+            },
+            description: {
+              short: "Pass multiple command-line arguments to the `pdf-engine`.",
+              long: "Use the given strings passed as a array as command-line arguments to the pdf-engine.\nThis is an alternative to `pdf-engine-opt` for passing multiple options.\n"
+            }
+          },
+          {
             name: "beamerarticle",
             schema: "boolean",
             tags: {
@@ -22676,7 +22693,11 @@ try {
           },
           "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
           "Manuscript configuration",
-          "internal-schema-hack"
+          "internal-schema-hack",
+          {
+            short: "Pass multiple command-line arguments to the\n<code>pdf-engine</code>.",
+            long: "Use the given strings passed as a array as command-line arguments to\nthe pdf-engine. This is an alternative to <code>pdf-engine-opt</code>\nfor passing multiple options."
+          }
         ],
         "schema/external-schemas.yml": [
           {
@@ -22905,12 +22926,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 177508,
+          _internalId: 181894,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 177500,
+              _internalId: 181886,
               type: "enum",
               enum: [
                 "png",
@@ -22926,7 +22947,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 177507,
+              _internalId: 181893,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -21672,6 +21672,10 @@ try {
             short: "Use the given string as a command-line argument to the\n<code>pdf-engine</code>.",
             long: "Use the given string as a command-line argument to the pdf-engine.\nFor example, to use a persistent directory foo for latexmk\u2019s auxiliary\nfiles, use <code>pdf-engine-opt: -outdir=foo</code>. Note that no check\nfor duplicate options is done."
           },
+          {
+            short: "Pass multiple command-line arguments to the\n<code>pdf-engine</code>.",
+            long: "Use the given strings passed as a array as command-line arguments to\nthe pdf-engine. This is an alternative to <code>pdf-engine-opt</code>\nfor passing multiple options."
+          },
           "Whether to produce a Beamer article from this presentation.",
           "Add an extra Beamer option using <code>\\setbeameroption{}</code>.",
           "The aspect ratio for this presentation.",
@@ -22693,11 +22697,7 @@ try {
           },
           "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
           "Manuscript configuration",
-          "internal-schema-hack",
-          {
-            short: "Pass multiple command-line arguments to the\n<code>pdf-engine</code>.",
-            long: "Use the given strings passed as a array as command-line arguments to\nthe pdf-engine. This is an alternative to <code>pdf-engine-opt</code>\nfor passing multiple options."
-          }
+          "internal-schema-hack"
         ],
         "schema/external-schemas.yml": [
           {
@@ -22926,12 +22926,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 181894,
+          _internalId: 182250,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 181886,
+              _internalId: 182242,
               type: "enum",
               enum: [
                 "png",
@@ -22947,7 +22947,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 181893,
+              _internalId: 182249,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -9057,6 +9057,23 @@
       }
     },
     {
+      "name": "pdf-engine-opts",
+      "tags": {
+        "formats": [
+          "$pdf-all",
+          "ms",
+          "context"
+        ]
+      },
+      "schema": {
+        "arrayOf": "string"
+      },
+      "description": {
+        "short": "Pass multiple command-line arguments to the `pdf-engine`.",
+        "long": "Use the given strings passed as a array as command-line arguments to the pdf-engine.\nThis is an alternative to `pdf-engine-opt` for passing multiple options.\n"
+      }
+    },
+    {
       "name": "beamerarticle",
       "schema": "boolean",
       "tags": {
@@ -15647,7 +15664,11 @@
     },
     "Disambiguating year suffix in author-date styles (e.g.&nbsp;“a” in “Doe,\n1999a”).",
     "Manuscript configuration",
-    "internal-schema-hack"
+    "internal-schema-hack",
+    {
+      "short": "Pass multiple command-line arguments to the\n<code>pdf-engine</code>.",
+      "long": "Use the given strings passed as a array as command-line arguments to\nthe pdf-engine. This is an alternative to <code>pdf-engine-opt</code>\nfor passing multiple options."
+    }
   ],
   "schema/external-schemas.yml": [
     {
@@ -15876,12 +15897,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 177508,
+    "_internalId": 181894,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 177500,
+        "_internalId": 181886,
         "type": "enum",
         "enum": [
           "png",
@@ -15897,7 +15918,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 177507,
+        "_internalId": 181893,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -14643,6 +14643,10 @@
       "short": "Use the given string as a command-line argument to the\n<code>pdf-engine</code>.",
       "long": "Use the given string as a command-line argument to the pdf-engine.\nFor example, to use a persistent directory foo for latexmk’s auxiliary\nfiles, use <code>pdf-engine-opt: -outdir=foo</code>. Note that no check\nfor duplicate options is done."
     },
+    {
+      "short": "Pass multiple command-line arguments to the\n<code>pdf-engine</code>.",
+      "long": "Use the given strings passed as a array as command-line arguments to\nthe pdf-engine. This is an alternative to <code>pdf-engine-opt</code>\nfor passing multiple options."
+    },
     "Whether to produce a Beamer article from this presentation.",
     "Add an extra Beamer option using <code>\\setbeameroption{}</code>.",
     "The aspect ratio for this presentation.",
@@ -15664,11 +15668,7 @@
     },
     "Disambiguating year suffix in author-date styles (e.g.&nbsp;“a” in “Doe,\n1999a”).",
     "Manuscript configuration",
-    "internal-schema-hack",
-    {
-      "short": "Pass multiple command-line arguments to the\n<code>pdf-engine</code>.",
-      "long": "Use the given strings passed as a array as command-line arguments to\nthe pdf-engine. This is an alternative to <code>pdf-engine-opt</code>\nfor passing multiple options."
-    }
+    "internal-schema-hack"
   ],
   "schema/external-schemas.yml": [
     {
@@ -15897,12 +15897,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 181894,
+    "_internalId": 182250,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 181886,
+        "_internalId": 182242,
         "type": "enum",
         "enum": [
           "png",
@@ -15918,7 +15918,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 181893,
+        "_internalId": 182249,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/schema/document-options.yml
+++ b/src/resources/schema/document-options.yml
@@ -177,6 +177,17 @@
       files, use `pdf-engine-opt: -outdir=foo`. Note that no check for 
       duplicate options is done.
 
+- name: pdf-engine-opts
+  tags:
+    formats: [$pdf-all, ms, context]
+  schema:
+    arrayOf: string
+  description:
+    short: "Pass multiple command-line arguments to the `pdf-engine`."
+    long: |
+      Use the given strings passed as a array as command-line arguments to the pdf-engine.
+      This is an alternative to `pdf-engine-opt` for passing multiple options.
+
 - name: beamerarticle
   schema: boolean
   tags:


### PR DESCRIPTION
clarifies #8897

We mentions this options at https://quarto.org/docs/output-formats/pdf-engine.html#alternate-pdf-engines and should be the prefer way 

PR in our doc site https://github.com/quarto-dev/quarto-web/pull/1029 will show example of it. 

This PR adds into the schema
