### PR TITLE
register cleanup for sassCache

### DIFF
--- a/src/core/cleanup.ts
+++ b/src/core/cleanup.ts
@@ -1,9 +1,8 @@
 /*
-* cleanup.ts
-*
-* Copyright (C) 2020-2022 Posit Software, PBC
-*
-*/
+ * cleanup.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
 
 import { info } from "../deno_ral/log.ts";
 
@@ -14,7 +13,9 @@ export function onCleanup(handler: VoidFunction) {
 }
 
 export function exitWithCleanup(code: number) {
-  for (const handler of cleanupHandlers) {
+  // Not using cleanupHandlers.reverse() to not mutate the original array
+  for (let i = cleanupHandlers.length - 1; i >= 0; i--) {
+    const handler = cleanupHandlers[i];
     try {
       handler();
     } catch (error) {

--- a/src/core/sass.ts
+++ b/src/core/sass.ts
@@ -307,7 +307,8 @@ export async function compileWithCache(
     const cacheDir = useSessionCache
       ? join(temp.baseDir, "sass")
       : quartoCacheDir("sass");
-    const cache = await sassCache(cacheDir);
+    // when using quarto session cache, we ensure to cleanup the cache files
+    const cache = await sassCache(cacheDir, !!useSessionCache);
     return cache.getOrSet(input, loadPaths, temp, cacheIdentifier, compressed);
   } else {
     const outputFilePath = temp.createFile({ suffix: ".css" });

--- a/src/core/sass.ts
+++ b/src/core/sass.ts
@@ -307,8 +307,8 @@ export async function compileWithCache(
     const cacheDir = useSessionCache
       ? join(temp.baseDir, "sass")
       : quartoCacheDir("sass");
-    // when using quarto session cache, we ensure to cleanup the cache files
-    const cache = await sassCache(cacheDir, !!useSessionCache);
+    // when using quarto session cache, we ensure to cleanup the cache files at TempContext cleanup
+    const cache = await sassCache(cacheDir, useSessionCache ? temp : undefined);
     return cache.getOrSet(input, loadPaths, temp, cacheIdentifier, compressed);
   } else {
     const outputFilePath = temp.createFile({ suffix: ".css" });

--- a/src/core/sass/cache.ts
+++ b/src/core/sass/cache.ts
@@ -163,7 +163,7 @@ class SassCache {
     registerCleanup(() => {
       try {
         this.kv.close();
-        if (!temp) safeRemoveIfExists(this.path);
+        if (temp) safeRemoveIfExists(this.path);
       } catch (error) {
         log.info(
           `Error occurred during sass cache cleanup for ${this.path}: ${error}`,

--- a/src/core/temp-types.ts
+++ b/src/core/temp-types.ts
@@ -9,4 +9,5 @@ export interface TempContext {
   createFile: (options?: Deno.MakeTempOptions) => string;
   createDir: (options?: Deno.MakeTempOptions) => string;
   cleanup: () => void;
+  onCleanup: (handler: VoidFunction) => VoidFunction[];
 }

--- a/src/core/temp-types.ts
+++ b/src/core/temp-types.ts
@@ -9,5 +9,5 @@ export interface TempContext {
   createFile: (options?: Deno.MakeTempOptions) => string;
   createDir: (options?: Deno.MakeTempOptions) => string;
   cleanup: () => void;
-  onCleanup: (handler: VoidFunction) => VoidFunction[];
+  onCleanup: (handler: VoidFunction) => void;
 }

--- a/src/core/temp.ts
+++ b/src/core/temp.ts
@@ -4,7 +4,7 @@
  * Copyright (C) 2020-2022 Posit Software, PBC
  */
 
-import { debug } from "../deno_ral/log.ts";
+import { debug, info } from "../deno_ral/log.ts";
 import { join } from "../deno_ral/path.ts";
 import { ensureDirSync, existsSync } from "fs/mod.ts";
 import { normalizePath, removeIfExists, safeRemoveIfExists } from "./path.ts";
@@ -58,6 +58,9 @@ export function createTempContext(options?: Deno.MakeTempOptions) {
     ...options,
     dir: tempDir,
   });
+
+  const tempContextCleanupHandlers: VoidFunction[] = [];
+
   return {
     baseDir: dir,
     createFile: (options?: Deno.MakeTempOptions) => {
@@ -68,9 +71,21 @@ export function createTempContext(options?: Deno.MakeTempOptions) {
     },
     cleanup: () => {
       if (dir) {
+        // Not using .reverse() to not mutate the original array
+        for (let i = tempContextCleanupHandlers.length - 1; i >= 0; i--) {
+          const handler = tempContextCleanupHandlers[i];
+          try {
+            handler();
+          } catch (error) {
+            info("Error occurred during tempContext handler cleanup: " + error);
+          }
+        }
         safeRemoveIfExists(dir);
         dir = undefined;
       }
+    },
+    onCleanup(handler: VoidFunction) {
+      tempContextCleanupHandlers.push(handler);
     },
   };
 }

--- a/src/core/temp.ts
+++ b/src/core/temp.ts
@@ -53,7 +53,7 @@ export function globalTempContext() {
   return tempContext;
 }
 
-export function createTempContext(options?: Deno.MakeTempOptions) {
+export function createTempContext(options?: Deno.MakeTempOptions): TempContext {
   let dir: string | undefined = Deno.makeTempDirSync({
     ...options,
     dir: tempDir,

--- a/src/project/serve/serve.ts
+++ b/src/project/serve/serve.ts
@@ -6,7 +6,13 @@
 
 import { info, warning } from "../../deno_ral/log.ts";
 import { existsSync } from "fs/mod.ts";
-import { basename, dirname, extname, join, relative } from "../../deno_ral/path.ts";
+import {
+  basename,
+  dirname,
+  extname,
+  join,
+  relative,
+} from "../../deno_ral/path.ts";
 import * as colors from "fmt/colors.ts";
 
 import * as ld from "../../core/lodash.ts";
@@ -906,7 +912,7 @@ function acquirePreviewLock(project: ProjectContext) {
   // write our pid to the lockfile
   Deno.writeTextFileSync(lockfile, String(Deno.pid));
 
-  // rmeove the lockfile when we exit
+  // remove the lockfile when we exit
   onCleanup(() => releasePreviewLock(project));
 }
 

--- a/tests/verify.ts
+++ b/tests/verify.ts
@@ -111,7 +111,7 @@ export const noErrorsOrWarnings: Verify = {
   name: "No Errors or Warnings",
   verify: (outputs: ExecuteOutput[]) => {
     const isErrorOrWarning = (output: ExecuteOutput) => {
-      return output.levelName.toLowerCase() === "warning" ||
+      return output.levelName.toLowerCase() === "warn" ||
         output.levelName.toLowerCase() === "error";
     };
 


### PR DESCRIPTION
This solves #10368 

First, opening for review. I still need to add some tests in this PR before we merge. 

This is a follow up on 
- https://github.com/quarto-dev/quarto-cli/pull/10218

so that opened Deno.kv connection are correctly closed  before we try to delete the create files. 

Challenge are the following 
- It happens we cleanup in several places 
	- Render services cleanup after render
	- on exit cleanup at the very end 
- At first I tried to add on exit cleanup, but in fact we clean TempContext earlier right after render, while cleaning all render services. 
- Sass Cache cleanup needs to happen before cleaning Temp Context or during Temp Context cleanup itself. 
- Though we have one of the Sass Cache that is not in Quarto Session Dir but on user cacher directory. This Deno.kv also needs to be closed before we exit (so that we do things cleanly). 

This PR is a proposal with the following to resolve thoses challenges

- It adds a mechanism to add cleanup handler to a TempContext. 
- SassCache using a TempContext can register a specific cleaning handler
- Other SassCache not using a TempContext (persistent cache) are cleanup as quarto exit handler, and cache db file is not removed)

We could do differently probably 
- As I believe we always create a temp context, we could attach all SassCache cleanup to TempContext cleanup phase, which will happen after render.
- Maybe we need more generic process where SassCache kv db should be a new render services where cleanup is attached to lifetime `kRenderServicesLifetime` object. Or even in this case a single kv db for all things we need to cache that would be available as a CacheContext like TempContext, and following same logic of being attach to lifetime object. 

Any how, I did the more obvious and easy to me. Testing locally, it solves this  and cleanup is working well ! 

