### PR TITLE
[quarto publish] Verify gh context before proceeding

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -111,6 +111,10 @@ All changes included in 1.5:
 
 - ([#8614](https://github.com/quarto-dev/quarto-cli/issues/8614)): Don't improperly forward column classes onto grids.
 
+## Publishing
+
+- ([#9308](https://github.com/quarto-dev/quarto-cli/issues/9308)): Improved error message when trying to publish to Github pages with `quarto publish gh-pages`.
+
 ## `quarto inspect`
 
 - ([#8939](https://github.com/quarto-dev/quarto-cli/pull/8939)): `quarto inspect` now takes an additional optional parameter to specify the output file, and provides the graph of include dependencies for the inspection target.

--- a/src/publish/gh-pages/gh-pages.ts
+++ b/src/publish/gh-pages/gh-pages.ts
@@ -112,6 +112,7 @@ async function publish(
 
   // get context
   const ghContext = await gitHubContextForPublish(options.input);
+  verifyContext(ghContext, "GitHub Pages");
 
   // create gh pages branch if there is none yet
   const createGhPagesBranch = !ghContext.ghPages;

--- a/src/publish/huggingface/huggingface.ts
+++ b/src/publish/huggingface/huggingface.ts
@@ -104,6 +104,7 @@ async function publish(
 
   // get context
   const ghContext = await gitHubContextForPublish(options.input);
+  verifyContext(ghContext, "Hugging Face Spaces");
 
   if (
     !ghContext.originUrl!.match(/^https:\/\/.*:.*@huggingface.co\/spaces\//)


### PR DESCRIPTION
We do not do it early enough and we should check the github context for publish before proceeding

This includes: 
- Is git available on the system ? 
- Is this a git tracked project ? 
- Is there a remote named `origin`  ? 

@cwickham you can check the wording of the error we currently throw by looking at `verifyContex()`
https://github.com/quarto-dev/quarto-cli/blob/1573bc693c174b89ac93d9cde4f051c215e630b1/src/publish/common/git.ts#L40-L66

Example when not a git initialized project 
````
❯ quarto publish gh-pages
ERROR: Unable to publish to GitHub Pages (the target directory is not a git repository)
````

or when no remote 
````
❯ quarto publish gh-pages
ERROR: Unable to publish to GitHub Pages (the git repository does not have a remote origin)
````

You can provide update on those to clarify if you think they should. We use them for `gh-pages` and new `huggingface`
