### PR TITLE
chore: update typst to 0.11.1

### DIFF
--- a/configuration
+++ b/configuration
@@ -14,7 +14,7 @@ export DENO_DOM=v0.1.35-alpha-artifacts
 export PANDOC=3.2
 export DARTSASS=1.70.0
 export ESBUILD=0.19.12
-export TYPST=0.11.0
+export TYPST=0.11.1
 
 
 # NB: we can't put comments in the same line as export statements because it

--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -105,7 +105,7 @@ All changes included in 1.5:
 - ([#9885](https://github.com/quarto-dev/quarto-cli/issues/9885)): Turn off Typst CSS with `css-property-parsing: none`, default `translate`.
 - ([#10055](https://github.com/quarto-dev/quarto-cli/pull/10055)): Enable `html-pre-tag-processing` with a fenced div, disable it in metadata with `none`.
 - ([#10075](https://github.com/quarto-dev/quarto-cli/pull/10075)): Bring `quarto create` templates for Typst up-to-date with the format.
-- Upgrade Typst to 0.11
+- Upgrade Typst to 0.11.1
 - Upgrade the Typst template to draw tables without grid lines by default, in accordance with latest Pandoc.
 
 ## Jupyter


### PR DESCRIPTION
I looked at the table examples and they looked good. 

We don't test the PDF output very much, but all smoke tests are running fine. 
