### PR TITLE
[R] Check correctly RScript to support R 4.1.3 and previous

### DIFF
--- a/src/core/knitr.ts
+++ b/src/core/knitr.ts
@@ -45,8 +45,10 @@ export async function checkRBinary() {
     const result = await execProcess({
       cmd: [rBin, "--version"],
       stdout: "piped",
+      stderr: "piped",
     });
-    if (result.success && result.stdout) {
+    // Before R4.2.3, the output version information is printed to stderr
+    if (result.success && (result.stdout || /R scripting front-end version/.test(result.stderr ?? ''))) {
       debug(`\n++R found at ${rBin} is working.`);
       return rBin;
     } else {


### PR DESCRIPTION
For R 4.1.3 and previous, `RScript --version` is a success but prints output to `stderr` and not `stdout`. So we were wrongly assuming something was wrong. 

This PR fix this by checking `stdout` or `stderr` for a specifc known string. 

@cscheid I suggest we backport this to Quarto 1.4 so that it works on older version. See slack discussion. 

EDIT: I also check that this is a regression between 1.3 and 1.4., that I introduced on https://github.com/quarto-dev/quarto-cli/pull/7013, so that is why backporting seems important to me. 

I tested locally with R all latest minor versions
````
3.0.3  3.0.3    2014-03-06    release
3.1.3  3.1.3    2015-03-09    release
3.2.5  3.2.5    2016-04-14    release
3.3.3  3.3.3    2017-03-06    release
3.4.4  3.4.4    2018-03-15    release
3.5.3  3.5.3    2019-03-11    release
3.6.3  3.6.3    2020-02-29    release
4.0.5  4.0.5    2021-03-31    release
4.1.3  4.1.3    2022-03-10    release
4.2.3  4.2.3    2023-03-15    release
4.3.3  4.3.3    2024-02-29    release
4.4.0  4.4.0    2024-04-24    release
````

cc @ianpittwood