### PR TITLE
Quarto LaTeX engine improvement on missing package detection

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -5,7 +5,7 @@ All changes included in 1.6:
 - ([#10039](https://github.com/quarto-dev/quarto-cli/issues/10039)): `quarto inspect` properly handles `!expr` tag in metadata.
 - ([#10188](https://github.com/quarto-dev/quarto-cli/issues/10188)): `quarto inspect` properly resolves includes across subdirectory boundaries.
 
-## Lua filters
+## Lua Filters
 
 - ([#10004](https://github.com/quarto-dev/quarto-cli/issues/10004)): Resolve callout titles, theorem names, and `code-summary` content through `quarto_ast_pipeline()` and `process_shortcodes()`.
 - ([#10196](https://github.com/quarto-dev/quarto-cli/issues/10196)): Protect against nil values in `float.caption_long`.
@@ -22,6 +22,13 @@ All changes included in 1.6:
 - ([#10181](https://github.com/quarto-dev/quarto-cli/issues/10181)): Remove workaround for image dimensions which is no longer necessary and mishandled image paths with spaces.
 - ([#10217](https://github.com/quarto-dev/quarto-cli/issues/10217)): Explicitly compute units for image dimensions in `typst` format when they're not given.
 - ([#10212](https://github.com/quarto-dev/quarto-cli/issues/10212)): Moves Pandoc variables to the function declaration for the default template.
+
+## `latex` and `pdf` Format
+
+- ([#10291](https://github.com/quarto-dev/quarto-cli/issues/10291)): Several improvement regarding Quarto LaTeX engine behavior for missing hyphenation log message:
+  - `latex-auto-install: false` now correctly opt out any missing hyphenation packages detection and installation. Only a warning will be thrown if any detected in the log.
+  - For default behavior (`latex-auto-install: true`), detection is still happening and missing packages are installed automatically. If it fails, Quarto does not fail anymore as PDF rendering as succeeded already. Only a warning will be thrown to log the installation failure.
+  - Log message about hyphenation package missing for `chinese` or `chinese-hans` languages are now ignored.
 
 ## Projects
 

--- a/src/command/render/latexmk/parse-error.ts
+++ b/src/command/render/latexmk/parse-error.ts
@@ -114,7 +114,7 @@ export function findMissingHyphenationFiles(logText: string) {
     // It seems some languages have no hyphenation files, so we just filter them out
     // e.g. `lang: zh` has no hyphenation files
     // https://github.com/quarto-dev/quarto-cli/issues/10291
-    const noHyphen = ["chinese-hans"];
+    const noHyphen = ["chinese-hans", "chinese"];
     if (noHyphen.includes(lang)) {
       return;
     }

--- a/src/command/render/latexmk/parse-error.ts
+++ b/src/command/render/latexmk/parse-error.ts
@@ -111,6 +111,14 @@ const resolvingMatchers = [
 export function findMissingHyphenationFiles(logText: string) {
   //ngerman gets special cased
   const filterLang = (lang: string) => {
+    // It seems some languages have no hyphenation files, so we just filter them out
+    // e.g. `lang: zh` has no hyphenation files
+    // https://github.com/quarto-dev/quarto-cli/issues/10291
+    const noHyphen = ["chinese-hans"];
+    if (noHyphen.includes(lang)) {
+      return;
+    }
+
     // NOTE Although the names of the corresponding lfd files match those in this list,
     // there are some exceptions, particularly in German and Serbian. So, ngerman is
     // called here german, which is the name in the CLDR and, actually, the most logical.

--- a/src/command/render/latexmk/pdf.ts
+++ b/src/command/render/latexmk/pdf.ts
@@ -180,13 +180,21 @@ async function initialCompileLatex(
       const logText = Deno.readTextFileSync(response.log);
       const missingHyphenationFile = findMissingHyphenationFiles(logText);
       if (missingHyphenationFile) {
-        if (await pkgMgr.installPackages([missingHyphenationFile])) {
-          // We installed hyphenation files, retry
-          continue;
-        } else {
-          writeError("missing hyphenation file", "", response.log);
-          return Promise.reject();
+        // try to install it, unless auto install is opted out
+        if (pkgMgr.autoInstall) {
+          logProgress("Installing missing hyphenation file...");
+          if (await pkgMgr.installPackages([missingHyphenationFile])) {
+            // We installed hyphenation files, retry
+            continue;
+          } else {
+            logProgress("Installing missing hyphenation file failed.");
+          }
         }
+        // Let's just through a warning, but it may not be fatal for the compilation
+        // and we can end normally
+        warning(
+          `Possibly missing hyphenation file: '${missingHyphenationFile}'. See more in logfile (by setting 'latex-clean: false').\n`,
+        );
       }
     } else if (pkgMgr.autoInstall) {
       // try autoinstalling

--- a/src/command/render/latexmk/pdf.ts
+++ b/src/command/render/latexmk/pdf.ts
@@ -205,8 +205,6 @@ async function initialCompileLatex(
         packagesUpdated = true;
       }
 
-      const logText = Deno.readTextFileSync(response.log);
-
       // Try to find and install packages
       const packagesInstalled = await findAndInstallPackages(
         pkgMgr,

--- a/tests/docs/smoke-all/2024/08/30/10291/latex-hyphen-lang-es-no-install.qmd
+++ b/tests/docs/smoke-all/2024/08/30/10291/latex-hyphen-lang-es-no-install.qmd
@@ -1,0 +1,26 @@
+---
+format: pdf
+lang: es
+latex-auto-install: false
+_quarto:
+  tests:
+    pdf:
+      noErrors: true 
+      printsMessage:
+        - WARN
+        - 'missing hyphenation.*hyphen-spanish'
+---
+
+```{r}
+#| include: false
+
+# Remove the hyphen package for spanish so that the test is meaningful
+if (tinytex::check_installed("hyphen-spanish")) {
+  message("Removing 'hyphen-spanish' package for the render")
+  tinytex::tlmgr_remove("hyphen-spanish")
+}
+```
+
+# Hola !
+
+automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente

--- a/tests/docs/smoke-all/2024/08/30/10291/latex-hyphen-lang-es.qmd
+++ b/tests/docs/smoke-all/2024/08/30/10291/latex-hyphen-lang-es.qmd
@@ -1,0 +1,21 @@
+---
+format: pdf
+lang: es
+_quarto:
+  tests:
+    pdf: null
+---
+
+```{r}
+#| include: false
+
+# Remove the hyphen package for spanish
+if (tinytex::check_installed("hyphen-spanish")) {
+  message("Removing 'hyphen-spanish' package for the render")
+  tinytex::tlmgr_remove("hyphen-spanish")
+}
+```
+
+# Hola !
+
+automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente automáticamente

--- a/tests/docs/smoke-all/2024/08/30/10291/latex-hyphen-lang-zh.qmd
+++ b/tests/docs/smoke-all/2024/08/30/10291/latex-hyphen-lang-zh.qmd
@@ -1,0 +1,9 @@
+---
+format: pdf
+lang: zh
+_quarto:
+  tests:
+    pdf: null
+---
+
+# 范叶亮


### PR DESCRIPTION
- Don't try installing hyphen package when auto installation 
- Ignore some log entries for missing hyphen  packages that don't really exists. (like 'chinese-hans' and 'chinese')

Closes #10291 

