### PR TITLE
use safeRemoveSync in one more place

### DIFF
--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -31,7 +31,7 @@ export const kSkipHidden = /[/\\][\.]/;
 
 export function removeIfExists(file: string) {
   if (existsSync(file)) {
-    Deno.removeSync(file, { recursive: true });
+    safeRemoveSync(file, { recursive: true });
   }
 }
 


### PR DESCRIPTION
This avoid `Deno.removeSync` issue on windows

No error right now because of this, but we should be safer on this because of existing deno issue
