### PR TITLE
id-less figures in another figure get lettered

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -100,6 +100,7 @@ All changes included in 1.5:
 - ([#9887](https://github.com/quarto-dev/quarto-cli/issues/9887)): Use correct supplement for div floats in Typst.
 - ([#9972](https://github.com/quarto-dev/quarto-cli/issues/9972)): Fix crashes with unnumbered sections.
 - ([#8797](https://github.com/quarto-dev/quarto-cli/issues/8797), [10086](https://github.com/quarto-dev/quarto-cli/issues/10086)): Tables should be centered in cell output.
+- ([#9857](https://github.com/quarto-dev/quarto-cli/issues/9857)): `id`-less figures inside another figure should be treated the same as `FloatRefTarget` and get lettered
 - ([#9885](https://github.com/quarto-dev/quarto-cli/issues/9885)): Turn off Typst CSS with `css-property-parsing: none`, default `translate`.
 - ([#10055](https://github.com/quarto-dev/quarto-cli/pull/10055)): Enable `html-pre-tag-processing` with a fenced div, disable it in metadata with `none`.
 - ([#10075](https://github.com/quarto-dev/quarto-cli/pull/10075)): Bring `quarto create` templates for Typst up-to-date with the format.

--- a/src/resources/filters/layout/typst.lua
+++ b/src/resources/filters/layout/typst.lua
@@ -121,7 +121,18 @@ end, function(layout)
     end)
   end)
   cells:insert(pandoc.RawInline("typst", ")\n"))
-  if layout.float.has_subfloats then
+  local has_subfloats = layout.float.has_subfloats
+  -- check for id-less figures that weren't made FloatRefTarget
+  if not has_subfloats then
+    _quarto.ast.walk(layout.float.content, {
+      Figure = function(figure)
+        if figure.id == nil or figure.id == "" then
+          has_subfloats = true
+        end
+      end
+    })
+  end
+  if has_subfloats then
     result:insert(_quarto.format.typst.function_call("quarto_super", {
       {"kind", kind},
       {"caption", _quarto.format.typst.as_typst_content(layout.float.caption_long)},

--- a/src/resources/filters/layout/typst.lua
+++ b/src/resources/filters/layout/typst.lua
@@ -122,13 +122,11 @@ end, function(layout)
   end)
   cells:insert(pandoc.RawInline("typst", ")\n"))
   local has_subfloats = layout.float.has_subfloats
-  -- check for id-less figures that weren't made FloatRefTarget
+  -- count any remaining figures (with no / bad ids) as floats
   if not has_subfloats then
     _quarto.ast.walk(layout.float.content, {
       Figure = function(figure)
-        if figure.id == nil or figure.id == "" then
-          has_subfloats = true
-        end
+        has_subfloats = true
       end
     })
   end

--- a/tests/docs/smoke-all/typst/typst-i18n.qmd
+++ b/tests/docs/smoke-all/typst/typst-i18n.qmd
@@ -12,8 +12,8 @@ _quarto:
       - ['Resumen', 'Nota', 'Conjetura']
       - []
       ensurePdfRegexMatches:
-      - ['Figura 1', 'Figura 2', 'Figura 3', 'Figura 4', 'Figura 5', 'Figura 6']
-      - ['Figure 1', 'Figure 2', 'Figure 3', 'Figure 4', 'Figure 5', 'Figure 6']
+      - ['Figura 1', 'Figura 2', 'Figura 3', 'Figura 4']
+      - ['Figure 1', 'Figure 2', 'Figure 3', 'Figure 4', 'Figure 5', 'Figura 5']
 ---
 
 ![Marcador]({{< placeholder 300 >}}){#fig-marcador}

--- a/tests/docs/smoke-all/typst/typst-subfig-badid.qmd
+++ b/tests/docs/smoke-all/typst/typst-subfig-badid.qmd
@@ -16,9 +16,9 @@ _quarto:
 
 ::: {#fig-panel2 layout-ncol=2}
 
-![Placeholder]({{< placeholder 200 >}})
+![Placeholder]({{< placeholder 200 >}}){#foo}
 
-![Placeholder]({{< placeholder 200 >}})
+![Placeholder]({{< placeholder 200 >}}){#bar}
 
 Panels
 

--- a/tests/docs/smoke-all/typst/typst-subfig.qmd
+++ b/tests/docs/smoke-all/typst/typst-subfig.qmd
@@ -1,0 +1,25 @@
+---
+title: "Typst messy subnumbering"
+format:
+  typst:
+    keep-typ: true
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          ['#grid\(columns: 2, gutter: 2em,(\r\n?|\n)  \[(\r\n?|\n)#block\[(\r\n?|\n)#figure']
+        -
+          ['#figure\(\[(\r\n?|\n)#grid\(columns: 2, gutter: 2em,(\r\n?|\n)  \[(\r\n?|\n)#block\[(\r\n?|\n)#figure']
+---
+
+
+::: {#fig-panel2 layout-ncol=2}
+
+![Placeholder]({{< placeholder 200 >}})
+
+![Placeholder]({{< placeholder 200 >}})
+
+Panels
+
+:::


### PR DESCRIPTION
A conservative fix: at the output stage, do equivalent walk to what was done in `crossref/preprocess.lua`, looking for figures with no id instead of `FloatRefTarget`.

fixes #9857

<img width="789" alt="image" src="https://github.com/quarto-dev/quarto-cli/assets/1366709/c85d4306-a12f-452c-95fb-8025e5481c5b">
