### PR TITLE
Don't error when running quarto run from Lua on windows

### DIFF
--- a/package/scripts/windows/quarto.cmd
+++ b/package/scripts/windows/quarto.cmd
@@ -101,17 +101,31 @@ SET "DENO_TLS_CA_STORE=system,mozilla"
 SET "DENO_NO_UPDATE_CHECK=1"
 SET "QUARTO_DENO_OPTIONS=--unstable-ffi --no-config --cached-only --allow-read --allow-write --allow-run --allow-env --allow-net --allow-ffi"
 
-REM --enable-experimental-regexp-engine is required for /regex/l, https://github.com/quarto-dev/quarto-cli/issues/9737
+REM Add expected V8 options to QUARTO_DENO_V8_OPTIONS
 IF DEFINED QUARTO_DENO_V8_OPTIONS (
-  SET "QUARTO_DENO_V8_OPTIONS=--enable-experimental-regexp-engine,--max-old-space-size=8192,--max-heap-size=8192,!QUARTO_DENO_V8_OPTIONS!"
+	REM --enable-experimental-regexp-engine is required for /regex/l, https://github.com/quarto-dev/quarto-cli/issues/9737
+	IF "!QUARTO_DENO_V8_OPTIONS!"=="!QUARTO_DENO_V8_OPTIONS:--enable-experimental-regexp-engine=!" (
+		SET "QUARTO_DENO_V8_OPTIONS=--enable-experimental-regexp-engine,!QUARTO_DENO_V8_OPTIONS!"
+	)
+	IF "!QUARTO_DENO_V8_OPTIONS!"=="!QUARTO_DENO_V8_OPTIONS:--max-old-space-size=!" (
+		SET "QUARTO_DENO_V8_OPTIONS=--max-old-space-size=8192,!QUARTO_DENO_V8_OPTIONS!"
+	)
+	IF "!QUARTO_DENO_V8_OPTIONS!"=="!QUARTO_DENO_V8_OPTIONS:--max-heap-size=!" (
+		SET "QUARTO_DENO_V8_OPTIONS=--max-heap-size=8192,!QUARTO_DENO_V8_OPTIONS!"
+	)
 ) ELSE (
   SET "QUARTO_DENO_V8_OPTIONS=--enable-experimental-regexp-engine,--max-old-space-size=8192,--max-heap-size=8192"
 )
 
+REM Prepend v8-flags for deno run if necessary
 IF NOT DEFINED QUARTO_DENO_EXTRA_OPTIONS (
   SET "QUARTO_DENO_EXTRA_OPTIONS=--v8-flags=!QUARTO_DENO_V8_OPTIONS!"
 ) ELSE (
-  SET "QUARTO_DENO_EXTRA_OPTIONS=--v8-flags=!QUARTO_DENO_V8_OPTIONS! !QUARTO_DENO_EXTRA_OPTIONS!"
+	IF "!QUARTO_DENO_EXTRA_OPTIONS!"=="!QUARTO_DENO_EXTRA_OPTIONS:--v8-flags=!" (
+  	SET "QUARTO_DENO_EXTRA_OPTIONS=--v8-flags=!QUARTO_DENO_V8_OPTIONS! !QUARTO_DENO_EXTRA_OPTIONS!"
+	)	ELSE (
+		ECHO WARN: QUARTO_DENO_EXTRA_OPTIONS already contains --v8-flags, skipping addition of QUARTO_DENO_V8_OPTIONS by quarto itself. This is unexpected and you should check your configuration.
+	)
 )
 
 !QUARTO_DENO! !QUARTO_ACTION! !QUARTO_DENO_OPTIONS! !QUARTO_DENO_EXTRA_OPTIONS! !QUARTO_IMPORT_MAP_ARG! !QUARTO_TARGET! %*


### PR DESCRIPTION
closes #10134 

Issue happens because `quarto.cmd` is called from Lua, inside Quarto context where all the environment variable will be set. This leads to `QUARTO_DENO_EXTRA_OPTIONS` already set with `--v8-flags` and we are adding it again 

Some flags can't be duplicated like `--v8-flags` and create an error when running deno.

This PR correctly check when QUARTO_DENO_ env var are set and only add flags to it if not present already.

To be clear, this is one quick fix. Other solution could be 

- Call `deno run` instead of `quarto run` is we really need only deno, and no quarto context. 
- Find a way to run safely in controlled environment quarto from Lua (currently an issue on windows with `pandoc.system.with_environment()`
- Other ideas ? 

I'll check linux script to understand why we haven't found this sooner, and also why our test suites did not error on this case. 