### PR TITLE
Typescript - add `await` to extension metadata resolution code

### DIFF
--- a/src/command/render/project.ts
+++ b/src/command/render/project.ts
@@ -264,7 +264,7 @@ export async function renderProject(
   pOptions: RenderOptions,
   pFiles?: string[],
 ): Promise<RenderResult> {
-  mergeExtensionMetadata(context, pOptions);
+  await mergeExtensionMetadata(context, pOptions);
   const { preRenderScripts, postRenderScripts } = await getProjectRenderScripts(
     context,
   );

--- a/tests/docs/project/prepost/extension/_extensions/author/prerender/pre-render.ts
+++ b/tests/docs/project/prepost/extension/_extensions/author/prerender/pre-render.ts
@@ -6,6 +6,7 @@ try {
 } catch (e) {
   if (e instanceof Deno.errors.NotFound) {
     Deno.writeTextFileSync(join(Deno.cwd(), "i-exist.txt"), "yes.");
+    Deno.writeTextFileSync(join(Deno.cwd(), "i-was-created.txt"), "yes.");
     console.log("pre-render ok");
   } else {
     throw e;

--- a/tests/smoke/project/project-prepost.test.ts
+++ b/tests/smoke/project/project-prepost.test.ts
@@ -9,7 +9,7 @@ import { docs } from "../../utils.ts";
 import { join } from "../../../src/deno_ral/path.ts";
 import { existsSync } from "../../../src/deno_ral/fs.ts";
 import { testQuartoCmd } from "../../test.ts";
-import { fileExists, noErrors, printsMessage, verifyNoPath } from "../../verify.ts";
+import { fileExists, noErrors, printsMessage, verifyNoPath, verifyPath } from "../../verify.ts";
 import { safeRemoveIfExists } from "../../../src/core/path.ts";
 
 const renderDir = docs("project/prepost/mutate-render-list");
@@ -72,7 +72,8 @@ testQuartoCmd(
   }],
   {
     teardown: async () => {
-      const path = join(docs("project/prepost/extension"), "i-exist.txt");
+      const path = join(docs("project/prepost/extension"), "i-was-created.txt");
+      verifyPath(path);
       safeRemoveIfExists(path);
     }
   });


### PR DESCRIPTION
Closes #10037.

I'm sufficiently spooked/annoyed at how Typescript handles warnings around `Promise<void>` that I think we should do a full code review. There should be some linting around calling a function that returns `Promise<void>` and not awaiting its results..