### PR TITLE
Do not use `freeze` in single-file renders

### DIFF
--- a/news/changelog-1.5.md
+++ b/news/changelog-1.5.md
@@ -239,6 +239,7 @@ All changes included in 1.5:
 - ([#9701](https://github.com/quarto-dev/quarto-cli/issues/9701)): Fix issue with callouts with non-empty titles that have no string content.
 - ([#9724](https://github.com/quarto-dev/quarto-cli/issues/9724)): Force-align text in floats of type `Listing` to the left.
 - ([#9727](https://github.com/quarto-dev/quarto-cli/issues/9727)): `lightbox`: do not overwrite `window.onload` events.
+- ([#9792](https://github.com/quarto-dev/quarto-cli/issues/9798)): Fix a 1.5 regression where `freeze` would be accidentally triggered in single-file renders.
 - Add support for `{{< lipsum >}}` shortcode, which is useful for emitting placeholder text. Provide a specific number of paragraphs (`{{< lipsum 3 >}}`).
 - Resolve data URIs in Pandoc's mediabag when rendering documents.
 - Increase v8's max heap size by default, to avoid out-of-memory errors when rendering large documents (also cf. https://github.com/denoland/deno/issues/18935).

--- a/src/command/render/render-files.ts
+++ b/src/command/render/render-files.ts
@@ -164,7 +164,7 @@ export async function renderExecute(
     (context.format.execute[kExecuteEnabled] !== false);
 
   // use previous frozen results if they are available
-  if (context.project && !alwaysExecute) {
+  if (context.project && !context.project.isSingleFile && !alwaysExecute) {
     // check if we are using the freezer
 
     const thaw = canFreeze &&

--- a/src/core/deno/debug.ts
+++ b/src/core/deno/debug.ts
@@ -41,7 +41,7 @@ export const getStackAsArray = (
   // to our expectations of quarto.ts being the entry point.
   // This will only happen in dev builds and when
   //
-  // export QUARTO_DENO_EXTRA_OPTIONS=--v8-flags=--stack-trace-limit=LARGE_ENOUGH_NUMBER
+  // export QUARTO_DENO_V8_OPTIONS=--stack-trace-limit=100
   //
   // is set.
   const m = rawStack[rawStack.length - 1].match(
@@ -49,7 +49,7 @@ export const getStackAsArray = (
   );
   if (!m) {
     warn(
-      "Could not find quarto.ts in stack trace, is QUARTO_DENO_EXTRA_OPTIONS with a sufficiently-large stack size set?",
+      "Could not find quarto.ts in stack trace, is QUARTO_DENO_V8_OPTIONS set with a sufficiently-large stack size?",
     );
   }
   if (m && (typeof format !== "undefined") && (format !== "raw")) {


### PR DESCRIPTION
Partial fix for #9792.

This doesn't have a regression test because it's tricky to set up, and it's only a partial fix anyway. It's a really narrow fix that seems quite safe.