### PR TITLE
update crossref.lua to use quarto_ast_pipeline

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -154,6 +154,7 @@ All changes included in 1.5:
 - ([#9059](https://github.com/quarto-dev/quarto-cli/issues/9059)): `quarto run` now properly works on Windows with Lua scripts.
 - ([#9282](https://github.com/quarto-dev/quarto-cli/issues/9282)): Fix name clash in Lua local declarations for `mediabag` in bundled releases.
 - ([#9394](https://github.com/quarto-dev/quarto-cli/issues/9394)): Make `template` a required field in the `about` schema.
+- ([#9426](https://github.com/quarto-dev/quarto-cli/issues/9426)): Update `crossref.lua` filter to avoid crashes and hangs in documents with custom AST nodes.
 - Add support for `{{< lipsum >}}` shortcode, which is useful for emitting placeholder text. Provide a specific number of paragraphs (`{{< lipsum 3 >}}`).
 - Resolve data URIs in Pandoc's mediabag when rendering documents.
 - Increase v8's max heap size by default, to avoid out-of-memory errors when rendering large documents (also cf. https://github.com/denoland/deno/issues/18935).

--- a/src/command/editor-support/crossref.ts
+++ b/src/command/editor-support/crossref.ts
@@ -126,6 +126,10 @@ const makeCrossrefCommand = () => {
           stdout: "piped",
         },
         input,
+        undefined, // mergeOutput?: "stderr>stdout" | "stdout>stderr",
+        undefined, // stderrFilter?: (output: string) => string,
+        undefined, // respectStreams?: boolean,
+        5000,
       );
 
       // check for error

--- a/src/resources/filters/crossref/crossref.lua
+++ b/src/resources/filters/crossref/crossref.lua
@@ -156,34 +156,8 @@ local quarto_normalize_filters = {
   end, normalize_filter()) },
 
   { name = "normalize-capture-reader-state", filter = normalize_capture_reader_state() },
-
-  { name = "pre-table-merge-raw-html", 
-    filter = table_merge_raw_html()
-  },
-
-  -- { name = "pre-content-hidden-meta",
-  --   filter = content_hidden_meta() },
-
-  -- 2023-04-11: We want to combine combine-1 and combine-2, but parse_md_in_html_rawblocks
-  -- can't be combined with parse_html_tables. combineFilters
-  -- doesn't inspect the contents of the results in the inner loop in case
-  -- the result is "spread" into a Blocks or Inlines.
-  
-  { name = "normalize-combined-1", filter = combineFilters({
-      parse_html_tables(),
-      parse_extended_nodes(),
-      code_filename(),
-    })
-  },
-  { 
-    name = "normalize-combine-2", 
-    filter = combineFilters({
-      parse_md_in_html_rawblocks(),
-      parse_floatreftargets(),
-      parse_blockreftargets(),
-    }),
-  },
 }
+tappend(quarto_normalize_filters, quarto_ast_pipeline())
 
 local quarto_pre_filters = {
   -- quarto-pre


### PR DESCRIPTION
Closes #9426.

This PR also adds a timeout to `quarto editor-support` so that we (hopefully) no longer get hanging instances of Pandoc coming from the VS Code extension.