### PR TITLE
scss - revert max-content change in title block to avoid overwide columns

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -9,6 +9,7 @@ All changes included in 1.5:
 - ([#8990](https://github.com/quarto-dev/quarto-cli/issues/8990)): Copy button now works for embedded code source in modal window when optin-in `code-tools` feature.
 - ([#9076](https://github.com/quarto-dev/quarto-cli/issues/9076)): Fix issue with `layout-ncol` and `column` settings in executable code cells.
 - ([#9125](https://github.com/quarto-dev/quarto-cli/issues/9125)): Fix issue in browser console with TOC selection when the document is using ids for headers with specific characters (e.g russian language headers).
+- ([#9539](https://github.com/quarto-dev/quarto-cli/issues/9539)): Improve SCSS of title blocks to avoid overwide columns in grid layout.
 
 ## PDF Format
 

--- a/src/resources/formats/html/templates/title-block.scss
+++ b/src/resources/formats/html/templates/title-block.scss
@@ -146,7 +146,8 @@ main.quarto-banner-title-block > section:first-child > h4 {
 #title-block-header.quarto-title-block.default {
   .quarto-title-meta {
     display: grid;
-    grid-template-columns: minmax(max-content, 1fr) 1fr;
+    // See https://github.com/quarto-dev/quarto-cli/issues/9539
+    grid-template-columns: repeat(2, 1fr);
     grid-column-gap: 1em;
   }
 


### PR DESCRIPTION
Closes #9539.
