### PR TITLE
read file for includes in Lua using binary mode

### DIFF
--- a/src/resources/filters/quarto-init/includes.lua
+++ b/src/resources/filters/quarto-init/includes.lua
@@ -49,7 +49,7 @@ function readIncludeFiles(meta, includes, target)
 
     local status, err = pcall(function () 
       -- read file contents
-      local f = io.open(pandoc.utils.stringify(file), "r")
+      local f = io.open(pandoc.utils.stringify(file), "rb")
       if f == nil then 
         fail("Error resolving " .. target .. "- unable to open file " .. file)
       end


### PR DESCRIPTION
This fix issue #8857 on windows where plotly.js dependency was being truncated at reading time.

@cscheid do we backport this to 1.4 ? It seems a good idea. 

Depending if we backport, I'll add to the right changelog

Tested locally with this file 

````markdown
--- 
title: "Development Indicators by Continent"
author: "Gapminder Analytics Group"
format: dashboard
--- 

```{python}
import plotly.express as px
df = px.data.gapminder()
```

## Row {height=60%}

```{python}
#| title: GDP and Life Expectancy 
px.scatter(  
  df, x="gdpPercap", y="lifeExp", 
  animation_frame="year", animation_group="country", 
  size="pop", color="continent", hover_name="country",
  facet_col="continent", log_x=True, size_max=45, 
  range_x=[100,100000], range_y=[25,90] 
)  
```

## Row {height=40%}

```{python}
#| title: Population
px.area(
  df, x="year", y="pop", 
  color="continent", line_group="country"
)
```

```{python}
#| title: Life Expectancy
px.line(
  df, x="year", y="lifeExp", 
  color="continent", line_group="country"
)
```
````

For the story, the issue is the following.

`format: dashboard` is setting `plotly-connected: false`. This will make **plotly** in Jupyter to embed the `plotly.js` as a dependency. 

Our processing is to retrieve this plotly dependency, and we reinject it in the document as a raw block. For this we export as a file in Typescript, and read this file in Lua.  When reading in Lua, it was using `"r"` mode only, and it creates an issue on Windows as the reading was truncated. Possibly because the `plotly.js` content contains some explicit `\r\n` that are messing the reading. Using binary mode `"rb"` solve the issue. 

Note that our internal `read_file` function is using `"rb"` 
https://github.com/quarto-dev/quarto-cli/blob/b7b6b5f6e3b895c5587b0639091da7e87c70d6e5/src/resources/pandoc/datadir/init.lua#L1861-L1867

the reading function for reading includes wasn't. 