### PR TITLE
`create project` can now open in Positron

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -19,6 +19,10 @@ All changes included in 1.6:
 - ([#10217](https://github.com/quarto-dev/quarto-cli/issues/10217)): Explicitly compute units for image dimensions in `typst` format when they're not given.
 - ([#10212](https://github.com/quarto-dev/quarto-cli/issues/10212)): Moves Pandoc variables to the function declaration for the default template.
 
+## Projects
+
+- ([#10268](https://github.com/quarto-dev/quarto-cli/issues/10268)]): `quarto create` supports opening project in Positron, in addition to VS Code and RStudio IDE.
+
 ## Engines
 
 ### `julia`

--- a/src/command/create/cmd.ts
+++ b/src/command/create/cmd.ts
@@ -30,7 +30,7 @@ export const createCommand = new Command()
   .option(
     "--open [editor:string]",
     `Open new artifact in this editor (${
-      kEditorInfos.map((info) => info.id).join(",")
+      kEditorInfos.map((info) => info.id).join(", ")
     })`,
   )
   .option("--no-open", "Do not open in an editor")

--- a/src/command/create/editor.ts
+++ b/src/command/create/editor.ts
@@ -7,7 +7,11 @@
 import { CreateResult } from "./cmd-types.ts";
 
 import { which } from "../../core/path.ts";
-import { isRStudioTerminal, isVSCodeTerminal } from "../../core/platform.ts";
+import {
+  isPositronTerminal,
+  isRStudioTerminal,
+  isVSCodeTerminal,
+} from "../../core/platform.ts";
 
 import { basename, dirname, join } from "../../deno_ral/path.ts";
 import { existsSync } from "fs/mod.ts";
@@ -29,6 +33,7 @@ export interface Editor {
 }
 
 export const kEditorInfos: EditorInfo[] = [
+  positronEditorInfo(),
   vscodeEditorInfo(),
   rstudioEditorInfo(),
 ];
@@ -136,6 +141,66 @@ function vscodeEditorInfo(): EditorInfo {
     editorInfo.actions.push({
       action: "path",
       arg: "/snap/bin/code",
+    });
+  }
+  return editorInfo;
+}
+
+function positronEditorInfo(): EditorInfo {
+  const editorInfo: EditorInfo = {
+    id: "positron",
+    name: "positron",
+    open: (path: string, createResult: CreateResult) => {
+      const artifactPath = createResult.path;
+      const cwd = Deno.statSync(artifactPath).isDirectory
+        ? artifactPath
+        : dirname(artifactPath);
+
+      return async () => {
+        const p = Deno.run({
+          cmd: [path, artifactPath],
+          cwd,
+        });
+        await p.status();
+      };
+    },
+    inEditor: isPositronTerminal(),
+    actions: [],
+  };
+
+  if (Deno.build.os === "windows") {
+    editorInfo.actions.push({
+      action: "which",
+      arg: "Positron.exe",
+    });
+    const pathActions = windowsAppPaths("Positron", "Positron.exe").map(
+      (path) => {
+        return {
+          action: "path",
+          arg: path,
+        } as ScanAction;
+      },
+    );
+    editorInfo.actions.push(...pathActions);
+  } else if (Deno.build.os === "darwin") {
+    editorInfo.actions.push({
+      action: "which",
+      arg: "positron",
+    });
+
+    const pathActions = macosAppPaths(
+      "Positron.app/Contents/Resources/app/bin/positron",
+    ).map((path) => {
+      return {
+        action: "path",
+        arg: path,
+      } as ScanAction;
+    });
+    editorInfo.actions.push(...pathActions);
+  } else {
+    editorInfo.actions.push({
+      action: "which",
+      arg: "positron",
     });
   }
   return editorInfo;

--- a/src/command/create/editor.ts
+++ b/src/command/create/editor.ts
@@ -189,7 +189,7 @@ function positronEditorInfo(): EditorInfo {
     });
 
     const pathActions = macosAppPaths(
-      "Positron.app/Contents/Resources/app/bin/positron",
+      "Positron.app/Contents/Resources/app/bin/code",
     ).map((path) => {
       return {
         action: "path",

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -24,6 +24,10 @@ export function isRStudio() {
   return !!Deno.env.get("RSTUDIO");
 }
 
+export function isPositron() {
+  return !!Deno.env.get("POSITRON");
+}
+
 export function isVSCodeOutputChannel() {
   return !!Deno.env.get("VSCODE_PID");
 }
@@ -44,6 +48,11 @@ export function isRStudioWorkbench() {
 
 export function isRStudioTerminal() {
   return !!Deno.env.get("RSTUDIO_TERM");
+}
+
+export function isPositronTerminal() {
+  // it seems there is no POSITRON_TERM variable set
+  return isPositron();
 }
 
 export function isServerSession() {


### PR DESCRIPTION
This PR teaches Quarto about Positron as an editor for `quarto create project`

- Either to select using `quarto create project --open positron`
- Either to detect when command is ran into Positron directly

Help page shows the new support

````
❯ quarto create --help

Usage:   quarto create [type] [commands...]
Version: 99.9.9

Description:

  Create a Quarto project or extension

Options:

  -h, --help              - Show this help.
  --open        [editor]  - Open new artifact in this editor (positron, vscode, rstudio)
  --no-open               - Do not open in an editor

(...)
````

I checked the Windows paths for default installation of both installers. 

This solves #10268 