### PR TITLE
deno arm build are now available in denoland/deno main repo

### DIFF
--- a/package/scripts/common/utils.sh
+++ b/package/scripts/common/utils.sh
@@ -23,8 +23,8 @@ else
     DENOFILES=deno-x86_64-unknown-linux-gnu.zip
     DENO_DIR=x86_64
   elif [[ $NIXARCH == "aarch64" ]]; then
-    DENOURL=https://github.com/LukeChannings/deno-arm64/releases/download
-    DENOFILES=deno-linux-arm64.zip
+    DENOURL=https://github.com/denoland/deno/releases/download
+    DENOFILES=deno-aarch64-unknown-linux-gnu.zip
     DENO_DIR=aarch64
   else
     echo "configure script failed: unrecognized architecture " ${NIXARCH}

--- a/package/src/common/dependencies/deno.ts
+++ b/package/src/common/dependencies/deno.ts
@@ -33,11 +33,14 @@ export function deno(version: string): Dependency {
 
   // Handle the configuration for this dependency
   const linuxAmd64DenoRelease = () => {
+    // Before 1.41 available at: 
     // https://github.com/LukeChannings/deno-arm64/releases/download/v1.28.2/deno-linux-arm64.zip
+    // but after 1.41 available at:
+    // https://github.com/denoland/deno/releases/download/v1.41.0/deno-aarch64-unknown-linux-gnu.zip
     return {
-      filename: `deno-linux-arm64.zip`,
+      filename: `deno-aarch64-unknown-linux-gnu.zip`,
       url:
-        `https://github.com/LukeChannings/deno-arm64/releases/download/${version}/`,
+        `https://github.com/denoland/deno/releases/download/${version}/`,
       configure: async (_config: Configuration, path: string) => {
         const vendor = Deno.env.get("QUARTO_VENDOR_BINARIES");
         if (vendor === undefined || vendor === "true") {


### PR DESCRIPTION
Before it was built in another project https://github.com/LukeChannings/deno-arm64/

This PR adapts our configuration following the update in #8907 which broke Create Installer workflow

