### PR TITLE
pptx - add a cleanup finalize step to remove RawBlock different from openxml

### DIFF
--- a/.github/workflows/test-ff-matrix.yml
+++ b/.github/workflows/test-ff-matrix.yml
@@ -7,6 +7,13 @@ on:
     paths-ignore:
       - "src/resources/language/**"
 
+concurrency:
+  # Use github.run_id on main branch
+  # Use github.event.pull_request.number on pull requests, so it's unique per pull request
+  # Use github.ref on other branches, so it's unique per branch
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-smokes:
     name: Run feature-format matrix on (${{ matrix.os }})

--- a/.github/workflows/test-ff-matrix.yml
+++ b/.github/workflows/test-ff-matrix.yml
@@ -150,6 +150,17 @@ jobs:
       # - name: Setup tmate session
       #   uses: mxschmitt/action-tmate@v3
 
+      # The Check Chromium step appears necessary to avoid a crash/hang when rendering PDFs
+      # https://github.com/quarto-dev/quarto-actions/issues/45#issuecomment-1562599451
+      # Same fix as in quarto-actions/quarto-render
+      # chromium is installed in the ubuntu runners in GHA, so no need to install it
+      - name: "Check Chromium"
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          echo $(which chromium-browser)
+          $(which chromium-browser) --headless https://www.chromestatus.com
+        shell: bash
+
       - name: Run all Smoke Tests Windows
         if: ${{ runner.os == 'Windows' && format('{0}', inputs.buckets) == '' && matrix.time-test == false }}
         env:

--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -36,6 +36,10 @@ All changes included in 1.5:
 
 - ([#9507](https://github.com/quarto-dev/quarto-cli/issues/9507)): Add support for rendering `FloatRefTarget` elements in `gfm` format.
 
+## Powerpoint Format
+
+- ([#9680](https://github.com/quarto-dev/quarto-cli/issues/9680), [#9681](https://github.com/quarto-dev/quarto-cli/issues/9681)): Fix issues with HTML tables parsed by Quarto when converting to powerpoint presentations.
+
 ## Website
 
 - ([#6779](https://github.com/quarto-dev/quarto-cli/issues/6779)): Add support for `logo-href` and `logo-alt` in `sidebar` (books and websites)

--- a/src/resources/filters/main.lua
+++ b/src/resources/filters/main.lua
@@ -90,6 +90,7 @@ import("./quarto-finalize/meta-cleanup.lua")
 import("./quarto-finalize/coalesceraw.lua")
 import("./quarto-finalize/descaffold.lua")
 import("./quarto-finalize/typst.lua")
+import("./quarto-finalize/pptx.lua")
 
 import("./normalize/flags.lua")
 import("./normalize/normalize.lua")
@@ -394,7 +395,8 @@ local quarto_finalize_filters = {
     flags = { "has_output_cells" }
   },
   { name = "finalize-wrapped-writer", filter = wrapped_writer() },
-  { name = "finalize-typst-state", filter = setup_typst_state() }
+  { name = "finalize-typst-state", filter = setup_typst_state() },
+  { name = "finalize-pptx-raw-cleanup", filter = pptx_raw_cleanup() }
 }
 
 local quarto_layout_filters = {

--- a/src/resources/filters/main.lua
+++ b/src/resources/filters/main.lua
@@ -82,6 +82,7 @@ import("./quarto-post/code.lua")
 import("./quarto-post/html.lua")
 import("./quarto-post/dashboard.lua")
 import("./quarto-post/email.lua")
+import("./quarto-post/pptx.lua")
 
 import("./quarto-finalize/dependencies.lua")
 import("./quarto-finalize/book-cleanup.lua")
@@ -90,7 +91,6 @@ import("./quarto-finalize/meta-cleanup.lua")
 import("./quarto-finalize/coalesceraw.lua")
 import("./quarto-finalize/descaffold.lua")
 import("./quarto-finalize/typst.lua")
-import("./quarto-finalize/pptx.lua")
 
 import("./normalize/flags.lua")
 import("./normalize/normalize.lua")
@@ -374,6 +374,7 @@ local quarto_post_filters = {
   { name = "post-render-gfm-fixups", filter = render_gfm_fixups() },
   { name = "post-render-hugo-fixups", filter = render_hugo_fixups() },
   { name = "post-render-email", filters = render_email() },
+  { name = "post-render-pptx-fixups", filter = render_pptx_fixups() }
 }
 
 local quarto_finalize_filters = {
@@ -396,7 +397,6 @@ local quarto_finalize_filters = {
   },
   { name = "finalize-wrapped-writer", filter = wrapped_writer() },
   { name = "finalize-typst-state", filter = setup_typst_state() },
-  { name = "finalize-pptx-raw-cleanup", filter = pptx_raw_cleanup() }
 }
 
 local quarto_layout_filters = {

--- a/src/resources/filters/quarto-finalize/pptx.lua
+++ b/src/resources/filters/quarto-finalize/pptx.lua
@@ -1,0 +1,16 @@
+function pptx_raw_cleanup() 
+  if not _quarto.format.isPowerPointOutput() then
+    return {}
+  end
+  return {
+    -- Remove any non-openxml RawBlock as it seems to mess pandoc Powerpoint writer
+    -- https://github.com/quarto-dev/quarto-cli/issues/9680
+    -- https://github.com/quarto-dev/quarto-cli/issues/9681
+    RawBlock = function(el)
+      if el.format ~= "openxml" then
+        return {}
+      end
+      return el
+    end
+  }
+end 

--- a/src/resources/filters/quarto-post/pptx.lua
+++ b/src/resources/filters/quarto-post/pptx.lua
@@ -1,4 +1,4 @@
-function pptx_raw_cleanup() 
+function render_pptx_fixups() 
   if not _quarto.format.isPowerPointOutput() then
     return {}
   end

--- a/tests/docs/smoke-all/2024/05/16/9680.qmd
+++ b/tests/docs/smoke-all/2024/05/16/9680.qmd
@@ -1,0 +1,59 @@
+---
+title: HTML table parsed by Quarto does not modify slides 
+format: html
+_quarto:
+  tests:
+    pptx: 
+      ensurePptxLayout:
+        - 
+          - 2
+          - "Title and Content"
+        - 
+          - 3
+          - "Title and Content"
+        - 
+          - 4
+          - "Title and Content"
+---
+
+## Test Table {#table-raw-html}
+
+```{=html}
+<div id="table-div">
+<table>
+<thead>
+  <tr>
+    <th>Sepal.Length</th>
+    <th>Sepal.Width</th>
+  </tr>
+</thead>
+<tbody>
+<tr>
+  <td>5.1</td>
+  <td>3.5</td>
+</tr>
+<tr>
+  <td>4.9</td>
+  <td>3.0</td>
+</tr>
+</tbody>
+</table>
+</div>
+```
+
+## Test Table {#table-gt}
+
+```{r}
+#| label: test
+head(iris, 1) |>  
+    gt::gt() |> 
+    gt::as_raw_html()
+```
+
+## Test table Md {#table-md}
+
+| Col1 | Col2 | Col3 |
+|------|------|------|
+| a    | a    | a    |
+| a    | a    | a    |
+| a    | a    | a    |

--- a/tests/docs/smoke-all/2024/05/16/9681.qmd
+++ b/tests/docs/smoke-all/2024/05/16/9681.qmd
@@ -1,0 +1,35 @@
+---
+title: No blank slides after HTML tables processed
+format: pptx
+_quarto:
+  tests:
+    pptx:
+      ensurePptxMaxSlides:
+        - 2
+---
+
+## Newlines in raw block are kept as HTML rawblock 
+
+`````{=html}
+<table>
+ <thead>
+  <tr>
+   <th style="text-align:right;"> Sepal.Length </th>
+   <th style="text-align:right;"> Sepal.Width </th>
+   <th style="text-align:right;"> Petal.Length </th>
+   <th style="text-align:right;"> Petal.Width </th>
+   <th style="text-align:left;"> Species </th>
+  </tr>
+ </thead>
+<tbody>
+  <tr>
+   <td style="text-align:right;"> 5.1 </td>
+   <td style="text-align:right;"> 3.5 </td>
+   <td style="text-align:right;"> 1.4 </td>
+   <td style="text-align:right;"> 0.2 </td>
+   <td style="text-align:left;"> setosa </td>
+  </tr>
+</tbody>
+</table>
+
+`````

--- a/tests/new-smoke-all-test.ps1
+++ b/tests/new-smoke-all-test.ps1
@@ -45,10 +45,22 @@ _quarto:
       ensureDocxRegexMatches:
         - []
         - []
+      ensureDocxXPath:
+        - []
+        - []
     pptx:
       ensurePptxRegexMatches:
         - []
         - []
+      ensurePptxXPath:
+      - 
+        - 2
+        - []
+        - []
+      ensurePptxLayout:
+        - 
+          - 2
+          - "Title and Content"
     asciidoc: default
 ---
 "@

--- a/tests/new-smoke-all-test.sh
+++ b/tests/new-smoke-all-test.sh
@@ -43,10 +43,22 @@ _quarto:
       ensureDocxRegexMatches:
         - []
         - []
+      ensureDocxXPath:
+        - []
+        - []
     pptx:
       ensurePptxRegexMatches:
         - []
         - []
+      ensurePptxXPath:
+      - 
+        - 2
+        - []
+        - []
+      ensurePptxLayout:
+        - 
+          - 2
+          - "Title and Content"
     asciidoc: default
 ---
 EOF

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -30,6 +30,7 @@ import {
   noErrorsOrWarnings,
   ensurePptxXpath,
   ensurePptxLayout,
+  ensurePptxMaxSlides,
 } from "../verify.ts";
 import { readYaml, readYamlFromMarkdown } from "../../src/core/yaml.ts";
 import { outputForInput } from "../utils.ts";
@@ -102,6 +103,7 @@ function resolveTestSpecs(
     ensurePptxRegexMatches,
     ensurePptxXpath,
     ensurePptxLayout,
+    ensurePptxMaxSlides,
     ensureSnapshotMatches
   };
 

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -29,6 +29,7 @@ import {
   noErrors,
   noErrorsOrWarnings,
   ensurePptxXpath,
+  ensurePptxLayout,
 } from "../verify.ts";
 import { readYaml, readYamlFromMarkdown } from "../../src/core/yaml.ts";
 import { outputForInput } from "../utils.ts";
@@ -100,6 +101,7 @@ function resolveTestSpecs(
     ensureJatsXpath,
     ensurePptxRegexMatches,
     ensurePptxXpath,
+    ensurePptxLayout,
     ensureSnapshotMatches
   };
 
@@ -133,6 +135,15 @@ function resolveTestSpecs(
                   fileExists(join(outputFile.supportPath, file)),
                 );
               }
+            }
+          } else if (["ensurePptxLayout", "ensurePptxXpath"].includes(key)) {
+            if (Array.isArray(value) && Array.isArray(value[0])) {
+              // several slides to check
+              value.forEach((slide: any) => {
+                verifyFns.push(verifyMap[key](outputFile.outputPath, ...slide));
+              });
+            } else {
+              verifyFns.push(verifyMap[key](outputFile.outputPath, ...value));
             }
           } else if (verifyMap[key]) {
             if (typeof value === "object") {

--- a/tests/verify.ts
+++ b/tests/verify.ts
@@ -7,7 +7,7 @@
 import { existsSync, walkSync} from "fs/mod.ts";
 import { DOMParser, NodeList } from "../src/core/deno-dom.ts";
 import { assert } from "testing/asserts.ts";
-import { join, relative } from "../src/deno_ral/path.ts";
+import { basename, dirname, join, relative, resolve } from "../src/deno_ral/path.ts";
 import { parseXmlDocument } from "slimdom";
 import xpath from "fontoxpath";
 import * as ld from "../src/core/lodash.ts";
@@ -47,7 +47,9 @@ export const withDocxContent = async <T>(
 export const withPptxContent = async <T>(
   file: string,
   slideNumber: number,
-  k: (xml: string) => Promise<T>
+  rels: boolean,
+  // takes the parsed XML and the XML file path
+  k: (xml: string, xmlFile: string) => Promise<T>
 ) => {
   const [_dir, stem] = dirAndStem(file);
   const temp = await Deno.makeTempDir();
@@ -59,13 +61,13 @@ export const withPptxContent = async <T>(
 
     // Open the core xml document and match the matches
     const slidePath = join(temp, "ppt", "slides");
-    const slideFile = join(slidePath, `slide${slideNumber}.xml`);
+    let slideFile = join(slidePath, rels ? join("_rels", `slide${slideNumber}.xml.rels`) : `slide${slideNumber}.xml`);
     assert(
       existsSync(slideFile),
       `Slide number ${slideNumber} is not in the Pptx`,
     );
     const xml = await Deno.readTextFile(slideFile);
-    const result = await k(xml);
+    const result = await k(xml, slideFile);
     return result;
   } finally {
     await Deno.remove(temp, { recursive: true });
@@ -463,13 +465,13 @@ export const verifyDocXDocument = (
 };
 
 export const verifyPptxDocument = (
-  callback: (doc: string) => Promise<void>,
+  callback: (doc: string, docFile: string) => Promise<void>,
   name?: string,
-): (file: string, slideNumber: number) => Verify => {
-  return (file: string, slideNumber: number) => ({
+): (file: string, slideNumber: number, rels?: boolean) => Verify => {
+  return (file: string, slideNumber: number, rels: boolean = false) => ({
     name: name ?? "Inspecting Pptx",
     verify: async (_output: ExecuteOutput[]) => {
-      return await withPptxContent(file, slideNumber, callback);
+      return await withPptxContent(file, slideNumber, rels, callback);
     },
   });
 };
@@ -498,6 +500,42 @@ const xmlChecker = (
         `Illegal XPath selector ${falseSelector} returned non-empty array. Failing document follows:\n\n${xmlText}}`,
       );
     }
+    return Promise.resolve();
+  };
+};
+
+const pptxLayoutChecker = (layoutName: string): (xmlText: string, xmlFile: string) => Promise<void> => {
+  return async (xmlText: string, xmlFile: string) => {
+    // Parse the XML from slide#.xml.rels
+    const xmlDoc = parseXmlDocument(xmlText);
+
+    // Select the Relationship element with the correct Type attribute
+    const relationshipSelector = "/Relationships/Relationship[substring(@Type, string-length(@Type) - string-length('relationships/slideLayout') + 1) = 'relationships/slideLayout']/@Target";
+    const slideLayoutFile = xpath.evaluateXPathToString(relationshipSelector, xmlDoc);
+
+    assert(
+      slideLayoutFile,
+      `Required XPath selector ${relationshipSelector} returned empty string. Failing document ${basename(xmlFile)} follows:\n\n${xmlText}}`,
+    );
+
+    // Construct the full path to the slide layout file
+    // slideLayoutFile is a relative path from the slide xm document, that the `_rels` equivalent was about
+    const layoutFilePath = resolve(dirname(dirname(xmlFile)), slideLayoutFile);
+
+    // Now we need to check the slide layout file
+    const layoutXml = Deno.readTextFileSync(layoutFilePath);
+
+    // Parse the XML from slideLayout#.xml
+    const layoutDoc = parseXmlDocument(layoutXml);
+
+    // Select the p:cSld element with the correct name attribute
+    const layoutSelector = '//p:cSld/@name';
+    const layout = xpath.evaluateXPathToString(layoutSelector, layoutDoc);
+    assert(
+      layout === layoutName,
+      `Slides is not using "${layoutName}" layout - Current value: "${layout}". Failing document ${basename(layoutFilePath)} follows:\n\n${layoutXml}}`,
+    );
+
     return Promise.resolve();
   };
 };
@@ -543,8 +581,19 @@ export const ensurePptxXpath = (
 ): Verify => {
   return verifyPptxDocument(
     xmlChecker(selectors, noMatchSelectors),
-    "Inspecting Pptx for XPath selectors",
+    `Inspecting Pptx for XPath selectors on slide ${slideNumber}`,
   )(file, slideNumber);
+};
+
+export const ensurePptxLayout = (
+  file: string,
+  slideNumber: number,
+  layoutName: string,
+): Verify => {
+  return verifyPptxDocument(
+    pptxLayoutChecker(layoutName),
+    `Inspecting Pptx for slide ${slideNumber} having layout ${layoutName}.`,
+  )(file, slideNumber, true);
 };
 
 export const ensureDocxRegexMatches = (


### PR DESCRIPTION
Pandoc may have an issue in its writer as, like other formats it will correctly ignore other format RawBlock, but it seems to mess the created pptx file (e.g. choosing the wrong layout, creating empty new slides)

We add those raw blocks in some places like HTML table parsing 

This fix #9680  and fix #9681 - some details can be found in each of those issue. 

This PR is too discussed the idea of doing such cleanup step. 

Other solution I had in mind would be to adapt the HTML processing step so that it adds the HTML RawBlock only for HTML format. This would be more generic but usually Pandoc does a good job to ignore RawBlock for a different format in the Writers.

Opening as Draft to discuss this.  Tests needs to be added too. 