### PR TITLE
quarto check: show typst version

### DIFF
--- a/src/command/check/check.ts
+++ b/src/command/check/check.ts
@@ -44,6 +44,7 @@ import { texLiveContext, tlVersion } from "../render/latexmk/texlive.ts";
 import { which } from "../../core/path.ts";
 import { dirname } from "../../deno_ral/path.ts";
 import { notebookContext } from "../../render/notebook/notebook-context.ts";
+import { typstBinaryPath } from "../../core/typst.ts";
 
 const kIndent = "      ";
 
@@ -126,6 +127,14 @@ async function checkVersions(_services: RenderServices) {
   } else {
     info(`      Deno version ${Deno.version.deno}: OK`);
   }
+
+  let typstVersion = lines(
+    (await execProcess({
+      cmd: [typstBinaryPath(), "--version"],
+      stdout: "piped"
+    })).stdout!,
+  )[0].split(' ')[1];
+  checkVersion(typstVersion, ">=0.10.0", "Typst");
 
   completeMessage("Checking versions of quarto dependencies......OK");
 }

--- a/src/resources/formats/typst/pandoc/quarto/typst-template.typ
+++ b/src/resources/formats/typst/pandoc/quarto/typst-template.typ
@@ -84,3 +84,8 @@
     columns(cols, doc)
   }
 }
+
+#set table(
+  inset: 6pt,
+  stroke: none
+)


### PR DESCRIPTION
Submitting two (I think) safe changes for CI testing:
- `quarto check` shows Typst version
- Typst table defaults to no grid lines. Copying this from Pandoc until we merge their latest templates, where this is already changed. (Not sure if this is the right place, will revisit then.)

