### PR TITLE
Docusaurus - use RawBlock for tables that would be emitted as HTML

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -25,6 +25,7 @@ All changes included in 1.5:
 ## Docusaurus Format
 
 - ([#8919](https://github.com/quarto-dev/quarto-cli/issues/8919)): Ensure enough backticks in code cell declarations.
+- ([#9179](https://github.com/quarto-dev/quarto-cli/issues/9179)): Emit tables that Pandoc would write as HTML as RawBlock elements to ensure they are rendered correctly in Docusaurus.
 
 ## Website
 

--- a/src/resources/extensions/quarto/docusaurus/docusaurus.lua
+++ b/src/resources/extensions/quarto/docusaurus/docusaurus.lua
@@ -113,6 +113,15 @@ local function tabset(node)
   return tabs
 end
 
+local function Table(tbl)
+  local out = pandoc.write(pandoc.Pandoc({tbl}), FORMAT, PANDOC_WRITER_OPTIONS)
+  -- if the table was written in a way that looks like HTML, then wrap it in the right RawBlock way
+  if string.match(out, "^%s*%<table") then
+    local unwrapped = pandoc.RawBlock('html', out)
+    return RawBlock(unwrapped)
+  end
+end
+
 quarto._quarto.ast.add_renderer("Tabset", function()
   return quarto._quarto.format.isDocusaurusOutput()
 end, function(node)
@@ -178,6 +187,7 @@ return {
     RawBlock = RawBlock,
     DecoratedCodeBlock = DecoratedCodeBlock,
     CodeBlock = CodeBlock,
+    Table = Table,
   },
   {
     Pandoc = Pandoc,

--- a/tests/docs/smoke-all/2024/04/10/9179.qmd
+++ b/tests/docs/smoke-all/2024/04/10/9179.qmd
@@ -1,0 +1,14 @@
+---
+title: Broken Tables
+_quarto:
+  tests:
+    docusaurus-md:
+      ensureFileRegexMatches:
+        - ["dangerouslySetInnerHTML"]
+---
+
+# Broken Markdown Tables
+
++-------+
+| # ad  |
++-------+


### PR DESCRIPTION
Closes #9179.