### PR TITLE
Handle notebook with no kernelspec metadata when execution is needed

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -109,6 +109,7 @@ All changes included in 1.5:
 - ([#9536](https://github.com/quarto-dev/quarto-cli/issues/9536)): Provide traceback when available in Jupyter error outputs.
 - ([#9470](https://github.com/quarto-dev/quarto-cli/issues/9470)): Fix images rendered by the Jupyter engine to be displayed with the same dimensions as those in notebooks.
 - ([#5413](https://github.com/quarto-dev/quarto-cli/issues/5413)): Fix issue with Jupyter engine cells and images with captions containing newlines.
+- ([#9896](https://github.com/quarto-dev/quarto-cli/issues/9896)): Fix an issue with executing notebook with no kernelspec metadata yet.
 
 ## Website Listings
 

--- a/src/execute/jupyter/jupyter.ts
+++ b/src/execute/jupyter/jupyter.ts
@@ -616,7 +616,7 @@ async function ensureYamlKernelspec(
   const yamlJupyter = readYamlFromMarkdown(markdown)?.jupyter;
   if (yamlJupyter && typeof yamlJupyter !== "boolean") {
     const [yamlKernelspec, _] = await jupyterKernelspecFromMarkdown(markdown);
-    if (yamlKernelspec.name !== kernelspec.name) {
+    if (yamlKernelspec.name !== kernelspec?.name) {
       const nb = jupyterFromJSON(Deno.readTextFileSync(target.source));
       nb.metadata.kernelspec = yamlKernelspec;
       Deno.writeTextFileSync(target.source, JSON.stringify(nb, null, 2));

--- a/tests/docs/smoke-all/2024/06/06/9896.ipynb
+++ b/tests/docs/smoke-all/2024/06/06/9896.ipynb
@@ -21,6 +21,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This document should have no metadata kernelspec defined in its ipynb json representation. \n",
+    "\n",
+    "If quarto render is called on it, then it will add some and the change should not be committed."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tests/docs/smoke-all/2024/06/06/9896.ipynb
+++ b/tests/docs/smoke-all/2024/06/06/9896.ipynb
@@ -1,0 +1,41 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "title: Starter ipynb with no kernel info\n",
+    "format: html\n",
+    "execute:\n",
+    "  enabled: true\n",
+    "jupyter:\n",
+    "  kernel: python3\n",
+    "_quarto:\n",
+    "  tests:\n",
+    "    html:\n",
+    "      ensureHtmlElements:\n",
+    "        - ['.cell-output-stdout']\n",
+    "        - []\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = 1\n",
+    "print(x)"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This follows up on d4ef8af for support of executing notebook with the kernel specification from the quarto configuration even if none present in the ipynb itself

fixes #9896