### PR TITLE
Lua,proof,pdf - don't crash when proof environment is empty.

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -9,8 +9,8 @@ All changes included in 1.6:
 
 - ([#10004](https://github.com/quarto-dev/quarto-cli/issues/10004)): Resolve callout titles, theorem names, and `code-summary` content through `quarto_ast_pipeline()` and `process_shortcodes()`.
 - ([#10196](https://github.com/quarto-dev/quarto-cli/issues/10196)): Protect against nil values in `float.caption_long`.
-- ([#10328](https://github.com/quarto-dev/quarto-cli/issues/10328)): Interpret subcells as subfloats when subcap
-  count matches subcell count.
+- ([#10328](https://github.com/quarto-dev/quarto-cli/issues/10328)): Interpret subcells as subfloats when subcap count matches subcell count.
+- ([#10624](https://github.com/quarto-dev/quarto-cli/issues/10624)): Don't crash when proof environments are empty in `pdf`.
 
 ## `typst` Format
 

--- a/src/resources/filters/customnodes/proof.lua
+++ b/src/resources/filters/customnodes/proof.lua
@@ -110,8 +110,11 @@ end, function(proof_tbl)
       preamble:insert(pandoc.RawInline("latex", "]"))
     end
     preamble:insert(pandoc.RawInline("latex", "\n"))
-    -- https://github.com/quarto-dev/quarto-cli/issues/6077
-    if el.content[1].t == "Para" then
+    if #el.content == 0 then
+      warn("Proof block has no content; skipping")
+      return pandoc.Null()
+      -- https://github.com/quarto-dev/quarto-cli/issues/6077
+    elseif el.content[1].t == "Para" then
       preamble:extend(el.content[1].content)
       el.content[1].content = preamble
     else

--- a/tests/docs/smoke-all/2024/08/27/10624.qmd
+++ b/tests/docs/smoke-all/2024/08/27/10624.qmd
@@ -1,0 +1,8 @@
+---
+title: "test"
+format: latex
+---
+
+::: {.solution .content-visible when-format="html"}
+hello
+:::


### PR DESCRIPTION
Closes #10624.