### PR TITLE
toc - update active link in toc before expanding

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -11,6 +11,7 @@ All changes included in 1.5:
 - ([#9125](https://github.com/quarto-dev/quarto-cli/issues/9125)): Fix issue in browser console with TOC selection when the document is using ids for headers with specific characters (e.g russian language headers).
 - ([#9539](https://github.com/quarto-dev/quarto-cli/issues/9539)): Improve SCSS of title blocks to avoid overwide columns in grid layout.
 - Improve accessibility `role` for `aria-expandable` elements by ensuring their role supports the `aria-expanded` attribute.
+- ([#3178](https://github.com/quarto-dev/quarto-cli/issues/3178)): TOC now correctly expands when web page has no content to scroll to.
 
 ## PDF Format
 

--- a/src/resources/formats/html/quarto.js
+++ b/src/resources/formats/html/quarto.js
@@ -781,6 +781,10 @@ window.document.addEventListener("DOMContentLoaded", function (_event) {
   window.addEventListener(
     "resize",
     throttle(() => {
+      if (tocEl) {
+        updateActiveLink();
+        walk(tocEl, 0);
+      }
       if (!isReaderMode()) {
         hideOverlappedSidebars();
       }

--- a/src/resources/formats/html/quarto.js
+++ b/src/resources/formats/html/quarto.js
@@ -134,8 +134,10 @@ window.document.addEventListener("DOMContentLoaded", function (_event) {
       window.innerHeight + window.pageYOffset >=
       window.document.body.offsetHeight
     ) {
+      // This is the no-scroll case where last section should be the active one
       sectionIndex = 0;
     } else {
+      // This finds the last section visible on screen that should be made active
       sectionIndex = [...sections].reverse().findIndex((section) => {
         if (section) {
           return window.pageYOffset >= section.offsetTop - sectionMargin;
@@ -739,6 +741,7 @@ window.document.addEventListener("DOMContentLoaded", function (_event) {
     // Process the collapse state if this is an UL
     if (el.tagName === "UL") {
       if (tocOpenDepth === -1 && depth > 1) {
+        // toc-expand: false
         el.classList.add("collapse");
       } else if (
         depth <= tocOpenDepth ||
@@ -757,10 +760,9 @@ window.document.addEventListener("DOMContentLoaded", function (_event) {
   };
 
   // walk the TOC and expand / collapse any items that should be shown
-
   if (tocEl) {
-    walk(tocEl, 0);
     updateActiveLink();
+    walk(tocEl, 0);
   }
 
   // Throttle the scroll event and walk peridiocally


### PR DESCRIPTION
toc expansion is controled by `toc-expand` and computed on client side once at initialization and then at scrolling.  It is based on links in the toc that are active. Default is first link to be the active one.

When no scrolling (body content height smaller than window height),  we need to update the active link to be last section seen on screen, and do this before we expand the toc.Welcome to the quarto GitHub repo!

solves #3178 

## Context 

Active link in TOC is updated based on window and body size (to detect scroll bar) or based on scroll position 
https://github.com/quarto-dev/quarto-cli/blob/99fad064789715bf2eb11dc9ee3adc59b7c15b8f/src/resources/formats/html/quarto.js#L130-L159

and expansion is done based on which `ul` from the toc has active link 
https://github.com/quarto-dev/quarto-cli/blob/99fad064789715bf2eb11dc9ee3adc59b7c15b8f/src/resources/formats/html/quarto.js#L716-L760

This works ok, but this is currently how we initialize 
https://github.com/quarto-dev/quarto-cli/blob/3e0f3a58e0c2a2d5bf2818b02ebdc3380db3ca68/src/resources/formats/html/quarto.js#L762-L766

and we only update on scrolling
https://github.com/quarto-dev/quarto-cli/blob/3e0f3a58e0c2a2d5bf2818b02ebdc3380db3ca68/src/resources/formats/html/quarto.js#L767-L780

Notice the different order. 

For the no scroll case, expanding before updating the active link does not work. This is because first link is made active by default, but then the update should see the no scroll bar and update the last link to be the active one. Then expansion should happen. 

When we scroll this is the order - update active link then expand. 

I think we should initialize the same way. 

I also added this to the resize event because when windows is resized to a no scroll bar state, the toc expansion won't be updated anymore. 

Hard to test in several cases, but I did test locally and I believe this change is safe going through the code logic in my head for what could happen. 
