### PR TITLE
fix `quarto run` for lua file on Windows

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -121,6 +121,7 @@ All changes included in 1.5:
 - ([#8937](https://github.com/quarto-dev/quarto-cli/issues/8937)): Fix unix launcher script to properly handle spaces in the path to the quarto executable.
 - ([#8898](https://github.com/quarto-dev/quarto-cli/issues/8898)): `.deb` and `.tar.gz` bundle contents are now associated to root user and group instead of default user and group for CI build runners.
 - ([#9041](https://github.com/quarto-dev/quarto-cli/issues/9041)): When creating an automatic citation key, replace spaces with underscores in inferred keys.
+- ([#9059](https://github.com/quarto-dev/quarto-cli/issues/9059)): `quarto run` now properly works on Windows with Lua scripts.
 - Add support for `{{< lipsum >}}` shortcode, which is useful for emitting placeholder text. Provide a specific number of paragraphs (`{{< lipsum 3 >}}`).
 - Resolve data URIs in Pandoc's mediabag when rendering documents.
 - Increase v8's max heap size by default, to avoid out-of-memory errors when rendering large documents (also cf. https://github.com/denoland/deno/issues/18935).

--- a/src/core/run/lua.ts
+++ b/src/core/run/lua.ts
@@ -1,9 +1,8 @@
 /*
-* lua.ts
-*
-* Copyright (C) 2020-2022 Posit Software, PBC
-*
-*/
+ * lua.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
 
 import { info } from "../../deno_ral/log.ts";
 
@@ -25,7 +24,7 @@ export const luaRunHandler: RunHandler = {
     options?: RunHandlerOptions,
   ) => {
     // lua run handlers don't support stdin
-    if (typeof (stdin) === "string") {
+    if (typeof stdin === "string") {
       throw new Error("Lua run handlers cannot be passed stdin");
     }
 
@@ -37,10 +36,6 @@ export const luaRunHandler: RunHandler = {
       "--to",
       "plain",
     ];
-    if (isWindows()) {
-      cmd.push("--lua-filter");
-      cmd.push(resourcePath("filters/init/init.lua"));
-    }
     cmd.push(
       "--lua-filter",
       script,

--- a/tests/smoke/run/run-script.test.ts
+++ b/tests/smoke/run/run-script.test.ts
@@ -1,0 +1,56 @@
+import { basename, join } from "../../../src/deno_ral/path.ts";
+import { ensureDirSync } from "fs/mod.ts";
+import { assert } from "testing/asserts.ts";
+import { execProcess } from "../../../src/core/process.ts";
+import { quartoDevCmd } from "../../utils.ts";
+import { unitTest } from "../../test.ts";
+
+const workingDir = Deno.makeTempDirSync();
+
+ensureDirSync(workingDir);
+
+const testRunCmd = (name: string, script: string) => {
+  unitTest(name, async () => {
+    const result = await execProcess({
+      cmd: [
+        quartoDevCmd(),
+        "run",
+        basename(script),
+      ],
+    });
+    assert(result.success);
+  }, 
+  {
+    teardown: () => {
+      try {
+        Deno.removeSync(basename(script));
+      } catch (_e) {
+        // ignore
+      }
+      return Promise.resolve();
+    },
+    cwd: () => {
+      return workingDir;
+    }
+  });
+}
+
+// Run Lua Script
+const luaScript = join(workingDir, "test.lua");
+Deno.writeTextFileSync(luaScript, "print('Hello, world!')");
+testRunCmd("run-lua-script", luaScript);
+
+// Run ts script
+const tsScript = join(workingDir, "test.ts");
+Deno.writeTextFileSync(tsScript, "console.log('Hello, world!')");
+testRunCmd("run-ts-script", tsScript);
+
+// Run Python script
+const pyScript = join(workingDir, "test.py");
+Deno.writeTextFileSync(pyScript, "print('Hello, world!')");
+testRunCmd("run-py-script", pyScript);
+
+// Run R script
+const rScript = join(workingDir, "test.R");
+Deno.writeTextFileSync(rScript, "print('Hello, world!')");
+testRunCmd("run-r-script", rScript);


### PR DESCRIPTION
fix #9059 

`init.lua` is now loaded in pandoc as part of the datadir. This PR remove some lines that should have been removed as part of f01b008 change (#978)

This also add tests for `quarto run`. 
