### PR TITLE
confluence - fix characters being added to title when title is unique

### DIFF
--- a/src/publish/confluence/api/index.ts
+++ b/src/publish/confluence/api/index.ts
@@ -94,7 +94,7 @@ export class ConfluenceClient {
     const CQL_CONTEXT =
       "%7B%22contentStatuses%22%3A%5B%22archived%22%2C%20%22current%22%2C%20%22draft%22%5D%7D"; //{"contentStatuses":["archived", "current", "draft"]}
 
-    cql = `${cql}&spaces=${space.key}&cqlcontext=${CQL_CONTEXT}`;
+    cql = `${cql}%20and%20space=${space.key}&cqlcontext=${CQL_CONTEXT}`;
 
     const result = await this.get<ContentArray>(`content/search?cql=${cql}`);
     return result?.results ?? [];


### PR DESCRIPTION
When publishing to Confluence, the docs mention:

>  Quarto may add some additional characters to meet the Confluences requirement that every page in a space has a unique name.

I noticed that characters were being added even if there wasn't a page with the same title within my space. However, I noticed there were pages with the same title in _other_ spaces. To me it looks like a small error in the way the CQL has been written, which this PR amends.