### PR TITLE
tests - avoid cleaning ff-matrix directory

### DIFF
--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -127,7 +127,7 @@ function resolveTestSpecs(
           verifyFns.push(noErrors);
         } else {
           // See if there is a project and grab it's type
-          const projectPath = findSmokeAllProjectDir(input)
+          const projectPath = findRootTestsProjectDir(input)
           const projectOutDir = findProjectOutputDir(projectPath);
           const outputFile = outputForInput(input, format, projectOutDir, projectPath, metadata);
           if (key === "fileExists") {
@@ -245,7 +245,7 @@ for (const { path: fileName } of files) {
   }
 
   // Get project path for this input and store it if this is a project (used for cleaning)
-  const projectPath = findSmokeAllProjectDir(input);
+  const projectPath = findRootTestsProjectDir(input);
   if (projectPath) testedProjects.add(projectPath);
 
   // Render project before testing individual document if required
@@ -332,6 +332,11 @@ Promise.all(testFilesPromises).then(() => {
   }
 }).catch((_error) => {});
 
-function findSmokeAllProjectDir(input: string) {
-  return findProjectDir(input, /smoke-all$/);
+function findRootTestsProjectDir(input: string) {
+  const smokeAllRootDir = 'smoke-all$'
+  const ffMatrixRootDir = 'feature-format-matrix[/]qmd-files$'
+
+  const RootTestsRegex = new RegExp(`${smokeAllRootDir}|${ffMatrixRootDir}`);
+  
+  return findProjectDir(input, RootTestsRegex);
 }

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -8,7 +8,7 @@
 import { basename, dirname, extname, join, relative } from "../src/deno_ral/path.ts";
 import { parseFormatString } from "../src/core/pandoc/pandoc-formats.ts";
 import { kMetadataFormat, kOutputExt } from "../src/config/constants.ts";
-import { safeExistsSync } from "../src/core/path.ts";
+import { pathWithForwardSlashes, safeExistsSync } from "../src/core/path.ts";
 import { readYaml } from "../src/core/yaml.ts";
 
 // caller is responsible for cleanup!
@@ -22,7 +22,7 @@ export function findProjectDir(input: string, until?: RegExp | undefined): strin
   let dir = dirname(input);
   // This is used for smoke-all tests and should stop there 
   // to avoid side effect of _quarto.yml outside of Quarto tests folders
-  while (dir !== "" && dir !== "." && (until ? !until.test(dir) : true)) {
+  while (dir !== "" && dir !== "." && (until ? !until.test(pathWithForwardSlashes(dir)) : true)) {
     const filename = ["_quarto.yml", "_quarto.yaml"].find((file) => {
       const yamlPath = join(dir, file);
       if (safeExistsSync(yamlPath)) {


### PR DESCRIPTION
ff-matrix is using a quarto project to store qmd files, and we use it with run-tests script too. Our Root test project detection needs to know about this.

I recently added this project root detection to solve our cleanup problem of projects in tests. I forgot that we do call `run-tests` scripts not only for smoke-all but all ff-matrix.

This adapt the logic for now until we make it more generic. 

To be clear this is required to avoid the whole feature-format-matrix folder to be deleted when running run-test locally

for example like this

```powershell
./run-tests.ps1 ..\dev-docs\feature-format-matrix\qmd-files\crossref\float\table\document.qmd
```

Opening this PR to check the change is working and not breaking anything 

