### PR TITLE
ci(bug_report.yml): fix indent

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -84,8 +84,8 @@ body:
         ```bash
         quarto check
         ```
-      validations:
-        required: true
+    validations:
+      required: true
 
   - type: markdown
     attributes:


### PR DESCRIPTION
The `validations` key was not indented properly as it was under `attributes`.