### PR TITLE
project - store and cache document-level metadata

### DIFF
--- a/src/execute/engine.ts
+++ b/src/execute/engine.ts
@@ -30,6 +30,7 @@ import { ProjectContext } from "../project/types.ts";
 import { pandocBuiltInFormats } from "../core/pandoc/pandoc-formats.ts";
 import { gitignoreEntries } from "../project/project-gitignore.ts";
 import { juliaEngine } from "./julia.ts";
+import { ensureFileInformationCache } from "../project/project-shared.ts";
 
 const kEngines: Map<string, ExecutionEngine> = new Map();
 
@@ -193,9 +194,9 @@ export async function fileExecutionEngineAndTarget(
   // markdown: MappedString | undefined,
   project: ProjectContext,
 ) {
-  const cached = project.engineAndTargetCache?.get(file);
-  if (cached) {
-    return cached;
+  const cached = ensureFileInformationCache(project, file);
+  if (cached && cached.engine && cached.target) {
+    return { engine: cached.engine, target: cached.target };
   }
 
   const engine = await fileExecutionEngine(file, flags, project);
@@ -209,11 +210,9 @@ export async function fileExecutionEngineAndTarget(
     throw new Error("Can't determine execution target for " + file);
   }
 
+  cached.engine = engine;
+  cached.target = target;
   const result = { engine, target };
-  if (!project.engineAndTargetCache) {
-    project.engineAndTargetCache = new Map();
-  }
-  project.engineAndTargetCache.set(file, result);
   return result;
 }
 

--- a/src/project/project-context.ts
+++ b/src/project/project-context.ts
@@ -66,6 +66,7 @@ import {
   ignoreFieldsForProjectType,
   normalizeFormatYaml,
   projectConfigFile,
+  projectFileMetadata,
   projectResolveBrand,
   projectResolveFullMarkdownForFile,
   projectVarsFile,
@@ -291,6 +292,9 @@ export async function projectContext(
               result,
             );
           },
+          fileMetadata: async (file: string, force?: boolean) => {
+            return projectFileMetadata(result, file, force);
+          },
           isSingleFile: false,
         };
 
@@ -368,6 +372,9 @@ export async function projectContext(
               result,
             );
           },
+          fileMetadata: async (file: string, force?: boolean) => {
+            return projectFileMetadata(result, file, force);
+          },
           notebookContext,
           isSingleFile: false,
         };
@@ -430,6 +437,9 @@ export async function projectContext(
                 flags,
                 context,
               );
+            },
+            fileMetadata: async (file: string, force?: boolean) => {
+              return projectFileMetadata(context, file, force);
             },
             isSingleFile: false,
           };

--- a/src/project/types.ts
+++ b/src/project/types.ts
@@ -50,6 +50,9 @@ export type FileInformation = {
   fullMarkdown?: MappedString;
   includeMap?: FileInclusion[];
   codeCells?: InspectedMdCell[];
+  engine?: ExecutionEngine;
+  target?: ExecutionTarget;
+  metadata?: Metadata;
 };
 
 export interface ProjectContext {
@@ -59,12 +62,6 @@ export interface ProjectContext {
   config?: ProjectConfig;
   notebookContext: NotebookContext;
   outputNameIndex?: Map<string, { file: string; format: Format } | undefined>;
-
-  // This is a cache of the engine and target for a given filename
-  engineAndTargetCache?: Map<
-    string,
-    { engine: ExecutionEngine; target: ExecutionTarget }
-  >;
 
   fileInformationCache: Map<string, FileInformation>;
 
@@ -87,6 +84,11 @@ export interface ProjectContext {
     file: string,
     force?: boolean,
   ) => Promise<{ engine: ExecutionEngine; target: ExecutionTarget }>;
+
+  fileMetadata: (
+    file: string,
+    force?: boolean,
+  ) => Promise<Metadata>;
 
   formatExtras?: (
     source: string,

--- a/src/project/types/single-file/single-file.ts
+++ b/src/project/types/single-file/single-file.ts
@@ -20,6 +20,7 @@ import { RenderFlags } from "../../../command/render/types.ts";
 import { MappedString } from "../../../core/mapped-text.ts";
 import { fileExecutionEngineAndTarget } from "../../../execute/engine.ts";
 import {
+  projectFileMetadata,
   projectResolveBrand,
   projectResolveFullMarkdownForFile,
 } from "../../project-shared.ts";
@@ -65,6 +66,9 @@ export function singleFileProjectContext(
         markdown,
         force,
       );
+    },
+    fileMetadata: async (file: string, force?: boolean) => {
+      return projectFileMetadata(result, file, force);
     },
     isSingleFile: true,
   };

--- a/src/quarto-core/inspect-types.ts
+++ b/src/quarto-core/inspect-types.ts
@@ -23,6 +23,7 @@ export type InspectedMdCell = {
 export interface InspectedFile {
   includeMap: FileInclusion[];
   codeCells: InspectedMdCell[];
+  metadata: Record<string, unknown>;
 }
 
 export interface InspectedConfig {

--- a/src/quarto-core/inspect.ts
+++ b/src/quarto-core/inspect.ts
@@ -25,6 +25,7 @@ import { kLocalDevelopment, quartoConfig } from "../core/quarto.ts";
 import { cssFileResourceReferences } from "../core/css.ts";
 import {
   projectExcludeDirs,
+  projectFileMetadata,
   projectResolveCodeCellsForFile,
 } from "../project/project-shared.ts";
 import { normalizePath, safeExistsSync } from "../core/path.ts";
@@ -92,9 +93,11 @@ export async function inspectConfig(path?: string): Promise<InspectedConfig> {
         }
 
         await projectResolveCodeCellsForFile(context, engine, file);
+        await projectFileMetadata(context, file);
         fileInformation[file] = {
           includeMap: context.fileInformationCache.get(file)?.includeMap ?? [],
           codeCells: context.fileInformationCache.get(file)?.codeCells ?? [],
+          metadata: context.fileInformationCache.get(file)?.metadata ?? {},
         };
       }
       const config: InspectedProjectConfig = {
@@ -191,6 +194,7 @@ export async function inspectConfig(path?: string): Promise<InspectedConfig> {
 
       await context.resolveFullMarkdownForFile(engine, path);
       await projectResolveCodeCellsForFile(context, engine, path);
+      await projectFileMetadata(context, path);
       const fileInformation = context.fileInformationCache.get(path);
 
       // data to write
@@ -205,6 +209,7 @@ export async function inspectConfig(path?: string): Promise<InspectedConfig> {
           [path]: {
             includeMap: fileInformation?.includeMap ?? [],
             codeCells: fileInformation?.codeCells ?? [],
+            metadata: fileInformation?.metadata ?? {},
           },
         },
       };


### PR DESCRIPTION
Quarto will now store and cache document-level metadata (_before_ engine execution) in the `ProjectContext` object.

In addition, `quarto inspect` will provide that information in the `fileInformation` field.