### PR TITLE
lua - preserve identifier of pandoc.Figure nodes in HTML rendering

### DIFF
--- a/tests/docs/smoke-all/2024/05/09/9631.qmd
+++ b/tests/docs/smoke-all/2024/05/09/9631.qmd
@@ -1,0 +1,12 @@
+---
+format: html
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ["#case1"]
+---
+
+![Caption](https://placeholder.co/400/400){#case1}
+
+![Caption](https://placeholder.co/400/400){#fig-1}


### PR DESCRIPTION
Closes #9631.