### PR TITLE
brand,project - store and forward per-file brand information

### DIFF
--- a/src/command/render/filters.ts
+++ b/src/command/render/filters.ts
@@ -193,7 +193,7 @@ export async function filterParamsJson(
     [kIsShinyPython]: isShinyPython,
     [kShinyPythonExec]: isShinyPython ? await pythonExec() : undefined,
     [kExecutionEngine]: options.executionEngine,
-    [kBrand]: options.project.resolveBrand(options.source),
+    [kBrand]: await options.project.resolveBrand(options.source),
   };
   return JSON.stringify(params);
 }

--- a/src/command/render/filters.ts
+++ b/src/command/render/filters.ts
@@ -193,7 +193,7 @@ export async function filterParamsJson(
     [kIsShinyPython]: isShinyPython,
     [kShinyPythonExec]: isShinyPython ? await pythonExec() : undefined,
     [kExecutionEngine]: options.executionEngine,
-    [kBrand]: options.format.render[kBrand],
+    [kBrand]: options.project.resolveBrand(options.source),
   };
   return JSON.stringify(params);
 }

--- a/src/command/render/render-contexts.ts
+++ b/src/command/render/render-contexts.ts
@@ -599,9 +599,6 @@ async function resolveFormats(
       );
     };
 
-    // resolve brand in project and forward it to format
-    mergedFormats[format].render.brand = await project.resolveBrand();
-
     // ensure that we have a valid forma
     const formatIsValid = isValidFormat(
       formatDesc,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -495,7 +495,6 @@ export interface FormatRender {
   [kValidateYaml]?: boolean;
   [kCanonicalUrl]?: boolean | string;
   [kBodyClasses]?: string;
-  [kBrand]?: Brand;
 }
 
 export interface FormatExecute {

--- a/src/core/sass/brand.ts
+++ b/src/core/sass/brand.ts
@@ -25,10 +25,12 @@ const defaultColorNameMap: Record<string, string> = {
 };
 
 export async function brandBootstrapSassBundles(
+  fileName: string | undefined,
   project: ProjectContext,
   key: string,
 ): Promise<SassBundle[]> {
   return (await brandBootstrapSassBundleLayers(
+    fileName,
     project,
     key,
     defaultColorNameMap,
@@ -42,11 +44,12 @@ export async function brandBootstrapSassBundles(
   );
 }
 export async function brandBootstrapSassBundleLayers(
+  fileName: string | undefined,
   project: ProjectContext,
   key: string,
   nameMap: Record<string, string> = {},
 ): Promise<SassBundleLayers[]> {
-  const brand = await project.resolveBrand();
+  const brand = await project.resolveBrand(fileName);
   const sassBundles: SassBundleLayers[] = [];
 
   if (brand?.data.color) {
@@ -92,10 +95,12 @@ export async function brandBootstrapSassBundleLayers(
 }
 
 export async function brandRevealSassBundleLayers(
+  input: string | undefined,
   _format: Format,
   project: ProjectContext,
 ): Promise<SassBundleLayers[]> {
   return brandBootstrapSassBundleLayers(
+    input,
     project,
     "reveal-theme",
     defaultColorNameMap,
@@ -103,10 +108,12 @@ export async function brandRevealSassBundleLayers(
 }
 
 export async function brandSassFormatExtras(
+  input: string | undefined,
   _format: Format,
   project: ProjectContext,
 ): Promise<FormatExtras> {
   const htmlSassBundleLayers = await brandBootstrapSassBundleLayers(
+    input,
     project,
     "brand",
     defaultColorNameMap,

--- a/src/format/dashboard/format-dashboard.ts
+++ b/src/format/dashboard/format-dashboard.ts
@@ -170,7 +170,7 @@ export function dashboardFormat() {
 
         // add _brand.yml sass bundle
         extras.html[kSassBundles].push(
-          ...await brandBootstrapSassBundles(project, "bootstrap"),
+          ...await brandBootstrapSassBundles(input, project, "bootstrap"),
         );
 
         const scripts: DependencyHtmlFile[] = [];

--- a/src/format/html/format-html.ts
+++ b/src/format/html/format-html.ts
@@ -172,7 +172,7 @@ export function htmlFormat(
             project,
             quiet,
           ),
-          await brandSassFormatExtras(format, project),
+          await brandSassFormatExtras(input, format, project),
           { [kFilterParams]: htmlFilterParams },
         );
       },

--- a/src/format/reveal/format-reveal-theme.ts
+++ b/src/format/reveal/format-reveal-theme.ts
@@ -180,6 +180,7 @@ export async function revealTheme(
   };
 
   const brandLayers: SassBundleLayers[] = await brandRevealSassBundleLayers(
+    input,
     format,
     project,
   );

--- a/src/project/project-context.ts
+++ b/src/project/project-context.ts
@@ -256,7 +256,8 @@ export async function projectContext(
         }
 
         const result: ProjectContext = {
-          resolveBrand: async () => projectResolveBrand(result),
+          resolveBrand: async (fileName?: string) =>
+            projectResolveBrand(result, fileName),
           resolveFullMarkdownForFile: (
             engine: ExecutionEngine | undefined,
             file: string,
@@ -339,7 +340,8 @@ export async function projectContext(
       } else {
         debug(`projectContext: Found Quarto project in ${dir}`);
         const result: ProjectContext = {
-          resolveBrand: async () => projectResolveBrand(result),
+          resolveBrand: async (fileName?: string) =>
+            projectResolveBrand(result, fileName),
           resolveFullMarkdownForFile: (
             engine: ExecutionEngine | undefined,
             file: string,
@@ -400,7 +402,8 @@ export async function projectContext(
           configResolvers.shift();
         } else if (force) {
           const context: ProjectContext = {
-            resolveBrand: async () => projectResolveBrand(context),
+            resolveBrand: async (fileName?: string) =>
+              projectResolveBrand(context, fileName),
             resolveFullMarkdownForFile: (
               engine: ExecutionEngine | undefined,
               file: string,

--- a/src/project/types.ts
+++ b/src/project/types.ts
@@ -53,6 +53,7 @@ export type FileInformation = {
   engine?: ExecutionEngine;
   target?: ExecutionTarget;
   metadata?: Metadata;
+  brand?: Brand;
 };
 
 export interface ProjectContext {
@@ -67,7 +68,7 @@ export interface ProjectContext {
 
   // This is a cache of _brand.yml for a project
   brandCache?: { brand?: Brand };
-  resolveBrand: () => Promise<Brand | undefined>;
+  resolveBrand: (fileName?: string) => Promise<Brand | undefined>;
 
   // expands markdown for a file
   // input file doesn't have to be markdown; it can be, for example, a knitr spin file

--- a/src/project/types/single-file/single-file.ts
+++ b/src/project/types/single-file/single-file.ts
@@ -34,7 +34,7 @@ export function singleFileProjectContext(
   const environmentMemoizer = makeProjectEnvironmentMemoizer(notebookContext);
 
   const result: ProjectContext = {
-    resolveBrand: () => projectResolveBrand(result),
+    resolveBrand: (fileName?: string) => projectResolveBrand(result, fileName),
     dir: normalizePath(dirname(source)),
     engines: [],
     files: {

--- a/src/resources/filters/modules/brand/brand.lua
+++ b/src/resources/filters/modules/brand/brand.lua
@@ -2,7 +2,14 @@
 -- Copyright (C) 2020-2024 Posit Software, PBC
 
 local function get_color(name)
-  local brand = param("brand").processedData -- from src/core/brand/brand.ts
+  local p = param("brand")
+  if p == nil then
+    return nil
+  end
+  local brand = p.processedData -- from src/core/brand/brand.ts
+  if brand == nil then
+    return nil
+  end
   return brand.color[name]
 end
 


### PR DESCRIPTION
Towards https://github.com/quarto-dev/quarto-cli/issues/10249.

This allows the following configurations in Quarto projects/files:

- `_quarto.yml` can provide a different brand file to be used (`brand: override.yml`) or indicate that no branding should be used (`brand: false`)
- documents and document metadata (through `metadata-files`, etc) can:
  - provide a different file to be used (`brand: override.yml`)
  - indicate that no branding should be used (`brand: false`)
  - indicate that the project branding information should be used (`brand: true`). This option is useful specifically in the context where a directory has a brand override (which should trigger for all files), but one particular file needs the override _not_ to happen.