### PR TITLE
change command-line arguments so latest Google Chrome doesn't segfault.

### DIFF
--- a/src/core/cri/cri.ts
+++ b/src/core/cri/cri.ts
@@ -82,8 +82,8 @@ export async function criClient(appPath?: string, port?: number) {
     app,
     "--headless",
     "--no-sandbox",
-    "--single-process",
     "--disable-gpu",
+    "--renderer-process-limit=1",
     `--remote-debugging-port=${port}`,
   ];
   const browser = Deno.run({ cmd, stdout: "piped", stderr: "piped" });


### PR DESCRIPTION
Closes #10626.

Closes #10573.

This PR has already been backported to v1.5, where the entry to the changelog was added.