### PR TITLE
latex - handle `fig-align` attributes on captionless images

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -26,6 +26,7 @@ All changes included in 1.5:
 - ([#9729](https://github.com/quarto-dev/quarto-cli/issues/9729)): Fix performance issue with Lua pattern matching and multiple capture groups.
 - ([#9892](https://github.com/quarto-dev/quarto-cli/issues/9892)): Add more line breaks after Pandoc template partial inclusions cf. [#7273](https://github.com/quarto-dev/quarto-cli/issues/7293) to avoid partials themselves requiring additional linebreaks.
 - ([#9944](https://github.com/quarto-dev/quarto-cli/issues/9944)): Fix issue with `lst-` crossrefs, `filename` attributes, and syntax highlighting.
+- ([#10091](https://github.com/quarto-dev/quarto-cli/issues/10091)): Fix regression with `fig-align` attributes in captionless images.
 
 ## RevealJS Format
 

--- a/src/resources/filters/quarto-post/latex.lua
+++ b/src/resources/filters/quarto-post/latex.lua
@@ -320,12 +320,25 @@ function render_latex()
         return nil
       end
       img.attributes[kFigAlign] = nil
-      -- \\centering doesn't work consistently here...
-      return pandoc.Inlines({
-        pandoc.RawInline('latex', '\\begin{center}\n'),
-        img,
-        pandoc.RawInline('latex', '\n\\end{center}\n')
-      })
+
+      if align == "left" then
+        return pandoc.Inlines({
+          img,
+          pandoc.RawInline('latex', '\\hfill\n'),
+        })
+      elseif align == "right" then
+        return pandoc.Inlines({
+          pandoc.RawInline('latex', '\\hfill\n'),
+          img,
+        })
+      else
+        -- \\centering doesn't work consistently here...
+        return pandoc.Inlines({
+          pandoc.RawInline('latex', '\\begin{center}\n'),
+          img,
+          pandoc.RawInline('latex', '\n\\end{center}\n')
+        })
+      end
     end,
     Callout = function(node)
       -- read and clear attributes

--- a/tests/docs/smoke-all/2024/06/21/10091.qmd
+++ b/tests/docs/smoke-all/2024/06/21/10091.qmd
@@ -1,0 +1,24 @@
+---
+title: Test
+subtitle: test
+format: latex
+_quarto:
+  tests:
+    latex:
+      ensureFileRegexMatches:
+        - 
+          - "hfill"
+---
+
+# Left
+
+![](./dummy.png){width=50 fig-align="left"}
+
+# Right
+
+![](./dummy.png){width=50 fig-align="right"}
+
+# Center
+
+![](./dummy.png){width=50 fig-align="center"}
+


### PR DESCRIPTION
Closes #10091.