### PR TITLE
Ignore code-link in Shiny document

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -47,6 +47,10 @@ All changes included in 1.5:
 
 - ([#9680](https://github.com/quarto-dev/quarto-cli/issues/9680), [#9681](https://github.com/quarto-dev/quarto-cli/issues/9681)): Fix issues with HTML tables parsed by Quarto when converting to powerpoint presentations.
 
+## Interactive Document
+
+- ([#9208](https://github.com/quarto-dev/quarto-cli/issues/9208)): `code-link` is ignored in `engine: knitr` interactive documents with `server: shiny`. This is because of a limitation from R package **downlit** when processing shiny pre-rendered document.
+
 ## Website
 
 - ([#6779](https://github.com/quarto-dev/quarto-cli/issues/6779)): Add support for `logo-href` and `logo-alt` in `sidebar` (books and websites)

--- a/src/execute/rmd.ts
+++ b/src/execute/rmd.ts
@@ -16,6 +16,7 @@ import { readYamlFromMarkdown } from "../core/yaml.ts";
 import { partitionMarkdown } from "../core/pandoc/pandoc-partition.ts";
 
 import { kCodeLink } from "../config/constants.ts";
+import { isServerShiny } from "../core/render.ts";
 
 import {
   checkRBinary,
@@ -179,6 +180,15 @@ export const knitrEngine: ExecutionEngine = {
 
     // see if we can code link
     if (options.format.render?.[kCodeLink]) {
+      // When using shiny document, code-link proceesing is not supported
+      // https://github.com/quarto-dev/quarto-cli/issues/9208
+      if (isServerShiny(options.format)) {
+        warning(
+          `'code-link' option will be ignored as it is not supported for 'server: shiny' due to 'downlit' R package limitation (https://github.com/quarto-dev/quarto-cli/issues/9208).`,
+        );
+        return Promise.resolve();
+      }
+      // Current knitr engine postprocess is all about applying downlit processing to the HTML output
       await callR<void>(
         "postprocess",
         {

--- a/tests/docs/smoke-all/2024/06/19/9208.qmd
+++ b/tests/docs/smoke-all/2024/06/19/9208.qmd
@@ -1,0 +1,31 @@
+---
+title: shiny code-link
+format: html
+code-link: true
+server: shiny
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      printsMessage:
+        - WARN
+        - 'code-link.*ignored'
+      ensureHtmlElements:
+        - []
+        - ['pre.downlit']
+---
+
+```{r}
+sliderInput("bins", "Number of bins:", 
+            min = 1, max = 50, value = 30)
+plotOutput("distPlot")
+```
+
+```{r}
+#| context: server
+output$distPlot <- renderPlot({
+  x <- faithful[, 2]  # Old Faithful Geyser data
+  bins <- seq(min(x), max(x), length.out = input$bins + 1)
+  hist(x, breaks = bins, col = 'darkgray', border = 'white')
+})
+```

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -33,6 +33,7 @@ import {
   ensurePptxLayout,
   ensurePptxMaxSlides,
   ensureLatexFileRegexMatches,
+  printsMessage,
 } from "../verify.ts";
 import { readYamlFromMarkdown } from "../../src/core/yaml.ts";
 import { findProjectDir, findProjectOutputDir, outputForInput } from "../utils.ts";
@@ -109,7 +110,8 @@ function resolveTestSpecs(
     ensurePptxXpath,
     ensurePptxLayout,
     ensurePptxMaxSlides,
-    ensureSnapshotMatches
+    ensureSnapshotMatches,
+    printsMessage
   };
 
   for (const [format, testObj] of Object.entries(specs)) {
@@ -153,6 +155,8 @@ function resolveTestSpecs(
             } else {
               verifyFns.push(verifyMap[key](outputFile.outputPath, ...value));
             }
+          } else if (key === "printsMessage") {
+            verifyFns.push(verifyMap[key](...value));
           } else if (verifyMap[key]) {
             // FIXME: We should find another way that having this requirement of keep-* in the metadata
             if (key === "ensureTypstFileRegexMatches") {

--- a/tests/verify.ts
+++ b/tests/verify.ts
@@ -134,12 +134,15 @@ export const noErrorsOrWarnings: Verify = {
 };
 
 export const printsMessage = (
-  level: "DEBUG" | "INFO" | "WARNING" | "ERROR",
-  regex: RegExp,
+  level: "DEBUG" | "INFO" | "WARN" | "ERROR",
+  regex: RegExp | string,
 ): Verify => {
   return {
     name: `${level} matches ${String(regex)}`,
     verify: (outputs: ExecuteOutput[]) => {
+      if (typeof regex === "string") {
+        regex = new RegExp(regex);
+      }
       const printedMessage = outputs.some((output) => {
         return output.levelName === level && output.msg.match(regex);
       });


### PR DESCRIPTION
As this is not supported due to some current downlit limitations

See #9208 

It does not solve the issue but avoid an undesired error by just ignoring with a warning. 
