### PR TITLE
fix(schema/definitions.yml): Giscus light/dark `theme` YAML key is missing

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -228,3 +228,4 @@ All changes included in 1.5:
 - `quarto install tinytex` will now try to set the default CTAN repository to the nearest mirror resolved from https://mirror.ctan.org.
 - `quarto render --to native` now works without triggering rmarkdown error about non HTML output when HTML dependencies are present in the knitr engine cell results.
 - Missing `tabsets` configuration for HTML documents has now been added in the YAML schema for validation and autocompletion. This boolean value controls the inclusion of tabsets in the document (e.g when `minimal: true` is set).
+- ([#10003](https://github.com/quarto-dev/quarto-cli/issues/10003)): fix Giscus light/dark theme YAML example in schema where `theme` is missing.

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -8751,7 +8751,7 @@ var require_yaml_intelligence_resources = __commonJS({
                           ],
                           description: {
                             short: "The giscus theme to use when displaying comments.",
-                            long: "The giscus theme to use when displaying comments. Light and dark themes are supported. If a single theme is provided by name, it will be used as light and dark theme. To use different themes, use `light` and `dark` key: \n\n```yaml\nwebsite:\n  comments:\n    giscus:\n      light: light # giscus theme used for light website theme\n      dark: dark_dimmed # giscus theme used for dark website theme\n```\n"
+                            long: "The giscus theme to use when displaying comments. Light and dark themes are supported. If a single theme is provided by name, it will be used as light and dark theme. To use different themes, use `light` and `dark` key: \n\n```yaml\nwebsite:\n  comments:\n    giscus:\n      theme:\n        light: light # giscus theme used for light website theme\n        dark: dark_dimmed # giscus theme used for dark website theme\n```\n"
                           }
                         },
                         language: {
@@ -21755,6 +21755,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "Enables inclusion of Pandoc default CSS for this document.",
         "One or more CSS style sheets.",
         "Enables hover over a section title to see an anchor link.",
+        "Enables tabsets to present content.",
         "Enables smooth scrolling within the page.",
         {
           short: "Method use to render math in HTML output",
@@ -22826,8 +22827,7 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
         "Manuscript configuration",
-        "internal-schema-hack",
-        "Enables tabsets to present content."
+        "internal-schema-hack"
       ],
       "schema/external-schemas.yml": [
         {
@@ -23056,12 +23056,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 186347,
+        _internalId: 186493,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 186339,
+            _internalId: 186485,
             type: "enum",
             enum: [
               "png",
@@ -23077,7 +23077,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 186346,
+            _internalId: 186492,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -8752,7 +8752,7 @@ try {
                             ],
                             description: {
                               short: "The giscus theme to use when displaying comments.",
-                              long: "The giscus theme to use when displaying comments. Light and dark themes are supported. If a single theme is provided by name, it will be used as light and dark theme. To use different themes, use `light` and `dark` key: \n\n```yaml\nwebsite:\n  comments:\n    giscus:\n      light: light # giscus theme used for light website theme\n      dark: dark_dimmed # giscus theme used for dark website theme\n```\n"
+                              long: "The giscus theme to use when displaying comments. Light and dark themes are supported. If a single theme is provided by name, it will be used as light and dark theme. To use different themes, use `light` and `dark` key: \n\n```yaml\nwebsite:\n  comments:\n    giscus:\n      theme:\n        light: light # giscus theme used for light website theme\n        dark: dark_dimmed # giscus theme used for dark website theme\n```\n"
                             }
                           },
                           language: {
@@ -21756,6 +21756,7 @@ try {
           "Enables inclusion of Pandoc default CSS for this document.",
           "One or more CSS style sheets.",
           "Enables hover over a section title to see an anchor link.",
+          "Enables tabsets to present content.",
           "Enables smooth scrolling within the page.",
           {
             short: "Method use to render math in HTML output",
@@ -22827,8 +22828,7 @@ try {
           },
           "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
           "Manuscript configuration",
-          "internal-schema-hack",
-          "Enables tabsets to present content."
+          "internal-schema-hack"
         ],
         "schema/external-schemas.yml": [
           {
@@ -23057,12 +23057,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 186347,
+          _internalId: 186493,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 186339,
+              _internalId: 186485,
               type: "enum",
               enum: [
                 "png",
@@ -23078,7 +23078,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 186346,
+              _internalId: 186492,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -1723,7 +1723,7 @@
                       ],
                       "description": {
                         "short": "The giscus theme to use when displaying comments.",
-                        "long": "The giscus theme to use when displaying comments. Light and dark themes are supported. If a single theme is provided by name, it will be used as light and dark theme. To use different themes, use `light` and `dark` key: \n\n```yaml\nwebsite:\n  comments:\n    giscus:\n      light: light # giscus theme used for light website theme\n      dark: dark_dimmed # giscus theme used for dark website theme\n```\n"
+                        "long": "The giscus theme to use when displaying comments. Light and dark themes are supported. If a single theme is provided by name, it will be used as light and dark theme. To use different themes, use `light` and `dark` key: \n\n```yaml\nwebsite:\n  comments:\n    giscus:\n      theme:\n        light: light # giscus theme used for light website theme\n        dark: dark_dimmed # giscus theme used for dark website theme\n```\n"
                       }
                     },
                     "language": {
@@ -14727,6 +14727,7 @@
     "Enables inclusion of Pandoc default CSS for this document.",
     "One or more CSS style sheets.",
     "Enables hover over a section title to see an anchor link.",
+    "Enables tabsets to present content.",
     "Enables smooth scrolling within the page.",
     {
       "short": "Method use to render math in HTML output",
@@ -15798,8 +15799,7 @@
     },
     "Disambiguating year suffix in author-date styles (e.g.&nbsp;“a” in “Doe,\n1999a”).",
     "Manuscript configuration",
-    "internal-schema-hack",
-    "Enables tabsets to present content."
+    "internal-schema-hack"
   ],
   "schema/external-schemas.yml": [
     {
@@ -16028,12 +16028,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 186347,
+    "_internalId": 186493,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 186339,
+        "_internalId": 186485,
         "type": "enum",
         "enum": [
           "png",
@@ -16049,7 +16049,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 186346,
+        "_internalId": 186492,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/schema/definitions.yml
+++ b/src/resources/schema/definitions.yml
@@ -315,8 +315,9 @@
                       website:
                         comments:
                           giscus:
-                            light: light # giscus theme used for light website theme
-                            dark: dark_dimmed # giscus theme used for dark website theme
+                            theme:
+                              light: light # giscus theme used for light website theme
+                              dark: dark_dimmed # giscus theme used for dark website theme
                       ```
                 language:
                   string:
@@ -750,7 +751,7 @@
                   description: "Whether this announcement may be dismissed by the user."
                 icon:
                   schema: string
-                  description: 
+                  description:
                     short: "The icon to display in the announcement"
                     long: |
                       Name of bootstrap icon (e.g. `github`, `twitter`, `share`) for the announcement.
@@ -758,7 +759,7 @@
                 position:
                   schema:
                     enum: ["above-navbar", "below-navbar"]
-                  description: 
+                  description:
                     short: "The position of the announcement."
                     long: |
                       The position of the announcement. One of `above-navbar` (default) or `below-navbar`.
@@ -775,7 +776,7 @@
                         light,
                         dark,
                       ]
-                  description: 
+                  description:
                     short: "The type of announcement. Affects the appearance of the announcement."
                     long: |
                       The type of announcement. One of `primary`, `secondary`, `success`, `danger`, `warning`,

--- a/src/resources/types/schema-types.ts
+++ b/src/resources/types/schema-types.ts
@@ -155,8 +155,9 @@ the discussions feature must be enabled. */;
 website:
   comments:
     giscus:
-      light: light # giscus theme used for light website theme
-      dark: dark_dimmed # giscus theme used for dark website theme
+      theme:
+        light: light # giscus theme used for light website theme
+        dark: dark_dimmed # giscus theme used for dark website theme
 ``` */
   };
   hypothesis?: boolean | {


### PR DESCRIPTION
The Giscus light/dark theme yaml example in the documentation is incorrect. This pull request fixes the example by updating the YAML structure to include a `theme` key under `website.comments.giscus`. The `theme` key contains the `light` and `dark` themes for the Giscus comments. This change ensures that the documentation accurately reflects the correct YAML structure for configuring Giscus themes.

Fixes #10003

FYI, `quarto build-js` was not ran for a change related to `"Enables tabsets to present content."`.