### PR TITLE
chore(bug_report.yml): make "quarto check" output mandatory

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -84,7 +84,9 @@ body:
         ```bash
         quarto check
         ```
-  
+      validations:
+        required: true
+
   - type: markdown
     attributes:
       value: "_Thanks for submitting this bug report!_"


### PR DESCRIPTION
A simple addition that should not break anything from a user experience point of view (at least for most users) by blocking posting if the `quarto check` output is not filled as we do frequently have to ask for it.