### PR TITLE
docs: Improve issue/discussion templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -28,7 +28,11 @@ body:
         print("Hello, world!")
         ```
 
-        ![A placeholder image](https://placehold.co/600x400.png)
+        ![An image]({{< placeholder 600 400 >}}){#fig-placeholder}
+
+        {{< lipsum 1 >}}
+
+        A reference to @fig-placeholder.
 
         The end.
         ````
@@ -49,16 +53,31 @@ body:
       placeholder: |
         You can include Quarto document code which includes code blocks like this:
 
+        `````md
         ````qmd
         ---
-        title: "Hello Quarto!"
+        title: "Reproducible Quarto Document"
         format: html
+        engine: jupyter
         ---
 
-        ```py
-        print("Hello Quarto!")
+        This is a reproducible Quarto document using `format: html`.
+        It is written in Markdown and contains embedded Python code.
+        When you run the code, it will produce a message.
+
+        ```{python}
+        print("Hello, world!")
         ```
+
+        ![An image]({{< placeholder 600 400 >}}){#fig-placeholder}
+
+        {{< lipsum 1 >}}
+
+        A reference to @fig-placeholder.
+
+        The end.
         ````
+        `````
 
         ---
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,6 +27,7 @@ body:
         ---
 
         You can share a Quarto document using the following syntax, _i.e._, using more backticks than you have in your document (usually four ` ```` `).
+        For example with Quarto CLI >=1.5:
 
         `````md
         ````qmd

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,8 +26,7 @@ body:
 
         ---
 
-        Finally, try to describe the best you can what you want to achieve or what is your issue, especially by providing a complete self-contained reproducible example (consider reading our ["Bug Reports" guide](https://quarto.org/bug-reports.html)).
-        This will help us to understand your question and answer it.
+        You can share a Quarto document using the following syntax, _i.e._, using more backticks than you have in your document (usually four ` ```` `).
 
         `````md
         ````qmd

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
         We are always happy to hear feedback from our users.
 
         This is the repository for the command-line program `quarto`:
-        
+
         - If you're reporting an issue with the VS Code extension, please visit https://github.com/quarto-dev/quarto
         - If you're reporting an issue inside RStudio, please visit https://github.com/rstudio/rstudio
 
@@ -23,6 +23,37 @@ body:
         If you want to ask for help, please use the [Q&A GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/q-a).
 
         Thank you for using Quarto!
+
+        ---
+
+        Finally, try to describe the best you can what you want to achieve or what is your issue, especially by providing a complete self-contained reproducible example (consider reading our ["Bug Reports" guide](https://quarto.org/bug-reports.html)).
+        This will help us to understand your question and answer it.
+
+        `````md
+        ````qmd
+        ---
+        title: "Reproducible Quarto Document"
+        format: html
+        engine: jupyter
+        ---
+
+        This is a reproducible Quarto document using `format: html`.
+        It is written in Markdown and contains embedded Python code.
+        When you run the code, it will produce a message.
+
+        ```{python}
+        print("Hello, world!")
+        ```
+
+        ![An image]({{< placeholder 600 400 >}}){#fig-placeholder}
+
+        {{< lipsum 1 >}}
+
+        A reference to @fig-placeholder.
+
+        The end.
+        ````
+        `````
 
   - type: textarea
     attributes:
@@ -39,22 +70,31 @@ body:
       placeholder: |
         You can share a Quarto document using the following syntax, _i.e._, using more backticks than you have in your document (usually four ` ```` `).
 
+        `````md
         ````qmd
         ---
         title: "Reproducible Quarto Document"
         format: html
+        engine: jupyter
         ---
 
         This is a reproducible Quarto document using `format: html`.
-        It is written in Markdown and contains embedded R code.
-        When you run the code, it will produce a plot.
+        It is written in Markdown and contains embedded Python code.
+        When you run the code, it will produce a message.
 
-        ```{r}
-        plot(cars)
+        ```{python}
+        print("Hello, world!")
         ```
+
+        ![An image]({{< placeholder 600 400 >}}){#fig-placeholder}
+
+        {{< lipsum 1 >}}
+
+        A reference to @fig-placeholder.
 
         The end.
         ````
+        `````
 
   - type: textarea
     attributes:


### PR DESCRIPTION
This pull request improves the reprex in the issue/discussion templates.
It updates the example to use Quarto 1.5  placeholder/lipsum shortcodes.

For the issue template, the example of a reproducible example is also place in the markdown header in addition to the text area placeholder.
This should improve discoverability.

PR to be merged upon 1.5 release.