### PR TITLE
stack entry in unnamed function still diffs ok

### DIFF
--- a/src/core/deno/debug.ts
+++ b/src/core/deno/debug.ts
@@ -81,8 +81,11 @@ export const getStackAsArray = (
           col: m1[4] + (m1[1] ? 6 : 0),
         };
       }
-      // other stack entry? (with parentheses)
-      const m2 = s.match(/^.*at (async )?(.*) \((src\/.+):(\d+):(\d+)\)$/);
+      // other stack entry
+      // (with parentheses)
+      const m2 = s.match(/^.*at (async )?(.*) \((src\/.+):(\d+):(\d+)\)$/) ||
+        // without parentheses - async and name will be empty
+        s.match(/^.*at (async )?(.*)(src\/.+):(\d+):(\d+)$/);
       if (m2) {
         return {
           pos: m2[3],


### PR DESCRIPTION
Some stack entries may not have function names. For example, a function expression will often not have a name

My stack looked like

```
Stack trace:
    at file:///Users/gordon/src/quarto-cli/src/core/deno/debug.ts:109:13
    at Array.map (<anonymous>)
    at getStackAsArray (file:///Users/gordon/src/quarto-cli/src/core/deno/debug.ts:72:44)
    at getStack (file:///Users/gordon/src/quarto-cli/src/core/deno/debug.ts:155:5)
    at file:///Users/gordon/src/quarto-cli/src/command/render/pandoc.ts:1349:19
```

The stack diff-er failed on that last one.

It's inside an unnamed function expression:

https://github.com/quarto-dev/quarto-cli/blob/29f0a967a7c32a4ef9cd91d77c5a436500da5131/src/command/render/pandoc.ts#L1348-L1352

#### Proposed solution 

If we don't match stack entry with parentheses in the regex, try again without them.

The name shows as blank, but name is not part of the key for stack comparison, so this is ok:

<img width="853" alt="image" src="https://github.com/user-attachments/assets/33bf79e6-fa2e-4539-9531-f812cb5cc1a5">
