### PR TITLE
check - show latest git hash if running 99.9.9

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -127,5 +127,6 @@ All changes included in 1.5:
 - Add support for `{{< lipsum >}}` shortcode, which is useful for emitting placeholder text. Provide a specific number of paragraphs (`{{< lipsum 3 >}}`).
 - Resolve data URIs in Pandoc's mediabag when rendering documents.
 - Increase v8's max heap size by default, to avoid out-of-memory errors when rendering large documents (also cf. https://github.com/denoland/deno/issues/18935).
+- When running `quarto check` from a development build (from a git repository), show the git commit hash in addition to the version string.
 - Upgrade Deno to 1.41.0
 - `quarto install tinytex` will now try to set the default CTAN repository to the nearest mirror resolved from https://mirror.ctan.org.

--- a/src/command/check/check.ts
+++ b/src/command/check/check.ts
@@ -71,7 +71,7 @@ export async function check(target: Target): Promise<void> {
 }
 
 async function checkVersions(_services: RenderServices) {
-  const checkVersion = (
+  const checkVersion = async (
     version: string | undefined,
     constraint: string,
     name: string,
@@ -133,6 +133,17 @@ async function checkVersions(_services: RenderServices) {
 async function checkInstall(services: RenderServices) {
   completeMessage("Checking Quarto installation......OK");
   info(`      Version: ${quartoConfig.version()}`);
+  if (quartoConfig.version() === "99.9.9") {
+    // if they're running a dev version, we assume git is installed
+    // print the output of git rev-parse HEAD
+    const gitHead = await execProcess({
+      cmd: ["git", "rev-parse", "HEAD"],
+      stdout: "piped",
+    });
+    if (gitHead.stdout) {
+      info(`      commit: ${gitHead.stdout.trim()}`);
+    }
+  }
   info(`      Path: ${quartoConfig.binPath()}`);
   if (Deno.build.os === "windows") {
     try {


### PR DESCRIPTION
This makes our bug reporter's lives marginally easier (see eg #9144).