### PR TITLE
Use basename in knitr engine

### DIFF
--- a/src/command/render/render-files.ts
+++ b/src/command/render/render-files.ts
@@ -233,7 +233,7 @@ export async function renderExecute(
   popTiming();
 
   // write the freeze file if we are in a project
-  if (context.project && canFreeze) {
+  if (context.project && !context.project.isSingleFile && canFreeze) {
     // write the freezer file
     const freezeFile = freezeExecuteResult(
       context.target.source,

--- a/src/execute/rmd.ts
+++ b/src/execute/rmd.ts
@@ -129,7 +129,7 @@ export const knitrEngine: ExecutionEngine = {
         markdown: resolveInlineExecute(options.target.markdown.value),
       },
       options.tempDir,
-      options.projectDir,
+      options.project?.isSingleFile ? undefined : options.projectDir,
       options.quiet,
       // fixup .rmarkdown file references
       (output) => {


### PR DESCRIPTION
Closes #9478.

Now that everything is a project, we can use `basename(input)` safely in knitr engine.

This PR also fixes one instance of stray `.quarto` directories being created (in this case, erroneously attempting to use the freezer).