### PR TITLE
Revealjs - Cleaning how theme dependency is processed 

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -14,7 +14,9 @@ All changes included in 1.6:
 
 ## `revealjs` Format
 
-- Update to Reveal JS 5.1.0
+- Update to Reveal JS 5.1.0.
+- Prevent empty SASS built css file to be included in header.
+- Remove wrong `sourceMappingUrl` entry in SASS built css.
 - ([#7715](https://github.com/quarto-dev/quarto-cli/issues/7715)): Revealjs don't support anymore special Pandoc syntax making BulletList in Blockquotes become incremental list. This was confusing and unexpected behavior. Supported syntax for incremental list is documented at <https://quarto.org/docs/presentations/revealjs/#incremental-lists>.
 - ([#9742](https://github.com/quarto-dev/quarto-cli/issues/9742)): Links to cross-referenced images correctly works.
 

--- a/src/core/sass.ts
+++ b/src/core/sass.ts
@@ -17,6 +17,8 @@ import * as ld from "./lodash.ts";
 import { lines } from "./text.ts";
 import { sassCache } from "./sass/cache.ts";
 import { md5HashBytes } from "./hash.ts";
+import { kSourceMappingRegexes } from "../config/constants.ts";
+import { writeTextFileSyncPreserveMode } from "./write.ts";
 
 export interface SassVariable {
   name: string;
@@ -326,4 +328,16 @@ export async function compileWithCache(
     );
     return outputFilePath;
   }
+}
+
+// Clean sourceMappingUrl from css after saas compilation
+export function cleanSourceMappingUrl(cssPath: string): void {
+  const cleaned = Deno.readTextFileSync(cssPath).replaceAll(
+    kSourceMappingRegexes[0],
+    "",
+  ).replaceAll(
+    kSourceMappingRegexes[1],
+    "",
+  );
+  writeTextFileSyncPreserveMode(cssPath, cleaned);
 }

--- a/src/core/write.ts
+++ b/src/core/write.ts
@@ -1,0 +1,27 @@
+/*
+ * write.ts
+ *
+ * Copyright (C)2024 Posit Software, PBC
+ */
+
+export function writeTextFileSyncPreserveMode(
+  path: string,
+  data: string,
+  options?: Deno.WriteFileOptions | undefined,
+): void {
+  // Preserve the existing permissions if possible
+  // See https://github.com/quarto-dev/quarto-cli/issues/660
+  let mode;
+  if (Deno.build.os !== "windows") {
+    const stat = Deno.statSync(path);
+    if (stat.mode !== null) {
+      mode = stat.mode;
+    }
+  }
+
+  if (mode !== undefined) {
+    options = { ...options, mode }; // Merge provided options with mode
+  }
+
+  Deno.writeTextFileSync(path, data, options);
+}

--- a/src/format/reveal/format-reveal-theme.ts
+++ b/src/format/reveal/format-reveal-theme.ts
@@ -20,6 +20,7 @@ import { isFileRef } from "../../core/http.ts";
 import { pathWithForwardSlashes } from "../../core/path.ts";
 import { formatResourcePath } from "../../core/resources.ts";
 import {
+  cleanSourceMappingUrl,
   compileSass,
   mergeLayers,
   outputVariable,
@@ -188,6 +189,8 @@ export async function revealTheme(
 
   // compile sass
   const css = await compileSass([bundleLayers, ...brandLayers], temp);
+  // Remove sourcemap information
+  cleanSourceMappingUrl(css);
   // convert from string to bytes
   const hash = md5HashBytes(Deno.readFileSync(css));
   const fileName = `quarto-${hash}`;

--- a/tests/docs/smoke-all/2024/05/03/9548.qmd
+++ b/tests/docs/smoke-all/2024/05/03/9548.qmd
@@ -6,12 +6,14 @@ _quarto:
   tests:
     revealjs:
       ensureHtmlElements:
-        - ['head > link[rel="stylesheet"][href$="quarto-4f64e0fc78c89fc90127583bb01c366c.css"]']
+        - []
         - ['head > link[rel="stylesheet"][href$="beige.css"]']
+      ensureFileRegexMatches:
+        - ['<link .* href=.+revealjs/dist/theme/quarto-([a-f0-9]{32})\.css']
 ---
 
 # Revealjs theme handling
 
-User provided theme should be used to build a `quarto-<hash>.css` using SASS and the `theme: beige` should internally by overridden to `theme: quarto` so that the later is added in Pandoc's template
+User provided them9548_files/libs/revealjs/dist/theme/e should be used to build a `quarto-<hash>.css` using SASS and the `theme: beige` should internally by overridden to `theme: quarto` so that the later is added in Pandoc's template
 
 2024-08-26: `quarto.css` now carries the MD5 hash of the content to allow different revealjs themes to work on the same website.

--- a/tests/docs/smoke-all/2024/05/03/9548.qmd
+++ b/tests/docs/smoke-all/2024/05/03/9548.qmd
@@ -14,6 +14,6 @@ _quarto:
 
 # Revealjs theme handling
 
-User provided them9548_files/libs/revealjs/dist/theme/e should be used to build a `quarto-<hash>.css` using SASS and the `theme: beige` should internally by overridden to `theme: quarto` so that the later is added in Pandoc's template
+User provided theme should be used to build a `quarto-<hash>.css` using SASS and the `theme: beige` should internally by overridden to `theme: quarto` so that the later is added in Pandoc's template
 
 2024-08-26: `quarto.css` now carries the MD5 hash of the content to allow different revealjs themes to work on the same website.


### PR DESCRIPTION
This PR is a proposal to do several things, as part of refactoring. 

- `sourceMappingUrl` cleaning we do for some themes with bootstrap is not done with revealjs. This refactor our code to do this. This will fix #10423 

- With our current `quarto-html` dependency, used with revealjs, it leads to adding as dependency an empty file. Basically, `quarto-html-<hash>.css` was only containing `sourceMappingUrl` comment line, and now is empty. This PR now check for emptyness of the processed CSS file and if so, it does not add the CSS file as a HTML dependency. This save some typescript processing too. 

I did not add any test because not sure what should be tested in this case. I tried adding one to check that if a `quarto-html-<hash>.css` exists, it is not empty, but I think this was a bad test. 

Hopefully this change makes sense. Happy to discuss it. 

Also, this PR uses now regex for the revealjs test that check a resource with hash, because it is at least the third time this week we would need to modify this test. 