### PR TITLE
errors: explicitly `Deno.exit(1)` when CommandError is caught at top-level

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -27,3 +27,4 @@ All changes included in 1.6:
 
 - ([#10162](https://github.com/quarto-dev/quarto-cli/issues/10162)): Use Edge on `macOS` as a Chromium browser when available.
 - ([#10235](https://github.com/quarto-dev/quarto-cli/issues/10235)): Configure the CI schedule trigger to activate exclusively for the upstream repository.
+- ([#10295](https://github.com/quarto-dev/quarto-cli/issues/10235)): fix regression to return error status to shell when `CommandError` is thrown.

--- a/src/quarto.ts
+++ b/src/quarto.ts
@@ -160,6 +160,7 @@ export async function quarto(
   } catch (e) {
     if (e instanceof CommandError) {
       logError(e, false);
+      Deno.exit(1);
     } else {
       throw e;
     }


### PR DESCRIPTION
Closes #10295.