### PR TITLE
Lua,tables - fix crash on Table FloatRefTargets with `echo: false` and `eval: false`

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -135,6 +135,7 @@ All changes included in 1.5:
 - ([#8417](https://github.com/quarto-dev/quarto-cli/issues/8417)): Maintain a single AST element in the output cells when parsing HTML from RawBlock elements.
 - ([#8582](https://github.com/quarto-dev/quarto-cli/issues/8582)): Improve the algorithm for extracting table elements from HTML RawBlock elements.
 - ([#8770](https://github.com/quarto-dev/quarto-cli/issues/8770)): Handle inconsistently-defined float types and identifier names more robustly in HTML tables.
+- ([#9862](https://github.com/quarto-dev/quarto-cli/issues/9862)): Fix crash with labeled tables in cells with `eval: false` and `echo: false`.
 
 ## Engines
 

--- a/src/resources/filters/quarto-pre/table-classes.lua
+++ b/src/resources/filters/quarto-pre/table-classes.lua
@@ -62,6 +62,9 @@ function table_classes()
       if kind ~= "tbl" then
         return nil
       end
+      if float.content == nil then
+        return nil
+      end
 
       if (float.caption_long == nil or 
           float.caption_long.content == nil or 

--- a/tests/docs/smoke-all/2024/06/04/9862.qmd
+++ b/tests/docs/smoke-all/2024/06/04/9862.qmd
@@ -1,0 +1,13 @@
+---
+title: "Untitled"
+format: html
+execute:
+  echo: false
+---
+
+```{r}
+#| eval: false
+#| label: tbl-t2
+#| tbl-cap: hggfh
+mtcars |> head() |> knitr::kable()
+```


### PR DESCRIPTION
Closes #9863.