### PR TITLE
citation - replace spaces with underscores, cf #9041

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -120,7 +120,8 @@ All changes included in 1.5:
 - ([#8873](https://github.com/quarto-dev/quarto-cli/issues/8873)): Don't overwrite supporting files when creating a project.
 - ([#8937](https://github.com/quarto-dev/quarto-cli/issues/8937)): Fix unix launcher script to properly handle spaces in the path to the quarto executable.
 - ([#8898](https://github.com/quarto-dev/quarto-cli/issues/8898)): `.deb` and `.tar.gz` bundle contents are now associated to root user and group instead of default user and group for CI build runners.
-- Add support for `{{< lipsum >}}` shortcode, which is useful for emitting placeholder text. Specify a specific number of paragraphs (`{{< lipsum 3 >}}`).
+- ([#9041](https://github.com/quarto-dev/quarto-cli/issues/9041)): When creating an automatic citation key, replace spaces with underscores in inferred keys.
+- Add support for `{{< lipsum >}}` shortcode, which is useful for emitting placeholder text. Provide a specific number of paragraphs (`{{< lipsum 3 >}}`).
 - Resolve data URIs in Pandoc's mediabag when rendering documents.
 - Increase v8's max heap size by default, to avoid out-of-memory errors when rendering large documents (also cf. https://github.com/denoland/deno/issues/18935).
 - Upgrade Deno to 1.41.0

--- a/src/core/csl.ts
+++ b/src/core/csl.ts
@@ -154,7 +154,9 @@ export function suggestId(author: CSLName[], date?: CSLDate) {
   }
 
   // Create a deduplicated string against the existing entries
-  let suggestedId = `${citeIdLeading.toLowerCase()}${datePart}`;
+  let suggestedId = `${
+    citeIdLeading.replaceAll(/\s+/g, "_").toLowerCase()
+  }${datePart}`;
   if (suggestedId.length === 0) {
     suggestedId = "untitled";
   }

--- a/tests/docs/smoke-all/2024/03/11/9041.qmd
+++ b/tests/docs/smoke-all/2024/03/11/9041.qmd
@@ -1,0 +1,21 @@
+---
+title: "Documentation"
+author:
+  - name: "Hervy Qurrotul Ainur Rozi"
+    email: hervyqa@proton.me
+    url: https://hervyqa.id
+date: "2024-02-24"
+date-modified: "2024-03-09"
+format:
+  html:
+    citation: true
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - ['@online\{qurrotul_ainur_rozi2024']
+        - []
+---
+
+## askldfjh
+


### PR DESCRIPTION
Improves the autogeneration of citation keys, closes #9041.