### PR TITLE
fix more pandoc nils

### DIFF
--- a/src/resources/filters/layout/docx.lua
+++ b/src/resources/filters/layout/docx.lua
@@ -90,7 +90,7 @@ function docxDivCaption(captionEl, align)
   local caption = pandoc.Para({
     pandoc.RawInline("openxml", docxParaStyles(align))
   })
-  tappend(caption.content, captionEl.content)
+  tappend(caption.content, captionEl and captionEl.content or pandoc.Inlines({}))
   return caption
 end
 

--- a/src/resources/filters/layout/lightbox.lua
+++ b/src/resources/filters/layout/lightbox.lua
@@ -144,7 +144,12 @@ function lightbox()
     subFloatEl = _quarto.ast.walk(subFloatEl, {
       traverse = 'topdown',
       Image = function(imgEl)
-        local caption_content = subFloatEl.caption_long.content or subFloatEl.caption_long
+        local caption_content
+        if subFloatEl.caption_long then
+          caption_content = subFloatEl.caption_long.content or subFloatEl.caption_long
+        else
+          caption_content = pandoc.Inlines({})
+        end
         local caption = full_caption_prefix(parentFloat, subFloatEl)
         tappend(caption, caption_content)
         local subImgModified = processImg(imgEl, { automatic = true, caption = caption, gallery = gallery })

--- a/tests/docs/smoke-all/2024/04/25/lightbox-no-caption.qmd
+++ b/tests/docs/smoke-all/2024/04/25/lightbox-no-caption.qmd
@@ -1,0 +1,17 @@
+---
+title: "lightbox no caption"
+lightbox: true
+format:
+  html: {}
+  docx: {}
+---
+
+::: {#fig-multi layout-nrow=3}
+
+![](la-palma-map.png){#fig-a}
+
+![](la-palma-map.png){#fig-b}
+
+Captions (a) bala; (b) bala
+:::
+


### PR DESCRIPTION
more mechanical fixes for lightbox and docx
where pandoc is now correctly populating nils for `caption_long` of an image

fixes #9444
fixes #9477
