### PR TITLE
lua - don't strip fig-alt from image when rendering html figure

### DIFF
--- a/dev-docs/feature-format-matrix/qmd-files/image/alt-text/document.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/image/alt-text/document.qmd
@@ -1,0 +1,45 @@
+---
+title: "Alt text"
+format:
+  html:
+    quality: 2
+  revealjs:
+    quality: 2
+_quarto:
+  tests:
+    html: &html_like_tests
+      ensureHtmlElements:
+        - ['img#case1[alt="Alt"]', 
+           'img#case2[alt="Alt"]',
+           'div#fig-case3 img[alt="Alt"]',
+           'div#fig-case4 img[alt="Alt"]',
+           'div#tbl-case5 img[alt="Alt"]',
+           'div#tbl-case6 img[alt="Alt"]']
+        - []
+    revealjs: *html_like_tests
+---
+
+## In HTML
+
+With caption, becomes a pandoc.Figure, but not a float:
+
+![Caption](https://placeholder.co/400/400){#case1 fig-alt="Alt"}
+
+Without caption, it's simply an image:
+
+![](https://placeholder.co/400/400){#case2 fig-alt="Alt"}
+
+In crossreferenceable figures, with and without captions:
+
+![Caption](https://placeholder.co/400/400){#fig-case3 fig-alt="Alt"}
+
+![](https://placeholder.co/400/400){#fig-case4 fig-alt="Alt"}
+
+In crossreferenceable non-figure floats, with and without captions:
+
+![Caption](https://placeholder.co/400/400){#tbl-case5 fig-alt="Alt"}
+
+![](https://placeholder.co/400/400){#tbl-case6 fig-alt="Alt"}
+
+
+

--- a/src/resources/filters/layout/html.lua
+++ b/src/resources/filters/layout/html.lua
@@ -167,9 +167,9 @@ function renderHtmlFigure(el, render)
     end
   end
 
-  local keys = tkeys(el.attr.attributes)
-  for _,k in pairs(keys) do
-    if isFigAttribute(k) then
+  for _, k in pairs(tkeys(el.attr.attributes)) do
+    -- can't strip fig-alt here
+    if isFigAttribute(k) and k ~= kFigAlt then
       el.attr.attributes[k] = nil
     end
   end

--- a/tests/docs/smoke-all/2024/03/25/9190.qmd
+++ b/tests/docs/smoke-all/2024/03/25/9190.qmd
@@ -1,0 +1,11 @@
+---
+title: "Alt text"
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ['img[alt="Alt"]']
+        - []
+---
+
+![Caption](https://placeholder.co/400/400){fig-alt="Alt"}


### PR DESCRIPTION
... since that needs to stay for postprocessing

Closes #9190.