### PR TITLE
theme key with format revealjs should never be overriden by user user input

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -23,6 +23,7 @@ All changes included in 1.5:
 
 - ([#8382](https://github.com/quarto-dev/quarto-cli/issues/8382)): Strip whitespace from `div.columns` elements that might have been introduced by third-party processing.
 - ([#9117](https://github.com/quarto-dev/quarto-cli/issues/9117)): Fix an issue with input filename containing special characters.
+- ([#9548](https://github.com/quarto-dev/quarto-cli/issues/9548)): Providing `theme` at top level when `format: revealjs` is now probably inserting the right css in the resulting html.
 
 ## Docusaurus Format
 

--- a/src/command/render/pandoc.ts
+++ b/src/command/render/pandoc.ts
@@ -43,6 +43,7 @@ import {
   isIpynbOutput,
   isLatexOutput,
   isMarkdownOutput,
+  isRevealjsOutput,
   isTypstOutput,
 } from "../../config/format.ts";
 import {
@@ -122,6 +123,7 @@ import {
   kSelfContained,
   kSyntaxDefinitions,
   kTemplate,
+  kTheme,
   kTitle,
   kTitlePrefix,
   kTocLocation,
@@ -986,6 +988,12 @@ export async function runPandoc(
       // don't do if they've overridden the value in a format
       const formats = engineMetadata[kMetadataFormat] as Metadata;
       if (ld.isObject(formats) && metadataGetDeep(formats, key).length > 0) {
+        continue;
+      }
+
+      // don't process some format specific metadata that may have been processed already
+      // - theme is handled specifically already for revealjs with a metadata override and should not be overridden by user input
+      if (key === kTheme && isRevealjsOutput(options.format.pandoc)) {
         continue;
       }
       // perform the override

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -629,7 +629,7 @@ export const kCapBottom = "bottom";
 // Pandoc Input Traits
 export const kPositionedRefs = "positioned-refs";
 
-// https://pandoc.org/MANUAL.html#default-files
+// https://pandoc.org/MANUAL.html#defaults-files
 // note: we are keeping some things out of 'defaults' b/ca
 // they are known to be valid in metadata. this includes:
 //    "csl",

--- a/tests/docs/smoke-all/2024/05/03/9548.qmd
+++ b/tests/docs/smoke-all/2024/05/03/9548.qmd
@@ -1,0 +1,15 @@
+---
+title: theme at top level
+format: revealjs
+theme: beige
+_quarto:
+  tests:
+    revealjs:
+      ensureHtmlElements:
+        - ['head > link[rel="stylesheet"][href$="quarto.css"]']
+        - ['head > link[rel="stylesheet"][href$="beige.css"]']
+---
+
+# Revealjs theme handling
+
+User provided theme should be used to build a `quarto.css` using SASS and the `theme: beige` should internally by overridden to `theme: quarto` so that the later is added in Pandoc's template


### PR DESCRIPTION
At latest step, we do override some user metadata, and theme is one of theme. However, for revealjs format it has a special handling internally as a quarto theme is built using providing theme key in the metadata. So, we should not override it.

fixes #9548 - revealjs theming broken when `theme` specified at top-level of frontmatter

See discussion there for details of what is happening. 