### PR TITLE
Update to actions/checkout@v4

### DIFF
--- a/.github/workflows/actions/launcher/action.yml
+++ b/.github/workflows/actions/launcher/action.yml
@@ -7,7 +7,7 @@ description: 'Builds the Quarto Launcher'
 runs:
   using: "composite"
   steps: 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       uses: actions-rs/toolchain@v1
       with:
         toolchain: 1.63.0

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -31,7 +31,7 @@ jobs:
       tag_pushed: ${{ steps.version_commit.outputs.tag_pushed }}
     if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository == 'quarto-dev/quarto-cli')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -88,7 +88,7 @@ jobs:
     needs: [configure]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.configure.outputs.version_commit }}
 
@@ -107,7 +107,7 @@ jobs:
     needs: [configure]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.configure.outputs.version_commit }}
 
@@ -141,7 +141,7 @@ jobs:
     needs: [configure]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.configure.outputs.version_commit }}
 
@@ -175,7 +175,7 @@ jobs:
     needs: [configure]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.configure.outputs.version_commit }}
 
@@ -220,7 +220,7 @@ jobs:
     needs: [configure]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.configure.outputs.version_commit }}
 
@@ -251,7 +251,7 @@ jobs:
     needs: [configure]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.configure.outputs.version_commit }}
 
@@ -305,7 +305,7 @@ jobs:
           rustup.exe toolchain install 1.63.0 --component rustfmt --component clippy --no-self-update
           rustup.exe default 1.63.0
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.configure.outputs.version_commit }}
 
@@ -366,7 +366,7 @@ jobs:
     needs: [configure]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.configure.outputs.version_commit }}
 
@@ -562,7 +562,7 @@ jobs:
       ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Revert commit of version.txt
         if: ${{ needs.configure.outputs.pushed }}

--- a/.github/workflows/performance-check.yml
+++ b/.github/workflows/performance-check.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # checkout full tree
           fetch-depth: 0

--- a/.github/workflows/test-bundle.yml
+++ b/.github/workflows/test-bundle.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # checkout full tree
           fetch-depth: 0

--- a/.github/workflows/test-quarto-latexmk.yml
+++ b/.github/workflows/test-quarto-latexmk.yml
@@ -22,7 +22,7 @@ jobs:
           - { os: ubuntu-latest }
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test-smokes-parallel.yml
+++ b/.github/workflows/test-smokes-parallel.yml
@@ -35,7 +35,7 @@ jobs:
       BUCKETS: ${{ steps.tests-buckets.outputs.BUCKETS }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Fix temp dir to use runner one (windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
First part of adapting to Node 16 deprecation in Github action runners

Contributes to #7922 and #8906