### PR TITLE
Chore/QuartoNotebookRunner.jl 0.10.0

### DIFF
--- a/src/resources/julia/Project.toml
+++ b/src/resources/julia/Project.toml
@@ -2,4 +2,4 @@
 QuartoNotebookRunner = "4c0109c6-14e9-4c88-93f0-2b974d3468f4"
 
 [compat]
-QuartoNotebookRunner = "=0.9.1"
+QuartoNotebookRunner = "=0.10.0"


### PR DESCRIPTION
## Description

This updates the [`QuartoNotebookRunner.jl`](https://github.com/PumasAI/QuartoNotebookRunner.jl) version to `0.10.0` which adds support for the following:

- R code cells, implemented in https://github.com/PumasAI/QuartoNotebookRunner.jl/pull/100, which uses the `RCall.jl` package for evaluating R code.
- Support for notebook parameters, implemented in https://github.com/PumasAI/QuartoNotebookRunner.jl/pull/105.

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
