### PR TITLE
(`brand.yml`) sass - create explicit sass cache object, use deno.kv

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,7 @@
       "runtimeExecutable": "${workspaceFolder}/package/dist/bin/tools/deno",
       "runtimeArgs": [
         "run",
+        "--unstable-kv",
         "--unstable-ffi",
         "--importmap=${workspaceFolder}/src/import_map.json",
         "--inspect-brk",
@@ -42,6 +43,7 @@
       "runtimeArgs": [
         "test",
         "--config=test-conf.json",
+        "--unstable-kv",
         "--unstable-ffi",
         "--allow-all",
         "--check",

--- a/package/launcher/src/main.rs
+++ b/package/launcher/src/main.rs
@@ -82,6 +82,7 @@ fn main() {
 
     // Define the base deno options
     let mut deno_options: Vec<String> = vec![
+        String::from("--unstable-kv"),
         String::from("--unstable-ffi"),
         String::from("--no-config"),
         String::from("--cached-only"),

--- a/package/scripts/common/quarto
+++ b/package/scripts/common/quarto
@@ -169,7 +169,7 @@ fi
 export DENO_TLS_CA_STORE=system,mozilla
 export DENO_NO_UPDATE_CHECK=1
 # Be sure to include any already defined QUARTO_DENO_OPTIONS
-QUARTO_DENO_OPTIONS="--unstable-ffi --no-config ${QUARTO_CACHE_OPTIONS} --allow-read --allow-write --allow-run --allow-env --allow-net --allow-ffi ${QUARTO_DENO_OPTIONS}"
+QUARTO_DENO_OPTIONS="--unstable-ffi --unstable-kv --no-config ${QUARTO_CACHE_OPTIONS} --allow-read --allow-write --allow-run --allow-env --allow-net --allow-ffi ${QUARTO_DENO_OPTIONS}"
 
 # --enable-experimental-regexp-engine is required for /regex/l, https://github.com/quarto-dev/quarto-cli/issues/9737
 if [ "$QUARTO_DENO_V8_OPTIONS" != "" ]; then

--- a/package/scripts/windows/quarto.cmd
+++ b/package/scripts/windows/quarto.cmd
@@ -99,7 +99,7 @@ IF NOT DEFINED QUARTO_DENO (
 
 SET "DENO_TLS_CA_STORE=system,mozilla"
 SET "DENO_NO_UPDATE_CHECK=1"
-SET "QUARTO_DENO_OPTIONS=--unstable-ffi --no-config --cached-only --allow-read --allow-write --allow-run --allow-env --allow-net --allow-ffi"
+SET "QUARTO_DENO_OPTIONS=--unstable-kv --unstable-ffi --no-config --cached-only --allow-read --allow-write --allow-run --allow-env --allow-net --allow-ffi"
 
 REM Add expected V8 options to QUARTO_DENO_V8_OPTIONS
 IF DEFINED QUARTO_DENO_V8_OPTIONS (

--- a/package/src/quarto-bld
+++ b/package/src/quarto-bld
@@ -17,4 +17,4 @@ export DENO_NO_UPDATE_CHECK=1
 
 # TODO: Consider generating a source map or something to get a good stack
 # Create the Deno bundle
-"$QUARTO_DENO" run --unstable-ffi --allow-env --allow-read --allow-write --allow-run --allow-net --allow-ffi --v8-flags=--stack-trace-limit=100 --importmap="${SCRIPT_PATH}/../../src/dev_import_map.json" "$SCRIPT_PATH/bld.ts" $@
+"$QUARTO_DENO" run --unstable-kv --unstable-ffi --allow-env --allow-read --allow-write --allow-run --allow-net --allow-ffi --v8-flags=--stack-trace-limit=100 --importmap="${SCRIPT_PATH}/../../src/dev_import_map.json" "$SCRIPT_PATH/bld.ts" $@

--- a/package/src/quarto-bld.cmd
+++ b/package/src/quarto-bld.cmd
@@ -9,4 +9,4 @@ if NOT DEFINED QUARTO_DENO (
 SET "RUST_BACKTRACE=full"
 SET "DENO_NO_UPDATE_CHECK=1"
 
-"%QUARTO_DENO%" run --unstable-ffi --allow-read --allow-write --allow-run --allow-env --allow-net --allow-ffi --importmap=%~dp0\..\..\src\dev_import_map.json %~dp0\bld.ts %*
+"%QUARTO_DENO%" run --unstable-kv --unstable-ffi --allow-read --allow-write --allow-run --allow-env --allow-net --allow-ffi --importmap=%~dp0\..\..\src\dev_import_map.json %~dp0\bld.ts %*

--- a/package/src/util/deno.ts
+++ b/package/src/util/deno.ts
@@ -20,6 +20,7 @@ export async function bundle(
   }
   denoBundleCmd.push(denoExecPath);
   denoBundleCmd.push("bundle");
+  denoBundleCmd.push("--unstable-kv");
   denoBundleCmd.push("--unstable-ffi");
   denoBundleCmd.push(
     "--importmap=" + configuration.importmap,
@@ -54,6 +55,7 @@ export async function compile(
   }
   denoBundleCmd.push(denoExecPath);
   denoBundleCmd.push("compile");
+  denoBundleCmd.push("--unstable-kv");
   denoBundleCmd.push("--unstable-ffi");
   denoBundleCmd.push(
     "--importmap=" + configuration.importmap,
@@ -85,6 +87,7 @@ export async function install(
   }
   denoBundleCmd.push(denoExecPath);
   denoBundleCmd.push("install");
+  denoBundleCmd.push("--unstable-kv");
   denoBundleCmd.push("--unstable-ffi");
   denoBundleCmd.push(
     "--importmap=" + configuration.importmap,

--- a/src/core/run/deno.ts
+++ b/src/core/run/deno.ts
@@ -44,6 +44,7 @@ export const denoRunHandler: RunHandler = {
           importMap,
           "--cached-only",
           "--allow-all",
+          "--unstable-kv",
           "--unstable-ffi",
           script,
           ...args,

--- a/src/core/sass.ts
+++ b/src/core/sass.ts
@@ -15,9 +15,7 @@ import { dartCompile } from "./dart-sass.ts";
 
 import * as ld from "./lodash.ts";
 import { lines } from "./text.ts";
-import { md5Hash } from "./hash.ts";
-import { debug } from "../deno_ral/log.ts";
-import { safeExistsSync } from "./path.ts";
+import { sassCache } from "./sass/cache.ts";
 
 export interface SassVariable {
   name: string;
@@ -300,10 +298,6 @@ export async function compileWithCache(
   cacheIdentifier?: string,
 ) {
   if (cacheIdentifier) {
-    // Calculate a hash for the input and identifier
-    const identifierHash = md5Hash(cacheIdentifier);
-    const inputHash = md5Hash(input);
-
     // If there are imports, the computed input Hash is incorrect
     // so we should be using a session cache which will cache
     // across renders, but not persistently
@@ -313,50 +307,8 @@ export async function compileWithCache(
     const cacheDir = useSessionCache
       ? join(temp.baseDir, "sass")
       : quartoCacheDir("sass");
-    const cacheIdxPath = join(cacheDir, "index.json");
-
-    const outputFile = `${identifierHash}.css`;
-    const outputFilePath = join(cacheDir, outputFile);
-
-    // Check whether we can use a cached file
-    let cacheIndex: { [key: string]: { key: string; hash: string } } = {};
-    let writeCache = true;
-    if (existsSync(outputFilePath)) {
-      try {
-        cacheIndex = JSON.parse(Deno.readTextFileSync(cacheIdxPath));
-        const existingEntry = cacheIndex[identifierHash];
-        writeCache = !existingEntry || (existingEntry.hash !== inputHash);
-      } catch {
-        debug(`The scss cache index file ${cacheIdxPath} can't be read.`);
-      }
-    }
-
-    // We need to refresh the cache
-    if (writeCache) {
-      try {
-        await dartCompile(
-          input,
-          outputFilePath,
-          temp,
-          loadPaths,
-          compressed,
-        );
-      } catch (error) {
-        // Compilation failed, so clear out the output file (if exists)
-        // which will be invalid CSS
-        try {
-          if (safeExistsSync(outputFilePath)) {
-            Deno.removeSync(outputFilePath);
-          }
-        } finally {
-          //doesn't matter
-        }
-        throw error;
-      }
-      cacheIndex[identifierHash] = { key: cacheIdentifier, hash: inputHash };
-      Deno.writeTextFileSync(cacheIdxPath, JSON.stringify(cacheIndex));
-    }
-    return outputFilePath;
+    const cache = await sassCache(cacheDir);
+    return cache.getOrSet(input, loadPaths, temp, cacheIdentifier, compressed);
   } else {
     const outputFilePath = temp.createFile({ suffix: ".css" });
     // Skip the cache and just compile

--- a/src/core/sass/cache.ts
+++ b/src/core/sass/cache.ts
@@ -1,0 +1,207 @@
+/*
+ * cache.ts
+ *
+ * A persistent cache for sass compilation based partly on Deno.KV.
+ *
+ * Copyright (C) 2024 Posit Software, PBC
+ */
+
+import { InternalError } from "../lib/error.ts";
+import { md5Hash } from "../hash.ts";
+import { join } from "../../deno_ral/path.ts";
+import { ensureDirSync, existsSync } from "../../deno_ral/fs.ts";
+import { dartCompile } from "../dart-sass.ts";
+import { TempContext } from "../temp.ts";
+import { safeRemoveIfExists } from "../path.ts";
+import * as log from "../../deno_ral/log.ts";
+
+class SassCache {
+  kv: Deno.Kv;
+  path: string;
+
+  constructor(kv: Deno.Kv, path: string) {
+    this.kv = kv;
+    this.path = path;
+  }
+
+  async getFromHash(
+    hash: string,
+    inputHash: string,
+    force?: boolean,
+  ): Promise<string | null> {
+    log.debug(
+      `SassCache.getFromHash(hash=${hash}, inputHash=${inputHash}, force=${force})`,
+    );
+    // verify that the hash is a valid md5 hash
+    if (hash.length !== 32 || !/^[0-9a-f]{32}$/.test(hash)) {
+      throw new InternalError(`Invalid hash length: ${hash.length}`);
+    }
+
+    const result = await this.kv.get(["entry", hash]);
+    if (result.value === null) {
+      log.debug(`  cache miss`);
+      return null;
+    }
+    if (typeof result.value !== "object") {
+      throw new InternalError(
+        `Unsupported SassCache entry type\nExpected SassCacheEntry, got ${typeof result
+          .value}`,
+      );
+    }
+    const v = result.value as Record<string, unknown>;
+    if (typeof v.key !== "string" || typeof v.hash !== "string") {
+      throw new InternalError(
+        `Unsupported SassCache entry type\nExpected SassCacheEntry, got ${typeof result
+          .value}`,
+      );
+    }
+    const outputFilePath = join(this.path, `${hash}.css`);
+
+    // if the hash doesn't match the key, return null
+    if ((v.hash !== inputHash && !force) || !existsSync(outputFilePath)) {
+      if (v.hash !== inputHash) {
+        log.debug(`  hash mismatch: ${v.hash} !== ${inputHash}`);
+      } else if (force) {
+        log.debug(`  forcing recomputation`);
+      } else {
+        log.debug(`  output file missing: ${outputFilePath}`);
+      }
+      return null;
+    }
+
+    log.debug(`  cache hit`);
+    return outputFilePath;
+  }
+
+  async setFromHash(
+    identifierHash: string,
+    inputHash: string,
+    input: string,
+    loadPaths: string[],
+    temp: TempContext,
+    cacheIdentifier: string,
+    compressed?: boolean,
+  ): Promise<string> {
+    log.debug(`SassCache.setFromHash(${identifierHash}, ${inputHash}), ...`);
+    const outputFilePath = join(this.path, `${identifierHash}.css`);
+    try {
+      await dartCompile(
+        input,
+        outputFilePath,
+        temp,
+        loadPaths,
+        compressed,
+      );
+    } catch (error) {
+      // Compilation failed, so clear out the output file (if exists)
+      // which will be invalid CSS
+      try {
+        safeRemoveIfExists(outputFilePath);
+      } finally {
+        // doesn't matter
+      }
+      throw error;
+    }
+    await this.kv.set(["entry", identifierHash], {
+      key: cacheIdentifier,
+      hash: inputHash,
+    });
+    return outputFilePath;
+  }
+
+  async set(
+    input: string,
+    loadPaths: string[],
+    temp: TempContext,
+    cacheIdentifier: string,
+    compressed?: boolean,
+  ): Promise<string> {
+    const identifierHash = md5Hash(cacheIdentifier);
+    const inputHash = md5Hash(input);
+    return this.setFromHash(
+      identifierHash,
+      inputHash,
+      input,
+      loadPaths,
+      temp,
+      cacheIdentifier,
+      compressed,
+    );
+  }
+
+  async getOrSet(
+    input: string,
+    loadPaths: string[],
+    temp: TempContext,
+    cacheIdentifier: string,
+    compressed?: boolean,
+  ): Promise<string> {
+    log.debug(`SassCache.getOrSet(...)`);
+    const identifierHash = md5Hash(cacheIdentifier);
+    const inputHash = md5Hash(input);
+    const existing = await this.getFromHash(identifierHash, inputHash);
+    if (existing !== null) {
+      log.debug(`  cache hit`);
+      return existing;
+    }
+    log.debug(`  cache miss, setting`);
+    return this.setFromHash(
+      identifierHash,
+      inputHash,
+      input,
+      loadPaths,
+      temp,
+      cacheIdentifier,
+      compressed,
+    );
+  }
+}
+
+const currentSassCacheVersion = 1;
+
+const requiredQuartoVersions: Record<number, string> = {
+  1: "1.6.0",
+};
+
+async function checkVersion(kv: Deno.Kv, path: string) {
+  const version = await kv.get(["version"]);
+  if (version.value === null) {
+    await kv.set(["version"], 1);
+  } else {
+    if (typeof version.value !== "number") {
+      throw new Error(
+        `Unsupported SassCache version type in ${path}\nExpected number, got ${typeof version
+          .value}`,
+      );
+    }
+    if (version.value < currentSassCacheVersion) {
+      // in the future we should clean this automatically, but this is v1 and there should be
+      // no old data anywhere.
+      throw new Error(
+        `Found outdated SassCache version. Please clear ${path}.`,
+      );
+    }
+    if (version.value > currentSassCacheVersion) {
+      throw new Error(
+        `Found a SassCache version that's newer than supported. Please clear ${path} or upgrade Quarto to ${
+          requiredQuartoVersions[currentSassCacheVersion]
+        } or later.`,
+      );
+    }
+  }
+}
+
+const _sassCache: Record<string, SassCache> = {};
+export async function sassCache(path: string): Promise<SassCache> {
+  if (!_sassCache[path]) {
+    log.debug(`Creating SassCache at ${path}`);
+    ensureDirSync(path);
+    const kvFile = join(path, "sass.kv");
+    const kv = await Deno.openKv(kvFile);
+    await checkVersion(kv, kvFile);
+    _sassCache[path] = new SassCache(kv, path);
+  }
+  log.debug(`Returning SassCache at ${path}`);
+  const result = _sassCache[path];
+  return result;
+}

--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -56,7 +56,7 @@ $Env:QUARTO_DEBUG = "true"
 # Preparing running Deno with default arguments
 
 $QUARTO_IMPORT_MAP_ARG="--importmap=$(Join-Path $QUARTO_SRC_DIR "dev_import_map.json")"
-$QUARTO_DENO_OPTIONS="--config test-conf.json --v8-flags=--enable-experimental-regexp-engine,--max-old-space-size=8192,--max-heap-size=8192 --unstable-ffi --allow-read --allow-write --allow-run --allow-env --allow-net --check"
+$QUARTO_DENO_OPTIONS="--config test-conf.json --v8-flags=--enable-experimental-regexp-engine,--max-old-space-size=8192,--max-heap-size=8192 --unstable-kv --unstable-ffi --allow-read --allow-write --allow-run --allow-env --allow-net --check"
 
 # Parsing argument passed to the script
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -23,7 +23,7 @@ export QUARTO_BIN_PATH=$DENO_DIR
 export QUARTO_SHARE_PATH="`cd "$QUARTO_ROOT/src/resources/";pwd`"
 export QUARTO_DEBUG=true
 
-QUARTO_DENO_OPTIONS="--config test-conf.json --v8-flags=--enable-experimental-regexp-engine,--max-old-space-size=8192,--max-heap-size=8192 --unstable-ffi --allow-read --allow-write --allow-run --allow-env --allow-net"
+QUARTO_DENO_OPTIONS="--config test-conf.json --v8-flags=--enable-experimental-regexp-engine,--max-old-space-size=8192,--max-heap-size=8192 --unstable-kv --unstable-ffi --allow-read --allow-write --allow-run --allow-env --allow-net"
 
 
 if [[ -z $GITHUB_ACTION ]] && [[ -z $QUARTO_TESTS_NO_CONFIG ]]
@@ -146,7 +146,7 @@ if [[ $@ == *"--coverage"* ]]; then
   [[ $@ =~ .*--coverage=(.+) ]] && export COV="${BASH_REMATCH[1]}"
 
   echo Generating coverage report...
-  ${DENO_DIR}/deno coverage --unstable-ffi ${COV} --lcov > ${COV}.lcov
+  ${DENO_DIR}/deno coverage --unstable-kv --unstable-ffi ${COV} --lcov > ${COV}.lcov
   genhtml -o ${COV}/html ${COV}.lcov
   open ${COV}/html/index.html
 fi


### PR DESCRIPTION
(To avoid another big merge issue, this time we'll be doing tons of small PRs against `main`)

This PR adds an explicit `SassCache` class and uses Deno KV (locally) to manage the mapping of hashes. This should not have any present performance impacts, but will make it so that it's safe for future versions of Quarto to parallelize multiple calls against this cache. In addition, we explicitly manage and check the version of the cache stored in disk, so that future changes that cause backwards incompatibility will have a safe upgrade path.