### PR TITLE
inspect - track multiple inclusions

### DIFF
--- a/src/core/lib/break-quarto-md-types.ts
+++ b/src/core/lib/break-quarto-md-types.ts
@@ -10,7 +10,7 @@ import { Shortcode } from "./parse-shortcode-types.ts";
 import { MappedString } from "./text-types.ts";
 
 export interface CodeCellType {
-  language: string;
+  language: string; // I'd like to say "string but not '_directive'" but I don't know how
 }
 
 export interface DirectiveCell {

--- a/src/quarto-core/inspect-types.ts
+++ b/src/quarto-core/inspect-types.ts
@@ -14,6 +14,7 @@ import {
 export type InspectedMdCell = {
   start: number;
   end: number;
+  file: string;
   source: string;
   language: string;
   metadata: Record<string, unknown>;

--- a/tests/docs/websites/issue-9253/index.qmd
+++ b/tests/docs/websites/issue-9253/index.qmd
@@ -7,3 +7,5 @@ This is a Quarto website.
 To learn more about Quarto websites visit <https://quarto.org/docs/websites>.
 
 {{< include _include.qmd >}}
+
+{{< include _include.qmd >}}


### PR DESCRIPTION
This tracks cells more precisely, as well as multiple includes into the same file.

The information in `quarto inspect` should now be sufficient to create a script that runs precisely the same code as what engine execution sees.
