### PR TITLE
css-property-processing and complete html-pre-tag-processing

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -97,6 +97,8 @@ All changes included in 1.5:
 - ([#9555](https://github.com/quarto-dev/quarto-cli/issues/9555)): Text elements in Typst are internationalized.
 - ([#9887](https://github.com/quarto-dev/quarto-cli/issues/9887)): Use correct supplement for div floats in Typst.
 - ([#9972](https://github.com/quarto-dev/quarto-cli/issues/9972)): Fix crashes with unnumbered sections.
+- ([#9885](https://github.com/quarto-dev/quarto-cli/issues/9885)): Turn off Typst CSS with `css-property-parsing: none`, default `translate`.
+- ([#10055](https://github.com/quarto-dev/quarto-cli/pull/10055)): Enable `html-pre-tag-processing` with a fenced div, disable it in metadata with `none`.
 - ([#10075](https://github.com/quarto-dev/quarto-cli/pull/10075)): Bring `quarto create` templates for Typst up-to-date with the format.
 - Upgrade Typst to 0.11
 - Upgrade the Typst template to draw tables without grid lines by default, in accordance with latest Pandoc.

--- a/src/command/render/filters.ts
+++ b/src/command/render/filters.ts
@@ -24,6 +24,7 @@ import {
   kFormatIdentifier,
   kHeaderIncludes,
   kHtmlMathMethod,
+  kHtmlPreTagProcessing,
   kHtmlTableProcessing,
   kIncludeAfter,
   kIncludeAfterBody,
@@ -895,5 +896,6 @@ const extractTypstFilterParams = (format: Format) => {
   return {
     [kTocIndent]: format.metadata[kTocIndent],
     [kCssPropertyProcessing]: format.metadata[kCssPropertyProcessing],
+    [kHtmlPreTagProcessing]: format.metadata[kHtmlPreTagProcessing],
   };
 };

--- a/src/command/render/filters.ts
+++ b/src/command/render/filters.ts
@@ -15,6 +15,7 @@ import {
   kCodeFold,
   kCodeLineNumbers,
   kCodeSummary,
+  kCssPropertyProcessing,
   kEnableCrossRef,
   kFigAlign,
   kFigEnv,
@@ -893,5 +894,6 @@ async function resolveFilterExtension(
 const extractTypstFilterParams = (format: Format) => {
   return {
     [kTocIndent]: format.metadata[kTocIndent],
+    [kCssPropertyProcessing]: format.metadata[kCssPropertyProcessing],
   };
 };

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -136,6 +136,7 @@ export const kPreviewModeRaw = "raw";
 export const kFontPaths = "font-paths";
 
 export const kHtmlTableProcessing = "html-table-processing";
+export const kHtmlPreTagProcessing = "html-pre-tag-processing";
 export const kCssPropertyProcessing = "css-property-processing";
 export const kUseRsvgConvert = "use-rsvg-convert";
 export const kValidateYaml = "validate-yaml";

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -136,6 +136,7 @@ export const kPreviewModeRaw = "raw";
 export const kFontPaths = "font-paths";
 
 export const kHtmlTableProcessing = "html-table-processing";
+export const kCssPropertyProcessing = "css-property-processing";
 export const kUseRsvgConvert = "use-rsvg-convert";
 export const kValidateYaml = "validate-yaml";
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -92,6 +92,7 @@ import {
   kGladtex,
   kHighlightStyle,
   kHtmlMathMethod,
+  kHtmlPreTagProcessing,
   kHtmlTableProcessing,
   kInclude,
   kIncludeAfterBody,
@@ -486,6 +487,7 @@ export interface FormatRender {
   [kClearCellOptions]?: boolean;
   [kIpynbProduceSourceNotebook]?: boolean;
   [kHtmlTableProcessing]?: "none";
+  [kHtmlPreTagProcessing]?: "none";
   [kCssPropertyProcessing]?: "none" | "translate";
   [kUseRsvgConvert]?: boolean;
   [kValidateYaml]?: boolean;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -56,6 +56,7 @@ import {
   kCrossrefTblTitle,
   kCrossrefThmTitle,
   kCss,
+  kCssPropertyProcessing,
   kDfPrint,
   kDisplayName,
   kDownloadUrl,
@@ -485,6 +486,7 @@ export interface FormatRender {
   [kClearCellOptions]?: boolean;
   [kIpynbProduceSourceNotebook]?: boolean;
   [kHtmlTableProcessing]?: "none";
+  [kCssPropertyProcessing]?: "none" | "translate";
   [kUseRsvgConvert]?: boolean;
   [kValidateYaml]?: boolean;
   [kCanonicalUrl]?: boolean | string;

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -16858,6 +16858,16 @@ var require_yaml_intelligence_resources = __commonJS({
           description: "If `none`, do not process tables in HTML input."
         },
         {
+          name: "html-pre-tag-processing",
+          schema: {
+            enum: [
+              "none",
+              "parse"
+            ]
+          },
+          description: "If `none`, ignore any divs with `html-pre-tag-processing=parse` enabled."
+        },
+        {
           name: "css-property-processing",
           schema: {
             enum: [
@@ -21916,6 +21926,11 @@ var require_yaml_intelligence_resources = __commonJS({
           long: "Specify the default dpi (dots per inch) value for conversion from\npixels to inch/ centimeters and vice versa. (Technically, the correct\nterm would be ppi: pixels per inch.) The default is <code>96</code>.\nWhen images contain information about dpi internally, the encoded value\nis used instead of the default specified by this option."
         },
         "If <code>none</code>, do not process tables in HTML input.",
+        "If <code>none</code>, ignore any divs with\n<code>html-pre-tag-processing=parse</code> enabled.",
+        {
+          short: "CSS property translation",
+          long: "If <code>translate</code>, translate CSS properties into output\nformat properties. If <code>none</code>, do not process css\nproperties."
+        },
         "If <code>true</code>, attempt to use <code>rsvg-convert</code> to\nconvert SVG images to PDF.",
         "Logo image (placed in bottom right corner of slides)",
         {
@@ -22841,11 +22856,7 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
         "Manuscript configuration",
-        "internal-schema-hack",
-        {
-          short: "CSS property translation",
-          long: "If <code>translate</code>, translate CSS properties into output\nformat properties. If <code>none</code>, do not process css\nproperties."
-        }
+        "internal-schema-hack"
       ],
       "schema/external-schemas.yml": [
         {
@@ -23074,12 +23085,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 186496,
+        _internalId: 187067,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 186488,
+            _internalId: 187059,
             type: "enum",
             enum: [
               "png",
@@ -23095,7 +23106,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 186495,
+            _internalId: 187066,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -16858,6 +16858,20 @@ var require_yaml_intelligence_resources = __commonJS({
           description: "If `none`, do not process tables in HTML input."
         },
         {
+          name: "css-property-processing",
+          schema: {
+            enum: [
+              "none",
+              "translate"
+            ]
+          },
+          default: "translate",
+          description: {
+            short: "CSS property translation",
+            long: "If `translate`, translate CSS properties into output format properties. If `none`, do not process css properties."
+          }
+        },
+        {
           name: "use-rsvg-convert",
           schema: "boolean",
           default: true,
@@ -22827,7 +22841,11 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
         "Manuscript configuration",
-        "internal-schema-hack"
+        "internal-schema-hack",
+        {
+          short: "CSS property translation",
+          long: "If <code>translate</code>, translate CSS properties into output\nformat properties. If <code>none</code>, do not process css\nproperties."
+        }
       ],
       "schema/external-schemas.yml": [
         {
@@ -23056,12 +23074,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 186493,
+        _internalId: 186496,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 186485,
+            _internalId: 186488,
             type: "enum",
             enum: [
               "png",
@@ -23077,7 +23095,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 186492,
+            _internalId: 186495,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -16859,6 +16859,16 @@ try {
             description: "If `none`, do not process tables in HTML input."
           },
           {
+            name: "html-pre-tag-processing",
+            schema: {
+              enum: [
+                "none",
+                "parse"
+              ]
+            },
+            description: "If `none`, ignore any divs with `html-pre-tag-processing=parse` enabled."
+          },
+          {
             name: "css-property-processing",
             schema: {
               enum: [
@@ -21917,6 +21927,11 @@ try {
             long: "Specify the default dpi (dots per inch) value for conversion from\npixels to inch/ centimeters and vice versa. (Technically, the correct\nterm would be ppi: pixels per inch.) The default is <code>96</code>.\nWhen images contain information about dpi internally, the encoded value\nis used instead of the default specified by this option."
           },
           "If <code>none</code>, do not process tables in HTML input.",
+          "If <code>none</code>, ignore any divs with\n<code>html-pre-tag-processing=parse</code> enabled.",
+          {
+            short: "CSS property translation",
+            long: "If <code>translate</code>, translate CSS properties into output\nformat properties. If <code>none</code>, do not process css\nproperties."
+          },
           "If <code>true</code>, attempt to use <code>rsvg-convert</code> to\nconvert SVG images to PDF.",
           "Logo image (placed in bottom right corner of slides)",
           {
@@ -22842,11 +22857,7 @@ try {
           },
           "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
           "Manuscript configuration",
-          "internal-schema-hack",
-          {
-            short: "CSS property translation",
-            long: "If <code>translate</code>, translate CSS properties into output\nformat properties. If <code>none</code>, do not process css\nproperties."
-          }
+          "internal-schema-hack"
         ],
         "schema/external-schemas.yml": [
           {
@@ -23075,12 +23086,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 186496,
+          _internalId: 187067,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 186488,
+              _internalId: 187059,
               type: "enum",
               enum: [
                 "png",
@@ -23096,7 +23107,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 186495,
+              _internalId: 187066,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -16859,6 +16859,20 @@ try {
             description: "If `none`, do not process tables in HTML input."
           },
           {
+            name: "css-property-processing",
+            schema: {
+              enum: [
+                "none",
+                "translate"
+              ]
+            },
+            default: "translate",
+            description: {
+              short: "CSS property translation",
+              long: "If `translate`, translate CSS properties into output format properties. If `none`, do not process css properties."
+            }
+          },
+          {
             name: "use-rsvg-convert",
             schema: "boolean",
             default: true,
@@ -22828,7 +22842,11 @@ try {
           },
           "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
           "Manuscript configuration",
-          "internal-schema-hack"
+          "internal-schema-hack",
+          {
+            short: "CSS property translation",
+            long: "If <code>translate</code>, translate CSS properties into output\nformat properties. If <code>none</code>, do not process css\nproperties."
+          }
         ],
         "schema/external-schemas.yml": [
           {
@@ -23057,12 +23075,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 186493,
+          _internalId: 186496,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 186485,
+              _internalId: 186488,
               type: "enum",
               enum: [
                 "png",
@@ -23078,7 +23096,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 186492,
+              _internalId: 186495,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -9830,6 +9830,20 @@
       "description": "If `none`, do not process tables in HTML input."
     },
     {
+      "name": "css-property-processing",
+      "schema": {
+        "enum": [
+          "none",
+          "translate"
+        ]
+      },
+      "default": "translate",
+      "description": {
+        "short": "CSS property translation",
+        "long": "If `translate`, translate CSS properties into output format properties. If `none`, do not process css properties."
+      }
+    },
+    {
       "name": "use-rsvg-convert",
       "schema": "boolean",
       "default": true,
@@ -15799,7 +15813,11 @@
     },
     "Disambiguating year suffix in author-date styles (e.g.&nbsp;“a” in “Doe,\n1999a”).",
     "Manuscript configuration",
-    "internal-schema-hack"
+    "internal-schema-hack",
+    {
+      "short": "CSS property translation",
+      "long": "If <code>translate</code>, translate CSS properties into output\nformat properties. If <code>none</code>, do not process css\nproperties."
+    }
   ],
   "schema/external-schemas.yml": [
     {
@@ -16028,12 +16046,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 186493,
+    "_internalId": 186496,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 186485,
+        "_internalId": 186488,
         "type": "enum",
         "enum": [
           "png",
@@ -16049,7 +16067,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 186492,
+        "_internalId": 186495,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -9830,6 +9830,16 @@
       "description": "If `none`, do not process tables in HTML input."
     },
     {
+      "name": "html-pre-tag-processing",
+      "schema": {
+        "enum": [
+          "none",
+          "parse"
+        ]
+      },
+      "description": "If `none`, ignore any divs with `html-pre-tag-processing=parse` enabled."
+    },
+    {
       "name": "css-property-processing",
       "schema": {
         "enum": [
@@ -14888,6 +14898,11 @@
       "long": "Specify the default dpi (dots per inch) value for conversion from\npixels to inch/ centimeters and vice versa. (Technically, the correct\nterm would be ppi: pixels per inch.) The default is <code>96</code>.\nWhen images contain information about dpi internally, the encoded value\nis used instead of the default specified by this option."
     },
     "If <code>none</code>, do not process tables in HTML input.",
+    "If <code>none</code>, ignore any divs with\n<code>html-pre-tag-processing=parse</code> enabled.",
+    {
+      "short": "CSS property translation",
+      "long": "If <code>translate</code>, translate CSS properties into output\nformat properties. If <code>none</code>, do not process css\nproperties."
+    },
     "If <code>true</code>, attempt to use <code>rsvg-convert</code> to\nconvert SVG images to PDF.",
     "Logo image (placed in bottom right corner of slides)",
     {
@@ -15813,11 +15828,7 @@
     },
     "Disambiguating year suffix in author-date styles (e.g.&nbsp;“a” in “Doe,\n1999a”).",
     "Manuscript configuration",
-    "internal-schema-hack",
-    {
-      "short": "CSS property translation",
-      "long": "If <code>translate</code>, translate CSS properties into output\nformat properties. If <code>none</code>, do not process css\nproperties."
-    }
+    "internal-schema-hack"
   ],
   "schema/external-schemas.yml": [
     {
@@ -16046,12 +16057,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 186496,
+    "_internalId": 187067,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 186488,
+        "_internalId": 187059,
         "type": "enum",
         "enum": [
           "png",
@@ -16067,7 +16078,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 186495,
+        "_internalId": 187066,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/filters/modules/constants.lua
+++ b/src/resources/filters/modules/constants.lua
@@ -68,6 +68,7 @@ local kCopyright = "copyright"
 local kLicense = "license"
 local kHtmlTableProcessing = "html-table-processing"
 local kHtmlPreTagProcessing = "html-pre-tag-processing"
+local kCssPropertyProcessing = "css-property-processing"
 
 -- for a given language, the comment character(s)
 local kLangCommentChars = {
@@ -224,6 +225,7 @@ return {
   kDefaultCodeAnnotationComment = kDefaultCodeAnnotationComment,
   kHtmlTableProcessing = kHtmlTableProcessing,
   kHtmlPreTagProcessing = kHtmlPreTagProcessing,
+  kCssPropertyProcessing = kCssPropertyProcessing,
 
   kColorUnknown = kColorUnknown,
   kColorNote = kColorNote,

--- a/src/resources/filters/normalize/parsehtml.lua
+++ b/src/resources/filters/normalize/parsehtml.lua
@@ -247,17 +247,19 @@ function parse_html_tables()
   end
 
   local filter
+  local disable_html_table_processing = false
+  local disable_html_pre_tag_processing = false
   if param(constants.kHtmlTableProcessing) == "none" then
-    return {}
+    disable_html_table_processing = true
   end
   if param(constants.kHtmlPreTagProcessing) == "none" then
-    return {}
+    disable_html_pre_tag_processing = true
   end
 
   filter = {
     traverse = "topdown",
     Div = function(div)
-      if div.attributes[constants.kHtmlTableProcessing] then
+      if div.attributes[constants.kHtmlTableProcessing] and not disable_html_table_processing then
         -- catch and remove attributes
         local htmlTableProcessing = div.attributes[constants.kHtmlTableProcessing]
         div.attributes[constants.kHtmlTableProcessing] = nil
@@ -271,7 +273,7 @@ function parse_html_tables()
           end
         end
       end
-      if div.attributes[constants.kHtmlPreTagProcessing] then
+      if div.attributes[constants.kHtmlPreTagProcessing] and not disable_html_pre_tag_processing then
         local htmlPreTagProcessing = div.attributes[constants.kHtmlPreTagProcessing]
         if htmlPreTagProcessing == "parse" then
           local pre_tag = quarto.utils.match('Div/[1]/RawBlock')(div)
@@ -282,7 +284,7 @@ function parse_html_tables()
       end
     end,
     RawBlock = function(el)
-      if not should_handle_raw_html_as_table(el) then
+      if not should_handle_raw_html_as_table(el) or disable_html_table_processing then
         return nil
       end
       return handle_raw_html_as_table(el)

--- a/src/resources/filters/quarto-post/typst-css-to-props.lua
+++ b/src/resources/filters/quarto-post/typst-css-to-props.lua
@@ -1,5 +1,8 @@
+local constants = require("modules/constants")
+
 function render_typst_css_to_props()
-  if not _quarto.format.isTypstOutput() then
+  if not _quarto.format.isTypstOutput() or
+    param(constants.kCssPropertyProcessing, 'translate') ~= 'translate' then
     return {}
   end
 

--- a/src/resources/schema/document-render.yml
+++ b/src/resources/schema/document-render.yml
@@ -215,6 +215,14 @@
     enum: [none]
   description: If `none`, do not process tables in HTML input.
 
+- name: css-property-processing
+  schema:
+    enum: [none, translate]
+  default: translate
+  description:
+    short: CSS property translation
+    long: If `translate`, translate CSS properties into output format properties. If `none`, do not process css properties.
+
 - name: use-rsvg-convert
   schema: boolean
   default: true

--- a/src/resources/schema/document-render.yml
+++ b/src/resources/schema/document-render.yml
@@ -215,6 +215,11 @@
     enum: [none]
   description: If `none`, do not process tables in HTML input.
 
+- name: html-pre-tag-processing
+  schema:
+    enum: [none, parse]
+  description: If `none`, ignore any divs with `html-pre-tag-processing=parse` enabled.
+
 - name: css-property-processing
   schema:
     enum: [none, translate]

--- a/tests/docs/smoke-all/typst/css-property-processing/default.qmd
+++ b/tests/docs/smoke-all/typst/css-property-processing/default.qmd
@@ -1,0 +1,18 @@
+---
+format: typst
+keep-typ: true
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - '\[#set text\(fill: rgb\(255, 0, 255\)\); B\]'
+        - []
+---
+
+```{=html}
+<table>
+    <tr><td>A</td><td style="color: magenta;">B</td></tr>
+</table>
+```
+

--- a/tests/docs/smoke-all/typst/css-property-processing/none.qmd
+++ b/tests/docs/smoke-all/typst/css-property-processing/none.qmd
@@ -1,0 +1,19 @@
+---
+format:
+  typst:
+    css-property-processing: none
+keep-typ: true
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+        - ['\[B\]']
+        - ['rgb\(255, 0, 255\)']
+---
+
+```{=html}
+<table>
+    <tr><td>A</td><td style="color: magenta;">B</td></tr>
+</table>
+```
+

--- a/tests/docs/smoke-all/typst/css-property-processing/translate.qmd
+++ b/tests/docs/smoke-all/typst/css-property-processing/translate.qmd
@@ -1,0 +1,20 @@
+---
+format:
+  typst:
+    css-property-processing: translate
+keep-typ: true
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - '\[#set text\(fill: rgb\(255, 0, 255\)\); B\]'
+        - []
+---
+
+```{=html}
+<table>
+    <tr><td>A</td><td style="color: magenta;">B</td></tr>
+</table>
+```
+


### PR DESCRIPTION
Fixes #9885 

Also provides support for `html-pre-tag-processing` in the metadata, and corrects a bug where `html-pre-tag-processing` and `html-table-processing` would interfere.

I couldn't figure out how to document/schematize `html-pre-tag-processing` when used on a fenced div. Hopefully that's the last loose end for these related features.