### PR TITLE
fixup regression regarding longtable handling (and some tests fixes)

### DIFF
--- a/dev-docs/feature-format-matrix/qmd-files/crossref/float/table/document.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/crossref/float/table/document.qmd
@@ -32,6 +32,7 @@ _quarto:
           - "a[href=\"#tbl-2\"].quarto-xref"
     dashboard: *dom-tests
     revealjs: # reveal resolves anchors differently, using the section headings instead of the float ids
+      ensureHtmlElements:
         - 
           - "div#tbl-1.quarto-float figure.quarto-float.quarto-float-tbl table"
           - "div#tbl-2.quarto-float figure.quarto-float.quarto-float-tbl img"

--- a/dev-docs/feature-format-matrix/qmd-files/raw-blocks/interpreted/pandoc-json/document.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/raw-blocks/interpreted/pandoc-json/document.qmd
@@ -11,7 +11,7 @@ format:
   typst:
     quality: 2
     comment: "Typst itself interprets the -- as –"
-    output-ext: typ
+    keep-typ: true
   revealjs:
     quality: 1
   docx:

--- a/dev-docs/feature-format-matrix/qmd-files/raw-blocks/interpreted/pandoc-native/document.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/raw-blocks/interpreted/pandoc-native/document.qmd
@@ -10,7 +10,7 @@ format:
   dashboard:
     quality: 1
   typst:
-    output-ext: typ
+    keep-typ: true
     quality: 2
   revealjs:
     quality: 1

--- a/src/resources/filters/quarto-post/latex.lua
+++ b/src/resources/filters/quarto-post/latex.lua
@@ -438,7 +438,7 @@ function render_latex_fixups()
       if _quarto.format.isRawLatex(raw) then
         local long_table_match = _quarto.modules.patterns.match_all_in_table(_quarto.patterns.latexLongtablePattern)
         local caption_match = _quarto.modules.patterns.match_all_in_table(_quarto.patterns.latexCaptionPattern)
-        if long_table_match(raw.text) and caption_match(raw.text) then
+        if long_table_match(raw.text) and not caption_match(raw.text) then
           raw.text = raw.text:gsub(
             _quarto.modules.patterns.combine_patterns(_quarto.patterns.latexLongtablePattern), "\\begin{longtable*}%2\\end{longtable*}", 1)
           return raw

--- a/tests/docs/smoke-all/2024/01/19/docusaurus/docusaurus-tabsets.qmd
+++ b/tests/docs/smoke-all/2024/01/19/docusaurus/docusaurus-tabsets.qmd
@@ -3,7 +3,7 @@ format: docusaurus-md
 _quarto:
   tests:
     docusaurus-md:
-      ensure-snapshot-matches: true
+      ensureSnapshotMatches: true
 ---
 
 ::: {.panel-tabset}

--- a/tests/docs/smoke-all/2024/02/13/empty-floats.qmd
+++ b/tests/docs/smoke-all/2024/02/13/empty-floats.qmd
@@ -4,7 +4,7 @@ format: latex
 _quarto:
   tests:
     latex:
-      verifyNoErrors: true
+      noErrors: true
 ---
 
 :::{#fig-1}

--- a/tests/docs/smoke-all/2024/03/22/8998.qmd
+++ b/tests/docs/smoke-all/2024/03/22/8998.qmd
@@ -6,8 +6,9 @@ engine: jupyter
 _quarto:
   tests:
     revealjs:
-      - []
-      - ["python"]
+      ensureFileRegexMatches:
+        - []
+        - ["python"]
 ---
 
 - Turn off alarm

--- a/tests/docs/smoke-all/crossrefs/float/jats/jats-float-options-1.qmd
+++ b/tests/docs/smoke-all/crossrefs/float/jats/jats-float-options-1.qmd
@@ -10,7 +10,7 @@ crossref:
 _quarto:
   tests:
     jats:
-      ensureJatsXPath:
+      ensureJatsXpath:
         - []
         - 
           - "//xref[@rid=\"tbl-letters\"]"

--- a/tests/docs/smoke-all/crossrefs/float/latex/latex-longtable-fixup-caption-no-crossref.qmd
+++ b/tests/docs/smoke-all/crossrefs/float/latex/latex-longtable-fixup-caption-no-crossref.qmd
@@ -1,13 +1,13 @@
 ---
-format: latex
+format: pdf
+keep-tex: true
 title: "Long Table kable fixups etc"
 _quarto:
   tests:
-    latex:
-      ensureFileRegexMatches:
+    pdf:
+      ensureLatexFileRegexMatches:
         - ['\\begin\{longtable\}']
         - []
-    pdf: null
 ---
 
 ## Raw longtable table with no crossref and caption from kable function

--- a/tests/docs/smoke-all/crossrefs/float/latex/latex-longtable-fixup-caption-no-crossref.qmd
+++ b/tests/docs/smoke-all/crossrefs/float/latex/latex-longtable-fixup-caption-no-crossref.qmd
@@ -1,0 +1,33 @@
+---
+format: latex
+title: "Long Table kable fixups etc"
+_quarto:
+  tests:
+    latex:
+      ensureFileRegexMatches:
+        - ['\\begin\{longtable\}']
+        - []
+    pdf: null
+---
+
+## Raw longtable table with no crossref and caption from kable function
+
+In this case we'll issue a warning about of the type 
+````
+Raw LaTeX table found with non-tbl label: tab:not-tbl
+Won't be able to cross-reference this table using Quarto's native crossref system.
+````
+```{r}
+#| label: not-tbl
+#| echo: false
+df <- tibble::tibble(
+  x = 1:20,
+  y = rnorm(20),
+  z = rnorm(20)
+)
+knitr::kable(df, 
+  format = "latex", 
+  longtable = TRUE, 
+  booktabs = TRUE, 
+  caption = "A long table with a caption")
+```

--- a/tests/docs/smoke-all/crossrefs/float/latex/latex-longtable-fixup-no-cap-no-crossref.qmd
+++ b/tests/docs/smoke-all/crossrefs/float/latex/latex-longtable-fixup-no-cap-no-crossref.qmd
@@ -1,0 +1,30 @@
+---
+format: latex
+keep-tex: true
+title: "Long Table kable fixups etc"
+_quarto:
+  tests:
+    latex:
+      ensureFileRegexMatches:
+        - ['\\begin\{longtable\*\}']
+        - ['\\begin\{longtable\}']
+    pdf: null
+---
+
+## Raw longtable table with no crossref and no caption
+
+In this case, Quarto will transform to longtable* 
+
+```{r}
+#| echo: false
+df <- tibble::tibble(
+  x = 1:20,
+  y = rnorm(20),
+  z = rnorm(20)
+)
+knitr::kable(df, 
+  format = "latex", 
+  longtable = TRUE, 
+  booktabs = TRUE)
+```
+

--- a/tests/docs/smoke-all/crossrefs/float/latex/latex-longtable-fixup-no-cap-no-crossref.qmd
+++ b/tests/docs/smoke-all/crossrefs/float/latex/latex-longtable-fixup-no-cap-no-crossref.qmd
@@ -1,14 +1,13 @@
 ---
-format: latex
+format: pdf
 keep-tex: true
 title: "Long Table kable fixups etc"
 _quarto:
   tests:
-    latex:
-      ensureFileRegexMatches:
+    pdf:
+      ensureLatexFileRegexMatches:
         - ['\\begin\{longtable\*\}']
         - ['\\begin\{longtable\}']
-    pdf: null
 ---
 
 ## Raw longtable table with no crossref and no caption

--- a/tests/docs/smoke-all/crossrefs/theorem/lemma-1.qmd
+++ b/tests/docs/smoke-all/crossrefs/theorem/lemma-1.qmd
@@ -1,7 +1,7 @@
 ---
 format:
   typst:
-    output-ext: typ
+    keep-typ: true
 _quarto:
   tests:
     html:

--- a/tests/docs/smoke-all/crossrefs/theorem/theorem-1.qmd
+++ b/tests/docs/smoke-all/crossrefs/theorem/theorem-1.qmd
@@ -1,7 +1,7 @@
 ---
 format:
   typst:
-    output-ext: typ
+    keep-typ: true
 _quarto:
   tests:
     html:

--- a/tests/docs/smoke-all/crossrefs/theorem/theorem-2.qmd
+++ b/tests/docs/smoke-all/crossrefs/theorem/theorem-2.qmd
@@ -1,7 +1,7 @@
 ---
 format:
   typst:
-    output-ext: typ
+    keep-typ: true
 _quarto:
   tests:
     html:

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -155,11 +155,11 @@ function resolveTestSpecs(
             // FIXME: We should find another way that having this requirement of keep-* in the metadata
             if (key === "ensureTypstFileRegexMatches") {
               if (!metadata.format?.typst?.['keep-typ'] && !metadata['keep-typ']) {
-                throw new Error("Using ensureTypstFileRegexMatches requires setting `keep-typ: true`");
+                throw new Error(`Using ensureTypstFileRegexMatches requires setting 'keep-typ: true' in file ${input}`);
               }
             } else if (key === "ensureLatexFileRegexMatches") {
               if (!metadata.format?.pdf?.['keep-tex'] && !metadata['keep-tex']) {
-                throw new Error("Using ensureLatexFileRegexMatches requires setting `keep-tex: true`");
+                throw new Error(`Using ensureLatexFileRegexMatches requires setting 'keep-tex: true' in file ${input}`);
               }
             }
             if (typeof value === "object") {
@@ -168,7 +168,7 @@ function resolveTestSpecs(
               verifyFns.push(verifyMap[key](outputFile.outputPath, value));
             }
           } else {
-            throw new Error("Unknown verify function used: " + key);
+            throw new Error(`Unknown verify function used: ${key} in file ${input}`) ;
           }
         }
       }

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -154,11 +154,11 @@ function resolveTestSpecs(
           } else if (verifyMap[key]) {
             // FIXME: We should find another way that having this requirement of keep-* in the metadata
             if (key === "ensureTypstFileRegexMatches") {
-              if (!metadata.format?.['keep-typ'] && !metadata['keep-typ']) {
+              if (!metadata.format?.typst?.['keep-typ'] && !metadata['keep-typ']) {
                 throw new Error("Using ensureTypstFileRegexMatches requires setting `keep-typ: true`");
               }
             } else if (key === "ensureLatexFileRegexMatches") {
-              if (!metadata.format?.['keep-tex'] && !metadata['keep-tex']) {
+              if (!metadata.format?.pdf?.['keep-tex'] && !metadata['keep-tex']) {
                 throw new Error("Using ensureLatexFileRegexMatches requires setting `keep-tex: true`");
               }
             }

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -152,6 +152,16 @@ function resolveTestSpecs(
               verifyFns.push(verifyMap[key](outputFile.outputPath, ...value));
             }
           } else if (verifyMap[key]) {
+            // FIXME: We should find another way that having this requirement of keep-* in the metadata
+            if (key === "ensureTypstFileRegexMatches") {
+              if (!metadata.format?.['keep-typ'] && !metadata['keep-typ']) {
+                throw new Error("Using ensureTypstFileRegexMatches requires setting `keep-typ: true`");
+              }
+            } else if (key === "ensureLatexFileRegexMatches") {
+              if (!metadata.format?.['keep-tex'] && !metadata['keep-tex']) {
+                throw new Error("Using ensureLatexFileRegexMatches requires setting `keep-tex: true`");
+              }
+            }
             if (typeof value === "object") {
               verifyFns.push(verifyMap[key](outputFile.outputPath, ...value));
             } else {

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -32,6 +32,7 @@ import {
   ensurePptxXpath,
   ensurePptxLayout,
   ensurePptxMaxSlides,
+  ensureLatexFileRegexMatches,
 } from "../verify.ts";
 import { readYaml, readYamlFromMarkdown } from "../../src/core/yaml.ts";
 import { outputForInput } from "../utils.ts";
@@ -96,6 +97,7 @@ function resolveTestSpecs(
   const verifyMap: Record<string, any> = {
     ensureHtmlElements,
     ensureFileRegexMatches,
+    ensureLatexFileRegexMatches,
     ensureTypstFileRegexMatches,
     ensureDocxRegexMatches,
     ensureDocxXpath,

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -168,7 +168,7 @@ function resolveTestSpecs(
               verifyFns.push(verifyMap[key](outputFile.outputPath, value));
             }
           } else {
-            throw new Error(`Unknown verify function used: ${key} in file ${input}`) ;
+            throw new Error(`Unknown verify function used: ${key} in file ${input} for format ${format}`) ;
           }
         }
       }

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -114,7 +114,7 @@ function resolveTestSpecs(
   for (const [format, testObj] of Object.entries(specs)) {
     let checkWarnings = true;
     const verifyFns: Verify[] = [];
-    if (testObj) {
+    if (testObj && typeof testObj === "object") {
       for (
         // deno-lint-ignore no-explicit-any
         const [key, value] of Object.entries(testObj as Record<string, any>)

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -155,6 +155,8 @@ function resolveTestSpecs(
             } else {
               verifyFns.push(verifyMap[key](outputFile.outputPath, value));
             }
+          } else {
+            throw new Error("Unknown verify function used: " + key);
           }
         }
       }


### PR DESCRIPTION
This is a regression following lua regex change

Change happened at c8bfc13 and introduced regression by changing the condition.
This commits correctly put back the right condition

And also adds two tests that would have allow us to find this problem. 

This PR also adds improvement in our test suites by adding a function to test the intermediate .tex file while testing the pdf output rendering with LaTeX too. 

* `ensureLatexFileRegex` is the equivalent of `ensureTypstRegex`. 
	* `keep-tex: true` is required
	* Intermediate .tex file is correctly cleaned up. 
	* Same behavior as with typst.
	 	
* This was done by a refactoring with a new `verifyKeepFileRegexMatches` that could be used in our regular test suite (not smoke all). I moved function around to regroup so diff may not be easy to read. 🤔 

* Some error are also now thrown by the test suite to help find early some problem
	* Using in a smoke-all a verify function that does not exist was previously ignored. 
		* meaning Nothing was tested in case of a typo for example
	* When `ensureLatexFileRegex` or `ensureTypstRegex` are used, respectively `keep-tex: true` and `keep-typ: true` are checked as they are required.
  
Hopefully, all the test will run ok ! 