### PR TITLE
[GHA] FIx CI failure for R on v1.4 patch branc

### DIFF
--- a/tests/renv.lock
+++ b/tests/renv.lock
@@ -1053,7 +1053,7 @@
     },
     "httpuv": {
       "Package": "httpuv",
-      "Version": "1.6.12",
+      "Version": "1.6.14",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
@@ -1064,7 +1064,7 @@
         "promises",
         "utils"
       ],
-      "Hash": "c992f75861325961c29a188b45e549f7"
+      "Hash": "16abeb167dbf511f8cc0552efaf05bab"
     },
     "httr": {
       "Package": "httr",


### PR DESCRIPTION
This is short term quick fix to unblock CI. 

Possibly older version of package does not play well on windows and older R version. I'll check later. Hopefully, this will solve. 

Also, I don't know why the cache did not apply here... 🤔 I'll look into it. 