### PR TITLE
Adapt our test logic to correctly support project with subfolders

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -62,6 +62,8 @@ All changes included in 1.5:
 - ([#8986](https://github.com/quarto-dev/quarto-cli/issues/8986)): Search: only build subfuse index when it's safe to do so.
 - ([#9356](https://github.com/quarto-dev/quarto-cli/issues/9356)): Don't process column classes for figures inside the About divs.
 - ([#9781](https://github.com/quarto-dev/quarto-cli/issues/9781)): Correctly hide elements from click event in collapsed margin sidebar.
+- Sidebar navigation item now correctly supports `rel` attribute.
+- `target` attribute for sidebar navigation items is now correctly inserted with HTML escapes.
 
 ## Book
 

--- a/src/resources/projects/website/templates/navtools.ejs
+++ b/src/resources/projects/website/templates/navtools.ejs
@@ -41,7 +41,7 @@ const isWide = toolCount > 2; %>
       </ul>
     </div>
   <% } else { %>
-    <a href="<%- tool.href %>" <%- tool.rel ? `rel="${tool.rel}"` : "" %> title="<%- tool.text %>" class="quarto-navigation-tool px-1" aria-label="<%- tool['aria-label'] || tool.text %>"<%= tool.target ? ` target="${tool.target}"` : "" %>><i class="bi bi-<%- tool.icon %>"></i></a>
+    <a href="<%- tool.href %>" <%= tool.rel ? `rel="${tool.rel}"` : "" %> title="<%- tool.text %>" class="quarto-navigation-tool px-1" aria-label="<%- tool['aria-label'] || tool.text %>"<%= tool.target ? ` target="${tool.target}"` : "" %>><i class="bi bi-<%- tool.icon %>"></i></a>
   <% } %>
 <% }) %>
 

--- a/src/resources/projects/website/templates/sidebaritem.ejs
+++ b/src/resources/projects/website/templates/sidebaritem.ejs
@@ -3,7 +3,7 @@
 <% if (item.href && item.text && !item.contents) { %>
 <li class="sidebar-item">
   <div class="sidebar-item-container"> 
-  <a href="<%- item.href %>" class="sidebar-item-text sidebar-link<%- item.active ? " active" : "" %>"<%- item.target ? ` target="${item.target}"` : "" %>><% partial('navicon.ejs', { item }) %> <span class="menu-text"><%= item.text %></span></a>
+  <a href="<%- item.href %>" class="sidebar-item-text sidebar-link<%- item.active ? " active" : "" %>"<%= item.rel ? ` rel="${item.rel}"` : "" %><%= item.target ? ` target="${item.target}"` : "" %>><% partial('navicon.ejs', { item }) %> <span class="menu-text"><%= item.text %></span></a>
   </div>
 </li>
 <% } else if (item.contents && item.text) { %>  
@@ -19,7 +19,7 @@
     <% if (item.contents.length > 0) { %>
       <div class="sidebar-item-container"> 
           <% if (item.href) { %>
-            <a href="<%- item.href %>" class="sidebar-item-text sidebar-link<%- item.active ? " active" : "" %>"<%- item.target ? ` target="${item.target}"` : "" %>><% partial('navicon.ejs', { item }) %> <span class="menu-text"><%= item.text %></span></a>
+            <a href="<%- item.href %>" class="sidebar-item-text sidebar-link<%- item.active ? " active" : "" %>"<%= item.rel ? ` rel="${item.rel}"` : "" %><%= item.target ? ` target="${item.target}"` : "" %>><% partial('navicon.ejs', { item }) %> <span class="menu-text"><%= item.text %></span></a>
           <% } else { %> 
             <a class="sidebar-item-text sidebar-link text-start<%- isCollapsed ? " collapsed" : "" %>" data-bs-toggle="collapse" data-bs-target="#<%- sectionId %>"  role="navigation" aria-expanded="<%- isCollapsed ? "false" : "true" %>"><% partial('navicon.ejs', { item }) %> <span class="menu-text"><%= item.text %></span></a>
           <% }  %>      

--- a/tests/docs/smoke-all/2024/06/12/9969/.gitignore
+++ b/tests/docs/smoke-all/2024/06/12/9969/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+_site

--- a/tests/docs/smoke-all/2024/06/12/9969/_quarto.yml
+++ b/tests/docs/smoke-all/2024/06/12/9969/_quarto.yml
@@ -1,0 +1,26 @@
+project:
+  type: website
+
+website:
+  title: "Sidebar-target"
+  navbar:
+    left:
+      - href: index.qmd
+        text: Home
+  sidebar:
+    contents:
+      - href: https://quarto.org
+        target: _blank
+        rel: external
+        text: Quarto website
+      - text: PRERELEASE
+        href: https://prerelease.quarto.org
+        target: _blank
+        rel: external
+        contents:
+          - href: https://prerelease.quarto.org
+            target: _blank
+            rel: external
+            text: Quarto prerelease website
+
+format: html

--- a/tests/docs/smoke-all/2024/06/12/9969/index.qmd
+++ b/tests/docs/smoke-all/2024/06/12/9969/index.qmd
@@ -1,0 +1,18 @@
+---
+title: "Sidebar-target"
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - 
+          - 'nav#quarto-sidebar a[target="_blank"].sidebar-link'
+          - 'nav#quarto-sidebar a[rel="external"].sidebar-link'
+        - 
+          - "nav#quarto-sidebar a[target='\"_blank\"']"
+          - "nav#quarto-sidebar a[rel='\"external\"']"
+          - "nav#quarto-sidebar a.sidebar-link:not([rel])"
+---
+
+This is a Quarto website.
+
+To learn more about Quarto websites visit <https://quarto.org/docs/websites>.

--- a/tests/smoke/extensions/extension-render-project.test.ts
+++ b/tests/smoke/extensions/extension-render-project.test.ts
@@ -4,7 +4,7 @@
  * Copyright (C) 2020-2022 Posit Software, PBC
  */
 
-import { docs } from "../../utils.ts";
+import { docs, projectOutputForInput } from "../../utils.ts";
 
 import { basename, dirname, extname, join, relative } from "../../../src/deno_ral/path.ts";
 import { ensureHtmlElements } from "../../verify.ts";
@@ -12,30 +12,12 @@ import { testQuartoCmd } from "../../test.ts";
 import { noErrors } from "../../verify.ts";
 import { existsSync } from "fs/mod.ts";
 
-const siteOutputForInput = (rootDir: string, input: string) => {
-  const dir = join(rootDir, "_site");
-  const stem = basename(input, extname(input));
-
-  const outputPath = join(
-    dir,
-    dirname(relative(rootDir, input)),
-    `${stem}.html`,
-  );
-  const supportPath = join(dir, `site_libs`);
-
-  return {
-    outputPath,
-    supportPath,
-  };
-};
-
 const testRender = (
-  rootDir: string,
   input: string,
   includeSelectors: string[],
   excludeSelectors: string[],
 ) => {
-  const output = siteOutputForInput(rootDir, input);
+  const output = projectOutputForInput(input);
   const verifySel = ensureHtmlElements(
     output.outputPath,
     includeSelectors,
@@ -63,8 +45,7 @@ const rootDir = docs("extensions/project/");
 
 // Render the home page and verify the output
 // contains the extension shortcodes and filter elements
-const rootInput = join(rootDir, "posts/welcome/index.qmd");
-testRender(rootDir, rootInput, [
+testRender(join(rootDir, "posts/welcome/index.qmd"), [
   "a.lightbox",
   "i.fa-solid.fa-anchor",
   "i.fa-solid.fa-bacteria",
@@ -74,7 +55,7 @@ testRender(rootDir, rootInput, [
 // Render the welcome page (subdirectory) and verify the output
 // contains the extension shortcodes and filter elements
 const subdirInput = join(rootDir, "posts/welcome/index.qmd");
-testRender(rootDir, subdirInput, [
+testRender(join(rootDir, "posts/welcome/index.qmd"), [
   "a.lightbox",
   "i.fa-solid.fa-anchor",
   "i.fa-solid.fa-bacteria",

--- a/tests/smoke/jats/render-manuscript.test.ts
+++ b/tests/smoke/jats/render-manuscript.test.ts
@@ -11,7 +11,6 @@ import { ensureMECAValidates, ensureXmlValidatesWithXsd } from "../../verify.ts"
 import { testRender } from "../render/render.ts";
 
 const xsdPath = docs(join("jats", "xsd", "JATS-Archiving-1-2-MathML2-DTD"));
-const projectOutDir = "_manuscript";
 
 const testContext = undefined;
 const args = undefined;
@@ -19,7 +18,7 @@ const args = undefined;
 // Test a basic manuscript render (this will include a sub-notebook which should
 // nonetheless validate)
 const input = docs(join("jats", "manuscript", "index.ipynb"));
-const output = outputForInput(input, "jats", projectOutDir);
+const output = outputForInput(input, "jats");
 const mecaOutput = join(dirname(output.outputPath), "index-meca.zip");
 
 // Test the article and ensure that it validates
@@ -29,6 +28,5 @@ testRender(
   false,
   [ensureXmlValidatesWithXsd(output.outputPath, xsdPath), ensureMECAValidates(mecaOutput)],
   testContext,
-  args,
-  projectOutDir,
+  args
 );

--- a/tests/smoke/project/common.ts
+++ b/tests/smoke/project/common.ts
@@ -21,14 +21,15 @@ export async function cleanWorking() {
 
 export type OutputVerify = (outputDir: string) => Verify[];
 
+// This is similar to testSite.
+// It tests a project render, and allow to verify output directory assertions
 export const testProjectRender = (
   input: string,
   to: string,
-  outputDir: string,
-  outputVerify: OutputVerify
+  outputVerify: OutputVerify = (_outDir: string): Verify[] => [],
 ) => {
 
-  const output = outputForInput(input, to, outputDir);
+  const output = outputForInput(input, to);
   const outDir = dirname(output.outputPath);
   const outVerify = outputVerify(outDir);
 

--- a/tests/smoke/render/render-email.test.ts
+++ b/tests/smoke/render/render-email.test.ts
@@ -38,8 +38,8 @@ testRender(docs("email/email-attach.qmd"), "email", false, [fileExists(previewFi
 // Test an email render that has no subject line, this verifies that `rsc_email_subject` key is present and the value is an empty string
 testRender(docs("email/email-no-subject.qmd"), "email", false, [fileExists(previewFile), validJsonWithFields(jsonFile, {"rsc_email_subject": ""})], cleanupCtx);
 
-// Render in a project with an output directory and confirm that everything ends up in the output directory
-testProjectRender(docs("email/project/email-attach.qmd"), "email", "_out", (outputDir: string) => {
+// Render in a project with an output directory set in _quarto.yml and confirm that everything ends up in the output directory
+testProjectRender(docs("email/project/email-attach.qmd"), "email", (outputDir: string) => {
   const verify: Verify[]= [];
   const json = join(outputDir, ".output_metadata.json");
   const preview = join(outputDir, "email-preview", "index.html");

--- a/tests/smoke/render/render.ts
+++ b/tests/smoke/render/render.ts
@@ -80,10 +80,11 @@ export function cleanoutput(
   input: string, 
   to: string, 
   projectOutDir?: string,
+  projectRoot?: string,
   // deno-lint-ignore no-explicit-any
   metadata?: Record<string, any>,
 ) {
-  const out = outputForInput(input, to, projectOutDir, metadata);
+  const out = outputForInput(input, to, projectOutDir, projectRoot, metadata);
   if (safeExistsSync(out.outputPath)) {
     safeRemoveSync(out.outputPath);
   }

--- a/tests/smoke/site/render-navbar-tools-rel.test.ts
+++ b/tests/smoke/site/render-navbar-tools-rel.test.ts
@@ -3,17 +3,17 @@
  *
  * Copyright (C) 2020-2022 Posit Software, PBC
  */
-import { docs, siteOutputForInput } from "../../utils.ts";
+import { docs, projectOutputForInput } from "../../utils.ts";
 import { ensureFileRegexMatches } from "../../verify.ts";
 import { testSite } from "./site.ts";
 
 testSite(
   docs("websites/issue-5756/index.qmd"),
-  docs("websites/issue-5756/index.qmd"),
+  docs("websites/issue-5756"),
   [],
   [],
   ensureFileRegexMatches(
-    siteOutputForInput(docs("websites/issue-5756/index.qmd"))
+    projectOutputForInput(docs("websites/issue-5756/index.qmd"))
       .outputPath,
     ['rel="me"'],
     [],

--- a/tests/smoke/site/render-shortcode-navbar.test.ts
+++ b/tests/smoke/site/render-shortcode-navbar.test.ts
@@ -4,7 +4,7 @@
 * Copyright (C) 2020-2022 Posit Software, PBC
 *
 */
-import { docs, siteOutputForInput } from "../../utils.ts";
+import { docs, projectOutputForInput } from "../../utils.ts";
 import { ensureFileRegexMatches } from "../../verify.ts";
 import { testSite } from "./site.ts";
 
@@ -14,7 +14,7 @@ testSite(
   [],
   [],
   ensureFileRegexMatches(
-    siteOutputForInput(docs("websites/issue-3686/index.qmd"))
+    projectOutputForInput(docs("websites/issue-3686/index.qmd"))
       .outputPath,
     [],
     [/\{\{\&lt\;/, /\&gt\;\}\}/],

--- a/tests/smoke/site/site.ts
+++ b/tests/smoke/site/site.ts
@@ -6,7 +6,7 @@
 import { existsSync } from "fs/mod.ts";
 import { dirname } from "../../../src/deno_ral/path.ts";
 import { testQuartoCmd, Verify } from "../../test.ts";
-import { siteOutputForInput } from "../../utils.ts";
+import { projectOutputForInput } from "../../utils.ts";
 import { ensureHtmlElements, noErrorsOrWarnings } from "../../verify.ts";
 
 export const testSite = (
@@ -16,7 +16,7 @@ export const testSite = (
   excludeSelectors: string[],
   ...verify: Verify[]
 ) => {
-  const output = siteOutputForInput(input);
+  const output = projectOutputForInput(input);
 
   const verifySel = ensureHtmlElements(
     output.outputPath,

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -125,8 +125,9 @@ function resolveTestSpecs(
           verifyFns.push(noErrors);
         } else {
           // See if there is a project and grab it's type
-          const projectOutDir = findProjectOutputDir(findSmokeAllProjectDir(input));
-          const outputFile = outputForInput(input, format, projectOutDir, metadata);
+          const projectPath = findSmokeAllProjectDir(input)
+          const projectOutDir = findProjectOutputDir(projectPath);
+          const outputFile = outputForInput(input, format, projectOutDir, projectPath, metadata);
           if (key === "fileExists") {
             for (
               const [path, file] of Object.entries(
@@ -284,7 +285,7 @@ for (const { path: fileName } of files) {
                   return Promise.resolve(true);
                 },
                 teardown: () => {
-                  cleanoutput(input, format, undefined, metadata);
+                  cleanoutput(input, format, undefined, undefined, metadata);
                   testSpecResolve(); // Resolve the promise for the testSpec
                   return Promise.resolve();
                 },

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -60,6 +60,9 @@ export function findProjectOutputDir(projectdir: string | undefined) {
   if (type === "website") {
     return (yaml as any)?.project?.["output-dir"] || "_site";
   }
+  if (type === "manuscript") {
+    return (yaml as any)?.project?.["output-dir"] || "_manuscript";
+  }
 }
 
 // Gets output that should be created for this input file and target format

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -53,7 +53,6 @@ export function findProjectOutputDir(projectdir: string | undefined) {
   } catch (error) {
     throw new Error("Failed to read quarto project YAML", error);
   }
-
   if (type === "book") {
     return "_book";
   }
@@ -63,6 +62,10 @@ export function findProjectOutputDir(projectdir: string | undefined) {
   if (type === "manuscript") {
     return (yaml as any)?.project?.["output-dir"] || "_manuscript";
   }
+  if (type === "default") {
+    return (yaml as any)?.project?.["output-dir"];
+  }
+  return (yaml as any)?.project?.["output-dir"];
 }
 
 // Gets output that should be created for this input file and target format

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -62,10 +62,8 @@ export function findProjectOutputDir(projectdir: string | undefined) {
   if (type === "manuscript") {
     return (yaml as any)?.project?.["output-dir"] || "_manuscript";
   }
-  if (type === "default") {
-    return (yaml as any)?.project?.["output-dir"];
-  }
-  return (yaml as any)?.project?.["output-dir"];
+  // type default explicit or just unset
+  return (yaml as any)?.project?.["output-dir"] || "";
 }
 
 // Gets output that should be created for this input file and target format
@@ -142,10 +140,10 @@ export function outputForInput(
     }
   }
 
-  const outputPath: string = projectRoot && projectOutDir
+  const outputPath: string = projectRoot && projectOutDir !== undefined
       ? join(projectRoot, projectOutDir, dir, `${stem}.${outputExt}`)
       : join(dir, `${stem}.${outputExt}`);
-  const supportPath: string = projectRoot && projectOutDir
+  const supportPath: string = projectRoot && projectOutDir !== undefined
     ? join(projectRoot, projectOutDir, dir, `${stem}_files`)
     : join(dir, `${stem}_files`);
 

--- a/tests/verify.ts
+++ b/tests/verify.ts
@@ -282,14 +282,14 @@ export const ensureHtmlElements = (
   noMatchSelectors?: string[],
 ): Verify => {
   return {
-    name: "Inspecting HTML for Selectors",
+    name: `Inspecting HTML for Selectors in ${file}`,
     verify: async (_output: ExecuteOutput[]) => {
       const htmlInput = await Deno.readTextFile(file);
       const doc = new DOMParser().parseFromString(htmlInput, "text/html")!;
       selectors.forEach((sel) => {
         assert(
           doc.querySelector(sel) !== null,
-          `Required DOM Element ${sel} is missing.`,
+          `Required DOM Element ${sel} is missing in ${file}.`,
         );
       });
 
@@ -297,7 +297,7 @@ export const ensureHtmlElements = (
         noMatchSelectors.forEach((sel) => {
           assert(
             doc.querySelector(sel) === null,
-            `Illegal DOM Element ${sel} is present.`,
+            `Illegal DOM Element ${sel} is present in ${file}.`,
           );
         });
       }


### PR DESCRIPTION
This PR tries to simplify how our project rendering works by improving the project detection for a tested file and the output file path detection to take into account subfolder. 

This solves the test problem at #9595 and once merged, we should see that test will pass. 

Opening this PR to see if any test is beaking due to this change in CI. 

BTW this work has surfaced another bug regaring quoting of `rel` attributes. It seems one has been missed from last time it was being fixed (f356b962eb8551e2748242d7c9bfc8de24acd861) and test was not run because not correctly name. 

I'll check other possible problem with this in our ejs template and add a changelog