### PR TITLE
Handle API change in `is_manifest_current` in Julia 1.11

### DIFF
--- a/src/resources/julia/ensure_environment.jl
+++ b/src/resources/julia/ensure_environment.jl
@@ -14,7 +14,13 @@ function manifest_has_correct_julia_version()
   return version.major == VERSION.major && version.minor == VERSION.minor
 end
 
-manifest_matches_project_toml = Pkg.is_manifest_current() === true # this returns nothing if there's no manifest
+is_manifest_current = @static if VERSION < v"1.11.0-DEV.1135"
+  Pkg.is_manifest_current()
+else
+  Pkg.is_manifest_current(dirname(Base.active_project()))
+end
+
+manifest_matches_project_toml = is_manifest_current === true # this returns nothing if there's no manifest
 
 if manifest_matches_project_toml && manifest_has_correct_julia_version()
   Pkg.instantiate()


### PR DESCRIPTION
Fixes https://github.com/quarto-dev/quarto-cli/issues/10225

As CI here doesn't have the ability to test multiple Julia versions, we can't have a test for this. I just checked that the error didn't appear locally with and without `QUARTO_JULIA=/Users/krumbiegel/.julia/juliaup/julia-1.11.0-rc1+0.aarch64.apple.darwin14/bin/julia`.