### PR TITLE
update create extension format:typst templates

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -97,6 +97,7 @@ All changes included in 1.5:
 - ([#9555](https://github.com/quarto-dev/quarto-cli/issues/9555)): Text elements in Typst are internationalized.
 - ([#9887](https://github.com/quarto-dev/quarto-cli/issues/9887)): Use correct supplement for div floats in Typst.
 - ([#9972](https://github.com/quarto-dev/quarto-cli/issues/9972)): Fix crashes with unnumbered sections.
+- ([#10075](https://github.com/quarto-dev/quarto-cli/pull/10075)): Bring `quarto create` templates for Typst up-to-date with the format.
 - Upgrade Typst to 0.11
 - Upgrade the Typst template to draw tables without grid lines by default, in accordance with latest Pandoc.
 

--- a/src/resources/create/extensions/format-typst/_extensions/qstart-filesafename-qend/typst-show.typ
+++ b/src/resources/create/extensions/format-typst/_extensions/qstart-filesafename-qend/typst-show.typ
@@ -57,6 +57,13 @@ $endif$
 $if(toc)$
   toc: $toc$,
 $endif$
+$if(toc-title)$
+  toc_title: [$toc-title$],
+$endif$
+$if(toc-indent)$
+  toc_indent: $toc-indent$,
+$endif$
+  toc_depth: $toc-depth$,
   cols: $if(columns)$$columns$$else$1$endif$,
   doc,
 )

--- a/src/resources/create/extensions/format-typst/_extensions/qstart-filesafename-qend/typst-template.typ
+++ b/src/resources/create/extensions/format-typst/_extensions/qstart-filesafename-qend/typst-template.typ
@@ -10,6 +10,7 @@
 //   - https://typst.app/docs/tutorial/making-a-template/
 //   - https://github.com/typst/templates
 
+
 #let article(
   title: none,
   authors: none,
@@ -24,6 +25,9 @@
   fontsize: 11pt,
   sectionnumbering: none,
   toc: false,
+  toc_title: none,
+  toc_depth: none,
+  toc_indent: 1.5em,
   doc,
 ) = {
   set page(
@@ -68,15 +72,21 @@
 
   if abstract != none {
     block(inset: 2em)[
-    #text(weight: "semibold")[Abstract] #h(1em) #abstract
+    #text(weight: "semibold")[$labels.abstract$] #h(1em) #abstract
     ]
   }
 
   if toc {
+    let title = if toc_title == none {
+      auto
+    } else {
+      toc_title
+    }
     block(above: 0em, below: 2em)[
     #outline(
-      title: auto,
-      depth: none
+      title: toc_title,
+      depth: toc_depth,
+      indent: toc_indent
     );
     ]
   }
@@ -87,3 +97,8 @@
     columns(cols, doc)
   }
 }
+
+#set table(
+  inset: 6pt,
+  stroke: none
+)


### PR DESCRIPTION
fixes #10065

Content copied from `src/resources/formats/typst/pandoc/quarto`

We'd prefer to generate this, but fix it manually for now.

Note this also contains 

* toc updates from 2f23c19
* i18n

in addition to the Pandoc table stroke/inset changes.
