### PR TITLE
Faster previewing of .html resource files

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -157,6 +157,7 @@ All changes included in 1.5:
 - ([#9282](https://github.com/quarto-dev/quarto-cli/issues/9282)): Fix name clash in Lua local declarations for `mediabag` in bundled releases.
 - ([#9394](https://github.com/quarto-dev/quarto-cli/issues/9394)): Make `template` a required field in the `about` schema.
 - ([#9426](https://github.com/quarto-dev/quarto-cli/issues/9426)): Update `crossref.lua` filter to avoid crashes and hangs in documents with custom AST nodes.
+- ([#9492](https://github.com/quarto-dev/quarto-cli/issues/9492)): Improve performance of `quarto preview` when serving resource files of the following formats: HTML, PDF, DOCX, and plaintext.
 - Add support for `{{< lipsum >}}` shortcode, which is useful for emitting placeholder text. Provide a specific number of paragraphs (`{{< lipsum 3 >}}`).
 - Resolve data URIs in Pandoc's mediabag when rendering documents.
 - Increase v8's max heap size by default, to avoid out-of-memory errors when rendering large documents (also cf. https://github.com/denoland/deno/issues/18935).

--- a/src/project/serve/serve.ts
+++ b/src/project/serve/serve.ts
@@ -560,7 +560,20 @@ async function internalPreviewServer(
           watcher.project(),
           filePathRelative,
         );
+
+        if (!inputFile) {
+          // If we couldn't find a input file, check if this is a resource file.
+          // If so, we can bail out early, since we don't need to render it.
+          // This is great for performance, as refreshing the watcher can be slow.
+          const fileSourcePath = join(watcher.project().dir, filePathRelative);
+          const projectResourceFiles = watcher.project().files.resources;
+          if (projectResourceFiles?.includes(fileSourcePath)) {
+            return undefined;
+          }
+        }
+
         if (!inputFile || !existsSync(inputFile.file)) {
+          // If we got here, we need to look harder for an input file.
           inputFile = await inputFileForOutputFile(
             await watcher.refreshProject(),
             filePathRelative,


### PR DESCRIPTION
## Description

Fixes https://github.com/quarto-dev/quarto-cli/issues/9492

Before this commit, the previewing of .html resource files was slow in larger websites. This was because the internalPreviewServer was looking too hard for a .qmd file to render, including refreshing the project. On the
posit-dev/py-shiny-site repo, refreshing the project is very slow because expanding the list of resource files takes multiple seconds.

(One of the pages on the py-shiny-site that I'm working on is a content listing with a eighteen iframes, each of which points to an .html resource file. This fix saves something like two minutes for that page preview!)

I may look separately into why the expansion takes sooo long. In trying to come up with a minimal repro I tried to recreate the slowness in a new project and was not able to.

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [x] updated the appropriate changelog
