### PR TITLE
jupyter - add support for setup/cleanup (and daemonization) of third-party kernels

### DIFF
--- a/src/resources/jupyter/lang/julia/setup.jl
+++ b/src/resources/jupyter/lang/julia/setup.jl
@@ -10,10 +10,10 @@ import IJulia
 # clear console history
 IJulia.clear_history()
 
-fig_width = {0}
-fig_height = {1}
-fig_format = :{2}
-fig_dpi = {3}
+fig_width = {fig_width}
+fig_height = {fig_height}
+fig_format = :{fig_format}
+fig_dpi = {fig_dpi}
 
 # no retina format type, use svg for high quality type/marks
 if fig_format == :retina
@@ -62,7 +62,7 @@ end
   
 # Set run_path if specified
 try
-  run_path = raw"{4}"
+  run_path = raw"{run_path}"
   if !isempty(run_path)
     cd(run_path)
   end

--- a/src/resources/jupyter/lang/python/setup.py
+++ b/src/resources/jupyter/lang/python/setup.py
@@ -6,14 +6,14 @@ import types
 import json
 
 # figure size/format
-fig_width = {0}
-fig_height = {1}
-fig_format = '{2}'
-fig_dpi = {3}
-interactivity = '{5}'
-is_shiny = {6}
-is_dashboard = {7}
-plotly_connected = {8}
+fig_width = {fig_width}
+fig_height = {fig_height}
+fig_format = '{fig_format}'
+fig_dpi = {fig_dpi}
+interactivity = '{interactivity}'
+is_shiny = {is_shiny}
+is_dashboard = {is_dashboard}
+plotly_connected = {plotly_connected}
 
 # matplotlib defaults / format
 try:
@@ -183,16 +183,16 @@ for module in list(sys.modules.values()):
 print(json.dumps(kernel_deps))
 
 # set run_path if requested
-if r'{4}':
-  os.chdir(r'{4}')
+if r'{run_path}':
+  os.chdir(r'{run_path}')
 
 # reset state
 %reset
 
 # shiny
-# Checking for shiny by using {6} directly because we're after the %reset. We don't want
+# Checking for shiny by using {is_shiny} directly because we're after the %reset. We don't want
 # to set a variable that stays in global scope.
-if {6}:
+if {is_shiny}:
   try:
     import htmltools as _htmltools
     import ast as _ast

--- a/src/resources/jupyter/notebook.py
+++ b/src/resources/jupyter/notebook.py
@@ -88,7 +88,6 @@ def build_kernel_options(options):
       "params": params,
       "run_path": run_path,
       "quiet": quiet,
-      "execute": execute,
       "eval": eval,
       "allow_errors": allow_errors,
       "fig_width": fig_width,


### PR DESCRIPTION
See #9100.

This PR will enable setup, cleanup, and daemonization cells in arbitrary jupyter kernels (let's call this "quarto execution"). Kernels communicate their support of quarto execution in two ways as described in the [docs PR](https://github.com/quarto-dev/quarto-web/pull/1054):
