### PR TITLE
Better project cleanup for our smoke-all test workflow

### DIFF
--- a/tests/smoke/render/render.ts
+++ b/tests/smoke/render/render.ts
@@ -15,6 +15,8 @@ import {
   noSupportingFiles,
   outputCreated,
 } from "../../verify.ts";
+import { safeRemoveSync } from "../../../src/core/path.ts";
+import { safeExistsSync } from "../../../src/core/path.ts";
 
 export function testSimpleIsolatedRender(
   file: string,
@@ -82,11 +84,11 @@ export function cleanoutput(
   metadata?: Record<string, any>,
 ) {
   const out = outputForInput(input, to, projectOutDir, metadata);
-  if (existsSync(out.outputPath)) {
-    Deno.removeSync(out.outputPath);
+  if (safeExistsSync(out.outputPath)) {
+    safeRemoveSync(out.outputPath);
   }
-  if (existsSync(out.supportPath)) {
-    Deno.removeSync(out.supportPath, { recursive: true });
+  if (safeExistsSync(out.supportPath)) {
+    safeRemoveSync(out.supportPath, { recursive: true });
   }
 }
 

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -275,7 +275,9 @@ for (const { path: fileName } of files) {
 
 function findProjectDir(input: string): string | undefined {
   let dir = dirname(input);
-  while (dir !== "" && dir !== ".") {
+  // This is used for smoke-all tests and should stop there 
+  // to avoid side effect of _quarto.yml outside of Quarto tests folders
+  while (dir !== "" && dir !== "." && /smoke-all$/.test(dir)) {
     const filename = ["_quarto.yml", "_quarto.yaml"].find((file) => {
       const yamlPath = join(dir, file);
       if (existsSync(yamlPath)) {


### PR DESCRIPTION
This PR was done while working on #9741 tests. 

It gave me the opportunity to look into our testing logic for smoke-all, and do a first round of improvment. 

This PR will correctly cleanup all our tests that are projects. Currently, our cleanup logic was only done for file input and not considering project output directory. So we add a lot of left over, and possibly this could be the cause of the sequential smoke-all workflow still failling. So I wanted to tackle this. 

Our logic is the following 

- We run smoke-all test for any .qmd file, either asked or found using globs.  This means we call `quarto render` on individual inputs, look at the test spec and do the related check on this output. 
- `quarto render` is project context aware, meaning when call on a file inside a folder tree that has a _quarto.yml, it will be used as configuration. So for example, a .qmd inside a website will be output inside `_site` directory. We do take into account this logic. 
- So now when we detect a project for an input, we store the project path so that when all the tests are finished, we are able to cleanup all output directory created, and `.quarto` folder leftover. 
- This PR does not change the quarto render done pre-test when `_quarto.render-project` is set to `true`. In this case, a first `quarto render` on the whole project is done, then each file will be tested with an incremental render. 

Hopefully, this PR will break not test, and will help keeps our local testing cleanup, and our tests on CI cleaner. 

Next step is to better handle project path computation to support .qmd in subdirectory. Which is not possible today, and preventing some feature to be tested. 

Let's see if all tests passes ! 