### PR TITLE
Chore: update QuartoNotebookRunner to 0.11.0

### DIFF
--- a/src/resources/julia/Project.toml
+++ b/src/resources/julia/Project.toml
@@ -2,4 +2,4 @@
 QuartoNotebookRunner = "4c0109c6-14e9-4c88-93f0-2b974d3468f4"
 
 [compat]
-QuartoNotebookRunner = "=0.10.2"
+QuartoNotebookRunner = "=0.11.0"


### PR DESCRIPTION
Relevant user-facing updates in this release:

- support for REPL "modes" (thanks to @MHellmund)
- change to `--color=yes` as the default for output (again, thanks to @MHellmund)
- fix handling of PDF output for `Plots.jl` plots
- the code run in worker `julia` processes is now precompiled and should reduce initial latency when running notebooks.

