### PR TITLE
float, typst - ignore cap-location margin and default to bottom

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -106,6 +106,7 @@ All changes included in 1.5:
 - ([#9885](https://github.com/quarto-dev/quarto-cli/issues/9885)): Turn off Typst CSS with `css-property-parsing: none`, default `translate`.
 - ([#10055](https://github.com/quarto-dev/quarto-cli/pull/10055)): Enable `html-pre-tag-processing` with a fenced div, disable it in metadata with `none`.
 - ([#10075](https://github.com/quarto-dev/quarto-cli/pull/10075)): Bring `quarto create` templates for Typst up-to-date with the format.
+- ([#10123](https://github.com/quarto-dev/quarto-cli/issues/10123)): Warn when unsupported caption location is used, and default to `bottom`.
 - Upgrade Typst to 0.11.1
 - Upgrade the Typst template to draw tables without grid lines by default, in accordance with latest Pandoc.
 

--- a/src/resources/filters/customnodes/floatreftarget.lua
+++ b/src/resources/filters/customnodes/floatreftarget.lua
@@ -991,7 +991,7 @@ end, function(float)
   local content = quarto.utils.as_blocks(float.content or {})
   local caption_location = cap_location(float)
 
-  if (caption_location ~= "top" or caption_location ~= "bottom") then
+  if (caption_location ~= "top" and caption_location ~= "bottom") then
     -- warn this is not supported and default to bottom
     warn("Typst does not support this caption location: " .. caption_location .. ". Defaulting to bottom for '" .. float.identifier .. "'.")
     caption_location = "bottom"

--- a/src/resources/filters/customnodes/floatreftarget.lua
+++ b/src/resources/filters/customnodes/floatreftarget.lua
@@ -993,7 +993,7 @@ end, function(float)
 
   if (caption_location ~= "top" or caption_location ~= "bottom") then
     -- warn this is not supported and default to bottom
-    warn("Typst does not support placing caption in margin. Defaulting to bottom for '" .. float.identifier .. "'.")
+    warn("Typst does not support this caption location: " .. caption_location .. ". Defaulting to bottom for '" .. float.identifier .. "'.")
     caption_location = "bottom"
   end
 

--- a/src/resources/filters/customnodes/floatreftarget.lua
+++ b/src/resources/filters/customnodes/floatreftarget.lua
@@ -991,6 +991,12 @@ end, function(float)
   local content = quarto.utils.as_blocks(float.content or {})
   local caption_location = cap_location(float)
 
+  if (caption_location == "margin") then
+    -- warn this is not supported and default to bottom
+    warn("Typst does not support placing caption in margin. Defaulting to bottom for '" .. float.identifier .. "'.")
+    caption_location = "bottom"
+  end
+
   if (ref == "lst") then
     -- FIXME: 
     -- Listings shouldn't emit centered blocks. 

--- a/src/resources/filters/customnodes/floatreftarget.lua
+++ b/src/resources/filters/customnodes/floatreftarget.lua
@@ -991,7 +991,7 @@ end, function(float)
   local content = quarto.utils.as_blocks(float.content or {})
   local caption_location = cap_location(float)
 
-  if (caption_location == "margin") then
+  if (caption_location ~= "top" or caption_location ~= "bottom") then
     -- warn this is not supported and default to bottom
     warn("Typst does not support placing caption in margin. Defaulting to bottom for '" .. float.identifier .. "'.")
     caption_location = "bottom"


### PR DESCRIPTION
Not perfect, but avoid rendering issue because of unsupported feature 

- Related to https://github.com/quarto-dev/quarto-cli/issues/10123

@cscheid too late for this ? 

For context I found the issue while preparing my Quarto workshop where I wanted to demo format switching without modifying document - does not work well for typst because of rendering error. So I am currently doing this kind of things `#| fig-cap-location: !expr if (knitr::pandoc_to('typst')) 'bottom' else 'margin'` which I should probably not show. 😅 

Supporting Article Layout for typst could take some time, and I strongly believe we should at least ignore its features trigger by configuration and not just errors are rendering by writing bad typ file content. That is why I prepared this PR. 

