### PR TITLE
Add `layout = auto`

### DIFF
--- a/src/resources/filters/layout/layout.lua
+++ b/src/resources/filters/layout/layout.lua
@@ -195,7 +195,7 @@ function layout_cells(float_or_div, cells)
   -- check for layout
   elseif layout ~= nil then
     -- parse the layout
-    layout = parseLayoutWidths(layout, #cells)
+    layout = parseLayoutWidths(layout, cells)
     
     -- manage/perform next insertion into the layout
     local cellIndex = 1


### PR DESCRIPTION
Will close #7832.

- Requires Pandoc dependency refresh for `pandoc.image` API.
- Currently only works on LaTeX because of layout algorithm mismatch between LaTeX and HTML

## Usage

`layout` attribute now supports `auto` keyword, which we take to mean "layout all cells in a single row and automatically adjust image heights so they're all matched."

Example:

````markdown
---
title: hello
---

::: {#fig-1 layout=auto} 

![Hanno](./hanno.png)

![Surus](./surus.png)

Elephants

:::

See @fig-1
````

### LaTeX output

![image](https://github.com/quarto-dev/quarto-cli/assets/285675/ed979495-b5be-4327-b2ea-86ac55809ec7)

### HTML output

Currently broken:

![image](https://github.com/quarto-dev/quarto-cli/assets/285675/34009166-97cb-4ec4-b816-f6b1a7a1060f)