### PR TITLE
Do not render latex inside svgs

### DIFF
--- a/src/resources/formats/pdf/pandoc/latex.template
+++ b/src/resources/formats/pdf/pandoc/latex.template
@@ -312,7 +312,7 @@ $if(graphics)$
 \makeatother
 $endif$
 $if(svg)$
-\usepackage{svg}
+\usepackage[inkscapelatex=false]{svg}
 $endif$
 $if(strikeout)$
 $-- also used for underline

--- a/src/resources/formats/pdf/pandoc/template.tex
+++ b/src/resources/formats/pdf/pandoc/template.tex
@@ -254,7 +254,7 @@ $if(lhs)$
 \lstnewenvironment{code}{\lstset{language=Haskell,basicstyle=\small\ttfamily}}{}
 $endif$
 $if(svg)$
-\usepackage{svg}
+\usepackage[inkscapelatex=false]{svg}
 $endif$
 $if(strikeout)$
 $-- also used for underline


### PR DESCRIPTION
## Description

This PR adds a flag to the latex template to stops the latex 'svg' package trying to render latex inside the SVG, and instead do a direct translation SVG -> PDF.

By default, the latex `svg` package tries to render latex which occurs inside text inside SVGs.

This change will have two effects:

1) Text in SVGs will no longer be rendered using latex (for example, `$x^2$` will just appear as is, not be rendered.

2) There is a bug in the latex 'svg' package, where it does not resize svgs correctly which are too wide for the page. This fixes that. This issue was discussed in #9282 


