### PR TITLE
processTextDependency: safely insert in table

### DIFF
--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -1548,7 +1548,7 @@ local function processTextDependency(dependency, meta)
    if meta[textLoc] == nil then
       meta[textLoc] = {}
    end
-   meta[textLoc]:insert(pandoc.RawBlock(FORMAT, rawText.text))
+   table.insert(meta[textLoc], pandoc.RawBlock(FORMAT, rawText.text))
  end
 
  -- make the usePackage statement


### PR DESCRIPTION
This code is attempting to safely add a text location for locations that may not be initialized:

https://github.com/quarto-dev/quarto-cli/blob/65906be2844869cf5b4f53aee1eaa9c0884e5add/src/resources/pandoc/datadir/init.lua#L1548-L1551

However, when I tried to add a text location, it crashed, because `{}` does not have a metatable so the colon syntax won't work.

So do this instead:

```lua
   table.insert(meta[textLoc], pandoc.RawBlock(FORMAT, rawText.text))
```

It's also possible to add the metatable:

```lua
      setmetatable(meta[textLoc], {__index = table})
```

but that's silly.

The reason we are often lulled into thinking we can use `:` is that Pandoc objects _do_ have metatables pointing to table.

Fortunately or unfortunately, there is no way to test this directly, because `resolveLocation` will err if the location is unknown.

It turns out I don't want to add a text location for the work I'm doing, so I am submitting this as a separate fix.