### PR TITLE
i18n for typst

### DIFF
--- a/src/resources/filters/customnodes/floatreftarget.lua
+++ b/src/resources/filters/customnodes/floatreftarget.lua
@@ -988,7 +988,7 @@ end, function(float)
     -- luacov: enable
   end
   local kind = "quarto-float-" .. ref
-  local supplement = info.name
+  local supplement = titleString('fig', info.name)
   -- FIXME: custom numbering doesn't work yet
   -- local numbering = ""
   -- if float.parent_id then

--- a/src/resources/filters/customnodes/theorem.lua
+++ b/src/resources/filters/customnodes/theorem.lua
@@ -100,7 +100,7 @@ local function ensure_typst_theorems(reftype)
     letted_typst_theorem[reftype] = true
     local theorem_type = theorem_types[reftype]
     quarto.doc.include_text("in-header", "#let " .. theorem_type.env .. " = thmbox(\"" ..
-     theorem_type.env .. "\", \"" .. theorem_type.title .. "\")")
+     theorem_type.env .. "\", \"" .. titleString(reftype, theorem_type.title) .. "\")")
   end
 end
 

--- a/src/resources/filters/layout/pandoc3_figure.lua
+++ b/src/resources/filters/layout/pandoc3_figure.lua
@@ -161,7 +161,7 @@ function render_pandoc3_figure()
           caption = figure.caption.long[1],
           kind = "quarto-float-fig",
           caption_location = crossref.categories.by_ref_type["fig"].caption_location,
-          supplement = "Figure",
+          supplement = titleString('fig', 'Figure'),
         })
       end
     }

--- a/src/resources/filters/layout/typst.lua
+++ b/src/resources/filters/layout/typst.lua
@@ -95,7 +95,7 @@ end, function(layout)
     return float.content
     -- luacov: enable
   end
-  local supplement = info.name
+  local supplement = titleString(ref, info.name)
 
   -- typst output currently only supports a single grid
   -- as output, so no rows of varying columns, etc.

--- a/src/resources/filters/layout/typst.lua
+++ b/src/resources/filters/layout/typst.lua
@@ -138,7 +138,7 @@ end, function(layout)
       caption_location = caption_location,
       caption = layout.float.caption_long,
       kind = kind,
-      supplement = info.prefix,
+      supplement = titleString(ref, info.prefix),
       numbering = info.numbering,
       identifier = layout.float.identifier
     }

--- a/src/resources/filters/layout/typst.lua
+++ b/src/resources/filters/layout/typst.lua
@@ -133,7 +133,7 @@ end, function(layout)
       _quarto.format.typst.as_typst_content(cells)
     }, false))
   else
-    return make_typst_figure {
+    result:extend(make_typst_figure {
       content = cells,
       caption_location = caption_location,
       caption = layout.float.caption_long,
@@ -141,7 +141,7 @@ end, function(layout)
       supplement = titleString(ref, info.prefix),
       numbering = info.numbering,
       identifier = layout.float.identifier
-    }
+    })
   end
   return result
 end)

--- a/src/resources/filters/layout/typst.lua
+++ b/src/resources/filters/layout/typst.lua
@@ -133,7 +133,7 @@ end, function(layout)
       _quarto.format.typst.as_typst_content(cells)
     }, false))
   else
-    result:insert(make_typst_figure {
+    return make_typst_figure {
       content = cells,
       caption_location = caption_location,
       caption = layout.float.caption_long,
@@ -141,7 +141,7 @@ end, function(layout)
       supplement = info.prefix,
       numbering = info.numbering,
       identifier = layout.float.identifier
-    })
+    }
   end
   return result
 end)

--- a/src/resources/formats/typst/pandoc/quarto/typst-template.typ
+++ b/src/resources/formats/typst/pandoc/quarto/typst-template.typ
@@ -61,7 +61,7 @@
 
   if abstract != none {
     block(inset: 2em)[
-    #text(weight: "semibold")[Abstract] #h(1em) #abstract
+    #text(weight: "semibold")[$labels.abstract$] #h(1em) #abstract
     ]
   }
 

--- a/tests/docs/smoke-all/typst/typst-i18n.qmd
+++ b/tests/docs/smoke-all/typst/typst-i18n.qmd
@@ -1,0 +1,45 @@
+---
+title: "Typst internationalization"
+lang: es
+abstract: Escribo algo.
+format:
+  typst:
+    keep-typ: true
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+      - ['Resumen', 'Nota', 'Conjetura']
+      - []
+      ensurePdfRegexMatches:
+      - ['Figura 1', 'Figura 2', 'Figura 3']
+      - ['Figura 4']
+---
+
+![Marcador]({{< placeholder 300 >}}){#fig-marcador}
+
+![Marcador desconocido]({{< placeholder 300 >}})
+
+::: {#fig-panel layout-ncol=2}
+
+![Marcador]({{< placeholder 200 >}}){#fig-layout-a}
+
+![Marcador]({{< placeholder 200 >}}){#fig-layout-b}
+
+Panels
+
+:::
+
+::: {.callout-note}
+
+Información
+
+:::
+
+::: {#cnj-redondo}
+
+# Redondo
+
+El mundo es redondo.
+
+:::

--- a/tests/docs/smoke-all/typst/typst-i18n.qmd
+++ b/tests/docs/smoke-all/typst/typst-i18n.qmd
@@ -12,8 +12,8 @@ _quarto:
       - ['Resumen', 'Nota', 'Conjetura']
       - []
       ensurePdfRegexMatches:
-      - ['Figura 1', 'Figura 2', 'Figura 3']
-      - ['Figura 4']
+      - ['Figura 1', 'Figura 2', 'Figura 3', 'Figura 4', 'Figura 5', 'Figura 6']
+      - ['Figure 1', 'Figure 2', 'Figure 3', 'Figure 4', 'Figure 5', 'Figure 6']
 ---
 
 ![Marcador]({{< placeholder 300 >}}){#fig-marcador}

--- a/tests/docs/smoke-all/typst/typst-i18n.qmd
+++ b/tests/docs/smoke-all/typst/typst-i18n.qmd
@@ -30,6 +30,17 @@ Panels
 
 :::
 
+::: {#fig-panel2 layout-ncol=2}
+
+![Marcador]({{< placeholder 200 >}})
+
+![Marcador]({{< placeholder 200 >}})
+
+Panels
+
+:::
+
+
 ::: {.callout-note}
 
 Información


### PR DESCRIPTION
Closes #9555

Internationalization of
- Abstract title
- Figures
- Theorems etc

Loose ends on this draft
- [x] I don't know how to test a pandoc3 figure - where does this arise? I fixed this but didn't test it.
- [x] Similarly, what is a `PanelLayout` in Typst? I tried the HTML [Panel Layouts](https://quarto.org/docs/interactive/layout.html#panel-layout) `::: {layout = "[ [1,1] ]"}` but no surprise that didn't work.
   https://github.com/quarto-dev/quarto-cli/blob/301b2353dc93d07af83558a8defe48e46590f1c2/src/resources/filters/layout/typst.lua#L141
- [ ] Submit a PR to fix jgm/pandoc#9724 and see if this affects the change to the Typst template.

