### PR TITLE
fix bad path quoting

### DIFF
--- a/package/scripts/common/quarto
+++ b/package/scripts/common/quarto
@@ -49,7 +49,7 @@ if [ -f "$DEV_PATH" ]; then
   fi
 
   # Local import map
-  QUARTO_IMPORT_ARGMAP=--importmap="$QUARTO_SRC_PATH/dev_import_map.json"
+  QUARTO_IMPORT_MAP_ARG=--importmap=$QUARTO_SRC_PATH/dev_import_map.json
 
   # Turn on type checking for dev version
   QUARTO_DENO_OPTIONS=--check
@@ -104,7 +104,7 @@ else
   fi
 
   # release vendored import map
-  QUARTO_IMPORT_ARGMAP=--importmap="$SCRIPT_PATH/vendor/import_map.json"
+  QUARTO_IMPORT_MAP_ARG=--importmap=$SCRIPT_PATH/vendor/import_map.json
 
   if [ "$1" == "--version" ] || [ "$1" == "-v" ]; then
     if [ "$QUARTO_FORCE_VERSION" != "" ]; then
@@ -175,7 +175,7 @@ fi
 
 if [ "$QUARTO_TS_PROFILE" != "" ]; then
   QUARTO_DENO_EXTRA_OPTIONS="--inspect-brk ${QUARTO_DENO_EXTRA_OPTIONS}"
-  QUARTO_TS_PROFILE=true "${QUARTO_DENO}" ${QUARTO_ACTION} ${QUARTO_DENO_OPTIONS} ${QUARTO_DENO_EXTRA_OPTIONS} "${QUARTO_IMPORT_ARGMAP}" "${QUARTO_TARGET}" "$@"
+  QUARTO_TS_PROFILE=true "${QUARTO_DENO}" ${QUARTO_ACTION} ${QUARTO_DENO_OPTIONS} ${QUARTO_DENO_EXTRA_OPTIONS} "${QUARTO_IMPORT_MAP_ARG}" "${QUARTO_TARGET}" "$@"
 else
-  "${QUARTO_DENO}" ${QUARTO_ACTION} ${QUARTO_DENO_OPTIONS} ${QUARTO_DENO_EXTRA_OPTIONS} ${QUARTO_IMPORT_ARGMAP} "${QUARTO_TARGET}" "$@" 
+  "${QUARTO_DENO}" ${QUARTO_ACTION} ${QUARTO_DENO_OPTIONS} ${QUARTO_DENO_EXTRA_OPTIONS} "${QUARTO_IMPORT_MAP_ARG}" "${QUARTO_TARGET}" "$@" 
 fi


### PR DESCRIPTION
Back in the deno 1.33 update, I broke our launcher in paths with quotes. This PR fixes it (Thanks, @kevinushey!)

Incidentally, it also changes the var name to fix a spoonerism on my part.

This should fix https://github.com/rstudio/rstudio/issues/12902