### PR TITLE
gfm - use mathjax in HTML preview

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -41,6 +41,7 @@ All changes included in 1.5:
 
 ## GFM Format
 
+- ([#8283](https://github.com/quarto-dev/quarto-cli/issues/8283)): Maths are rendered using Mathjax in the HTML preview of a `format: gfm` document.
 - ([#9507](https://github.com/quarto-dev/quarto-cli/issues/9507)): Add support for rendering `FloatRefTarget` elements in `gfm` format.
 
 ## Powerpoint Format

--- a/src/preview/preview-text.ts
+++ b/src/preview/preview-text.ts
@@ -240,6 +240,8 @@ async function gfmPreview(file: string, request: Request) {
       cmd.push("--highlight-style");
       cmd.push(highlightPath);
     }
+    // Github renders math with MathJax now, so our preview mode does the same
+    cmd.push("--mathjax");
     const result = await execProcess(
       { cmd, stdout: "piped", stderr: "piped" },
       Deno.readTextFileSync(file),


### PR DESCRIPTION
which is coherent with  Github now rendering maths in GFM using mathjax. So preview should be better aligned with end result on Github.

Closes #8283 

@cscheid I am not sure how to add test for the HTML preview generated. This will be in a Temp directory 
https://github.com/quarto-dev/quarto-cli/blob/4120e0970acccfb48d9618048d4a2079f01dc001/src/preview/preview-text.ts#L167-L168

So not sure I can access it easily to test the content; 

Anyhow, I think this is safe enough with low impact so we may be good without test on this. 