### PR TITLE
allow output-dir to be an absolute path

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -180,6 +180,7 @@ All changes included in 1.5:
 - ([#9527](https://github.com/quarto-dev/quarto-cli/pull/9527)): Add `quarto.format` and `quarto.format.typst` to Quarto's public Lua filter API.
 - ([#9547](https://github.com/quarto-dev/quarto-cli/issues/9547)): Fix issue with `quarto preview` and resources found in URLs with hash and search fragments.
 - ([#9550](https://github.com/quarto-dev/quarto-cli/issues/9550)): Don't crash when subcaptions are incorrectly specified with `fig-subcap: true` but no embedded subcaptions.
+- ([#9652](https://github.com/quarto-dev/quarto-cli/pull/9652)): Allow `--output-dir` to refer to absolute paths in `quarto render`.
 - Add support for `{{< lipsum >}}` shortcode, which is useful for emitting placeholder text. Provide a specific number of paragraphs (`{{< lipsum 3 >}}`).
 - Resolve data URIs in Pandoc's mediabag when rendering documents.
 - Increase v8's max heap size by default, to avoid out-of-memory errors when rendering large documents (also cf. https://github.com/denoland/deno/issues/18935).

--- a/src/project/project-shared.ts
+++ b/src/project/project-shared.ts
@@ -76,7 +76,9 @@ export function projectFormatOutputDir(
 export function projectOutputDir(context: ProjectContext): string {
   let outputDir = context.config?.project[kProjectOutputDir];
   if (outputDir) {
-    outputDir = join(context.dir, outputDir);
+    if (!isAbsolute(outputDir)) {
+      outputDir = join(context.dir, outputDir);
+    }
   } else {
     outputDir = context.dir;
   }


### PR DESCRIPTION
This makes Quarto's rendering of R package files a little cleaner when users want `--output-dir=/tmp`