### PR TITLE
`quarto inspect` - allow `!expr` tag in yaml metadata

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -2,4 +2,5 @@ All changes included in 1.6:
 
 ## `quarto inspect`
 
+- ([#10039](https://github.com/quarto-dev/quarto-cli/issues/10039)): `quarto inspect` properly handles `!expr` tag in metadata.
 - ([#10188](https://github.com/quarto-dev/quarto-cli/issues/10188)): `quarto inspect` properly resolves includes across subdirectory boundaries.

--- a/src/project/project-shared.ts
+++ b/src/project/project-shared.ts
@@ -45,6 +45,7 @@ import { parse } from "yaml/mod.ts";
 import { mappedIndexToLineCol } from "../core/lib/mapped-text.ts";
 import { normalizeNewlines } from "../core/lib/text.ts";
 import { DirectiveCell } from "../core/lib/break-quarto-md-types.ts";
+import { QuartoJSONSchema } from "../core/yaml.ts";
 
 export function projectExcludeDirs(context: ProjectContext): string[] {
   const outputDir = projectOutputDir(context);
@@ -410,7 +411,9 @@ export async function projectResolveCodeCellsForFile(
           cell.sourceWithYaml ?? cell.source,
         );
         const metadata = cellOptions.yaml
-          ? parse(cellOptions.yaml.value) as Record<string, unknown>
+          ? parse(cellOptions.yaml.value, {
+            schema: QuartoJSONSchema,
+          }) as Record<string, unknown>
           : {};
         const lineLocator = mappedIndexToLineCol(cell.sourceVerbatim);
         result.push({

--- a/tests/docs/inspect/10039.qmd
+++ b/tests/docs/inspect/10039.qmd
@@ -1,0 +1,19 @@
+---
+title: YAML tag literals, plain
+---
+
+```{r}
+#| label: setup
+#| include: false
+library(ggplot2)
+
+p <- split(mtcars, mtcars[["cyl"]])
+p <- lapply(p, \(x) ggplot(x, aes(x = wt, y = mpg)) +
+                      geom_point())
+```
+
+```{r}
+#| label: plot
+#| fig-cap: !expr names(p)[[1]]
+p[[1]]
+```

--- a/tests/smoke/inspect/inspect-code-cells.test.ts
+++ b/tests/smoke/inspect/inspect-code-cells.test.ts
@@ -48,4 +48,48 @@ import { assert } from "testing/asserts.ts";
       }
     },
   );
+
+
+  
+})();
+
+(() => {
+  const input = "docs/inspect/10039.qmd";
+  const output = "docs/inspect/_10039.json";
+  testQuartoCmd(
+    "inspect",
+    [input, output],
+    [
+      {
+        name: "inspect-tagged-metadata",
+        verify: async (outputs: ExecuteOutput[]) => {
+          assert(existsSync(output));
+          const json = JSON.parse(Deno.readTextFileSync(output));
+          const info = json.fileInformation["docs/inspect/10039.qmd"];
+          const codeCells = info.codeCells;
+          assertObjectMatch(info.codeCells[1], {
+            "start": 14,
+            "end": 18,
+            "file": "docs/inspect/10039.qmd",
+            "source": "p[[1]]\n",
+            "language": "r",
+            "metadata": {
+              "label": "plot",
+              "fig-cap": {
+                "value": "names(p)[[1]]",
+                "tag": "!expr"
+              }
+            }
+          });
+        }
+      }
+    ],
+    {
+      teardown: async () => {
+        if (existsSync(output)) {
+          Deno.removeSync(output);
+        }
+      }
+    },
+  );
 })();


### PR DESCRIPTION
Closes #10039 