### PR TITLE
fix: epub reference link

### DIFF
--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -13034,7 +13034,7 @@ var require_yaml_intelligence_resources = __commonJS({
           schema: "string",
           description: {
             short: "Text describing the specialized type of this publication.",
-            long: "Text describing the specialized type of this publication.\n\nAn informative registry of specialized EPUB Publication \ntypes for use with this element is maintained in the \n[TypesRegistry](https://www.w3.org/publishing/epub3/epub-packages.html#bib-typesregistry), \nbut Authors may use any text string as a value.\n"
+            long: "Text describing the specialized type of this publication.\n\nAn informative registry of specialized EPUB Publication \ntypes for use with this element is maintained in the \n[TypesRegistry](https://www.w3.org/publishing/epub32/epub-packages.html#bib-typesregistry), \nbut Authors may use any text string as a value.\n"
           }
         },
         {
@@ -22934,12 +22934,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 182259,
+        _internalId: 182264,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 182251,
+            _internalId: 182256,
             type: "enum",
             enum: [
               "png",
@@ -22955,7 +22955,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 182258,
+            _internalId: 182263,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -13035,7 +13035,7 @@ try {
             schema: "string",
             description: {
               short: "Text describing the specialized type of this publication.",
-              long: "Text describing the specialized type of this publication.\n\nAn informative registry of specialized EPUB Publication \ntypes for use with this element is maintained in the \n[TypesRegistry](https://www.w3.org/publishing/epub3/epub-packages.html#bib-typesregistry), \nbut Authors may use any text string as a value.\n"
+              long: "Text describing the specialized type of this publication.\n\nAn informative registry of specialized EPUB Publication \ntypes for use with this element is maintained in the \n[TypesRegistry](https://www.w3.org/publishing/epub32/epub-packages.html#bib-typesregistry), \nbut Authors may use any text string as a value.\n"
             }
           },
           {
@@ -22935,12 +22935,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 182259,
+          _internalId: 182264,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 182251,
+              _internalId: 182256,
               type: "enum",
               enum: [
                 "png",
@@ -22956,7 +22956,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 182258,
+              _internalId: 182263,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -6006,7 +6006,7 @@
       "schema": "string",
       "description": {
         "short": "Text describing the specialized type of this publication.",
-        "long": "Text describing the specialized type of this publication.\n\nAn informative registry of specialized EPUB Publication \ntypes for use with this element is maintained in the \n[TypesRegistry](https://www.w3.org/publishing/epub3/epub-packages.html#bib-typesregistry), \nbut Authors may use any text string as a value.\n"
+        "long": "Text describing the specialized type of this publication.\n\nAn informative registry of specialized EPUB Publication \ntypes for use with this element is maintained in the \n[TypesRegistry](https://www.w3.org/publishing/epub32/epub-packages.html#bib-typesregistry), \nbut Authors may use any text string as a value.\n"
       }
     },
     {
@@ -15906,12 +15906,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 182259,
+    "_internalId": 182264,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 182251,
+        "_internalId": 182256,
         "type": "enum",
         "enum": [
           "png",
@@ -15927,7 +15927,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 182258,
+        "_internalId": 182263,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/schema/document-epub.yml
+++ b/src/resources/schema/document-epub.yml
@@ -66,7 +66,7 @@
 
       An informative registry of specialized EPUB Publication 
       types for use with this element is maintained in the 
-      [TypesRegistry](https://www.w3.org/publishing/epub3/epub-packages.html#bib-typesregistry), 
+      [TypesRegistry](https://www.w3.org/publishing/epub32/epub-packages.html#bib-typesregistry), 
       but Authors may use any text string as a value.
 
 - name: format


### PR DESCRIPTION
This PR updates to use the EPUB 3.2 link and fix the broken link in the reference schema.

Related to:
- #9005