### PR TITLE
Allow using a custom env for loading QuartoNotebookRunner

### DIFF
--- a/src/execute/julia.ts
+++ b/src/execute/julia.ts
@@ -258,7 +258,10 @@ async function startOrReuseJuliaServer(
           "using QuartoNotebookRunner",
         ],
         env: {
-          "JULIA_LOAD_PATH": "@:@stdlib", // ignore the main env
+          // ignore the main env
+          "JULIA_LOAD_PATH": Deno.build.os === "windows"
+            ? "@;@stdlib"
+            : "@:@stdlib",
         },
       });
       const qnrTestProc = qnrTestCommand.spawn();
@@ -303,7 +306,7 @@ async function startOrReuseJuliaServer(
             "Hidden",
           ],
           env: {
-            "JULIA_LOAD_PATH": "@:@stdlib", // ignore the main env
+            "JULIA_LOAD_PATH": "@;@stdlib", // ignore the main env
           },
         },
       );
@@ -325,6 +328,9 @@ async function startOrReuseJuliaServer(
           resourcePath("julia/quartonotebookrunner.jl"),
           transportFile,
         ],
+        env: {
+          "JULIA_LOAD_PATH": "@:@stdlib", // ignore the main env
+        },
       });
       trace(
         options,

--- a/src/resources/julia/start_quartonotebookrunner_detached.jl
+++ b/src/resources/julia/start_quartonotebookrunner_detached.jl
@@ -9,5 +9,7 @@ if length(ARGS) > 4
   error("Too many arguments")
 end
 
+env = copy(ENV)
+env["JULIA_LOAD_PATH"] = "@:@stdlib" # ignore the main env
 cmd = `$julia_bin --startup-file=no --project=$project $julia_file $transport_file`
-run(detach(cmd), wait = false)
+run(detach(setenv(cmd, env)), wait = false)


### PR DESCRIPTION
## Description

This PR adds an environment variable `QUARTO_JULIA_PROJECT` with which one can load QuartoNotebookRunner from a different environment than the one handled by quarto itself.

This is primarily intended for development purposes or custom setups where a different version of QuartoNotebookRunner than the one specified in the internal Project.toml should be used.

I noticed while adding this that quarto tried to load a very old version of QuartoNotebookRunner from my global env when I specified an empty project. So I've additionally removed the global env from the load path for the relevant julia processes, because we never intend to load anything from there. It's either the custom env or the quarto-handled env.


## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
