### PR TITLE
format-resources needs to use strict globbing.

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -128,6 +128,7 @@ All changes included in 1.5:
 
 - ([#8385](https://github.com/quarto-dev/quarto-cli/issues/8385)): Properly copy project resources when extensions are installed at project level.
 - ([#8547](https://github.com/quarto-dev/quarto-cli/issues/8547)): Support installing extensions from github branch with forward slash in the name.
+- ([#9918](https://github.com/quarto-dev/quarto-cli/issues/9918)): `format-resources` can use explicit [Quarto glob syntax](https://quarto.org/docs/reference/globs.html), e.g. `format-resources: dir/**/*` to copy all files in `dir` and its subdirectories to input root, but use `format-resources: dir` to copy `dir` and its contents to input root.
 - ([#9948](https://github.com/quarto-dev/quarto-cli/issues/9948)): New extension type: `metadata`. Example use case: support `pre-render` and `post-render` script lists in `project` metadata.
 
 ## Shortcodes

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -730,6 +730,7 @@ async function readExtension(
         extensionDir,
         formatMeta[kFormatResources] as string[],
         [],
+        { mode: "strict" },
       );
       if (resolved.include.length > 0) {
         formatMeta[kFormatResources] = resolved.include.map((include) => {

--- a/tests/docs/extensions/format-resources/9918/_extensions/test/_extension.yml
+++ b/tests/docs/extensions/format-resources/9918/_extensions/test/_extension.yml
@@ -1,0 +1,13 @@
+title: Test
+author: Christophe Dervieux
+version: 1.0.0
+quarto-required: ">=1.3"
+contributes:
+  formats:
+    html:
+      format-resources:
+        - folder-to-root
+        - files-to-root/**/*
+        - dummy-4.txt
+    gfm:
+      format-resources: folder-to-root

--- a/tests/docs/extensions/format-resources/9918/_extensions/test/dummy-4.txt
+++ b/tests/docs/extensions/format-resources/9918/_extensions/test/dummy-4.txt
@@ -1,0 +1,1 @@
+This file should be copied to root project for rendering as it is included as a format-resources

--- a/tests/docs/extensions/format-resources/9918/_extensions/test/files-to-root/dummy-2.txt
+++ b/tests/docs/extensions/format-resources/9918/_extensions/test/files-to-root/dummy-2.txt
@@ -1,0 +1,1 @@
+This file should be copied to root project for rendering as it is included as a format-resources

--- a/tests/docs/extensions/format-resources/9918/_extensions/test/files-to-root/dummy-3.txt
+++ b/tests/docs/extensions/format-resources/9918/_extensions/test/files-to-root/dummy-3.txt
@@ -1,0 +1,1 @@
+This file should be copied to root project for rendering as it is included as a format-resources

--- a/tests/docs/extensions/format-resources/9918/_extensions/test/folder-to-root/dummy.txt
+++ b/tests/docs/extensions/format-resources/9918/_extensions/test/folder-to-root/dummy.txt
@@ -1,0 +1,1 @@
+This file should be copied to root project for rendering as it is included as a format-resources

--- a/tests/docs/extensions/format-resources/9918/index.qmd
+++ b/tests/docs/extensions/format-resources/9918/index.qmd
@@ -1,0 +1,9 @@
+---
+title: Untitled
+format:
+  test-html: default
+  test-gfm: default
+---
+
+This document uses a test extension that should include nested resources
+

--- a/tests/smoke/extensions/extension-render-format-resources.test.ts
+++ b/tests/smoke/extensions/extension-render-format-resources.test.ts
@@ -1,0 +1,33 @@
+/*
+* extension-render-doc.test.ts
+*
+* Copyright (C) 2020-2022 Posit Software, PBC
+*
+*/
+
+import { safeRemoveSync } from "../../../src/core/path.ts";
+import { dirname, join } from "../../../src/deno_ral/path.ts";
+import { fileLoader } from "../../utils.ts";
+import { fileExists, folderExists, pathDoNotExists } from "../../verify.ts";
+import { testRender } from "../render/render.ts";
+
+// This file uses custom formats 'test-html' provided by test extension
+const input = fileLoader("extensions/format-resources/9918")("index.qmd", "test-html");
+const rootDir = dirname(input.input)
+const resourcesFile = [
+  join('folder-to-root', 'dummy.txt'),
+  'dummy-2.txt', 'dummy-3.txt', 'dummy-4.txt',
+].map((x) => join(rootDir, x))
+testRender(input.input, "test-html", false, 
+  [
+    folderExists(join(rootDir, "folder-to-root")),
+    ...resourcesFile.map(fileExists),
+    pathDoNotExists(join(rootDir, "dummy.txt")),
+  ],
+  {
+    teardown: () => {
+      resourcesFile.forEach((x) => safeRemoveSync(x));
+      return Promise.resolve();
+    },
+  }
+);

--- a/tests/smoke/render/render.ts
+++ b/tests/smoke/render/render.ts
@@ -68,10 +68,10 @@ export function testRender(
     {
       ...context,
       setup: async () => {
-        assert(safeExistsSync(input), `Input file ${input} does not exist. Test could not be ran.`);
         if (context?.setup) {
           await context?.setup();
         }
+        assert(safeExistsSync(input), `Input file ${input} does not exist. Test could not be ran.`);
       },
       teardown: async () => {
         if (context?.teardown) {

--- a/tests/smoke/render/render.ts
+++ b/tests/smoke/render/render.ts
@@ -17,6 +17,7 @@ import {
 } from "../../verify.ts";
 import { safeRemoveSync } from "../../../src/core/path.ts";
 import { safeExistsSync } from "../../../src/core/path.ts";
+import { assert } from "../../../src/vendor/deno.land/std@0.217.0/assert/assert.ts";
 
 export function testSimpleIsolatedRender(
   file: string,
@@ -66,6 +67,12 @@ export function testRender(
     verify,
     {
       ...context,
+      setup: async () => {
+        assert(safeExistsSync(input), `Input file ${input} does not exist. Test could not be ran.`);
+        if (context?.setup) {
+          await context?.setup();
+        }
+      },
       teardown: async () => {
         if (context?.teardown) {
           await context?.teardown();

--- a/tests/verify.ts
+++ b/tests/verify.ts
@@ -180,6 +180,16 @@ export const fileExists = (file: string): Verify => {
   };
 };
 
+export const pathDoNotExists = (path: string): Verify => {
+  return {
+    name: `path ${path} exists`,
+    verify: (_output: ExecuteOutput[]) => {
+      verifyNoPath(path);
+      return Promise.resolve();
+    },
+  };
+};
+
 export const directoryContainsOnlyAllowedPaths = (dir: string, paths: string[]): Verify => {
   return {
     name: `Ensure only has ${paths.length} paths in folder`,


### PR DESCRIPTION
Fixes #9918 

As explained in there, change done https://github.com/quarto-dev/quarto-cli/commit/7d95eb886f161a4cee5572b49b191ce1b084f3e7 to solve https://github.com/quarto-dev/quarto-cli/issues/6241 have broken some extensions that expected a `folder` to be used as file resource. 

This is supposed to work as this is shown by older example like https://github.com/quarto-dev/quarto-cli/issues/4377 
and because you would expect a format resources to be into folder (for LaTeX template for example). 

So this PR fixes it but allowing Quarto globs but in strict mode, meaning if one want to use globs, they need to ask for it explicitly 
Example 
````yaml
  formats:
    html:
      format-resources:
        - folder-to-root
        - files-to-root/**/*
        - dummy-4.txt
 ````

We need `format-resources` in extension to be able to move a folder and not just its content. And without strict mode, any value passed will be transformed to a smartGlob by adding `**/*` to directory to resolve all the file content. Our format-resources process copy the files to root then.

We want 1.3 behavior here where this copy a folder. 1.4 broke it so this is really a regression, that we could consider backporting

