### PR TITLE
jupyter fixups - convert string to singleton array of strings

### DIFF
--- a/src/core/jupyter/jupyter-fixups.ts
+++ b/src/core/jupyter/jupyter-fixups.ts
@@ -228,22 +228,36 @@ export function fixupFrontMatter(nb: JupyterNotebook): JupyterNotebook {
   return nb;
 }
 
+const fixupOutputs = (nb: JupyterNotebook): JupyterNotebook => {
+  for (const cell of nb.cells) {
+    for (const output of cell.outputs ?? []) {
+      if (typeof output.text === "string") {
+        output.text = [output.text];
+      }
+    }
+  }
+  return nb;
+};
+
 type JupyterFixup = (nb: JupyterNotebook) => JupyterNotebook;
 
 export const defaultFixups: JupyterFixup[] = [
   fixupBokehCells,
   fixupFrontMatter,
   fixupStreams,
+  fixupOutputs,
 ];
 
 export const minimalFixups: JupyterFixup[] = [
   fixupBokehCells,
   fixupStreams,
+  fixupOutputs,
 ];
 
 // books can't have the front matter fixup
 export const bookFixups: JupyterFixup[] = [
   fixupBokehCells,
+  fixupOutputs,
 ];
 
 export function fixupJupyterNotebook(


### PR DESCRIPTION
Closes #9344.

Before we merge this, we should make sure we understand precisely what's going on. From my understanding of the [notebook file format](https://nbformat.readthedocs.io/en/latest/format_description.html#stream-output), the field `text` should always be a string, and never an array of strings. But clearly Quarto is expecting an array of strings (see #9344 again).

So, it's possible that the source of the bug is elsewhere, and that we should ensure `text` is a _single string instead_.