### PR TITLE
inspect - add information about code cells

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -112,6 +112,7 @@ All changes included in 1.5:
 ## `quarto inspect`
 
 - ([#8939](https://github.com/quarto-dev/quarto-cli/pull/8939)): `quarto inspect` now takes an additional optional parameter to specify the output file, and provides the graph of include dependencies for the inspection target.
+- ([#9264](https://github.com/quarto-dev/quarto-cli/pull/9264)): `quarto inspect` now provides information about the code cells in the inspection target.
 
 ## `quarto check`
 

--- a/src/project/project-shared.ts
+++ b/src/project/project-shared.ts
@@ -43,7 +43,7 @@ import { breakQuartoMd } from "../core/lib/break-quarto-md.ts";
 import { partitionCellOptionsText } from "../core/lib/partition-cell-options.ts";
 import { parse } from "yaml/mod.ts";
 import { mappedIndexToLineCol } from "../core/lib/mapped-text.ts";
-import { InternalError } from "../core/lib/error.ts";
+import { normalizeNewlines } from "../core/lib/text.ts";
 
 export function projectExcludeDirs(context: ProjectContext): string[] {
   const outputDir = projectOutputDir(context);
@@ -386,7 +386,7 @@ export async function projectResolveCodeCellsForFile(
       result.push({
         start: lineLocator(0).line,
         end: lineLocator(cell.sourceVerbatim.value.length - 1).line,
-        source: cell.source.value,
+        source: normalizeNewlines(cell.source.value),
         language: cell.cell_type.language,
         metadata,
       });

--- a/src/project/project-shared.ts
+++ b/src/project/project-shared.ts
@@ -38,6 +38,12 @@ import { createTempContext } from "../core/temp.ts";
 import { RenderContext, RenderFlags } from "../command/render/types.ts";
 import { LanguageCellHandlerOptions } from "../core/handlers/types.ts";
 import { ExecutionEngine } from "../execute/types.ts";
+import { InspectedMdCell } from "../quarto-core/inspect-types.ts";
+import { breakQuartoMd } from "../core/lib/break-quarto-md.ts";
+import { partitionCellOptionsText } from "../core/lib/partition-cell-options.ts";
+import { parse } from "yaml/mod.ts";
+import { mappedIndexToLineCol } from "../core/lib/mapped-text.ts";
+import { InternalError } from "../core/lib/error.ts";
 
 export function projectExcludeDirs(context: ProjectContext): string[] {
   const outputDir = projectOutputDir(context);
@@ -334,6 +340,62 @@ export async function directoryMetadataForInputFile(
   return config;
 }
 
+const mdForFile = async (
+  project: ProjectContext,
+  engine: ExecutionEngine | undefined,
+  file: string,
+): Promise<MappedString> => {
+  if (engine) {
+    return await engine.markdownForFile(file);
+  } else {
+    // Last resort, just read the file
+    return Promise.resolve(mappedStringFromFile(file));
+  }
+};
+
+export async function projectResolveCodeCellsForFile(
+  project: ProjectContext,
+  engine: ExecutionEngine | undefined,
+  file: string,
+  markdown?: MappedString,
+  force?: boolean,
+): Promise<InspectedMdCell[]> {
+  const cache = ensureFileInformationCache(project, file);
+  if (!force && cache.codeCells) {
+    return cache.codeCells || [];
+  }
+  if (!markdown) {
+    markdown = await mdForFile(project, engine, file);
+  }
+
+  const chunks = await breakQuartoMd(markdown);
+  const result: InspectedMdCell[] = [];
+  for (const cell of chunks.cells) {
+    if (
+      typeof cell.cell_type !== "string" &&
+      cell.cell_type.language !== "_directive"
+    ) {
+      const cellOptions = partitionCellOptionsText(
+        cell.cell_type.language,
+        cell.sourceWithYaml ?? cell.source,
+      );
+      const metadata = cellOptions.yaml
+        ? parse(cellOptions.yaml.value) as Record<string, unknown>
+        : {};
+      const lineLocator = mappedIndexToLineCol(cell.sourceVerbatim);
+      result.push({
+        start: lineLocator(0).line,
+        end: lineLocator(cell.sourceVerbatim.value.length - 1).line,
+        source: cell.source.value,
+        language: cell.cell_type.language,
+        metadata,
+      });
+    }
+  }
+  cache.codeCells = result;
+  return result;
+}
+
 export async function projectResolveFullMarkdownForFile(
   project: ProjectContext,
   engine: ExecutionEngine | undefined,
@@ -349,12 +411,7 @@ export async function projectResolveFullMarkdownForFile(
   const temp = createTempContext();
 
   if (!markdown) {
-    if (engine) {
-      markdown = await engine.markdownForFile(file);
-    } else {
-      // Last resort, just read the file
-      markdown = mappedStringFromFile(file);
-    }
+    markdown = await mdForFile(project, engine, file);
   }
 
   const options: LanguageCellHandlerOptions = {

--- a/src/project/types.ts
+++ b/src/project/types.ts
@@ -10,6 +10,7 @@ import { Format, FormatExtras } from "../config/types.ts";
 import { MappedString } from "../core/mapped-text.ts";
 import { PartitionedMarkdown } from "../core/pandoc/types.ts";
 import { ExecutionEngine, ExecutionTarget } from "../execute/types.ts";
+import { InspectedMdCell } from "../quarto-core/inspect-types.ts";
 import { NotebookContext } from "../render/notebook/notebook-types.ts";
 import {
   NavigationItem as NavItem,
@@ -42,9 +43,11 @@ export type FileInclusion = {
   source: string;
   target: string;
 };
+
 export type FileInformation = {
   fullMarkdown?: MappedString;
   includeMap?: FileInclusion[];
+  codeCells?: InspectedMdCell[];
 };
 
 export interface ProjectContext {

--- a/src/quarto-core/inspect-types.ts
+++ b/src/quarto-core/inspect-types.ts
@@ -1,0 +1,45 @@
+/*
+ * inspect.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
+
+import { Format } from "../config/types.ts";
+import {
+  FileInclusion,
+  ProjectConfig,
+  ProjectFiles,
+} from "../project/types.ts";
+
+export type InspectedMdCell = {
+  start: number;
+  end: number;
+  source: string;
+  language: string;
+  metadata: Record<string, unknown>;
+};
+
+export interface InspectedFile {
+  includeMap: FileInclusion[];
+  codeCells: InspectedMdCell[];
+}
+
+export interface InspectedConfig {
+  quarto: {
+    version: string;
+  };
+  engines: string[];
+  fileInformation: Record<string, InspectedFile>;
+}
+
+export interface InspectedProjectConfig extends InspectedConfig {
+  dir: string;
+  config: ProjectConfig;
+  files: ProjectFiles;
+}
+
+export interface InspectedDocumentConfig extends InspectedConfig {
+  formats: Record<string, Format>;
+  resources: string[];
+  project?: InspectedProjectConfig;
+}

--- a/src/quarto-core/inspect.ts
+++ b/src/quarto-core/inspect.ts
@@ -22,13 +22,11 @@ import {
 } from "../command/render/resources.ts";
 import { kLocalDevelopment, quartoConfig } from "../core/quarto.ts";
 
-import {
-  FileInclusion,
-  ProjectConfig,
-  ProjectFiles,
-} from "../project/types.ts";
 import { cssFileResourceReferences } from "../core/css.ts";
-import { projectExcludeDirs } from "../project/project-shared.ts";
+import {
+  projectExcludeDirs,
+  projectResolveCodeCellsForFile,
+} from "../project/project-shared.ts";
 import { normalizePath, safeExistsSync } from "../core/path.ts";
 import { kExtensionDir } from "../extension/constants.ts";
 import { extensionFilesFromDirs } from "../extension/extension.ts";
@@ -37,29 +35,12 @@ import { notebookContext } from "../render/notebook/notebook-context.ts";
 import { RenderServices } from "../command/render/types.ts";
 import { singleFileProjectContext } from "../project/types/single-file/single-file.ts";
 
-export interface FileInspection {
-  includeMap: FileInclusion[];
-}
-
-export interface InspectedConfig {
-  quarto: {
-    version: string;
-  };
-  engines: string[];
-  fileInformation: Record<string, FileInspection>;
-}
-
-export interface InspectedProjectConfig extends InspectedConfig {
-  dir: string;
-  config: ProjectConfig;
-  files: ProjectFiles;
-}
-
-export interface InspectedDocumentConfig extends InspectedConfig {
-  formats: Record<string, Format>;
-  resources: string[];
-  project?: InspectedProjectConfig;
-}
+import {
+  InspectedConfig,
+  InspectedDocumentConfig,
+  InspectedFile,
+  InspectedProjectConfig,
+} from "./inspect-types.ts";
 
 export function isProjectConfig(
   config: InspectedConfig,
@@ -92,12 +73,14 @@ export async function inspectConfig(path?: string): Promise<InspectedConfig> {
 
   const inspectedProjectConfig = async () => {
     if (context?.config) {
-      const fileInformation: Record<string, FileInspection> = {};
+      const fileInformation: Record<string, InspectedFile> = {};
       for (const file of context.files.input) {
         const engine = await fileExecutionEngine(file, undefined, context);
         await context.resolveFullMarkdownForFile(engine, file);
+        await projectResolveCodeCellsForFile(context, engine, file);
         fileInformation[file] = {
           includeMap: context.fileInformationCache.get(file)?.includeMap ?? [],
+          codeCells: context.fileInformationCache.get(file)?.codeCells ?? [],
         };
       }
       const config: InspectedProjectConfig = {
@@ -182,6 +165,8 @@ export async function inspectConfig(path?: string): Promise<InspectedConfig> {
       }
 
       await context.resolveFullMarkdownForFile(engine, path);
+      await projectResolveCodeCellsForFile(context, engine, path);
+      const fileInformation = context.fileInformationCache.get(path);
 
       // data to write
       const config: InspectedDocumentConfig = {
@@ -193,8 +178,8 @@ export async function inspectConfig(path?: string): Promise<InspectedConfig> {
         resources,
         fileInformation: {
           [path]: {
-            includeMap: context.fileInformationCache.get(path)?.includeMap ??
-              [],
+            includeMap: fileInformation?.includeMap ?? [],
+            codeCells: fileInformation?.codeCells ?? [],
           },
         },
       };

--- a/tests/docs/project/book/_include.qmd
+++ b/tests/docs/project/book/_include.qmd
@@ -1,0 +1,4 @@
+```{python}
+#| echo: true
+print("Hello, world")
+```

--- a/tests/docs/project/book/intro.qmd
+++ b/tests/docs/project/book/intro.qmd
@@ -5,3 +5,5 @@ Hello world. this is an introduction
 [@afzal2020]
 
 [A figure](./cover.png){#fig-1}
+
+{{< include _include.qmd >}}

--- a/tests/smoke/inspect/inspect-code-cells.test.ts
+++ b/tests/smoke/inspect/inspect-code-cells.test.ts
@@ -1,34 +1,42 @@
 /*
-* inspect-recursive-include.test.ts
+* inspect-code-cells.test.ts
 *
 * Copyright (C) 2020-2024 Posit Software, PBC
 *
 */
+
 import { assertObjectMatch } from "https://deno.land/std@0.93.0/assert/assert_object_match.ts";
 import { existsSync } from "../../../src/deno_ral/fs.ts";
-import { FileInclusion } from "../../../src/project/types.ts";
+import {  } from "../../../src/project/types.ts";
 import {
   ExecuteOutput,
   testQuartoCmd,
 } from "../../test.ts";
-import { assert, assertEquals } from "testing/asserts.ts";
+import { assert } from "testing/asserts.ts";
 
 (() => {
-  const input = "docs/websites/issue-9253/index.qmd";
-  const output = "docs/websites/issue-9253/index.json";
+  const input = "docs/project/book/_include.qmd";
+  const output = "docs/project/book/_include.json";
   testQuartoCmd(
     "inspect",
     [input, output],
     [
       {
-        name: "inspect-include",
+        name: "inspect-code-cells",
         verify: async (outputs: ExecuteOutput[]) => {
           assert(existsSync(output));
           const json = JSON.parse(Deno.readTextFileSync(output));
-          const info = json.fileInformation["docs/websites/issue-9253/index.qmd"];
-          const includeMap: FileInclusion[] = info.includeMap;
-          assertObjectMatch(info.includeMap[0], { target: "_include.qmd" });
-          assertObjectMatch(info.includeMap[1], { source: "_include.qmd", target: "_include2.qmd" });
+          const info = json.fileInformation["docs/project/book/_include.qmd"];
+          const codeCells = info.codeCells;
+          assertObjectMatch(info.codeCells[0], { 
+            start: 0,
+            end: 3,
+            source: "print(\"Hello, world\")\n",
+            language: "python",
+            metadata: {
+              "echo": true
+            }
+          });
         }
       }
     ],


### PR DESCRIPTION
Minimal example:

````
---
title: test
---

```{r}
#| echo: true
#| warning: true
cat("Hello!")
```
````

```
$ quarto inspect test.qmd
...
  "fileInformation": {
    "test.qmd": {
      "includeMap": [],
      "codeCells": [
        {
          "start": 4,
          "end": 8,
          "source": "cat(\"Hello!\")\n",
          "language": "r",
          "metadata": {
            "echo": true,
            "warning": true
          }
        }
      ]
    }
  }
...
```

