### PR TITLE
use template needs to work also with starter template

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -24,7 +24,12 @@ import {
   relative,
 } from "../deno_ral/path.ts";
 import { Metadata, QuartoFilter } from "../config/types.ts";
-import { kSkipHidden, normalizePath, resolvePathGlobs } from "../core/path.ts";
+import {
+  kSkipHidden,
+  normalizePath,
+  resolvePathGlobs,
+  safeExistsSync,
+} from "../core/path.ts";
 import { toInputRelativePaths } from "../project/project-shared.ts";
 import { projectType } from "../project/types/project-types.ts";
 import { mergeConfigs } from "../core/config.ts";
@@ -413,7 +418,9 @@ export async function readExtensions(
   organization?: string,
 ) {
   const extensions: Extension[] = [];
-  const extensionDirs = Deno.readDirSync(extensionsDirectory);
+  const extensionDirs = safeExistsSync(extensionsDirectory)
+    ? Deno.readDirSync(extensionsDirectory)
+    : [];
   for (const extensionDir of extensionDirs) {
     if (extensionDir.isDirectory) {
       const extFile = extensionFile(

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -418,7 +418,8 @@ export async function readExtensions(
   organization?: string,
 ) {
   const extensions: Extension[] = [];
-  const extensionDirs = safeExistsSync(extensionsDirectory)
+  const extensionDirs = safeExistsSync(extensionsDirectory) &&
+      Deno.statSync(extensionsDirectory).isDirectory
     ? Deno.readDirSync(extensionsDirectory)
     : [];
   for (const extensionDir of extensionDirs) {
@@ -444,7 +445,7 @@ export async function readExtensions(
           join(extensionsDirectory, extensionDir.name),
           extensionDir.name,
         );
-        if (ownedExtensions) {
+        if (ownedExtensions.length > 0) {
           extensions.push(...ownedExtensions);
         }
       }
@@ -692,9 +693,9 @@ async function readExtension(
     contributes?.format as Metadata || {};
 
   // Read any embedded extension
-  const embeddedExtensions = existsSync(join(extensionDir, kExtensionDir))
-    ? await readExtensions(join(extensionDir, kExtensionDir))
-    : [];
+  const embeddedExtensions = await readExtensions(
+    join(extensionDir, kExtensionDir),
+  );
 
   // Resolve 'default' specially
   Object.keys(formats).forEach((key) => {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -445,7 +445,7 @@ export async function readExtensions(
           join(extensionsDirectory, extensionDir.name),
           extensionDir.name,
         );
-        if (ownedExtensions.length > 0) {
+        if (ownedExtensions) {
           extensions.push(...ownedExtensions);
         }
       }

--- a/src/extension/install.ts
+++ b/src/extension/install.ts
@@ -339,7 +339,7 @@ async function readAndCopyExtensions(
   const extensions = await readExtensions(extensionsDir);
   info(
     `    Found ${extensions.length} ${
-      extensions.length === 1 ? "extension" : "extensions"
+      extensions.length <= 1 ? "extension" : "extensions"
     }.`,
   );
 
@@ -385,15 +385,10 @@ export async function confirmInstallation(
 ) {
   const readExisting = async () => {
     try {
-      const existingExtensionsDir = join(installDir, kExtensionDir);
-      if (Deno.statSync(existingExtensionsDir).isDirectory) {
-        const existingExtensions = await readExtensions(
-          join(installDir, kExtensionDir),
-        );
-        return existingExtensions;
-      } else {
-        return [];
-      }
+      const existingExtensions = await readExtensions(
+        join(installDir, kExtensionDir),
+      );
+      return existingExtensions;
     } catch {
       return [];
     }

--- a/src/extension/install.ts
+++ b/src/extension/install.ts
@@ -339,7 +339,7 @@ async function readAndCopyExtensions(
   const extensions = await readExtensions(extensionsDir);
   info(
     `    Found ${extensions.length} ${
-      extensions.length <= 1 ? "extension" : "extensions"
+      extensions.length === 1 ? "extension" : "extensions"
     }.`,
   );
 

--- a/tests/smoke/use/template.test.ts
+++ b/tests/smoke/use/template.test.ts
@@ -58,3 +58,28 @@ testQuartoCmd(
     }
   }
 )
+
+const starterFolder = "starterFolder";
+const starterWorkingDir = join(tempDir, starterFolder);
+ensureDirSync(starterWorkingDir);
+testQuartoCmd(
+  "use",
+  ["template", "quarto-examples/website-template", "--no-prompt"],
+  [noErrorsOrWarnings, fileExists("_quarto.yml"), fileExists("index.qmd")],
+  {
+    setup: () => {
+      return Promise.resolve();
+    },
+    cwd: () => {
+      return starterWorkingDir;
+    },
+    teardown: () => {
+      try {
+       Deno.removeSync(starterWorkingDir, {recursive: true});
+      } catch {
+        
+      }
+       return Promise.resolve();
+    }
+  }
+)


### PR DESCRIPTION
`quarto use template` can be used to copy files from a remote even if it does not have extension

Tweaks from #8764 regarding installation of extension only needs to happen if there is an `_extension` folder

#8764 uses 
https://github.com/quarto-dev/quarto-cli/blob/0ba1c27665b288e3b61f4dffd519b6c88769fc6e/src/command/use/commands/template.ts#L83-L104

This PR makes sure that `readExtensions` returns empty list when `extensionsDirectory` doesn't exists. This should prevent any similar issue when using `readExtensions` in the future. 

closes #9256 

I did not add to changelog because it was only broken by #8764 merged in 1.5.15