### PR TITLE
ff matrix: title block metadata labels

### DIFF
--- a/dev-docs/feature-format-matrix/qmd-files/title-blocks/metadata-labels/abstract-title/document.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/title-blocks/metadata-labels/abstract-title/document.qmd
@@ -1,0 +1,44 @@
+---
+title: "Toward a Unified Theory of High-Energy Metaphysics: Silly String Theory"
+format:
+  html:
+    quality: 2
+  typst:
+    quality: 2
+  pdf:
+    quality: na
+  docx:
+    quality: 2
+  pptx:
+    quality: na
+    comment: abstract not shown
+  revealjs:
+    quality: na
+    comment: abstract not shown
+  dashboard:
+    quality: na
+    comment: abstract not shown
+date: 2008-02-29
+abstract: >
+  The characteristic theme of the works of Stone is
+  the bridge between culture and society. ...
+abstract-title: Abstract!
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        -
+          - 'Abstract\!'
+        - []
+    typst:
+      ensurePdfRegexMatches:
+        -
+          - 'Abstract\!'
+        - []
+    docx:
+      ensureDocxRegexMatches:
+        -
+          - 'Abstract\!'
+        - []
+
+---

--- a/dev-docs/feature-format-matrix/qmd-files/title-blocks/metadata-labels/abstract-title/document.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/title-blocks/metadata-labels/abstract-title/document.qmd
@@ -5,6 +5,7 @@ format:
     quality: 2
   typst:
     quality: 2
+    keep-typ: true
   pdf:
     quality: na
   docx:
@@ -31,7 +32,7 @@ _quarto:
           - 'Abstract\!'
         - []
     typst:
-      ensurePdfRegexMatches:
+      ensureTypstFileRegexMatches:
         -
           - 'Abstract\!'
         - []

--- a/dev-docs/feature-format-matrix/qmd-files/title-blocks/metadata-labels/affiliation-title/document.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/title-blocks/metadata-labels/affiliation-title/document.qmd
@@ -1,0 +1,35 @@
+---
+title: "Toward a Unified Theory of High-Energy Metaphysics: Silly String Theory"
+format:
+  html:
+    quality: 1
+  typst:
+    quality: na
+    comment: affiliation title not shown
+  pdf:
+    quality: na
+    comment: affiliation not shown
+  docx:
+    quality: na
+    comment: affiliation not shown
+  pptx:
+    quality: na
+    comment: affiliation not shown
+  revealjs:
+    quality: na
+    comment: affiliation title not shown
+  dashboard:
+    quality: na
+    comment: affiliation not shown
+affiliation-title: Affiliation!
+author:
+  - name: Josiah Carberry
+    id: jc
+    orcid: 0000-0002-1825-0097
+    email: josiah@psychoceramics.org
+    affiliation:
+      - name: Brown University
+        city: Providence
+        state: RI
+        url: https://www.brown.edu
+---

--- a/dev-docs/feature-format-matrix/qmd-files/title-blocks/metadata-labels/author-title/document.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/title-blocks/metadata-labels/author-title/document.qmd
@@ -1,0 +1,34 @@
+---
+title: "Toward a Unified Theory of High-Energy Metaphysics: Silly String Theory"
+format:
+  html:
+    quality: 1
+  typst:
+    quality: na
+    comment: author title not shown
+  pdf:
+    quality: na
+    comment: author title not shown
+  docx:
+    quality: na
+    comment: author title not shown
+  pptx:
+    quality: na
+    comment: author title not shown
+  revealjs:
+    quality: na
+    comment: author title not shown
+  dashboard:
+    quality: na
+    comment: author title not shown
+author:
+  - name: Josiah Carberry
+    id: jc
+    orcid: 0000-0002-1825-0097
+    email: josiah@psychoceramics.org
+    affiliation:
+      - name: Brown University
+        city: Providence
+        state: RI
+        url: https://www.brown.edu
+---

--- a/dev-docs/feature-format-matrix/qmd-files/title-blocks/metadata-labels/description-title/document.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/title-blocks/metadata-labels/description-title/document.qmd
@@ -1,0 +1,28 @@
+---
+title: "Toward a Unified Theory of High-Energy Metaphysics: Silly String Theory"
+format:
+  html:
+    quality: na
+    comment: description title not shown
+  typst:
+    quality: na
+    comment: description not shown
+  pdf:
+    quality: na
+    comment: description not shown
+  docx:
+    quality: na
+    comment: description not shown
+  pptx:
+    quality: na
+    comment: description not shown
+  revealjs:
+    quality: na
+    comment: description not shown
+  dashboard:
+    quality: na
+    comment: description not shown
+author: Josiah Carberry
+description-title: Description!
+description: A very serious theory
+---

--- a/dev-docs/feature-format-matrix/qmd-files/title-blocks/metadata-labels/doi-title/document.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/title-blocks/metadata-labels/doi-title/document.qmd
@@ -1,0 +1,55 @@
+---
+format:
+  html:
+    quality: na
+    comment: doi title not shown
+  typst:
+    quality: na
+    comment: doi not shown
+  pdf:
+    quality: na
+    comment: doi not shown
+  docx:
+    quality: na
+    comment: doi not shown
+  pptx:
+    quality: na
+    comment: doi not shown
+  revealjs:
+    quality: na
+    comment: doi not shown
+  dashboard:
+    quality: na
+    comment: doi not shown
+title: "Toward a Unified Theory of High-Energy Metaphysics: Silly String Theory"
+date: 2008-02-29
+title-block-banner: true
+author:
+  - name: Josiah Carberry
+    id: jc
+    orcid: 0000-0002-1825-0097
+    email: josiah@psychoceramics.org
+    affiliation:
+      - name: Brown University
+        city: Providence
+        state: RI
+        url: https://www.brown.edu
+abstract: >
+  The characteristic theme of the works of Stone is
+  the bridge between culture and society. ...
+abstract-title: Abstract!
+description: works of Stone
+keywords:
+  - Metaphysics
+  - String Theory
+license: "CC BY"
+copyright:
+  holder: Josiah Carberry
+  year: 2008
+citation:
+  container-title: Journal of Psychoceramics
+  volume: 1
+  issue: 1
+  doi: 10.5555/12345678
+funding: "The author received no specific funding for this work."
+---

--- a/dev-docs/feature-format-matrix/qmd-files/title-blocks/metadata-labels/published-title/document.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/title-blocks/metadata-labels/published-title/document.qmd
@@ -1,0 +1,36 @@
+---
+title: "Toward a Unified Theory of High-Energy Metaphysics: Silly String Theory"
+date: 2008-02-29
+published-title: Published!
+format:
+  html:
+    quality: 1
+  typst:
+    quality: na
+    comment: published title not shown
+  pdf:
+    quality: na
+    comment: published title not shown
+  docx:
+    quality: na
+    comment: published title not shown
+  pptx:
+    quality: na
+    comment: published title not shown
+  revealjs:
+    quality: na
+    comment: published title not shown
+  dashboard:
+    quality: na
+    comment: publication date not shown
+author:
+  - name: Josiah Carberry
+    id: jc
+    orcid: 0000-0002-1825-0097
+    email: josiah@psychoceramics.org
+    affiliation:
+      - name: Brown University
+        city: Providence
+        state: RI
+        url: https://www.brown.edu
+---


### PR DESCRIPTION
In https://github.com/quarto-dev/quarto-cli/pull/10220#issuecomment-2214828744, @cscheid suggested I add feature-format matrix entries for `abstract-title`.

I did one better and filled in all of [Title Blocks - Metadata Labels](https://github.com/quarto-dev/quarto-cli/pull/10220#issuecomment-2214828744). (`abstract-title` would have been lonely on its own.)

To no one's surprise, these features are mostly NA - HTML is the only feature that uses most of `*-title`.

`abstract-title` is the one metadata label that is used across many formats - HTML, Typst, Docx.

<img width="1402" alt="image" src="https://github.com/quarto-dev/quarto-cli/assets/1366709/c067e420-00df-48bf-b1c2-75441a74db81">

I am giving myself a gold star ⭐ for finding two features (`description-title`, `doi-title`) that are N/A across all formats.  🎉 🍾 

This makes sense because these features are only used in templates and not directly by the formats. Doubtless there are templates out there that do use these features.

Includes tests within the ff matrix for `abstract-title` only.