### PR TITLE
Fix preview.js build on windows 

### DIFF
--- a/src/webui/quarto-preview/deno.lock
+++ b/src/webui/quarto-preview/deno.lock
@@ -203,7 +203,7 @@
   "workspace": {
     "packageJson": {
       "dependencies": [
-        "npm:@fluentui/react-components@^9.19.1",
+        "npm:@fluentui/react-components@~9.48.0",
         "npm:@fluentui/react-icons@^2.0.201",
         "npm:@types/react-dom@^18.2.0",
         "npm:@types/react@^18.2.0",

--- a/src/webui/quarto-preview/package.json
+++ b/src/webui/quarto-preview/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@fluentui/react-icons": "^2.0.201",
-    "@fluentui/react-components": "^9.19.1",
+    "@fluentui/react-components": "~9.48.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "ansi-output": "^0.0.1"


### PR DESCRIPTION
I finally found the problem by comparing our actions log as I discovered we can download, and have more information 

Here are the logs normalized with timestamp removed
- Working build : [7_make-installer-win.txt](https://github.com/quarto-dev/quarto-cli/files/15500808/7_make-installer-win.txt)
- Failing build: [4_make-installer-win.txt](https://github.com/quarto-dev/quarto-cli/files/15500813/4_make-installer-win.txt)

It seems update to `@fluentui/react-components-9.49.0` broke the build on windows. This is the update that brought the `@fluentui/react-teaching-popover` dependency that makes the build fails. 

This PR fixes the issue by pinning to last known working version 9.48.0, using `~` to pin to this minor version to use.

Locally it works now. I believe it will in CI. Let's see. 

If so, I think we  should backport, for our next 1.4 patch to have the file back. 

Fixes #9574 

I still don't know if we could build this less often or not. For reference and history, this was introduced in #5247 in this commit 
[`4591d20` (#5247)](https://github.com/quarto-dev/quarto-cli/pull/5247/commits/4591d20368b744629a25c18341c96e0a0b6b40d9)

It was added to configure.ts and so we build it always. 
