### PR TITLE
quarto commands - don't emit stack trace on Cliffy errors

### DIFF
--- a/package/scripts/common/quarto
+++ b/package/scripts/common/quarto
@@ -60,7 +60,9 @@ if [ -f "$DEV_PATH" ]; then
   fi
   export QUARTO_BIN_PATH=$SCRIPT_PATH
   export QUARTO_SHARE_PATH="${QUARTO_SHARE_PATH=$QUARTO_SRC_PATH/resources/}"
-  export QUARTO_DEBUG=true
+  if [ -z ${QUARTO_DEBUG+x} ]; then
+    export QUARTO_DEBUG=true
+  fi
   QUARTO_CACHE_OPTIONS="--cached-only"
 
   # Check for deno update

--- a/package/scripts/windows/quarto.cmd
+++ b/package/scripts/windows/quarto.cmd
@@ -34,7 +34,10 @@ IF EXIST "!QUARTO_TS_PATH!" (
 		SET "QUARTO_TARGET=!QUARTO_TS_PATH!"
 	)
 
-	SET QUARTO_DEBUG=true
+	IF NOT DEFINED QUARTO_DEBUG (
+		SET QUARTO_DEBUG=true 
+	)
+
 	:: Normalize path to remove ../.. stuff
 	for %%i in ("!SCRIPT_PATH!..\config\deno-version") do SET "DENO_VERSION_FILE=%%~fi"
 

--- a/src/core/lib/error.ts
+++ b/src/core/lib/error.ts
@@ -44,7 +44,7 @@ export class ErrorEx extends Error {
   public readonly printStack: boolean;
 }
 
-export function asErrorEx(e: unknown) {
+export function asErrorEx(e: unknown, defaultShowStack = true) {
   if (e instanceof ErrorEx) {
     return e;
   } else if (e instanceof Error) {
@@ -52,7 +52,7 @@ export function asErrorEx(e: unknown) {
     // so that the stack trace survives
 
     (e as any).printName = e.name !== "Error";
-    (e as any).printStack = !!e.message;
+    (e as any).printStack = defaultShowStack && !!e.message;
     return e as ErrorEx;
   } else {
     return new ErrorEx("Error", String(e), false, true);

--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -41,6 +41,7 @@ export interface LogMessageOptions {
 
 // deno-lint-ignore no-explicit-any
 export function appendLogOptions(cmd: Command<any>): Command<any> {
+  // deno-lint-ignore no-explicit-any
   const addLogOptions = (cmd: Command<any>) => {
     return cmd.option(
       "--log <file>",
@@ -315,9 +316,9 @@ export function logProgress(message: string) {
   log.info(colors.bold(colors.blue(message)));
 }
 
-export function logError(e: unknown) {
+export function logError(e: unknown, defaultShowStack = true) {
   // normalize
-  const err = asErrorEx(e);
+  const err = asErrorEx(e, defaultShowStack);
 
   // print error name if requested
   let message = err.printName ? `${err.name}: ${err.message}` : err.message;

--- a/src/quarto.ts
+++ b/src/quarto.ts
@@ -22,6 +22,8 @@ import { quartoConfig } from "./core/quarto.ts";
 import { execProcess } from "./core/process.ts";
 import { pandocBinaryPath } from "./core/resources.ts";
 import { appendProfileArg, setProfileFromArg } from "./quarto-core/profile.ts";
+import { logError } from "./core/log.ts";
+import { CommandError } from "cliffy/command/_errors.ts";
 
 import {
   devConfigsEqual,
@@ -153,7 +155,15 @@ export async function quarto(
     }
   }
 
-  await promise;
+  try {
+    await promise;
+  } catch (e) {
+    if (e instanceof CommandError) {
+      logError(e, false);
+    } else {
+      throw e;
+    }
+  }
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
Closes #9032.

(This doesn't fix all of the stack trace displays, and will need ongoing work. But it's the only way for us to do it)

It also changes Quarto's startup scripts to only set `QUARTO_DEBUG=true` in dev mode if `QUARTO_DEBUG` isn't already set, allowing us to test Quarto by (eg) `QUARTO_DEBUG=false quarto inspect a b c`.