### PR TITLE
Feature: `pandoc-native` and `pandoc-json` rawblock and rawinline elements

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -106,6 +106,10 @@ All changes included in 1.5:
 
 - ([#8939](https://github.com/quarto-dev/quarto-cli/pull/8939)): `quarto inspect` now takes an additional optional parameter to specify the output file, and provides the graph of include dependencies for the inspection target.
 
+## Quarto's input format
+
+- Quarto now supports raw block and raw inline elements of types `pandoc-native` and `pandoc-json`, and will use Pandoc's `native` and `json` reader to convert these elements to Pandoc's AST. This is useful in situations where emitting Markdown is not sufficient or convient enough to express the desired structure of a document.
+
 ## Other Fixes and Improvements
 
 - ([#8119](https://github.com/quarto-dev/quarto-cli/issues/8119)): More intelligently detect when ejs templates are modified during development, improving quality of life during preview.

--- a/src/resources/filters/normalize/extractquartodom.lua
+++ b/src/resources/filters/normalize/extractquartodom.lua
@@ -25,7 +25,35 @@ function parse_md_in_html_rawblocks()
         end
         return make_scaffold(pandoc.Span, inlines)
       end
-    end
+    end,
+    RawBlock = function(raw)
+      local result
+      if raw.format == "pandoc-native" then
+        result = pandoc.read(raw.text, "native").blocks
+      elseif raw.format == "pandoc-json" then
+        result = pandoc.read(raw.text, "json").blocks
+      else
+        return raw
+      end
+      return result
+    end,
+    RawInline = function(raw)
+      local result
+      if raw.format == "pandoc-native" then
+        result = quarto.utils.as_inlines(pandoc.read(raw.text, "native").blocks)
+      elseif raw.format == "pandoc-json" then
+        -- let's try to be minimally smart here, and handle lists differently from a single top-level element
+        result = quarto.utils.as_inlines(pandoc.read(raw.text, "json").blocks)
+      else
+        return raw
+      end
+      return result
+    end,
+    -- Meta = function(meta)
+    --   local filter = parse_md_in_html_rawblocks()
+    --   local result = _quarto.ast.walk_meta(meta, filter)
+    --   return result
+    -- end,
   }
 end
 

--- a/tests/docs/ast/test-pandoc-native-raw-in-meta.qmd
+++ b/tests/docs/ast/test-pandoc-native-raw-in-meta.qmd
@@ -1,0 +1,13 @@
+---
+format: html
+key-good: "`Str \"path-to-directory-with--two-dashes/file\"`{=pandoc-native}"
+key-bad: path-to-directory-with--two-dashes/file
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - ["--"]
+        - ["–"]
+---
+
+Hello {{< meta key-good >}}. (This would fail with `{{{< meta key-bad >}}}`)

--- a/tests/docs/ast/test-quarto-pandoc-json-raw.qmd
+++ b/tests/docs/ast/test-quarto-pandoc-json-raw.qmd
@@ -1,0 +1,13 @@
+---
+format: html
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - ["--"]
+        - ["–"]
+---
+
+(The JSON syntax is decidedly more verbose and not as nice, and really intended to be used by machine-generated markdown.)
+
+Here is a string that shouldn't be escaped: `{"pandoc-api-version":[1,23,1],"meta":{},"blocks":[{"t":"Plain","c":[{"t":"Str","c":"do--not--escape--this"}]}]}`{=pandoc-json}.

--- a/tests/docs/ast/test-quarto-pandoc-native-raw.qmd
+++ b/tests/docs/ast/test-quarto-pandoc-native-raw.qmd
@@ -1,0 +1,11 @@
+---
+format: html
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - ["--"]
+        - ["–"]
+---
+
+Here is a string that shouldn't be escaped: `Str "do--not--escape--this"`{=pandoc-native}.


### PR DESCRIPTION
Cf. our discussion in today's eng meeting.

Minimal self-describing test document that now passes the test suite:

````
---
format: html
_quarto:
  tests:
    html:
      ensureFileRegexMatches:
        - ["--"]
        - ["–"]
---

Here is a string that shouldn't be escaped: `Str "do--not--escape--this"`{=pandoc-native}.
````

This is useful as a mechanism for us to more easily circumvent Pandoc's Markdown parsing (see #9117 for a natural use case), and is also useful for third-party software libraries emitting markdown to be read by Quarto, since emitting Markdown robustly is quite hard to do in general.