### PR TITLE
Escape revealjs lib url in metadata using new pandoc-native inline

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -20,6 +20,7 @@ All changes included in 1.5:
 ## RevealJS Format
 
 - ([#8382](https://github.com/quarto-dev/quarto-cli/issues/8382)): Strip whitespace from `div.columns` elements that might have been introduced by third-party processing.
+- ([#9117](https://github.com/quarto-dev/quarto-cli/issues/9117)): Fix an issue with input filename containing special characters.
 
 ## Docusaurus Format
 

--- a/src/format/reveal/format-reveal-theme.ts
+++ b/src/format/reveal/format-reveal-theme.ts
@@ -82,7 +82,9 @@ export async function revealTheme(
 
   // compute reveal url
   const revealUrl = pathWithForwardSlashes(revealDir);
-  metadata[kRevealJsUrl] = revealUrl;
+  // escape to avoid pandoc markdown parsing from YAML default file
+  // https://github.com/quarto-dev/quarto-cli/issues/9117
+  metadata[kRevealJsUrl] = `${'`Str "'}${revealUrl}${'"`'}{=pandoc-native}`;
 
   // copy reveal dir
   const revealSrcDir = revealJsUrl ||

--- a/src/format/reveal/format-reveal-theme.ts
+++ b/src/format/reveal/format-reveal-theme.ts
@@ -85,7 +85,7 @@ export async function revealTheme(
   const revealUrl = pathWithForwardSlashes(revealDir);
   // escape to avoid pandoc markdown parsing from YAML default file
   // https://github.com/quarto-dev/quarto-cli/issues/9117
-  metadata[kRevealJsUrl] = pandocNativeStr(revealUrl);
+  metadata[kRevealJsUrl] = pandocNativeStr(revealUrl).mappedString().value;
 
   // copy reveal dir
   const revealSrcDir = revealJsUrl ||

--- a/src/format/reveal/format-reveal-theme.ts
+++ b/src/format/reveal/format-reveal-theme.ts
@@ -37,6 +37,7 @@ import { copyMinimal, copyTo } from "../../core/copy.ts";
 import { titleSlideScss } from "./format-reveal-title.ts";
 import { asCssFont, asCssNumber } from "../../core/css.ts";
 import { cssHasDarkModeSentinel } from "../../core/pandoc/css.ts";
+import { pandocNativeStr } from "../../core/pandoc/codegen.ts";
 
 export const kRevealLightThemes = [
   "white",
@@ -84,7 +85,7 @@ export async function revealTheme(
   const revealUrl = pathWithForwardSlashes(revealDir);
   // escape to avoid pandoc markdown parsing from YAML default file
   // https://github.com/quarto-dev/quarto-cli/issues/9117
-  metadata[kRevealJsUrl] = `${'`Str "'}${revealUrl}${'"`'}{=pandoc-native}`;
+  metadata[kRevealJsUrl] = pandocNativeStr(revealUrl);
 
   // copy reveal dir
   const revealSrcDir = revealJsUrl ||

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -211,7 +211,9 @@ export function revealjsFormat() {
               [kLinkCitations]: true,
               [kRevealJsScripts]: revealPluginData.pluginInit.scripts.map(
                 (script) => {
-                  return script.path;
+                  // escape to avoid pandoc markdown parsing from YAML default file
+                  // https://github.com/quarto-dev/quarto-cli/issues/9117
+                  return `${'`Str "'}${script.path}${'"`'}{=pandoc-native}`;
                 },
               ),
             } as Metadata,

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -214,7 +214,7 @@ export function revealjsFormat() {
                 (script) => {
                   // escape to avoid pandoc markdown parsing from YAML default file
                   // https://github.com/quarto-dev/quarto-cli/issues/9117
-                  return pandocNativeStr(script.path);
+                  return pandocNativeStr(script.path).mappedString().value;
                 },
               ),
             } as Metadata,

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -68,6 +68,7 @@ import { revealMetadataFilter } from "./metadata.ts";
 import { ProjectContext } from "../../project/types.ts";
 import { titleSlidePartial } from "./format-reveal-title.ts";
 import { registerWriterFormatHandler } from "../format-handlers.ts";
+import { pandocNativeStr } from "../../core/pandoc/codegen.ts";
 
 export function revealResolveFormat(format: Format) {
   format.metadata = revealMetadataFilter(format.metadata);
@@ -213,7 +214,7 @@ export function revealjsFormat() {
                 (script) => {
                   // escape to avoid pandoc markdown parsing from YAML default file
                   // https://github.com/quarto-dev/quarto-cli/issues/9117
-                  return `${'`Str "'}${script.path}${'"`'}{=pandoc-native}`;
+                  return pandocNativeStr(script.path);
                 },
               ),
             } as Metadata,

--- a/tests/docs/smoke-all/2024/03/27/9117--issue.qmd
+++ b/tests/docs/smoke-all/2024/03/27/9117--issue.qmd
@@ -1,0 +1,11 @@
+---
+format: revealjs
+_quarto:
+  tests:
+    revealjs:
+      ensureHtmlElements:
+        - ['*[src ^= "9117--issue_files/"', '*[href ^= "9117--issue_files/"']
+        - ['*[src ^= "9117–issue_files/"', '*[href ^= "9117–issue_files/"']
+---
+
+a little test


### PR DESCRIPTION
This syntax was introduced in #9159 and help solve cases like this where we need to prevent pandoc from parsing as Markdown the metadata fields passed in the YAML file used with `metadata-file:`

For context about `--metadata-file` see https://pandoc.org/MANUAL.html#option--metadata-file
> Read metadata from the supplied YAML (or JSON) file. This option can be used with every input format, but string scalars in the metadata file will always be parsed as Markdown. 

fixes #9117