### PR TITLE
Use same code as jupyter backend to handle includes and dependencies

### DIFF
--- a/src/execute/jupyter/jupyter.ts
+++ b/src/execute/jupyter/jupyter.ts
@@ -706,7 +706,7 @@ interface JupyterTargetData {
   kernelspec: JupyterKernelspec;
 }
 
-function executeResultIncludes(
+export function executeResultIncludes(
   tempDir: string,
   widgetDependencies?: JupyterWidgetDependencies,
 ): PandocIncludes | undefined {
@@ -728,7 +728,7 @@ function executeResultIncludes(
   }
 }
 
-function executeResultEngineDependencies(
+export function executeResultEngineDependencies(
   widgetDependencies?: JupyterWidgetDependencies,
 ): Array<unknown> | undefined {
   if (widgetDependencies) {


### PR DESCRIPTION
## Description

This PR adds some code to the julia backend that's also found in the jupyter backend which is needed to add includes or dependencies to the output. The need for this arose from https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/129 where I found out that quarto doesn't include certain scripts for julia when using PlotlyJS which it does include for jupyter. This missing code is the reason as far as I could tell (you can see that some of it was commented out before, so I just didn't know what it was needed for when implementing the julia backend).

I just copied this small block of code, it could be factored out if that's desired by the maintainers.

With this PR, I can render a PlotlyJS plot as the requires.js dependency is correctly injected into the html output when Plotly's presence is detected by quarto.

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] updated the appropriate changelog
