### PR TITLE
publish - Correctly get information from prompt to update existing record

### DIFF
--- a/src/command/publish/deployment.ts
+++ b/src/command/publish/deployment.ts
@@ -232,10 +232,10 @@ export async function chooseDeployment(
     options,
   });
 
-  if (confirm.value !== kOther) {
+  if (confirm !== kOther) {
     return depoyments.find((deployment) =>
       publishRecordIdentifier(deployment.target, deployment.account) ===
-        confirm.value
+        confirm
     );
   } else {
     return undefined;

--- a/src/command/publish/deployment.ts
+++ b/src/command/publish/deployment.ts
@@ -6,8 +6,7 @@
 
 import { warning } from "../../deno_ral/log.ts";
 
-import { Select } from "cliffy/prompt/select.ts";
-import { Confirm } from "cliffy/prompt/confirm.ts";
+import { Confirm, prompt, Select } from "cliffy/prompt/mod.ts";
 
 import { findProvider, publishProviders } from "../../publish/provider.ts";
 
@@ -226,16 +225,18 @@ export async function chooseDeployment(
     value: kOther,
   });
 
-  const confirm = await Select.prompt({
+  const confirm = await prompt([{
+    name: "destination",
     indent: "",
     message: "Publish update to:",
     options,
-  });
+    type: Select,
+  }]);
 
-  if (confirm !== kOther) {
+  if (confirm.destination !== kOther) {
     return depoyments.find((deployment) =>
       publishRecordIdentifier(deployment.target, deployment.account) ===
-        confirm
+        confirm.destination
     );
   } else {
     return undefined;


### PR DESCRIPTION
This PR correctly get prompt result for record to update

This should solve all our breakage with publish and update

- fixes #9764 
- fixes #9204
- fixes #9228


For the story, this is a breakage since 1.5.23 from an old PR (#8907) that we missed because we don't CI testing of `quarto publish` command, nor some Steps to follow for Manual testing to do when we modify these parts of the code base. 

Though this one would have been tricky because if needs prompt selection - so only manual testing would have help. 

I'll test the other provider before merging I'll do that next week. 