### PR TITLE
`.cell` granddiv of `.cell-output-display` should also `.scaffold`

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -97,6 +97,7 @@ All changes included in 1.5:
 - ([#9555](https://github.com/quarto-dev/quarto-cli/issues/9555)): Text elements in Typst are internationalized.
 - ([#9887](https://github.com/quarto-dev/quarto-cli/issues/9887)): Use correct supplement for div floats in Typst.
 - ([#9972](https://github.com/quarto-dev/quarto-cli/issues/9972)): Fix crashes with unnumbered sections.
+- ([#8797](https://github.com/quarto-dev/quarto-cli/issues/8797), [10086](https://github.com/quarto-dev/quarto-cli/issues/10086)): Tables should be centered in cell output.
 - ([#9885](https://github.com/quarto-dev/quarto-cli/issues/9885)): Turn off Typst CSS with `css-property-parsing: none`, default `translate`.
 - ([#10055](https://github.com/quarto-dev/quarto-cli/pull/10055)): Enable `html-pre-tag-processing` with a fenced div, disable it in metadata with `none`.
 - ([#10075](https://github.com/quarto-dev/quarto-cli/pull/10075)): Bring `quarto create` templates for Typst up-to-date with the format.

--- a/src/resources/filters/quarto-post/typst.lua
+++ b/src/resources/filters/quarto-post/typst.lua
@@ -127,7 +127,10 @@ function render_typst_fixups()
       return image
     end,
     Div = function(div)
-      local cod = quarto.utils.match(".cell/:child/.cell-output-display")(div)
+      -- is the div a .cell which contains .cell-output-display as child or grandchild?
+      local cod = quarto.utils.match(".cell/:child/Div/:child/.cell-output-display")(div)
+        or
+        quarto.utils.match(".cell/:child/.cell-output-display")(div)
       if cod then
           div.classes:extend({'quarto-scaffold'})
           cod.classes:extend({'quarto-scaffold'})

--- a/tests/docs/smoke-all/typst/tbl-align/issue10086.qmd
+++ b/tests/docs/smoke-all/typst/tbl-align/issue10086.qmd
@@ -1,0 +1,27 @@
+---
+title: "Hello, Quarto"
+format:
+  typst:
+    keep-typ: true
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          ['#figure\(\[(\r\n?|\n)#figure']
+        -
+          ['#block\[(\r\n?|\n)#figure\(\[(\r\n?|\n)#block\[(\r\n?|\n)#figure']
+---
+
+```{r}
+#| label: tbl-example1
+#| tbl-cap: Table created with `knitr::kable()`
+#| echo: false
+
+set.seed(1)
+data <- data.frame(x = rnorm(30), y = rnorm(30))
+knitr::kable(
+  head(data),
+  digits = 2
+)
+```


### PR DESCRIPTION
This fixes #10086 in a narrow way.

There can be an intervening div between `.cell` and `.cell-output-display`.

`.cell` and `.cell-output-display` should still be `.scaffold`

(In this particular case, the intervening div is already `.scaffold`. It doesn't appear to matter, since only an outermost `#block` hurts centering.)

We could probably more aggressively `.scaffold` on the producer side, rather than adding `.scaffold` on the consumer side. But this should be very safe and conservative.

