### PR TITLE
Check for gh-pages branch on remote but also locally.

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -144,6 +144,7 @@ All changes included in 1.5:
 ## Publishing
 
 - ([#9308](https://github.com/quarto-dev/quarto-cli/issues/9308)): Improved error message when trying to publish to Github pages with `quarto publish gh-pages`.
+- ([#9585](https://github.com/quarto-dev/quarto-cli/issues/9585)): Improved `quarto publish gh-pages` workflow when existing gh-pages branch is present or problem with the remote repository.
 
 ## `quarto inspect`
 

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -64,3 +64,21 @@ export async function lsFiles(
 
   return Promise.resolve(undefined);
 }
+
+export async function gitBranchExists(
+  branch: string,
+  cwd?: string,
+): Promise<boolean | undefined> {
+  if (await which("git")) {
+    const result = await execProcess({
+      cmd: ["git", "show-ref", "--verify", "--quiet", `refs/heads/${branch}`],
+      cwd,
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    return result.code === 0;
+  }
+
+  return Promise.resolve(undefined);
+}

--- a/src/core/github-types.ts
+++ b/src/core/github-types.ts
@@ -9,7 +9,8 @@ export type GitHubContext = {
   repo: boolean;
   originUrl?: string;
   repoUrl?: string;
-  ghPages?: boolean;
+  ghPagesRemote?: boolean;
+  ghPagesLocal?: boolean;
   siteUrl?: string;
   browse?: boolean;
   organization?: string;

--- a/src/publish/gh-pages/gh-pages.ts
+++ b/src/publish/gh-pages/gh-pages.ts
@@ -221,7 +221,7 @@ async function publish(
       /^https:\/\/(.+?)\.github\.io\/$/,
     );
     if (defaultSiteMatch) {
-      if (createGhPagesBranch) {
+      if (createGhPagesBranchRemote) {
         notifyGhPagesBranch = true;
       } else {
         try {
@@ -237,7 +237,7 @@ async function publish(
   }
 
   // if this is an update then warn that updates may require a browser refresh
-  if (!createGhPagesBranch && !notifyGhPagesBranch) {
+  if (!createGhPagesBranchRemote && !notifyGhPagesBranch) {
     info(colors.yellow(
       "NOTE: GitHub Pages sites use caching so you might need to click the refresh\n" +
         "button within your web browser to see changes after deployment.\n",

--- a/src/publish/gh-pages/gh-pages.ts
+++ b/src/publish/gh-pages/gh-pages.ts
@@ -27,7 +27,7 @@ import { joinUrl } from "../../core/url.ts";
 import { completeMessage, withSpinner } from "../../core/console.ts";
 import { renderForPublish } from "../common/publish.ts";
 import { RenderFlags } from "../../command/render/types.ts";
-import { gitCmds, gitVersion } from "../../core/git.ts";
+import { gitBranchExists, gitCmds, gitVersion } from "../../core/git.ts";
 import {
   anonymousAccount,
   gitHubContextForPublish,
@@ -71,7 +71,7 @@ async function publishRecord(
   input: string | ProjectContext,
 ): Promise<PublishRecord | undefined> {
   const ghContext = await gitHubContextForPublish(input);
-  if (ghContext.ghPages) {
+  if (ghContext.ghPagesRemote) {
     return {
       id: "gh-pages",
       url: ghContext.siteUrl || ghContext.originUrl,
@@ -114,17 +114,27 @@ async function publish(
   const ghContext = await gitHubContextForPublish(options.input);
   verifyContext(ghContext, "GitHub Pages");
 
-  // create gh pages branch if there is none yet
-  const createGhPagesBranch = !ghContext.ghPages;
-  if (createGhPagesBranch) {
+  // create gh pages branch on remote and local if there is none yet
+  const createGhPagesBranchRemote = !ghContext.ghPagesRemote;
+  const createGhPagesBranchLocal = !ghContext.ghPagesLocal;
+  if (createGhPagesBranchRemote) {
     // confirm
-    const confirmed = await Confirm.prompt({
+    let confirmed = await Confirm.prompt({
       indent: "",
       message: `Publish site to ${
         ghContext.siteUrl || ghContext.originUrl
       } using gh-pages?`,
       default: true,
     });
+    if (confirmed && !createGhPagesBranchLocal) {
+      confirmed = await Confirm.prompt({
+        indent: "",
+        message:
+          `A local gh-pages branch already exists. Should it be pushed to remote 'origin'?`,
+        default: true,
+      });
+    }
+
     if (!confirmed) {
       throw new Error();
     }
@@ -135,9 +145,29 @@ async function publish(
     }
     const oldBranch = await gitCurrentBranch(input);
     try {
-      await gitCreateGhPages(input);
+      // Create and push if necessary, or just push local branch
+      if (createGhPagesBranchLocal) {
+        await gitCreateGhPages(input);
+      } else {
+        await gitPushGhPages(input);
+      }
+    } catch {
+      // Something failed so clean up, i.e
+      // if we created the branch then delete it.
+      // Example of failure: Auth error on push (https://github.com/quarto-dev/quarto-cli/issues/9585)
+      if (createGhPagesBranchLocal && await gitBranchExists("gh-pages")) {
+        await gitCmds(input, [
+          ["checkout", oldBranch],
+          ["branch", "-D", "gh-pages"],
+        ]);
+      }
+      throw new Error(
+        "Publishing to gh-pages with `quarto publish gh-pages` failed.",
+      );
     } finally {
-      await gitCmds(input, [["checkout", oldBranch]]);
+      if (await gitCurrentBranch(input) !== oldBranch) {
+        await gitCmds(input, [["checkout", oldBranch]]);
+      }
       if (stash) {
         await gitStashApply(input);
       }
@@ -360,7 +390,14 @@ async function gitCreateGhPages(dir: string) {
   await gitCmds(dir, [
     ["checkout", "--orphan", "gh-pages"],
     ["rm", "-rf", "--quiet", "."],
-    ["commit", "--allow-empty", "-m", `Initializing gh-pages branch`],
-    ["push", "origin", `HEAD:gh-pages`],
+    ["commit", "--allow-empty", "-m", "Initializing gh-pages branch"],
   ]);
+  await gitPushGhPages(dir);
+}
+
+async function gitPushGhPages(dir: string) {
+  if (await gitCurrentBranch(dir) !== "gh-pages") {
+    await gitCmds(dir, [["checkout", "gh-pages"]]);
+  }
+  await gitCmds(dir, [["push", "origin", "HEAD:gh-pages"]]);
 }

--- a/src/publish/huggingface/huggingface.ts
+++ b/src/publish/huggingface/huggingface.ts
@@ -70,7 +70,7 @@ async function publishRecord(
   input: string | ProjectContext,
 ): Promise<PublishRecord | undefined> {
   const ghContext = await gitHubContextForPublish(input);
-  if (ghContext.ghPages) {
+  if (ghContext.ghPagesRemote) {
     return {
       id: kHuggingFace,
       url: ghContext.siteUrl || ghContext.originUrl,


### PR DESCRIPTION
publishing workflow needs to ensure that gh-pages does not exists yet before creating it, or offer to publish it on remote if existing.

This allows to handle more potential error while publishing like https://github.com/quarto-dev/quarto-cli/issues/9585

Process is now the following: 

- We check for `gh-pages` on remote origin. 
	-  if there is an error with contacting remote origin, then we failed nicely
- If no gh-pages on remote, we check for `gh-pages` locally too. 
	- 	This will be relevant to avoid creating a gh-pages branch and get an error (solves #9585)
- In prompt mode, we ask confirmation for publishing to remote, but also pushing the existing branch if any found. We don't want to publish without confirmaton an existing branch we did not create. 

- The publishing workflow will then do the following now
	- Stash change if any
	- If no local nor remote, it will create a new orphan branch, initialize content and push to origin
		- 	If this fails, we now catch the error, and delete the created gh-pages branch. Again this ensure that any special error like git  auth problem does not let a gh-pages branch locally that we created (fixes #9585 too).
		- Then it throws an error about quarto publish problem
	- If a local exist, it will push this branch on origin. 
		- If this fails we just throw a quarto publish problem

Opening for review in case I missed something here. 