### PR TITLE
Add `quarto.cli_path` in our Quarto LUA API 

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -140,6 +140,10 @@ All changes included in 1.5:
 
 - Quarto now supports raw block and raw inline elements of types `pandoc-native` and `pandoc-json`, and will use Pandoc's `native` and `json` reader to convert these elements to Pandoc's AST. This is useful in situations where emitting Markdown is not sufficient or convient enough to express the desired structure of a document.
 
+## Lua filters
+
+- ([#9572](https://github.com/quarto-dev/quarto-cli/issues/9572)): New Quarto Lua API: `quarto.cli_path` now returns the path to the Quarto CLI executable of the installation running the Lua script in quarto context.
+
 ## Other Fixes and Improvements
 
 - ([#8119](https://github.com/quarto-dev/quarto-cli/issues/8119)): More intelligently detect when ejs templates are modified during development, improving quality of life during preview.

--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -142,7 +142,7 @@ All changes included in 1.5:
 
 ## Lua filters
 
-- ([#9572](https://github.com/quarto-dev/quarto-cli/issues/9572)): New Quarto Lua API: `quarto.cli_path` now returns the path to the Quarto CLI executable of the installation running the Lua script in quarto context.
+- ([#9572](https://github.com/quarto-dev/quarto-cli/issues/9572)): Add `quarto.config.cli_path()` in Quarto LUA to return the path to the Quarto CLI executable of the installation running the Lua script in quarto context.
 
 ## Other Fixes and Improvements
 

--- a/src/command/render/filters.ts
+++ b/src/command/render/filters.ts
@@ -106,6 +106,8 @@ const kActiveFilters = "active-filters";
 
 const kQuartoVersion = "quarto-version";
 
+const kQuartoCliPath = "quarto-cli-path";
+
 const kQuartoSource = "quarto-source";
 
 const kHasResourcePath = "has-resource-path";
@@ -649,6 +651,9 @@ async function quartoFilterParams(
 
   // version
   params[kQuartoVersion] = quartoConfig.version();
+
+  // cli path
+  params[kQuartoCliPath] = quartoConfig.cliPath();
 
   // code-annotations
   params[kCodeAnnotations] = format.metadata[kCodeAnnotations];

--- a/src/resources/lua-types/quarto/config.lua
+++ b/src/resources/lua-types/quarto/config.lua
@@ -1,0 +1,16 @@
+---@meta
+
+quarto.config = {}
+
+--[[
+Return the current Quarto version as a `pandoc.Version` object.
+
+]]
+---@return pandoc.Version
+function quarto.config.version() end
+
+--[[
+Return the full path to quarto binary being used to run the Lua filter.
+]]
+---@return string
+function quarto.config.cli_path() end

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -1826,6 +1826,10 @@ local function version()
    end
 end
 
+local function cli_path()
+   return param('quarto-cli-path', nil)
+end
+
 local function projectProfiles()
    return param('quarto_profile', {})
 end
@@ -2089,7 +2093,8 @@ quarto = {
   json = json,
   base64 = base64,
   log = logging,
-  version = version()
+  version = version(),
+  cli_path = cli_path()
 }
 
 -- alias old names for backwards compatibility

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -2094,7 +2094,11 @@ quarto = {
   base64 = base64,
   log = logging,
   version = version(),
-  cli_path = cli_path()
+  -- map to quartoConfig information on TS side
+  config = {
+    cli_path = function() return cli_path() end,
+    version = function() return version() end
+  }
 }
 
 -- alias old names for backwards compatibility

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -1826,10 +1826,6 @@ local function version()
    end
 end
 
-local function cli_path()
-   return param('quarto-cli-path', nil)
-end
-
 local function projectProfiles()
    return param('quarto_profile', {})
 end
@@ -2096,7 +2092,7 @@ quarto = {
   version = version(),
   -- map to quartoConfig information on TS side
   config = {
-    cli_path = function() return cli_path() end,
+    cli_path = function() return param('quarto-cli-path', nil) end,
     version = function() return version() end
   }
 }


### PR DESCRIPTION
to get the full path to quarto binary 

* I did the same as `quarto.version` in Lua and `quartoConfig.version()` in TS. BTW the Lua part is not a function, but is documented as a function `quarto.version()` https://quarto.org/docs/extensions/lua-api.html#utility-functions but in fact is just a value in Lua 
 https://github.com/quarto-dev/quarto-cli/blob/8c9352361df5eebd07bddbbe8be640ff2b159a6b/src/resources/pandoc/datadir/init.lua#L2096
  https://github.com/quarto-dev/quarto-cli/blob/8c9352361df5eebd07bddbbe8be640ff2b159a6b/src/resources/pandoc/datadir/init.lua#L1819-L1827
  **We need to fix the documentation, or make it a function and also adapt this PR**. Any thoughts on that @cscheid ? 

* `bin_path` was sort of already taken because `quartoConfig.bin_path()` is the `QUARTO_BIN_PATH` env var, which is only the folder of the binary, and not its full name.

* To detect `quarto.exe` vs `quarto.cmd` on Windows, I did not find any value to test. We only use this difference in our test helpers, that needs to call Quarto. In our codebase, nothing else seems to call quarto directly, so we never needed that. That is why I did it only in `quartoConfig` by just checking `.exe` existence. It could be more clever, checking we are in Dev mode and also throwing issue in case of weird unexpected state (but there should always be `quarto.cmd` even when there is `quarto.exe`). 

* I did not check windows, but from CI experience calling `quarto` without extension always works. 


@gordonwoodhull this new LUA API could be used in your PR. 

@cscheid I am opened to different name than `cli_path()` and also different implementation if that it not clean enough. 

closes #9572 