### PR TITLE
feature matrix - fix path handling for windows and linux support

### DIFF
--- a/dev-docs/feature-format-matrix/create_table.py
+++ b/dev-docs/feature-format-matrix/create_table.py
@@ -1,6 +1,6 @@
 import yaml
 import json
-import glob
+import pathlib
 
 class Trie:
 
@@ -103,8 +103,8 @@ def table_cell(entry, _feature, _format_name, format_config):
 
 def compute_trie():
     trie = Trie()
-    for entry in glob.glob("qmd-files/**/document.qmd", recursive=True):
-        feature = entry.split("/")[1:-1]
+    for entry in pathlib.Path(".").glob("qmd-files/**/document.qmd"):
+        feature = entry.parts[1:-1]
         front_matter = extract_metadata_from_file(entry)
         try:
             format = front_matter["format"]


### PR DESCRIPTION
Currently it does not work for me if I try to render the feature matrix on windows. 

I suggest we use `pathlib` to handle file path instead of using `split()` and some separator which would require to handle each case. 

pathlib is from python 3.4 BTW https://docs.python.org/3/library/pathlib.html

I am opening this PR so that you can check this is working for you. 

@gordonwoodhull I can make a PR or a commit to your branch. Otherwise here is a patch 

````diff
diff --git a/dev-docs/feature-format-matrix/create_table.py b/dev-docs/feature-format-matrix/create_table.py
index 4989aecca..28bd4f3b5 100644
--- a/dev-docs/feature-format-matrix/create_table.py
+++ b/dev-docs/feature-format-matrix/create_table.py
@@ -1,6 +1,6 @@
 import yaml
 import json
-import glob
+import pathlib
 
 class Trie:
 
@@ -104,11 +104,12 @@ def table_cell(entry, _feature, _format_name, format_config):
 def compute_trie(detailed = False):
     trie = Trie()
     pattern = "qmd-files/**/*.qmd" if detailed else "qmd-files/**/document.qmd"
-    for entry in glob.glob(pattern, recursive=True):
+    for entry in pathlib.Path(".").glob(pattern):
+        pathParts = entry.parts
         if detailed:
-            feature = entry.split("/")[1:]
+            feature = pathParts[1:]
         else:
-            feature = entry.split("/")[1:-1]
+            feature = pathParts[1:-1]
         front_matter = extract_metadata_from_file(entry)
         try:
             format = front_matter["format"]
````