### PR TITLE
Chore: Update QuartoNotebookRunner to 0.11.2

### DIFF
--- a/src/resources/julia/Project.toml
+++ b/src/resources/julia/Project.toml
@@ -2,4 +2,4 @@
 QuartoNotebookRunner = "4c0109c6-14e9-4c88-93f0-2b974d3468f4"
 
 [compat]
-QuartoNotebookRunner = "=0.11.1"
+QuartoNotebookRunner = "=0.11.2"


### PR DESCRIPTION
0.11.2 fixes PlotlyJS require.js setup behavior in accordance with recent changes to quarto-cli, allows to use shortcodes to include qmd fragments, and improves type printing in some cases.