### PR TITLE
ipynb format is considered one being compatible for HTML related outputs

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -79,7 +79,8 @@ All changes included in 1.5:
 
 ## Shortcodes
 
-- ([#8316](https://github.com/quarto-dev/quarto-cli/issues/8316)): Add fallback value for the `env` shortcode
+- ([#8316](https://github.com/quarto-dev/quarto-cli/issues/8316)): Add fallback value for the `env` shortcode.
+- ([#9011](https://github.com/quarto-dev/quarto-cli/issues/9011)): `embed` shortcode now renders the embedded document without error when it is using knitr engine and have some outputs with HTML dependencies.
 
 ## Lightbox Images
 

--- a/src/resources/rmd/execute.R
+++ b/src/resources/rmd/execute.R
@@ -577,6 +577,10 @@ is_pandoc_latex_output <- function(format) {
   is_pandoc_to_format(format, c("latex", "beamer", "pdf"))
 }
 
+is_pandoc_ipynb_output <- function(format) {
+  is_pandoc_to_format(format, c("ipynb"))
+}
+
 # check if pandoc$to is among markdown outputs
 is_pandoc_markdown_output <- function(format) {
   markdown_formats <- c(
@@ -593,9 +597,16 @@ is_pandoc_markdown_output <- function(format) {
   is_pandoc_to_format(format, markdown_formats)
 }
 
-# `prefer-html: true` can be set in markdown format that supports HTML outputs
+# should be equivalent of TS function: 
+# isHtmlCompatible() in src/config/format.ts
 is_html_prefered <- function(format) {
-  is_pandoc_markdown_output(format) && isTRUE(format$render$`prefer-html`)
+  # `prefer-html: true` can be set in markdown format that supports HTML outputs
+  (
+    is_pandoc_markdown_output(format) &&
+    isTRUE(format$render$`prefer-html`)
+  ) ||
+  # this could happen when using embed shortcode which convert to ipynb output format.
+  is_pandoc_ipynb_output(format)
 }
 
 is_dashboard_output <- function(format) {

--- a/tests/docs/smoke-all/embed/tables/inset-table.qmd
+++ b/tests/docs/smoke-all/embed/tables/inset-table.qmd
@@ -8,7 +8,7 @@ format:
 ---
 
 ```{r}
-#| label: tbl-one
+#| label: tbl-kable
 #| tbl-cap: This is a kable table
 
 library(knitr)
@@ -16,7 +16,7 @@ kable(head(mtcars))
 ```
 
 ```{r}
-#| label: tbl-two
+#| label: tbl-gt
 #| tbl-cap: This is a gt table
 
 library(gt)
@@ -25,7 +25,7 @@ gt(head(mtcars))
 
 
 ```{r}
-#| label: tbl-three
+#| label: tbl-flextable
 #| tbl-cap: This is a flextable table
 
 library(flextable)
@@ -33,5 +33,12 @@ flextable(head(mtcars))
 ```
 
 
+```{r}
+#| label: tbl-kable-extra
+#| tbl-cap: This is a kableExtra table
+
+library(kableExtra)
+kableExtra::kbl(head(mtcars))
+```
 
 

--- a/tests/docs/smoke-all/embed/tables/inset-table.qmd
+++ b/tests/docs/smoke-all/embed/tables/inset-table.qmd
@@ -1,5 +1,6 @@
 ---
 title: "Notebook"
+html-table-processing: none # TODO: To fix in #8927
 format:
   ipynb: 
     notebook-preserve-cells: true

--- a/tests/docs/smoke-all/embed/tables/parent.qmd
+++ b/tests/docs/smoke-all/embed/tables/parent.qmd
@@ -9,11 +9,11 @@ _quarto:
       ensureHtmlElements:
         - 
           - '#kable .quarto-embed-nb-cell #tbl-kable .cell-output-display > *'
-          # TODO: Fix in #8927 - raw html table are not shown in embedded output
-          # - '#gt .quarto-embed-nb-cell #tbl-gt .cell-output-display > *'
+          # TODO: requires html-table-processing: none in embed file - fix #8927
+          - '#gt .quarto-embed-nb-cell #tbl-gt .cell-output-display > *'
           - '#flextable .quarto-embed-nb-cell #tbl-flextable .cell-output-display > *'
-          # TODO: Fix in #8927 - raw html table are not shown in embedded output
-          # - '#kable-extra .quarto-embed-nb-cell #tbl-kable-extra .cell-output-display > *'
+          # TODO: requires html-table-processing: none in embed file - fix #8927
+          - '#kable-extra .quarto-embed-nb-cell #tbl-kable-extra .cell-output-display > *'
 ---
 
 # With kable {#kable}

--- a/tests/docs/smoke-all/embed/tables/parent.qmd
+++ b/tests/docs/smoke-all/embed/tables/parent.qmd
@@ -3,7 +3,32 @@ title: "Test of embedding tables"
 format:
   html:
     toc: true
+_quarto:
+  tests:
+    html: 
+      ensureHtmlElements:
+        - 
+          - '#kable .quarto-embed-nb-cell #tbl-kable .cell-output-display > *'
+          # TODO: Fix in #8927 - raw html table are not shown in embedded output
+          # - '#gt .quarto-embed-nb-cell #tbl-gt .cell-output-display > *'
+          - '#flextable .quarto-embed-nb-cell #tbl-flextable .cell-output-display > *'
+          # TODO: Fix in #8927 - raw html table are not shown in embedded output
+          # - '#kable-extra .quarto-embed-nb-cell #tbl-kable-extra .cell-output-display > *'
 ---
 
-{{< embed inset-table.qmd#tbl-three >}}
+# With kable {#kable}
+
+{{< embed inset-table.qmd#tbl-kable >}}
+
+# with GT {#gt}
+
+{{< embed inset-table.qmd#tbl-gt >}}
+
+# with flextable {#flextable}
+
+{{< embed inset-table.qmd#tbl-flextable >}}
+
+# with kableExtra {#kable-extra}
+
+{{< embed inset-table.qmd#tbl-kable-extra >}}
 


### PR DESCRIPTION
closes #9011 

This is fixing only the issue where ipynb was not detected as a format supporting HTML output content from **knitr** cells. 

This PR contains test for this by improving the existing ones on `embed` feature. They do set `html-table-processing: none` in embed file so that the **gt** and **kableExtra** outputs are show. it is not working because of #8927)
