### PR TITLE
Fix stale suggestion text (installing chromium)

### DIFF
--- a/src/core/puppeteer.ts
+++ b/src/core/puppeteer.ts
@@ -264,7 +264,7 @@ export async function getBrowserExecutablePath() {
   if (executablePath === undefined) {
     error("Chrome not found");
     info(
-      "\nNo Chrome or Chromium installation was detected.\n\nPlease run 'quarto tools install chromium' to install Chromium.\n",
+      "\nNo Chrome or Chromium installation was detected.\n\nPlease run 'quarto install chromium' to install Chromium.\n",
     );
     throw new Error();
   }


### PR DESCRIPTION
## Description

Fixes stale suggestion text:

```
>quarto render
...
ERROR: Chrome not found

No Chrome or Chromium installation was detected.

Please run 'quarto tools install chromium' to install Chromium.

> quarto tools install chromium
This command has been superseded. Please use `quarto install` instead.
```

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
