### PR TITLE
Feature/publish hugging face

### DIFF
--- a/src/command/publish/cmd.ts
+++ b/src/command/publish/cmd.ts
@@ -163,7 +163,7 @@ async function publishAction(
   await initYamlIntelligence();
 
   // coalesce options
-  const publishOptions = await createPublishOptions(options, path);
+  const publishOptions = await createPublishOptions(options, provider, path);
 
   // helper to publish (w/ account confirmation)
   const doPublish = async (
@@ -302,6 +302,7 @@ async function publish(
 
 async function createPublishOptions(
   options: PublishCommandOptions,
+  provider?: PublishProvider,
   path?: string,
 ): Promise<PublishOptions> {
   const nbContext = notebookContext();
@@ -315,27 +316,27 @@ async function createPublishOptions(
   // determine publish input
   let input: ProjectContext | string | undefined;
 
+  if (provider && provider.resolveProjectPath) {
+    const resolvedPath = provider.resolveProjectPath(path);
+    if (Deno.statSync(resolvedPath).isDirectory) {
+      path = resolvedPath;
+    }
+  }
+
   // check for directory (either website or single-file project)
   const project = (await projectContext(path, nbContext)) ||
     singleFileProjectContext(path, nbContext);
+  console.log(project);
   if (Deno.statSync(path).isDirectory) {
-    if (project) {
-      if (projectIsWebsite(project)) {
-        input = project;
-      } else if (
-        projectIsManuscript(project) && project.files.input.length > 0
-      ) {
-        input = project;
-      } else if (project.files.input.length === 1) {
-        input = project.files.input[0];
-      }
+    if (projectIsWebsite(project)) {
+      input = project;
+    } else if (
+      projectIsManuscript(project) && project.files.input.length > 0
+    ) {
+      input = project;
+    } else if (project.files.input.length === 1) {
+      input = project.files.input[0];
     } else {
-      const inputFiles = await projectInputFiles(project);
-      if (inputFiles.files.length === 1) {
-        input = inputFiles.files[0];
-      }
-    }
-    if (!input) {
       throw new Error(
         `The specified path (${path}) is not a website, manuscript or book project so cannot be published.`,
       );

--- a/src/command/publish/cmd.ts
+++ b/src/command/publish/cmd.ts
@@ -318,8 +318,12 @@ async function createPublishOptions(
 
   if (provider && provider.resolveProjectPath) {
     const resolvedPath = provider.resolveProjectPath(path);
-    if (Deno.statSync(resolvedPath).isDirectory) {
-      path = resolvedPath;
+    try {
+      if (Deno.statSync(resolvedPath).isDirectory) {
+        path = resolvedPath;
+      }
+    } catch (_e) {
+      // ignore
     }
   }
 

--- a/src/command/publish/cmd.ts
+++ b/src/command/publish/cmd.ts
@@ -330,7 +330,6 @@ async function createPublishOptions(
   // check for directory (either website or single-file project)
   const project = (await projectContext(path, nbContext)) ||
     singleFileProjectContext(path, nbContext);
-  console.log(project);
   if (Deno.statSync(path).isDirectory) {
     if (projectIsWebsite(project)) {
       input = project;

--- a/src/command/publish/cmd.ts
+++ b/src/command/publish/cmd.ts
@@ -92,6 +92,10 @@ export const publishCommand =
       "quarto publish document.qmd",
     )
     .example(
+      "Publish project to Hugging Face Spaces",
+      "quarto publish huggingface",
+    )
+    .example(
       "Publish project to Netlify",
       "quarto publish netlify",
     )

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -6,6 +6,42 @@
 
 import { which } from "./path.ts";
 import { execProcess } from "./process.ts";
+import SemVer from "semver/mod.ts";
+
+export async function gitCmds(dir: string, cmds: Array<string[]>) {
+  for (const cmd of cmds) {
+    if (
+      !(await execProcess({
+        cmd: ["git", ...cmd],
+        cwd: dir,
+      })).success
+    ) {
+      throw new Error();
+    }
+  }
+}
+
+export async function gitVersion(): Promise<SemVer> {
+  const result = await execProcess(
+    {
+      cmd: ["git", "--version"],
+      stdout: "piped",
+    },
+  );
+  if (!result.success) {
+    throw new Error(
+      "Unable to determine git version. Please check that git is installed and available on your PATH.",
+    );
+  }
+  const match = result.stdout?.match(/git version (\d+\.\d+\.\d+)/);
+  if (match) {
+    return new SemVer(match[1]);
+  } else {
+    throw new Error(
+      `Unable to determine git version from string ${result.stdout}`,
+    );
+  }
+}
 
 export async function lsFiles(
   cwd?: string,

--- a/src/core/github.ts
+++ b/src/core/github.ts
@@ -11,29 +11,6 @@ import { join } from "../deno_ral/path.ts";
 import { existsSync } from "fs/mod.ts";
 import { isHttpUrl } from "./url.ts";
 import { GitHubContext } from "./github-types.ts";
-import SemVer from "semver/mod.ts";
-
-export async function gitVersion(): Promise<SemVer> {
-  const result = await execProcess(
-    {
-      cmd: ["git", "--version"],
-      stdout: "piped",
-    },
-  );
-  if (!result.success) {
-    throw new Error(
-      "Unable to determine git version. Please check that git is installed and available on your PATH.",
-    );
-  }
-  const match = result.stdout?.match(/git version (\d+\.\d+\.\d+)/);
-  if (match) {
-    return new SemVer(match[1]);
-  } else {
-    throw new Error(
-      `Unable to determine git version from string ${result.stdout}`,
-    );
-  }
-}
 
 export async function gitHubContext(dir: string) {
   // establish dir

--- a/src/core/github.ts
+++ b/src/core/github.ts
@@ -11,6 +11,29 @@ import { join } from "../deno_ral/path.ts";
 import { existsSync } from "fs/mod.ts";
 import { isHttpUrl } from "./url.ts";
 import { GitHubContext } from "./github-types.ts";
+import SemVer from "semver/mod.ts";
+
+export async function gitVersion(): Promise<SemVer> {
+  const result = await execProcess(
+    {
+      cmd: ["git", "--version"],
+      stdout: "piped",
+    },
+  );
+  if (!result.success) {
+    throw new Error(
+      "Unable to determine git version. Please check that git is installed and available on your PATH.",
+    );
+  }
+  const match = result.stdout?.match(/git version (\d+\.\d+\.\d+)/);
+  if (match) {
+    return new SemVer(match[1]);
+  } else {
+    throw new Error(
+      `Unable to determine git version from string ${result.stdout}`,
+    );
+  }
+}
 
 export async function gitHubContext(dir: string) {
   // establish dir

--- a/src/publish/common/errors.ts
+++ b/src/publish/common/errors.ts
@@ -1,0 +1,11 @@
+/*
+ * errors.ts
+ *
+ * Copyright (C) 2020-2024 Posit Software, PBC
+ */
+
+export const throwUnableToPublish = (reason: string, provider: string) => {
+  throw new Error(
+    `Unable to publish to ${provider} (${reason})`,
+  );
+};

--- a/src/publish/common/git.ts
+++ b/src/publish/common/git.ts
@@ -1,0 +1,66 @@
+/*
+ * git.ts
+ *
+ * Copyright (C) 2020-2024 Posit Software, PBC
+ */
+
+import { websiteBaseurl } from "../../project/types/website/website-config.ts";
+import { gitHubContext } from "../../core/github.ts";
+import { ProjectContext } from "../../project/types.ts";
+import { dirname } from "../../deno_ral/path.ts";
+import { AccountToken, AccountTokenType } from "../provider-types.ts";
+import { PublishOptions } from "../types.ts";
+import { GitHubContext } from "../../core/github-types.ts";
+import { throwUnableToPublish } from "./errors.ts";
+
+export async function gitHubContextForPublish(input: string | ProjectContext) {
+  // Create the base context
+  const dir = typeof input === "string" ? dirname(input) : input.dir;
+  const context = await gitHubContext(dir);
+
+  // always prefer configured website URL
+  if (typeof input !== "string") {
+    const configSiteUrl = websiteBaseurl(input?.config);
+    if (configSiteUrl) {
+      context.siteUrl = configSiteUrl;
+    }
+  }
+  return context;
+}
+
+export function anonymousAccount(): AccountToken {
+  return {
+    type: AccountTokenType.Anonymous,
+    name: "anonymous",
+    server: null,
+    token: "anonymous",
+  };
+}
+
+export function verifyContext(
+  ghContext: GitHubContext,
+  provider: string,
+) {
+  if (!ghContext.git) {
+    throwUnableToPublish(
+      "git does not appear to be installed on this system",
+      provider,
+    );
+  }
+
+  // validate we are in a git repo
+  if (!ghContext.repo) {
+    throwUnableToPublish(
+      "the target directory is not a git repository",
+      provider,
+    );
+  }
+
+  // validate that we have an origin
+  if (!ghContext.originUrl) {
+    throwUnableToPublish(
+      "the git repository does not have a remote origin",
+      provider,
+    );
+  }
+}

--- a/src/publish/gh-pages/gh-pages.ts
+++ b/src/publish/gh-pages/gh-pages.ts
@@ -29,8 +29,7 @@ import { completeMessage, withSpinner } from "../../core/console.ts";
 import { renderForPublish } from "../common/publish.ts";
 import { websiteBaseurl } from "../../project/types/website/website-config.ts";
 import { RenderFlags } from "../../command/render/types.ts";
-import SemVer from "semver/mod.ts";
-import { gitHubContext } from "../../core/github.ts";
+import { gitHubContext, gitVersion } from "../../core/github.ts";
 
 export const kGhpages = "gh-pages";
 const kGhpagesDescription = "GitHub Pages";
@@ -104,28 +103,6 @@ function resolveTarget(
   target: PublishRecord,
 ): Promise<PublishRecord | undefined> {
   return Promise.resolve(target);
-}
-
-async function gitVersion(): Promise<SemVer> {
-  const result = await execProcess(
-    {
-      cmd: ["git", "--version"],
-      stdout: "piped",
-    },
-  );
-  if (!result.success) {
-    throw new Error(
-      "Unable to determine git version. Please check that git is installed and available on your PATH.",
-    );
-  }
-  const match = result.stdout?.match(/git version (\d+\.\d+\.\d+)/);
-  if (match) {
-    return new SemVer(match[1]);
-  } else {
-    throw new Error(
-      `Unable to determine git version from string ${result.stdout}`,
-    );
-  }
 }
 
 async function publish(

--- a/src/publish/huggingface/huggingface.ts
+++ b/src/publish/huggingface/huggingface.ts
@@ -1,0 +1,275 @@
+/*
+ * huggingface.ts
+ *
+ * Copyright (C) 2020-2024 Posit Software, PBC
+ */
+
+import { info } from "../../deno_ral/log.ts";
+import { dirname, join } from "../../deno_ral/path.ts";
+import * as colors from "fmt/colors.ts";
+import { execProcess } from "../../core/process.ts";
+import { ProjectContext } from "../../project/types.ts";
+import {
+  AccountToken,
+  AccountTokenType,
+  PublishFiles,
+  PublishProvider,
+} from "../provider-types.ts";
+import { PublishOptions, PublishRecord } from "../types.ts";
+import { websiteBaseurl } from "../../project/types/website/website-config.ts";
+import { RenderFlags } from "../../command/render/types.ts";
+import { gitHubContext, gitVersion } from "../../core/github.ts";
+
+export const kHuggingFace = "huggingface";
+const kHuggingFaceDescription = "Hugging Face Spaces";
+
+export const huggingfaceProvider: PublishProvider = {
+  name: kHuggingFace,
+  description: kHuggingFaceDescription,
+  requiresServer: false,
+  listOriginOnly: false,
+  accountTokens: () => Promise.resolve([anonymousAccount()]),
+  authorizeToken,
+  removeToken: () => {},
+  publishRecord,
+  resolveTarget: (
+    _account: AccountToken,
+    target: PublishRecord,
+  ): Promise<PublishRecord | undefined> => Promise.resolve(target),
+  publish,
+  isUnauthorized,
+  isNotFound,
+  resolveProjectPath: (path: string) => join(path, "src"),
+};
+
+function anonymousAccount(): AccountToken {
+  return {
+    type: AccountTokenType.Anonymous,
+    name: "anonymous",
+    server: null,
+    token: "anonymous",
+  };
+}
+
+async function authorizeToken(options: PublishOptions) {
+  const ghContext = await gitHubContextForPublish(options.input);
+
+  if (!ghContext.git) {
+    throwUnableToPublish("git does not appear to be installed on this system");
+  }
+
+  // validate we are in a git repo
+  if (!ghContext.repo) {
+    throwUnableToPublish("the target directory is not a git repository");
+  }
+
+  // validate that we have an origin
+  if (!ghContext.originUrl) {
+    throwUnableToPublish("the git repository does not have a remote origin");
+  }
+  if (!ghContext.originUrl!.startsWith("https://huggingface.co/spaces/")) {
+    throwUnableToPublish(
+      "the git repository does not appear to have a Hugging Face Space origin",
+    );
+  }
+
+  // good to go!
+  return Promise.resolve(anonymousAccount());
+}
+
+async function publishRecord(
+  input: string | ProjectContext,
+): Promise<PublishRecord | undefined> {
+  const ghContext = await gitHubContextForPublish(input);
+  if (ghContext.ghPages) {
+    return {
+      id: "gh-pages",
+      url: ghContext.siteUrl || ghContext.originUrl,
+    };
+  }
+}
+
+async function publish(
+  _account: AccountToken,
+  _type: "document" | "site",
+  input: string,
+  _title: string,
+  _slug: string,
+  _render: (flags?: RenderFlags) => Promise<PublishFiles>,
+  options: PublishOptions,
+  _target?: PublishRecord,
+): Promise<[PublishRecord | undefined, URL | undefined]> {
+  // convert input to dir if necessary
+  input = Deno.statSync(input).isDirectory ? input : dirname(input);
+
+  // check if git version is new enough
+  const version = await gitVersion();
+
+  // git 2.17.0 appears to be the first to support git-worktree add --track
+  // https://github.com/git/git/blob/master/Documentation/RelNotes/2.17.0.txt#L368
+  if (version.compare("2.17.0") < 0) {
+    throw new Error(
+      "git version 2.17.0 or higher is required to publish to GitHub Pages",
+    );
+  }
+
+  // get context
+  const ghContext = await gitHubContextForPublish(options.input);
+
+  // sync from remote and push to main
+  await gitCmds(input, [
+    ["stash"],
+    ["fetch", "origin", "main"],
+    ["merge", "origin/main"],
+    ["stash", "pop"],
+    ["add", "-Af", "."],
+    ["commit", "--allow-empty", "-m", "commit from `quarto publish`"],
+    ["remote", "-v"],
+    ["push", "origin", "main"],
+  ]);
+
+  // warn users about latency between push and remote publish
+  info(colors.yellow(
+    "NOTE: Hugging Face Space sites build the content remotely and use caching.\n" +
+      "You might need to wait a moment for Hugging Face to rebuild your site, and\n" +
+      "then click the refresh button within your web browser to see changes after deployment.\n",
+  ));
+
+  return Promise.resolve([
+    undefined,
+    new URL(ghContext.originUrl!),
+  ]);
+}
+
+function isUnauthorized(_err: Error) {
+  return false;
+}
+
+function isNotFound(_err: Error) {
+  return false;
+}
+
+async function gitStash(dir: string) {
+  const result = await execProcess({
+    cmd: ["git", "stash"],
+    cwd: dir,
+  });
+  if (!result.success) {
+    throw new Error();
+  }
+}
+
+async function gitStashApply(dir: string) {
+  const result = await execProcess({
+    cmd: ["git", "stash", "apply"],
+    cwd: dir,
+  });
+  if (!result.success) {
+    throw new Error();
+  }
+}
+
+async function gitDirIsClean(dir: string) {
+  const result = await execProcess({
+    cmd: ["git", "diff", "HEAD"],
+    cwd: dir,
+    stdout: "piped",
+  });
+  if (result.success) {
+    return result.stdout!.trim().length === 0;
+  } else {
+    throw new Error();
+  }
+}
+
+async function gitCurrentBranch(dir: string) {
+  const result = await execProcess({
+    cmd: ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+    cwd: dir,
+    stdout: "piped",
+  });
+  if (result.success) {
+    return result.stdout!.trim();
+  } else {
+    throw new Error();
+  }
+}
+
+async function withWorktree(
+  dir: string,
+  siteDir: string,
+  f: () => Promise<void>,
+) {
+  await execProcess({
+    cmd: [
+      "git",
+      "worktree",
+      "add",
+      "--track",
+      "-B",
+      "gh-pages",
+      siteDir,
+      "origin/gh-pages",
+    ],
+    cwd: dir,
+  });
+
+  // remove files in existing site, i.e. start clean
+  await execProcess({
+    cmd: ["git", "rm", "-r", "--quiet", "."],
+    cwd: join(dir, siteDir),
+  });
+
+  try {
+    await f();
+  } finally {
+    await execProcess({
+      cmd: ["git", "worktree", "remove", siteDir],
+      cwd: dir,
+    });
+  }
+}
+
+async function gitCreateGhPages(dir: string) {
+  await gitCmds(dir, [
+    ["checkout", "--orphan", "gh-pages"],
+    ["rm", "-rf", "--quiet", "."],
+    ["commit", "--allow-empty", "-m", `Initializing gh-pages branch`],
+    ["push", "origin", `HEAD:gh-pages`],
+  ]);
+}
+
+async function gitCmds(dir: string, cmds: Array<string[]>) {
+  for (const cmd of cmds) {
+    if (
+      !(await execProcess({
+        cmd: ["git", ...cmd],
+        cwd: dir,
+      })).success
+    ) {
+      throw new Error();
+    }
+  }
+}
+
+// validate we have git
+const throwUnableToPublish = (reason: string) => {
+  throw new Error(
+    `Unable to publish to GitHub Pages (${reason})`,
+  );
+};
+
+async function gitHubContextForPublish(input: string | ProjectContext) {
+  // Create the base context
+  const dir = typeof input === "string" ? dirname(input) : input.dir;
+  const context = await gitHubContext(dir);
+
+  // always prefer configured website URL
+  if (typeof input !== "string") {
+    const configSiteUrl = websiteBaseurl(input?.config);
+    if (configSiteUrl) {
+      context.siteUrl = configSiteUrl;
+    }
+  }
+  return context;
+}

--- a/src/publish/provider-types.ts
+++ b/src/publish/provider-types.ts
@@ -76,4 +76,9 @@ export interface PublishProvider {
   ) => Promise<[PublishRecord | undefined, URL | undefined]>;
   isUnauthorized: (error: Error) => boolean;
   isNotFound: (error: Error) => boolean;
+
+  // if the provider has a quarto project path that is not the top level
+  // of the overall project (currently, huggingface spaces only),
+  // this function should return the path to the quarto project root
+  resolveProjectPath?: (path: string) => string;
 }

--- a/src/publish/provider.ts
+++ b/src/publish/provider.ts
@@ -10,7 +10,7 @@ import { quartoPubProvider } from "./quarto-pub/quarto-pub.ts";
 import { rsconnectProvider } from "./rsconnect/rsconnect.ts";
 import { positCloudProvider } from "./posit-cloud/posit-cloud.ts";
 import { confluenceProvider } from "./confluence/confluence.ts";
-import { PublishProvider } from "./provider-types.ts";
+import { huggingfaceProvider } from "./huggingface/huggingface.ts";
 import { AccountToken } from "./provider-types.ts";
 
 export function accountTokenText(token: AccountToken) {
@@ -24,17 +24,11 @@ const kPublishProviders = [
   positCloudProvider,
   netlifyProvider,
   confluenceProvider,
+  huggingfaceProvider,
 ];
 
 export function publishProviders() {
-  const providers: Array<PublishProvider> = [];
-  providers.push(quartoPubProvider);
-  providers.push(ghpagesProvider);
-  providers.push(rsconnectProvider);
-  providers.push(positCloudProvider);
-  providers.push(netlifyProvider);
-  providers.push(confluenceProvider);
-  return providers;
+  return kPublishProviders.slice();
 }
 
 export function findProvider(name?: string) {


### PR DESCRIPTION
This PR adds `huggingface` as a provider to `quarto publish`.

I've confirmed that the basic workflow works, including the checking and changing of the git remote to support their form of user/pass storage.

TODO: 

- [x] Document the new CLI options in the code
- [x] Document this on quarto-web as a new provider source (tracking on #9083)

Potential other things to do:

- [x] followup by changing our Dockerfile in HuggingFace so that the webserver we expose is smarter about caching (will track on #9082)
- [x] write a related `quarto create` target that clones a hugging face space. Currently, the user needs to start by locally cloning the repo. We could do better than that (will track on #9081).
