### PR TITLE
Chore: update QuartoNotebookRunner to 0.11.1

### DIFF
--- a/src/resources/julia/Project.toml
+++ b/src/resources/julia/Project.toml
@@ -2,4 +2,4 @@
 QuartoNotebookRunner = "4c0109c6-14e9-4c88-93f0-2b974d3468f4"
 
 [compat]
-QuartoNotebookRunner = "=0.11.0"
+QuartoNotebookRunner = "=0.11.1"


### PR DESCRIPTION
A couple minor fixes in this patch version:

- world age issues related to using `Revise` in a notebook.
- correctly render LaTeX math outputs from `LaTeXStrings.jl` and `SymPy.jl`.
- `InteractiveUtils` is now imported by default, in the same way as Jupyter, Pluto, and the REPL.
