### PR TITLE
lua,callout,revealjs - handle empty contents correctly

### DIFF
--- a/src/resources/filters/customnodes/callout.lua
+++ b/src/resources/filters/customnodes/callout.lua
@@ -169,7 +169,7 @@ function _callout_main()
     end
   
     -- contents 
-    local calloutContents = pandoc.Div(node.content, pandoc.Attr("", {"callout-content"}))
+    local calloutContents = pandoc.Div(node.content or pandoc.Blocks({}), pandoc.Attr("", {"callout-content"}))
     calloutBody.content:insert(calloutContents)
   
     -- set attributes (including hiding icon)

--- a/tests/docs/smoke-all/2024/08/27/issue-9821.qmd
+++ b/tests/docs/smoke-all/2024/08/27/issue-9821.qmd
@@ -1,0 +1,8 @@
+---
+title: revealtest
+format: revealjs
+---
+
+::: {.callout-tip}
+## Title only
+:::


### PR DESCRIPTION
This closes #9821.