### PR TITLE
`aria-role` improvements

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -10,6 +10,7 @@ All changes included in 1.5:
 - ([#9076](https://github.com/quarto-dev/quarto-cli/issues/9076)): Fix issue with `layout-ncol` and `column` settings in executable code cells.
 - ([#9125](https://github.com/quarto-dev/quarto-cli/issues/9125)): Fix issue in browser console with TOC selection when the document is using ids for headers with specific characters (e.g russian language headers).
 - ([#9539](https://github.com/quarto-dev/quarto-cli/issues/9539)): Improve SCSS of title blocks to avoid overwide columns in grid layout.
+- Improve accessibility `role` for `aria-expandable` elements by ensuring their role supports the `aria-expanded` attribute.
 
 ## PDF Format
 

--- a/src/resources/projects/website/templates/nav-before-body.ejs
+++ b/src/resources/projects/website/templates/nav-before-body.ejs
@@ -64,19 +64,19 @@ const navbarTocRight = nav['toc-location'] === "right" || nav['toc-location'] ==
   <nav class="quarto-secondary-nav">
     <div class="container-fluid d-flex">
       <button type="button" class="quarto-btn-toggle btn"
-      data-bs-toggle="collapse" data-bs-target=".quarto-sidebar-collapse-item" 
+      data-bs-toggle="collapse" role="navigation" data-bs-target=".quarto-sidebar-collapse-item" 
       aria-controls="quarto-sidebar" aria-expanded="false" aria-label="<%- nav.language['toggle-sidebar'] %>"
       onclick="if (window.quartoToggleHeadroom) { window.quartoToggleHeadroom(); }">
         <i class="bi bi-layout-text-sidebar-reverse"></i>
       </button>
       <% if (nav.showBreadCrumbs) { %>
         <h1 class="quarto-secondary-nav-title no-breadcrumbs"></h1>
-        <a class="flex-grow-1" role="button" data-bs-toggle="collapse" data-bs-target=".quarto-sidebar-collapse-item" 
+        <a class="flex-grow-1" role="navigation" data-bs-toggle="collapse" data-bs-target=".quarto-sidebar-collapse-item" 
         aria-controls="quarto-sidebar" aria-expanded="false" aria-label="<%- nav.language['toggle-sidebar'] %>"
         onclick="if (window.quartoToggleHeadroom) { window.quartoToggleHeadroom(); }">      
         </a>
       <% } else { %>
-        <a class="flex-grow-1 no-decor" role="button" data-bs-toggle="collapse" data-bs-target=".quarto-sidebar-collapse-item" 
+        <a class="flex-grow-1 no-decor" role="navigation" data-bs-toggle="collapse" data-bs-target=".quarto-sidebar-collapse-item" 
         aria-controls="quarto-sidebar" aria-expanded="false" aria-label="<%- nav.language['toggle-sidebar'] %>"
         onclick="if (window.quartoToggleHeadroom) { window.quartoToggleHeadroom(); }">      
           <h1 class="quarto-secondary-nav-title"></h1>

--- a/src/resources/projects/website/templates/nav-before-body.ejs
+++ b/src/resources/projects/website/templates/nav-before-body.ejs
@@ -64,26 +64,26 @@ const navbarTocRight = nav['toc-location'] === "right" || nav['toc-location'] ==
   <nav class="quarto-secondary-nav">
     <div class="container-fluid d-flex">
       <button type="button" class="quarto-btn-toggle btn"
-      data-bs-toggle="collapse" role="navigation" data-bs-target=".quarto-sidebar-collapse-item" 
+      data-bs-toggle="collapse" role="button" data-bs-target=".quarto-sidebar-collapse-item" 
       aria-controls="quarto-sidebar" aria-expanded="false" aria-label="<%- nav.language['toggle-sidebar'] %>"
       onclick="if (window.quartoToggleHeadroom) { window.quartoToggleHeadroom(); }">
         <i class="bi bi-layout-text-sidebar-reverse"></i>
       </button>
       <% if (nav.showBreadCrumbs) { %>
         <h1 class="quarto-secondary-nav-title no-breadcrumbs"></h1>
-        <a class="flex-grow-1" role="navigation" data-bs-toggle="collapse" data-bs-target=".quarto-sidebar-collapse-item" 
+        <a class="flex-grow-1" role="navigation" data-bs-toggle="collapse" data-bs-target=".quarto-sidebar-collapse-item" role="link"
         aria-controls="quarto-sidebar" aria-expanded="false" aria-label="<%- nav.language['toggle-sidebar'] %>"
         onclick="if (window.quartoToggleHeadroom) { window.quartoToggleHeadroom(); }">      
         </a>
       <% } else { %>
-        <a class="flex-grow-1 no-decor" role="navigation" data-bs-toggle="collapse" data-bs-target=".quarto-sidebar-collapse-item" 
+        <a class="flex-grow-1 no-decor" role="navigation" data-bs-toggle="collapse" data-bs-target=".quarto-sidebar-collapse-item" role="link"
         aria-controls="quarto-sidebar" aria-expanded="false" aria-label="<%- nav.language['toggle-sidebar'] %>"
         onclick="if (window.quartoToggleHeadroom) { window.quartoToggleHeadroom(); }">      
           <h1 class="quarto-secondary-nav-title"></h1>
         </a>     
       <% }  %>
       <% if (nav.sidebar && nav.sidebar.search) { %>
-      <button type="button" class="btn quarto-search-button" aria-label="<%- nav.language['search'] %>" onclick="window.quartoOpenSearch();">
+      <button type="button" class="btn quarto-search-button" aria-label="<%- nav.language['search-label'] %>" onclick="window.quartoOpenSearch();">
         <i class="bi bi-search"></i>
       </button>
       <% } %>

--- a/src/resources/projects/website/templates/navitem-dropdown.ejs
+++ b/src/resources/projects/website/templates/navitem-dropdown.ejs
@@ -6,7 +6,7 @@
   </li>  
 <% } else if (item.menu) { %>
   <li class="dropdown">
-    <a class="dropdown-toggle" href="#" id="<%- item.id %>" role="menu" data-bs-toggle="dropdown" aria-expanded="false"<%= item.rel ? ` rel="${item.rel}"` : "" %><%= item.target ? ` target="${item.target}"` : "" %>>
+    <a class="dropdown-toggle" href="#" id="<%- item.id %>" role="link" data-bs-toggle="dropdown" aria-expanded="false"<%= item.rel ? ` rel="${item.rel}"` : "" %><%= item.target ? ` target="${item.target}"` : "" %>>
       <% partial('navicon.ejs', { item }) %> <%- item.text %>
     </a>
     <ul class="dropdown-menu" aria-labelledby="<%- item.id %>">    

--- a/src/resources/projects/website/templates/navitem-dropdown.ejs
+++ b/src/resources/projects/website/templates/navitem-dropdown.ejs
@@ -6,7 +6,7 @@
   </li>  
 <% } else if (item.menu) { %>
   <li class="dropdown">
-    <a class="dropdown-toggle" href="#" id="<%- item.id %>" role="button" data-bs-toggle="dropdown" aria-expanded="false"<%= item.rel ? ` rel="${item.rel}"` : "" %><%= item.target ? ` target="${item.target}"` : "" %>>
+    <a class="dropdown-toggle" href="#" id="<%- item.id %>" role="menu" data-bs-toggle="dropdown" aria-expanded="false"<%= item.rel ? ` rel="${item.rel}"` : "" %><%= item.target ? ` target="${item.target}"` : "" %>>
       <% partial('navicon.ejs', { item }) %> <%- item.text %>
     </a>
     <ul class="dropdown-menu" aria-labelledby="<%- item.id %>">    

--- a/src/resources/projects/website/templates/navitem.ejs
+++ b/src/resources/projects/website/templates/navitem.ejs
@@ -6,7 +6,7 @@
   </li>  
 <% } else if (item.menu) { %>
   <li class="nav-item dropdown <%- item.text === undefined ? ' compact' : '' %>">
-    <a class="nav-link dropdown-toggle" href="#" id="<%- item.id %>" role="menu" data-bs-toggle="dropdown" aria-expanded="false" <%= item.rel ? ` rel="${item.rel}"` : "" %><%= item.target ? ` target="${item.target}"` : "" %>>
+    <a class="nav-link dropdown-toggle" href="#" id="<%- item.id %>" role="link" data-bs-toggle="dropdown" aria-expanded="false" <%= item.rel ? ` rel="${item.rel}"` : "" %><%= item.target ? ` target="${item.target}"` : "" %>>
       <% partial('navicon.ejs', { item }) %> <span class="menu-text"><%- item.text %></span>
     </a>
     <ul class="dropdown-menu<%- align === 'end' ? ' dropdown-menu-end' : ''%>" aria-labelledby="<%- item.id %>">    

--- a/src/resources/projects/website/templates/navitem.ejs
+++ b/src/resources/projects/website/templates/navitem.ejs
@@ -6,7 +6,7 @@
   </li>  
 <% } else if (item.menu) { %>
   <li class="nav-item dropdown <%- item.text === undefined ? ' compact' : '' %>">
-    <a class="nav-link dropdown-toggle" href="#" id="<%- item.id %>" role="button" data-bs-toggle="dropdown" aria-expanded="false" <%= item.rel ? ` rel="${item.rel}"` : "" %><%= item.target ? ` target="${item.target}"` : "" %>>
+    <a class="nav-link dropdown-toggle" href="#" id="<%- item.id %>" role="menu" data-bs-toggle="dropdown" aria-expanded="false" <%= item.rel ? ` rel="${item.rel}"` : "" %><%= item.target ? ` target="${item.target}"` : "" %>>
       <% partial('navicon.ejs', { item }) %> <span class="menu-text"><%- item.text %></span>
     </a>
     <ul class="dropdown-menu<%- align === 'end' ? ' dropdown-menu-end' : ''%>" aria-labelledby="<%- item.id %>">    

--- a/src/resources/projects/website/templates/navtoggle.ejs
+++ b/src/resources/projects/website/templates/navtoggle.ejs
@@ -1,5 +1,5 @@
 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse"
-  aria-controls="navbarCollapse" aria-expanded="false" aria-label="<%- language['toggle-navigation'] %>"
+  aria-controls="navbarCollapse" role="menu" aria-expanded="false" aria-label="<%- language['toggle-navigation'] %>"
   onclick="if (window.quartoToggleHeadroom) { window.quartoToggleHeadroom(); }">
   <span class="navbar-toggler-icon"></span>
 </button>

--- a/src/resources/projects/website/templates/navtools.ejs
+++ b/src/resources/projects/website/templates/navtools.ejs
@@ -26,7 +26,7 @@ const isWide = toolCount > 2; %>
     <% toolDropdownId = 'quarto-navigation-tool-dropdown-' + toolCount %>
     <% toolCount = toolCount + 1 %>
     <div class="dropdown">
-      <a href="<%- tool.href %>" title="<%- tool.text %>" id="<%- toolDropdownId %>" class="quarto-navigation-tool dropdown-toggle px-1" data-bs-toggle="dropdown" aria-expanded="false" aria-label="<%- tool['aria-label'] || tool.text %>"<%= tool.target ? ` target="${tool.target}"` : "" %>><i class="bi bi-<%- tool.icon %>"></i></a>
+      <a href="<%- tool.href %>" title="<%- tool.text %>" id="<%- toolDropdownId %>" class="quarto-navigation-tool dropdown-toggle px-1" data-bs-toggle="dropdown" aria-expanded="false" role="menu" aria-label="<%- tool['aria-label'] || tool.text %>"<%= tool.target ? ` target="${tool.target}"` : "" %>><i class="bi bi-<%- tool.icon %>"></i></a>
       <ul class="dropdown-menu<%- dropDownAlignClz %>" aria-labelledby="<%- toolDropdownId %>">
         <% tool.menu.forEach(item => { %> 
           <li>

--- a/src/resources/projects/website/templates/navtools.ejs
+++ b/src/resources/projects/website/templates/navtools.ejs
@@ -26,7 +26,7 @@ const isWide = toolCount > 2; %>
     <% toolDropdownId = 'quarto-navigation-tool-dropdown-' + toolCount %>
     <% toolCount = toolCount + 1 %>
     <div class="dropdown">
-      <a href="<%- tool.href %>" title="<%- tool.text %>" id="<%- toolDropdownId %>" class="quarto-navigation-tool dropdown-toggle px-1" data-bs-toggle="dropdown" aria-expanded="false" role="menu" aria-label="<%- tool['aria-label'] || tool.text %>"<%= tool.target ? ` target="${tool.target}"` : "" %>><i class="bi bi-<%- tool.icon %>"></i></a>
+      <a href="<%- tool.href %>" title="<%- tool.text %>" id="<%- toolDropdownId %>" class="quarto-navigation-tool dropdown-toggle px-1" data-bs-toggle="dropdown" aria-expanded="false" role="link" aria-label="<%- tool['aria-label'] || tool.text %>"<%= tool.target ? ` target="${tool.target}"` : "" %>><i class="bi bi-<%- tool.icon %>"></i></a>
       <ul class="dropdown-menu<%- dropDownAlignClz %>" aria-labelledby="<%- toolDropdownId %>">
         <% tool.menu.forEach(item => { %> 
           <li>

--- a/src/resources/projects/website/templates/sidebaritem.ejs
+++ b/src/resources/projects/website/templates/sidebaritem.ejs
@@ -21,9 +21,9 @@
           <% if (item.href) { %>
             <a href="<%- item.href %>" class="sidebar-item-text sidebar-link<%- item.active ? " active" : "" %>"<%- item.target ? ` target="${item.target}"` : "" %>><% partial('navicon.ejs', { item }) %> <span class="menu-text"><%= item.text %></span></a>
           <% } else { %> 
-            <a class="sidebar-item-text sidebar-link text-start<%- isCollapsed ? " collapsed" : "" %>" data-bs-toggle="collapse" data-bs-target="#<%- sectionId %>" aria-expanded="<%- isCollapsed ? "false" : "true" %>"><% partial('navicon.ejs', { item }) %> <span class="menu-text"><%= item.text %></span></a>
+            <a class="sidebar-item-text sidebar-link text-start<%- isCollapsed ? " collapsed" : "" %>" data-bs-toggle="collapse" data-bs-target="#<%- sectionId %>"  role="navigation" aria-expanded="<%- isCollapsed ? "false" : "true" %>"><% partial('navicon.ejs', { item }) %> <span class="menu-text"><%= item.text %></span></a>
           <% }  %>      
-          <a class="sidebar-item-toggle text-start<%- isCollapsed ?  " collapsed" : "" %>" data-bs-toggle="collapse" data-bs-target="#<%- sectionId %>" aria-expanded="<%- isCollapsed ? "false" : "true" %>" aria-label="<%- language['toggle-section'] %>">
+          <a class="sidebar-item-toggle text-start<%- isCollapsed ?  " collapsed" : "" %>" data-bs-toggle="collapse" data-bs-target="#<%- sectionId %>" role="navigation" aria-expanded="<%- isCollapsed ? "false" : "true" %>" aria-label="<%- language['toggle-section'] %>">
             <i class="bi bi-chevron-right ms-2"></i>
           </a> 
       </div>


### PR DESCRIPTION
In running lighthouse on a site being built with Quarto, I noticed that a number of mismatches occurred specific to `role` and `aria-expanded`. This will correct the roles to one’s which support `aria-expanded`.