### PR TITLE
log level seems to be WARN and not WARNING

### DIFF
--- a/tests/verify.ts
+++ b/tests/verify.ts
@@ -111,7 +111,7 @@ export const noErrorsOrWarnings: Verify = {
   name: "No Errors or Warnings",
   verify: (outputs: ExecuteOutput[]) => {
     const isErrorOrWarning = (output: ExecuteOutput) => {
-      return output.levelName.toLowerCase() === "warning" ||
+      return output.levelName.toLowerCase() === "warn" ||
         output.levelName.toLowerCase() === "error";
     };
 


### PR DESCRIPTION
Follow up on a change I made in another PR.  https://github.com/quarto-dev/quarto-cli/pull/10060/files#diff-79849e81ec8acc0c295a6668cce331a413b12ef597296c580464031899b7da4bL137

I noticed that our log level are now 
https://github.com/quarto-dev/quarto-cli/blob/be2792dd8d0960f1d205aeb62fa3544ec956e6d3/src/core/log.ts#L23
following a Deno upgrade months ago 
- #8907 (92cad4456c4e8b635979d6b39f45b507aba70edb)

Our tests needs adaptation. 

I am opening this PR because we may have missed a few problem as `noErrorsOrWarnings` was not more catching this new warning. 

This needs to be merged for adding new test to #10372 






