### PR TITLE
[backport] lua - don't strip fig-alt from image when rendering html figure since…

### DIFF
--- a/src/resources/filters/layout/html.lua
+++ b/src/resources/filters/layout/html.lua
@@ -167,9 +167,9 @@ function renderHtmlFigure(el, render)
     end
   end
 
-  local keys = tkeys(el.attr.attributes)
-  for _,k in pairs(keys) do
-    if isFigAttribute(k) then
+  for _, k in pairs(tkeys(el.attr.attributes)) do
+    -- can't strip fig-alt here
+    if isFigAttribute(k) and k ~= kFigAlt then
       el.attr.attributes[k] = nil
     end
   end

--- a/tests/docs/smoke-all/2024/03/25/9190.qmd
+++ b/tests/docs/smoke-all/2024/03/25/9190.qmd
@@ -1,0 +1,11 @@
+---
+title: "Alt text"
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ['img[alt="Alt"]']
+        - []
+---
+
+![Caption](https://placeholder.co/400/400){fig-alt="Alt"}


### PR DESCRIPTION
Closes #9535

As discussed there, 

This issue
- https://github.com/quarto-dev/quarto-cli/issues/8785 (https://github.com/quarto-dev/quarto-cli/pull/8866) (https://github.com/quarto-dev/quarto-cli/pull/8866/commits/3f821dd9506a789ec12914e239891e347c023c60) has been backported to 1.4

but the follow up  regression fix has not been backported 
- https://github.com/quarto-dev/quarto-cli/issues/9190 (https://github.com/quarto-dev/quarto-cli/pull/9191)

This PR backport the commit that fix it from #9191 - cbf6012c4223d45a210220b9222b605e2be238df

Let's see if test pass on v1.4 (PR on v1.4 for backporting now triggers CI automatically)