### PR TITLE
Lua - use information from float to obtain ref type when possible

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -94,6 +94,7 @@ All changes included in 1.5:
 
 - ([#8417](https://github.com/quarto-dev/quarto-cli/issues/8417)): Maintain a single AST element in the output cells when parsing HTML from RawBlock elements.
 - ([#8582](https://github.com/quarto-dev/quarto-cli/issues/8582)): Improve the algorithm for extracting table elements from HTML RawBlock elements.
+- ([#8770](https://github.com/quarto-dev/quarto-cli/issues/8770)): Handle inconsistently-defined float types and identifier names more robustly in HTML tables.
 
 ## Engines
 

--- a/src/resources/filters/common/floats.lua
+++ b/src/resources/filters/common/floats.lua
@@ -12,7 +12,8 @@ local kFloatAlignSuffix = "-align"
 -- local kResizeHeight = "resize.height"
 
 function align_attribute(float)
-  local prefix = refType(float.identifier)
+  assert(float.t == "FloatRefTarget")
+  local prefix = ref_type_from_float(float)
   local attr_key = prefix .. kFloatAlignSuffix
   local default = pandoc.utils.stringify(
     param(attr_key, pandoc.Str("default"))

--- a/src/resources/filters/common/refs.lua
+++ b/src/resources/filters/common/refs.lua
@@ -36,6 +36,24 @@ function hasRefParent(el)
   return el.attributes[kRefParent] ~= nil
 end
 
+--[[
+Return the ref type ("tbl", "fig", etc) for a given FloatRefTarget custom AST element.
+]]
+---@param float table # the FloatRefTarget element
+---@return string # ref type for the given float
+function ref_type_from_float(float)
+  local category = crossref.categories.by_name[float.type]
+  if category == nil then
+    fail("unknown float type '" .. float.type .. "'");
+    return ""
+  end
+  local result = refType(float.identifier)
+  if result ~= nil and result ~= category.ref_type then
+    warn("ref type '" .. result .. "' does not match category ref type '" .. category.ref_type .. "'");
+  end
+  return category.ref_type
+end
+
 function refType(id)
   local match = string.match(id, "^(%a+)%-")
   if match then

--- a/src/resources/filters/crossref/figures.lua
+++ b/src/resources/filters/crossref/figures.lua
@@ -18,9 +18,9 @@ function crossref_figures()
 
       -- get label and base caption
       -- local label = el.attr.identifier
-      local kind = refType(float.identifier)
+      local kind = ref_type_from_float(float)
       if kind == nil then
-        return nil
+        internal_error()
       end
     
       -- determine order, parent, and displayed caption

--- a/src/resources/filters/crossref/tables.lua
+++ b/src/resources/filters/crossref/tables.lua
@@ -228,6 +228,10 @@ function float_title_prefix(float, withDelimiter)
     fail("unknown float type '" .. float.type .. "'")
     return
   end
+  if float.order == nil then
+    warn("field 'order' is missing from float. Cannot determine title prefix for crossref.")
+    return {}
+  end
   
   return titlePrefix(category.ref_type, category.name, float.order, withDelimiter)
 end

--- a/src/resources/filters/layout/latex.lua
+++ b/src/resources/filters/layout/latex.lua
@@ -513,7 +513,12 @@ function latexFigurePosition(el, env)
   if env == kMarginFigureEnv then
     return attribute(el, kOffset, nil)
   else
-    local prefix = refType(el.identifier) or "fig"
+    local prefix
+    if el.t == "FloatRefTarget" then
+      prefix = ref_type_from_float(el)
+    else
+      prefix = refType(el.identifier) or "fig"
+    end
     return attribute(el, prefix .. "-pos", nil)
   end
 end

--- a/src/resources/filters/layout/typst.lua
+++ b/src/resources/filters/layout/typst.lua
@@ -86,7 +86,7 @@ end, function(layout)
     return render_floatless_typst_layout(layout)
   end
 
-  local ref = refType(layout.float.identifier)
+  local ref = ref_type_from_float(layout.float)
   local kind = "quarto-float-" .. ref
   local info = crossref.categories.by_ref_type[ref]
   if info == nil then

--- a/src/resources/filters/quarto-post/latex.lua
+++ b/src/resources/filters/quarto-post/latex.lua
@@ -243,7 +243,7 @@ function render_latex()
       FloatRefTarget = function(float)
         if float.attributes["ref-parent"] == nil then
           -- we're about to mess up here, force a [H] position
-          local ref = refType(float.identifier)
+          local ref = ref_type_from_float(float)
           if ref == nil then
             -- don't know what to do with this
             -- give up
@@ -340,7 +340,7 @@ function render_latex()
         traverse = "topdown",
         FloatRefTarget = function(float, float_node)
           if float.identifier ~= nil then
-            local ref = refType(float.identifier)
+            local ref = ref_type_from_float(float)
             if ref ~= nil then
               float.attributes[ref .. "-pos"] = "H"
               return float

--- a/src/resources/filters/quarto-pre/figures.lua
+++ b/src/resources/filters/quarto-pre/figures.lua
@@ -23,7 +23,7 @@ function quarto_pre_figures()
 end
   return {    
     FloatRefTarget = function(float)
-      local kind = refType(float.identifier)
+      local kind = ref_type_from_float(float)
       if kind ~= "fig" then
         return
       end

--- a/src/resources/filters/quarto-pre/table-classes.lua
+++ b/src/resources/filters/quarto-pre/table-classes.lua
@@ -58,7 +58,7 @@ function table_classes()
       return tbl
     end,
     FloatRefTarget = function(float)
-      local kind = refType(float.identifier)
+      local kind = ref_type_from_float(float)
       if kind ~= "tbl" then
         return nil
       end

--- a/src/resources/filters/quarto-pre/table-colwidth.lua
+++ b/src/resources/filters/quarto-pre/table-colwidth.lua
@@ -83,7 +83,7 @@ end
 
 -- propagate cell level tbl-colwidths to tables
 function table_colwidth_cell(float)
-  if refType(float.identifier) ~= "tbl" then
+  if ref_type_from_float(float) ~= "tbl" then
     return
   end
       

--- a/tests/docs/smoke-all/2024/03/25/8770.qmd
+++ b/tests/docs/smoke-all/2024/03/25/8770.qmd
@@ -1,0 +1,45 @@
+---
+title: "Reproducible Quarto Document"
+format: html
+keep-md: true
+---
+
+
+
+This is a reproducible Quarto document using `format: html`.
+It is written in Markdown and contains embedded python code.
+When you run the code, it will produce a table.
+
+::: {#aef3e535 .cell execution_count=1}
+``` {.python .cell-code}
+import pandas as pd
+df = pd.DataFrame([["test data"]])
+df.style.set_caption("test caption")
+```
+
+::: {.cell-output .cell-output-display execution_count=1}
+
+```{=html}
+<style type="text/css">
+</style>
+<table id="T_af282">
+  <caption>test caption</caption>
+  <thead>
+    <tr>
+      <th class="blank level0" >&nbsp;</th>
+      <th id="T_af282_level0_col0" class="col_heading level0 col0" >0</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th id="T_af282_level0_row0" class="row_heading level0 row0" >0</th>
+      <td id="T_af282_row0_col0" class="data row0 col0" >test data</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+:::
+:::
+
+


### PR DESCRIPTION
Closes #8770.

The bug arises from pandas emitting a raw HTML block with the following elements:

- a table that we were able to parse successfully and convert to a Table Pandoc element
- a caption (which meant that our FloatRefTarget recognized the table above as something to add to our crossref system)
- an identifier that is not what we expected for `FloatRefTarget` nodes of type `Table` (something like `T_99413`)

Eventually, this combination causes us to attempt to determine a ref type for an element with id `T_99413`, which came back `nil`, which caused the bug. This PR makes our code more robust by using the information from the FloatRefTarget node directly whenever available (introducing the `ref_type_from_float` function).