### PR TITLE
[GHA] Make RHEL build optional when creating release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -518,7 +518,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -60,6 +60,8 @@ jobs:
           echo -e "\n\nFull ${version} changelog up to this version:\n" >> "release_note.md"
           echo -e "  * View: https://github.com/${GITHUB_REPOSITORY}/blob/v${version_full}/news/changelog-${version}.md\n" >> "release_note.md"
           echo -e "  * Download: https://github.com/${GITHUB_REPOSITORY}/releases/download/v${version_full}/changelog.md\n" >> "release_note.md"
+          echo -e "" >> "release_note.md"
+          echo -e "Due to an issue with upstream dependency, the RHEL build may not included in this release. Follow #8944 for more information." >> "release_note.md"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -448,14 +448,14 @@ jobs:
   publish-release:
     if: ${{ inputs.publish-release }}
     runs-on: ubuntu-latest
-    needs:
-      [
+    needs: [
         configure,
         make-installer-deb,
         make-installer-arm64-deb,
         make-installer-win,
         make-installer-mac,
-        make-tarball-rhel,
+        # optional in release to not be blocked by RHEL build depending on conda-forge deno dependency
+        # make-tarball-rhel,
         make-arm64-tarball,
         make-tarball,
         make-source-tarball,
@@ -492,9 +492,11 @@ jobs:
           sha256sum quarto-${{needs.configure.outputs.version}}-macos.pkg >> ../quarto-${{needs.configure.outputs.version}}-checksums.txt
           popd
 
-          pushd RHEL\ Zip
-          sha256sum quarto-${{needs.configure.outputs.version}}-linux-rhel7-amd64.tar.gz >> ../quarto-${{needs.configure.outputs.version}}-checksums.txt
-          popd           
+          if [ -f "RHEL Zip/quarto-${{needs.configure.outputs.version}}-linux-rhel7-amd64.tar.gz" ]; then
+            pushd RHEL\ Zip
+            sha256sum quarto-${{needs.configure.outputs.version}}-linux-rhel7-amd64.tar.gz >> ../quarto-${{needs.configure.outputs.version}}-checksums.txt
+            popd
+          fi         
            
           pushd Deb\ Zip
           sha256sum quarto-${{needs.configure.outputs.version}}-linux-amd64.tar.gz >> ../quarto-${{needs.configure.outputs.version}}-checksums.txt
@@ -528,6 +530,7 @@ jobs:
           body_path: ./News/release_note.md
           draft: false
           prerelease: ${{ inputs.pre-release }}
+          fail_on_unmatched_files: false # rhel build may not be included
           files: |
             ./Source/quarto-${{needs.configure.outputs.version}}.tar.gz
             ./Deb Zip/quarto-${{needs.configure.outputs.version}}-linux-amd64.tar.gz
@@ -544,14 +547,14 @@ jobs:
 
   cleanup-when-failure:
     if: ${{ (failure() || cancelled()) && inputs.publish-release }}
-    needs:
-      [
+    needs: [
         configure,
         make-installer-deb,
         make-installer-arm64-deb,
         make-installer-win,
         make-installer-mac,
-        make-tarball-rhel,
+        # optional in release to not be blocked by RHEL build depending on conda-forge deno dependency
+        # make-tarball-rhel,
         make-arm64-tarball,
         make-tarball,
         make-source-tarball,


### PR DESCRIPTION
This is to unblock our pre-release creation while we take the time to fix #8944

- This make the rhel build optional - it will fail and show the Build installers as failed but it won't block the new GH release 
- It adds a message about RHEL artifact being missing in the release

