### PR TITLE
[references] Add tabsets among the flag for HTML features

### DIFF
--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -15986,6 +15986,17 @@ var require_yaml_intelligence_resources = __commonJS({
           description: "Enables hover over a section title to see an anchor link."
         },
         {
+          name: "tabsets",
+          schema: "boolean",
+          default: true,
+          tags: {
+            formats: [
+              "$html-doc"
+            ]
+          },
+          description: "Enables tabsets to present content."
+        },
+        {
           name: "smooth-scroll",
           schema: "boolean",
           default: false,
@@ -22815,7 +22826,8 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
         "Manuscript configuration",
-        "internal-schema-hack"
+        "internal-schema-hack",
+        "Enables tabsets to present content."
       ],
       "schema/external-schemas.yml": [
         {
@@ -23044,12 +23056,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 186345,
+        _internalId: 186347,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 186337,
+            _internalId: 186339,
             type: "enum",
             enum: [
               "png",
@@ -23065,7 +23077,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 186344,
+            _internalId: 186346,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -15987,6 +15987,17 @@ try {
             description: "Enables hover over a section title to see an anchor link."
           },
           {
+            name: "tabsets",
+            schema: "boolean",
+            default: true,
+            tags: {
+              formats: [
+                "$html-doc"
+              ]
+            },
+            description: "Enables tabsets to present content."
+          },
+          {
             name: "smooth-scroll",
             schema: "boolean",
             default: false,
@@ -22816,7 +22827,8 @@ try {
           },
           "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
           "Manuscript configuration",
-          "internal-schema-hack"
+          "internal-schema-hack",
+          "Enables tabsets to present content."
         ],
         "schema/external-schemas.yml": [
           {
@@ -23045,12 +23057,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 186345,
+          _internalId: 186347,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 186337,
+              _internalId: 186339,
               type: "enum",
               enum: [
                 "png",
@@ -23066,7 +23078,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 186344,
+              _internalId: 186346,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -8958,6 +8958,17 @@
       "description": "Enables hover over a section title to see an anchor link."
     },
     {
+      "name": "tabsets",
+      "schema": "boolean",
+      "default": true,
+      "tags": {
+        "formats": [
+          "$html-doc"
+        ]
+      },
+      "description": "Enables tabsets to present content."
+    },
+    {
       "name": "smooth-scroll",
       "schema": "boolean",
       "default": false,
@@ -15787,7 +15798,8 @@
     },
     "Disambiguating year suffix in author-date styles (e.g.&nbsp;“a” in “Doe,\n1999a”).",
     "Manuscript configuration",
-    "internal-schema-hack"
+    "internal-schema-hack",
+    "Enables tabsets to present content."
   ],
   "schema/external-schemas.yml": [
     {
@@ -16016,12 +16028,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 186345,
+    "_internalId": 186347,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 186337,
+        "_internalId": 186339,
         "type": "enum",
         "enum": [
           "png",
@@ -16037,7 +16049,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 186344,
+        "_internalId": 186346,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/schema/document-options.yml
+++ b/src/resources/schema/document-options.yml
@@ -62,6 +62,13 @@
     formats: [$html-doc]
   description: Enables hover over a section title to see an anchor link.
 
+- name: tabsets
+  schema: boolean
+  default: true
+  tags:
+    formats: [$html-doc]
+  description: Enables tabsets to present content.
+
 - name: smooth-scroll
   schema: boolean
   default: false


### PR DESCRIPTION
When settings `minimal: true`, some features can be re-enabled as mentioned in documentation https://quarto.org/docs/output-formats/html-basics.html#minimal-html

[Tabsets ](https://quarto.org/docs/output-formats/html-basics.html#tabsets) is among those. 

However it was not documented in our references because not in schema. 

This PR adds this 

YAML header example: 
````markdown
---
title: test
format: html
minimal: true
tabsets: true
---
````

For reference, those features that are disable are here in the code 
https://github.com/quarto-dev/quarto-cli/blob/e09ae925dd92950394ca7eb2376ca0e3fba34bc5/src/format/html/format-html.ts#L608-L623

And can be renable individually
https://github.com/quarto-dev/quarto-cli/blob/e09ae925dd92950394ca7eb2376ca0e3fba34bc5/src/format/html/format-html.ts#L246-L290