### PR TITLE
markdown - change markdown gen to automatically emit sufficiently-many : and `s

### DIFF
--- a/src/core/handlers/base.ts
+++ b/src/core/handlers/base.ts
@@ -27,7 +27,12 @@ import {
   optionCommentPatternFromLanguage,
 } from "../lib/partition-cell-options.ts";
 import { ConcreteSchema } from "../lib/yaml-schema/types.ts";
-import { pandocBlock, pandocList, pandocRawStr } from "../pandoc/codegen.ts";
+import {
+  pandocCode,
+  pandocDiv,
+  pandocList,
+  pandocRawStr,
+} from "../pandoc/codegen.ts";
 
 import {
   kCapLoc,
@@ -61,7 +66,13 @@ import {
   kTblCapLoc,
 } from "../../config/constants.ts";
 import { DirectiveCell } from "../lib/break-quarto-md-types.ts";
-import { basename, dirname, join, relative, resolve } from "../../deno_ral/path.ts";
+import {
+  basename,
+  dirname,
+  join,
+  relative,
+  resolve,
+} from "../../deno_ral/path.ts";
 import { figuresDir, inputFilesDir } from "../render.ts";
 import { ensureDirSync } from "fs/mod.ts";
 import { mappedStringFromFile } from "../mapped-text.ts";
@@ -629,12 +640,9 @@ export const baseHandler: LanguageHandler = {
 
     const unrolledOutput = isPowerpointOutput && !hasLayoutAttributes;
 
-    const t3 = pandocBlock("```");
-    const t4 = pandocBlock("````");
-
     const cellBlock = unrolledOutput
       ? pandocList({ skipFirstLineBreak: true })
-      : pandocBlock(":::")({
+      : pandocDiv({
         classes: ["cell", ...classes],
         attrs,
       });
@@ -667,7 +675,7 @@ export const baseHandler: LanguageHandler = {
 
     switch (options.echo) {
       case true: {
-        const cellInput = t3({
+        const cellInput = pandocCode({
           classes: cellInputClasses,
           attrs: cellInputAttrs,
         });
@@ -676,11 +684,11 @@ export const baseHandler: LanguageHandler = {
         break;
       }
       case "fenced": {
-        const cellInput = t4({
+        const cellInput = pandocCode({
           classes: ["markdown", ...cellInputClasses.slice(1)], // replace the language class with markdown
           attrs: cellInputAttrs,
         });
-        const cellFence = t3({
+        const cellFence = pandocCode({
           language: this.languageName,
           skipFirstLineBreak: true,
         });
@@ -695,7 +703,7 @@ export const baseHandler: LanguageHandler = {
       }
     }
 
-    const divBlock = pandocBlock(":::");
+    const divBlock = pandocDiv;
 
     // PandocNodes ignore self-pushes (n.push(n))
     // this makes it much easier to write the logic around "unrolled blocks"

--- a/src/execute/ojs/compile.ts
+++ b/src/execute/ojs/compile.ts
@@ -299,7 +299,7 @@ export async function ojsCompile(
         );
         ojsParseError(err, cellSrc);
 
-        const preDiv = pandocBlock("````")({
+        const preDiv = pandocCode({
           classes: ["numberLines", "java"],
           attrs: [
             `startFrom="${cellStartingLoc - 1}"`,
@@ -543,7 +543,7 @@ export async function ojsCompile(
           `startFrom="${cellStartingLoc - 1}"`,
           `source-offset="${cell.sourceOffset}"`,
         );
-        const srcDiv = pandocBlock("````")({
+        const srcDiv = pandocCode({
           classes: ourClasses,
           attrs: ourAttrs,
         });

--- a/tests/docs/smoke-all/mermaid/backticks.qmd
+++ b/tests/docs/smoke-all/mermaid/backticks.qmd
@@ -1,0 +1,21 @@
+---
+title: "mermaid backtick test"
+keep-md: true
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - []
+        - ["<p>This would have been"] # it can't be in a paragraph, it should be inside a code cell.
+---
+
+It's not important right now whether this syntax is correct for mermaid;
+the relevant aspect is that our pandoc codegen wasn't taking the
+inner number of backticks into account. This test checks for that.
+
+````{mermaid}
+%%| echo: true
+```
+This would have been a problem.
+```
+````


### PR DESCRIPTION
This is a followup to #8919. Our internal markdown gen library now automatically detects and emits the right number of backticks so code contents don't need to be explicitly taken into account.

It does the same thing for colons; that's technically unnecessary but makes for much more readable intermediate md output.