### PR TITLE
feat: Write yaml schema as (almost compliant) JSON Schema `$defs`

### DIFF
--- a/src/core/schema/types-from-schema.ts
+++ b/src/core/schema/types-from-schema.ts
@@ -22,7 +22,7 @@ import { toCapitalizationCase } from "../lib/text.ts";
 import { capitalizeWord as capitalize } from "../text.ts";
 import { join } from "../../deno_ral/path.ts";
 
-function typeNameFromSchemaName(schemaName: string) {
+export function typeNameFromSchemaName(schemaName: string) {
   return capitalize(toCapitalizationCase(schemaName.replaceAll("/", "-")));
 }
 


### PR DESCRIPTION
Follow up to #10634.

This PR restructures `src/resources/schema/json-schemas.json` to be closer to the final JSON Schema compliant structure (2020-12 draft). In particular, we now write all of the definitions into `$defs` as a named object, and we replace `$ref` fields with correct ref paths.

The `json-schemas.json` still isn't fully JSON Schema compliant, but the brand portions do pass validation checks.

``` python
import json
import jsonschema
from jsonschema import Draft202012Validator

schema_path = "/Users/garrick/work/quarto-dev/quarto-cli/src/resources/schema/json-schemas.json"

with open(schema_path, 'r') as schema_file:
    schema = json.load(schema_file)
```

``` python
def validate_json_schema(schema):
    try:
        Draft202012Validator.check_schema(schema)
        print("Schema is valid according to JSON Schema 2020-12 specification.")
    except jsonschema.exceptions.SchemaError as e:
        print(f"Schema is invalid: {e}")
```

``` python
validate_json_schema(schema)
```

    Schema is invalid: {'values': [None], 'hidden': True} is not of type 'array'

    Failed validating 'type' in metaschema['allOf'][0]['properties']['$defs']['additionalProperties']['$dynamicRef']['allOf'][1]['properties']['anyOf']['items']['$dynamicRef']['allOf'][3]['properties']['enum']:
        {'type': 'array', 'items': True}

    On schema['$defs']['PandocFormatOutputFile']['anyOf'][1]['enum']:
        {'values': [None], 'hidden': True}

``` python
schema["$defs"] = {k: v for k, v in schema["$defs"].items() if k.startswith("Brand")}
# not required but useful for brand-yaml work
schema["type"] = "object"
schema["properties"] = {"brand": {"$ref": "#/$defs/Brand"}}

validate_json_schema(schema)
```

    Schema is valid according to JSON Schema 2020-12 specification.

<details>
<summary>
<code>brand-schema.json</code>
</summary>

``` python
import json
print(json.dumps(schema, indent=2))
```

    {
      "$schema": "https://json-schema.org/draft/2020-12/schema",
      "$defs": {
        "BrandMeta": {
          "object": {
            "properties": {
              "name": {
                "anyOf": [
                  {
                    "type": "string"
                  },
                  {
                    "object": {
                      "properties": {
                        "full": {
                          "type": "string"
                        },
                        "short": {
                          "type": "string"
                        }
                      }
                    }
                  }
                ]
              },
              "link": {
                "anyOf": [
                  {
                    "type": "string"
                  },
                  {
                    "object": {
                      "properties": {
                        "home": {
                          "type": "string"
                        },
                        "mastodon": {
                          "type": "string"
                        },
                        "github": {
                          "type": "string"
                        },
                        "linkedin": {
                          "type": "string"
                        },
                        "twitter": {
                          "type": "string"
                        },
                        "facebook": {
                          "type": "string"
                        }
                      }
                    }
                  }
                ]
              }
            }
          }
        },
        "BrandStringLightDark": {
          "anyOf": [
            {
              "type": "string"
            },
            {
              "object": {
                "properties": {
                  "light": {
                    "type": "string"
                  },
                  "dark": {
                    "type": "string"
                  }
                }
              }
            }
          ]
        },
        "BrandLogo": {
          "anyOf": [
            {
              "type": "string"
            },
            {
              "object": {
                "properties": {
                  "with": {
                    "object": {
                      "properties": {}
                    }
                  },
                  "small": {
                    "$ref": "#/$defs/BrandStringLightDark"
                  },
                  "medium": {
                    "$ref": "#/$defs/BrandStringLightDark"
                  },
                  "large": {
                    "$ref": "#/$defs/BrandStringLightDark"
                  }
                }
              }
            }
          ]
        },
        "BrandColorValue": {
          "type": "string"
        },
        "BrandColor": {
          "object": {
            "properties": {
              "with": {
                "object": {
                  "properties": {}
                }
              },
              "foreground": {
                "$ref": "#/$defs/BrandColorValue"
              },
              "background": {
                "$ref": "#/$defs/BrandColorValue"
              },
              "primary": {
                "$ref": "#/$defs/BrandColorValue"
              },
              "secondary": {
                "$ref": "#/$defs/BrandColorValue"
              },
              "tertiary": {
                "$ref": "#/$defs/BrandColorValue"
              },
              "success": {
                "$ref": "#/$defs/BrandColorValue"
              },
              "info": {
                "$ref": "#/$defs/BrandColorValue"
              },
              "warning": {
                "$ref": "#/$defs/BrandColorValue"
              },
              "danger": {
                "$ref": "#/$defs/BrandColorValue"
              },
              "light": {
                "$ref": "#/$defs/BrandColorValue"
              },
              "dark": {
                "$ref": "#/$defs/BrandColorValue"
              },
              "emphasis": {
                "$ref": "#/$defs/BrandColorValue"
              },
              "link": {
                "$ref": "#/$defs/BrandColorValue"
              }
            }
          }
        },
        "BrandMaybeNamedColor": {
          "anyOf": [
            {
              "$ref": "#/$defs/BrandNamedThemeColor"
            },
            {
              "type": "string"
            }
          ]
        },
        "BrandNamedThemeColor": {
          "enum": [
            "foreground",
            "background",
            "primary",
            "secondary",
            "tertiary",
            "success",
            "info",
            "warning",
            "danger",
            "light",
            "dark",
            "emphasis",
            "link"
          ]
        },
        "BrandTypography": {
          "object": {
            "properties": {
              "with": {
                "$ref": "#/$defs/BrandFont"
              },
              "base": {
                "$ref": "#/$defs/BrandTypographyOptions"
              },
              "headings": {
                "$ref": "#/$defs/BrandTypographyOptionsNoSize"
              },
              "monospace": {
                "$ref": "#/$defs/BrandTypographyOptions"
              },
              "emphasis": {
                "object": {
                  "properties": {
                    "weight": {
                      "$ref": "#/$defs/BrandFontWeight"
                    },
                    "color": {
                      "$ref": "#/$defs/BrandMaybeNamedColor"
                    },
                    "background-color": {
                      "$ref": "#/$defs/BrandMaybeNamedColor"
                    }
                  }
                }
              },
              "link": {
                "object": {
                  "properties": {
                    "weight": {
                      "$ref": "#/$defs/BrandFontWeight"
                    },
                    "decoration": {
                      "type": "string"
                    },
                    "color": {
                      "$ref": "#/$defs/BrandMaybeNamedColor"
                    },
                    "background-color": {
                      "$ref": "#/$defs/BrandMaybeNamedColor"
                    }
                  }
                }
              }
            }
          }
        },
        "BrandTypographyOptions": {
          "object": {
            "properties": {
              "family": {
                "type": "string"
              },
              "size": {
                "type": "string"
              },
              "line-height": {
                "type": "string"
              },
              "weight": {
                "$ref": "#/$defs/BrandFontWeight"
              },
              "style": {
                "$ref": "#/$defs/BrandFontStyle"
              },
              "color": {
                "$ref": "#/$defs/BrandMaybeNamedColor"
              },
              "background-color": {
                "$ref": "#/$defs/BrandMaybeNamedColor"
              }
            }
          }
        },
        "BrandTypographyOptionsNoSize": {
          "object": {
            "properties": {
              "family": {
                "type": "string"
              },
              "line-height": {
                "type": "string"
              },
              "weight": {
                "$ref": "#/$defs/BrandFontWeight"
              },
              "style": {
                "$ref": "#/$defs/BrandFontStyle"
              },
              "color": {
                "$ref": "#/$defs/BrandMaybeNamedColor"
              },
              "background-color": {
                "$ref": "#/$defs/BrandMaybeNamedColor"
              }
            }
          }
        },
        "BrandFont": {
          "type": "array",
          "items": {
            "anyOf": [
              {
                "$ref": "#/$defs/BrandFontGoogle"
              },
              {
                "$ref": "#/$defs/BrandFontFile"
              },
              {
                "$ref": "#/$defs/BrandFontFamily"
              }
            ]
          }
        },
        "BrandFontWeight": {
          "enum": [
            100,
            200,
            300,
            400,
            500,
            600,
            700,
            800,
            900
          ]
        },
        "BrandFontStyle": {
          "enum": [
            "normal",
            "italic"
          ]
        },
        "BrandFontGoogle": {
          "object": {
            "properties": {
              "google": {
                "anyOf": [
                  {
                    "type": "string"
                  },
                  {
                    "object": {
                      "properties": {
                        "family": {
                          "type": "string"
                        },
                        "weight": {
                          "anyOf": [
                            {
                              "type": "array",
                              "items": {
                                "$ref": "#/$defs/BrandFontWeight"
                              }
                            },
                            {
                              "$ref": "#/$defs/BrandFontWeight"
                            }
                          ]
                        },
                        "style": {
                          "anyOf": [
                            {
                              "type": "array",
                              "items": {
                                "$ref": "#/$defs/BrandFontStyle"
                              }
                            },
                            {
                              "$ref": "#/$defs/BrandFontStyle"
                            }
                          ]
                        },
                        "display": {
                          "enum": [
                            "auto",
                            "block",
                            "swap",
                            "fallback",
                            "optional"
                          ]
                        }
                      }
                    }
                  }
                ]
              }
            }
          }
        },
        "BrandFontFile": {
          "object": {
            "properties": {
              "family": {
                "type": "string"
              },
              "files": {
                "anyOf": [
                  {
                    "type": "array",
                    "items": {
                      "anyOf": [
                        {
                          "type": "string"
                        },
                        {
                          "type": "string"
                        }
                      ]
                    }
                  },
                  {
                    "anyOf": [
                      {
                        "type": "string"
                      },
                      {
                        "type": "string"
                      }
                    ]
                  }
                ]
              }
            }
          }
        },
        "BrandFontFamily": {
          "type": "string"
        },
        "Brand": {
          "object": {
            "properties": {
              "meta": {
                "$ref": "#/$defs/BrandMeta"
              },
              "logo": {
                "$ref": "#/$defs/BrandLogo"
              },
              "color": {
                "$ref": "#/$defs/BrandColor"
              },
              "typography": {
                "$ref": "#/$defs/BrandTypography"
              },
              "defaults": {
                "type": "object"
              }
            }
          }
        }
      },
      "type": "object",
      "properties": {
        "brand": {
          "$ref": "#/$defs/Brand"
        }
      }
    }

</details>
