### PR TITLE
Prevent hidden element in collapse margin sidebar to trigger events

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -57,6 +57,7 @@ All changes included in 1.5:
 - ([#8851](https://github.com/quarto-dev/quarto-cli/issues/8851)): Don't strip `index.html` from external paths.
 - ([#8977](https://github.com/quarto-dev/quarto-cli/issues/8977)): Don't decorate about links within external link icons.
 - ([#9356](https://github.com/quarto-dev/quarto-cli/issues/9356)): Don't process column classes for figures inside the About divs.
+- ([#9781](https://github.com/quarto-dev/quarto-cli/issues/9781)): Correctly hide elements from click event in collapsed margin sidebar.
 
 ## Book
 

--- a/src/resources/formats/html/quarto.js
+++ b/src/resources/formats/html/quarto.js
@@ -319,6 +319,7 @@ window.document.addEventListener("DOMContentLoaded", function (_event) {
           for (const child of el.children) {
             child.style.opacity = 0;
             child.style.overflow = "hidden";
+            child.style.pointerEvents = "none";
           }
 
           nexttick(() => {
@@ -360,6 +361,7 @@ window.document.addEventListener("DOMContentLoaded", function (_event) {
 
               const clone = child.cloneNode(true);
               clone.style.opacity = 1;
+              clone.style.pointerEvents = null;
               clone.style.display = null;
               toggleContents.append(clone);
             }
@@ -434,6 +436,7 @@ window.document.addEventListener("DOMContentLoaded", function (_event) {
           for (const child of el.children) {
             child.style.opacity = 1;
             child.style.overflow = null;
+            child.style.pointerEvents = null;
           }
 
           const placeholderEl = window.document.getElementById(


### PR DESCRIPTION
When hiding the sidebar, we change opacity and add overflow hidden, but opacity: 0 does not prevent event to be triggered.
Though it has the best performance: https://www.sitepoint.com/hide-elements-in-css/#1opacityandfilteropacity

So for the hidden TOC node, we use pointer-events: none to prevent any event to be triggered.
https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-eventsWelcome to the quarto GitHub repo!

fixes #9781 