### PR TITLE
Bugfix/9850

### DIFF
--- a/dev-docs/feature-format-matrix/qmd-files/layout/fig-align/toplevel-id-nocaption.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/layout/fig-align/toplevel-id-nocaption.qmd
@@ -18,7 +18,7 @@ _quarto:
     latex:
       ensureFileRegexMatches:
       -
-        - '\\hfill\\captionsetup\{labelsep=none\}\\includegraphics\{100.png\}'
+        - '\\hfill\\includegraphics\{100.png\}'
       - []
     typst:
       ensureTypstFileRegexMatches:

--- a/src/resources/filters/customnodes/floatreftarget.lua
+++ b/src/resources/filters/customnodes/floatreftarget.lua
@@ -342,26 +342,6 @@ end, function(float)
   end
   latex_caption = latex_caption or pandoc.Inlines({})
 
-  if #latex_caption == 0 then
-    local caption_setup = quarto.LatexInlineCommand({
-      name = "captionsetup",
-      arg = "labelsep=none"
-    })
-    local pt = pandoc.utils.type(float.content)
-    if pt == "Block" then
-      if float.content.content == nil then
-        -- it's a block that doesn't support inner content
-        -- attempt a best-effort fix by replacing it with a wrapping div
-        float.content = pandoc.Div({float.content})
-      end
-      float.content.content:insert(1, caption_setup)
-    elseif pt == "Blocks" then
-      float.content:insert(1, caption_setup)
-    else
-      internal_error()
-    end
-  end
-
   local label_cmd = quarto.LatexInlineCommand({
     name = "label",
     arg = pandoc.RawInline("latex", float.identifier)

--- a/tests/docs/smoke-all/2023/09/19/issue-2546.qmd
+++ b/tests/docs/smoke-all/2023/09/19/issue-2546.qmd
@@ -5,7 +5,6 @@ _quarto:
     latex:
       ensureFileRegexMatches:
         - 
-          - "\\\\captionsetup\\{labelsep=none\\}"
           - "\\\\caption\\{\\\\label\\{fig-chapter-2\\}One with a caption\\}"
         - []
     html:

--- a/tests/docs/smoke-all/2024/06/03/9850.qmd
+++ b/tests/docs/smoke-all/2024/06/03/9850.qmd
@@ -1,0 +1,16 @@
+---
+title: "Untitled"
+format: latex
+_quarto:
+  tests:
+    latex:
+      ensureFileRegexMatches:
+        - []
+        - ["labelsep=none"]
+---
+
+```{r}
+#| label: tbl-problem
+gt::gtcars[1:5, 1:5] |> 
+    gt::gt()
+```


### PR DESCRIPTION
Closes #9850.

From my testing, it seems we don't need the `labelsep=none` environment in case of missing captions.