### PR TITLE
ipynb - check if svg display data is encoded or not

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -123,6 +123,7 @@ All changes included in 1.5:
 - ([#9635](https://github.com/quarto-dev/quarto-cli/issues/9635)): Respect `{shortcodes=false}` when resolving `include` shortcodes.
 - ([#9664](https://github.com/quarto-dev/quarto-cli/pull/9664)): Add `placeholder` shortcode to produce placeholder images.
 - ([#9665](https://github.com/quarto-dev/quarto-cli/issues/9665)): Fix issue with key-value arguments of shortcode handlers in code contexts.
+- ([#9793](https://github.com/quarto-dev/quarto-cli/issues/9793)): `embed` shortcode now correctly retrieve svg image from embdedded cell.
 
 ## Lightbox Images
 

--- a/src/core/jupyter/jupyter.ts
+++ b/src/core/jupyter/jupyter.ts
@@ -1930,11 +1930,15 @@ function mdImageOutput(
     ? (data as string[]).join("")
     : data as string;
 
-  // base64 decode if it's not encoded svg
-  // when used in embed context, Pandoc will generate ipynb with base64 encoded svg data
-  // https://github.com/quarto-dev/quarto-cli/issues/9793
   const outputFile = join(options.assets.base_dir, imageFile);
-  if (mimeType !== kImageSvg || !imageText.trimStart().startsWith("<svg")) {
+  if (
+    // base64 decode if it's not svg
+    mimeType !== kImageSvg ||
+    // or if it is encoded svg; this could happen when used in embed context,
+    // as Pandoc will generate ipynb with base64 encoded svg data
+    // https://github.com/quarto-dev/quarto-cli/issues/9793
+    !/<svg/.test(imageText)
+  ) {
     const imageData = base64decode(imageText);
 
     // if we are in retina mode, then derive width and height from the image

--- a/src/core/jupyter/jupyter.ts
+++ b/src/core/jupyter/jupyter.ts
@@ -1930,9 +1930,11 @@ function mdImageOutput(
     ? (data as string[]).join("")
     : data as string;
 
-  // base64 decode if it's not svg
+  // base64 decode if it's not encoded svg
+  // when used in embed context, Pandoc will generate ipynb with base64 encoded svg data
+  // https://github.com/quarto-dev/quarto-cli/issues/9793
   const outputFile = join(options.assets.base_dir, imageFile);
-  if (mimeType !== kImageSvg) {
+  if (mimeType !== kImageSvg || !imageText.trimStart().startsWith("<svg")) {
     const imageData = base64decode(imageText);
 
     // if we are in retina mode, then derive width and height from the image

--- a/tests/docs/smoke-all/2024/05/29/9713/main.qmd
+++ b/tests/docs/smoke-all/2024/05/29/9713/main.qmd
@@ -1,0 +1,8 @@
+---
+format: typst
+_quarto:
+  tests:
+    typst: null
+---
+
+{{< embed plots.qmd#plot >}}

--- a/tests/docs/smoke-all/2024/05/29/9713/plots.qmd
+++ b/tests/docs/smoke-all/2024/05/29/9713/plots.qmd
@@ -1,0 +1,10 @@
+---
+title: "Plots"
+fig-format: svg
+---
+
+```{r}
+#| label: plot
+plot(1:10)
+```
+


### PR DESCRIPTION
fixes #9793 

We assumed svg mime type data was never encoded. 

However,  this is not the case when the Notebook file is produced by a pandoc convert `--to ipynb`. In this case, Pandoc will base64 encode the svg file. The svg data needs to be decoded before being written to the file at embedding time.Welcome to the quarto GitHub repo!

For Quarto, this will mostly happens in render context when embed is used as we generate this type of ipynb document internally. 
It could also happens if a Python code in cell would also output a `display_data` with svg mime type and encoded data. It does not seem to be the common usage. 

This is quite a narrow fix I believe, and as mentioned in #9793 , this is doing the same kind of check that we do in another function 
https://github.com/quarto-dev/quarto-cli/blob/122b0f3093c560a6c24365fc9241bb83d4590ef4/src/core/jupyter/jupyter.ts#L991-L997

cc @cwickham if you want to try on your side, though I added your example as a test