### PR TITLE
Set media background to quarto body background

### DIFF
--- a/src/resources/formats/html/glightbox/lightbox.css
+++ b/src/resources/formats/html/glightbox/lightbox.css
@@ -5,6 +5,10 @@ body:not(.glightbox-mobile) div.gslide-description .gslide-desc {
   background-color: var(--quarto-body-bg);
 }
 
+body:not(.glightbox-mobile) div.gslide-media {
+  background-color: var(--quarto-body-bg);
+}
+
 .goverlay {
   background: rgba(0, 0, 0, 0.7);
 }


### PR DESCRIPTION
This will allow transparent images to be seen on the media background

Closes #9047 

![chrome_eSgylyBi6G](https://github.com/quarto-dev/quarto-cli/assets/6791940/9987a9c3-8fc7-43d9-aaf9-ae2c5717681a)

````yaml
format: 
  html:
    backgroundcolor: "red"
````

@dragonstyle do you think this is not a good idea ? I believe non-transparent images won't be affected by a set background on the div.