### PR TITLE
fix: Microsoft Edge not detected (Quarto 1.6.4) on macOS

### DIFF
--- a/src/core/puppeteer.ts
+++ b/src/core/puppeteer.ts
@@ -206,9 +206,7 @@ async function findChrome(): Promise<string | undefined> {
       "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
       "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
     ];
-    return programs.find((p) => {
-      safeExistsSync(p);
-    });
+    return programs.find(safeExistsSync);
   } else if (Deno.build.os === "windows") {
     // Try the HKLM key
     const programs = ["chrome.exe", "msedge.exe"];


### PR DESCRIPTION
Fix the TypeScript checking for path of chrome/chromium.

Fixes #10464

This is a follow up PR of:
- #10172