### PR TITLE
backport fix HTML table in PPTX and typst

### DIFF
--- a/news/changelog-1.4.md
+++ b/news/changelog-1.4.md
@@ -2,6 +2,7 @@
 
 - ([#9550](https://github.com/quarto-dev/quarto-cli/issues/9550)): Don't crash when subcaptions are incorrectly specified with `fig-subcap: true` but no embedded subcaptions.
 - ([#9593](https://github.com/quarto-dev/quarto-cli/issues/9593)): Fix regression with `column-margin` when used in spans in a paragraph.
+- ([#9602](https://github.com/quarto-dev/quarto-cli/issues/9602)): Fix regression with parsed HTML tables not being correcty included in various format like pptx and typst.
 
 ## Fixed in previous releases
 

--- a/src/resources/filters/normalize/parsehtml.lua
+++ b/src/resources/filters/normalize/parsehtml.lua
@@ -126,7 +126,7 @@ function parse_html_tables()
               blocks:insert(result)
             end
           end
-          return pandoc.Div(blocks)
+          return make_scaffold(pandoc.Div, blocks)
         end
       end
       return el

--- a/tests/docs/smoke-all/2024/04/26/9365.qmd
+++ b/tests/docs/smoke-all/2024/04/26/9365.qmd
@@ -1,0 +1,38 @@
+---
+title: Parsed HTML table in PPTX
+keep-typ: true
+_quarto:
+  tests:
+    pptx: 
+      ensurePptxXpath:
+        - 2
+        - ['//a:tbl']
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        - ['<test-table>[\s]*#figure\(']
+        - ['<test-table>[\s]*#block\[[\s]*#figure\(']
+---
+
+# Test table {#test-table}
+
+```{=html}
+<table>
+<thead>
+  <tr>
+    <th>Sepal.Length</th>
+    <th>Sepal.Width</th>
+  </tr>
+</thead>
+<tbody>
+<tr>
+  <td>5.1</td>
+  <td>3.5</td>
+</tr>
+<tr>
+  <td>4.9</td>
+  <td>3.0</td>
+</tr>
+</tbody>
+</table>
+```

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -28,6 +28,7 @@ import {
   fileExists,
   noErrors,
   noErrorsOrWarnings,
+  ensurePptxXpath,
 } from "../verify.ts";
 import { readYaml, readYamlFromMarkdown } from "../../src/core/yaml.ts";
 import { outputForInput } from "../utils.ts";
@@ -98,6 +99,7 @@ function resolveTestSpecs(
     ensureOdtXpath,
     ensureJatsXpath,
     ensurePptxRegexMatches,
+    ensurePptxXpath,
     ensureSnapshotMatches
   };
 

--- a/tests/verify.ts
+++ b/tests/verify.ts
@@ -22,25 +22,55 @@ import { isWindows } from "../src/core/platform.ts";
 import { execProcess } from "../src/core/process.ts";
 import { canonicalizeSnapshot, checkSnapshot } from "./verify-snapshot.ts";
 
-export const withDocxContent = async <T>(file: string,
-  k: (xml: string) => Promise<T>) => {
-    const [_dir, stem] = dirAndStem(file);
-    const temp = await Deno.makeTempDir();
-    try {
-      // Move the docx to a temp dir and unzip it
-      const zipFile = join(temp, stem + ".zip");
-      await Deno.copyFile(file, zipFile);
-      await unzip(zipFile);
-  
-      // Open the core xml document and match the matches
-      const docXml = join(temp, "word", "document.xml");
-      const xml = await Deno.readTextFile(docXml);
-      const result = await k(xml);
-      return result;
-    } finally {
-      await Deno.remove(temp, { recursive: true });
-    }
-  };
+export const withDocxContent = async <T>(
+  file: string,
+  k: (xml: string) => Promise<T>
+) => {
+  const [_dir, stem] = dirAndStem(file);
+  const temp = await Deno.makeTempDir();
+  try {
+    // Move the docx to a temp dir and unzip it
+    const zipFile = join(temp, stem + ".zip");
+    await Deno.copyFile(file, zipFile);
+    await unzip(zipFile);
+
+    // Open the core xml document and match the matches
+    const docXml = join(temp, "word", "document.xml");
+    const xml = await Deno.readTextFile(docXml);
+    const result = await k(xml);
+    return result;
+  } finally {
+    await Deno.remove(temp, { recursive: true });
+  }
+};
+
+export const withPptxContent = async <T>(
+  file: string,
+  slideNumber: number,
+  k: (xml: string) => Promise<T>
+) => {
+  const [_dir, stem] = dirAndStem(file);
+  const temp = await Deno.makeTempDir();
+  try {
+    // Move the pptx to a temp dir and unzip it
+    const zipFile = join(temp, stem + ".zip");
+    await Deno.copyFile(file, zipFile);
+    await unzip(zipFile);
+
+    // Open the core xml document and match the matches
+    const slidePath = join(temp, "ppt", "slides");
+    const slideFile = join(slidePath, `slide${slideNumber}.xml`);
+    assert(
+      existsSync(slideFile),
+      `Slide number ${slideNumber} is not in the Pptx`,
+    );
+    const xml = await Deno.readTextFile(slideFile);
+    const result = await k(xml);
+    return result;
+  } finally {
+    await Deno.remove(temp, { recursive: true });
+  }
+};
 
 export const noErrors: Verify = {
   name: "No Errors",
@@ -375,6 +405,18 @@ export const verifyDocXDocument = (
   });
 };
 
+export const verifyPptxDocument = (
+  callback: (doc: string) => Promise<void>,
+  name?: string,
+): (file: string, slideNumber: number) => Verify => {
+  return (file: string, slideNumber: number) => ({
+    name: name ?? "Inspecting Pptx",
+    verify: async (_output: ExecuteOutput[]) => {
+      return await withPptxContent(file, slideNumber, callback);
+    },
+  });
+};
+
 const xmlChecker = (
   selectors: string[],
   noMatchSelectors?: string[],
@@ -434,6 +476,18 @@ export const ensureDocxXpath = (
     xmlChecker(selectors, noMatchSelectors),
     "Inspecting Docx for XPath selectors",
   )(file);
+};
+
+export const ensurePptxXpath = (
+  file: string,
+  slideNumber: number,
+  selectors: string[],
+  noMatchSelectors?: string[],
+): Verify => {
+  return verifyPptxDocument(
+    xmlChecker(selectors, noMatchSelectors),
+    "Inspecting Pptx for XPath selectors",
+  )(file, slideNumber);
 };
 
 export const ensureDocxRegexMatches = (


### PR DESCRIPTION
 from #9602 fix

- Use scaffolded Divs for parsed HTML table so that  it is removed and not converted in output format
- Use make_scaffold as _quarto.ast.scafold_element does not exist in 1.4
- Add a test for powerpoint using XPATH
- Add a test for typst table
  Ensure the figure is not wrap in a block that prevents the alignment to work.
  This #block was created by the unneeded `Div` that is now a scaffolded one.Welcome to the quarto GitHub repo!

