### PR TITLE
revealjs - Prevent unexpected Pandoc syntax list in blockquote to beome incremental list

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -15,6 +15,7 @@ All changes included in 1.6:
 ## `revealjs` Format
 
 - Update to Reveal JS 5.1.0.
+- ([#7715](https://github.com/quarto-dev/quarto-cli/issues/7715)): Revealjs don't support anymore special Pandoc syntax making BulletList in Blockquotes become incremental list. This was confusing and unexpected behavior. Supported syntax for incremental list is documented at <https://quarto.org/docs/presentations/revealjs/#incremental-lists>.
 
 ## `typst` Format
 

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -834,6 +834,27 @@ function revealHtmlPostprocessor(
       supporting: [],
     };
 
+    // Remove blockquote scaffolding added in Lua post-render to prevent Pandoc syntax for applying
+    if (doc.querySelectorAll("div.blockquote-list-scaffold")) {
+      const blockquoteListScaffolds = doc.querySelectorAll(
+        "div.blockquote-list-scaffold",
+      );
+      for (const blockquoteListScaffold of blockquoteListScaffolds) {
+        const blockquoteListScaffoldEL = blockquoteListScaffold as Element;
+        const blockquoteListScaffoldParent =
+          blockquoteListScaffoldEL.parentNode;
+        if (blockquoteListScaffoldParent) {
+          while (blockquoteListScaffoldEL.firstChild) {
+            blockquoteListScaffoldParent.insertBefore(
+              blockquoteListScaffoldEL.firstChild,
+              blockquoteListScaffoldEL,
+            );
+          }
+          blockquoteListScaffoldParent.removeChild(blockquoteListScaffoldEL);
+        }
+      }
+    }
+
     // apply highlighting mode to body
     doc.body.classList.add("quarto-" + highlightingMode);
 

--- a/src/resources/filters/main.lua
+++ b/src/resources/filters/main.lua
@@ -392,7 +392,8 @@ local quarto_post_filters = {
   { name = "post-render-gfm-fixups", filter = render_gfm_fixups() },
   { name = "post-render-hugo-fixups", filter = render_hugo_fixups() },
   { name = "post-render-email", filters = render_email() },
-  { name = "post-render-pptx-fixups", filter = render_pptx_fixups() }
+  { name = "post-render-pptx-fixups", filter = render_pptx_fixups() },
+  { name = "post-render-revealjs-fixups", filter = render_reveal_fixups() }
 }
 
 local quarto_finalize_filters = {

--- a/src/resources/filters/quarto-post/reveal.lua
+++ b/src/resources/filters/quarto-post/reveal.lua
@@ -52,3 +52,19 @@ function asCssSize(size)
     return size
   end
 end
+
+function render_reveal_fixups()
+  if not _quarto.format.isRevealJsOutput() then
+    return {}
+  end
+  return {
+    -- Prevent BulletList in blockquote to be made incremental with .fragment class
+    -- https://github.com/quarto-dev/quarto-cli/issues/7715
+    BlockQuote = function(b)
+      if #b.content and b.content[1].t == "BulletList" then
+        b.content = pandoc.Div(b.content, pandoc.Attr('', {'blockquote-list-scaffold'}))
+        return b
+      end
+    end
+  }
+end

--- a/tests/docs/smoke-all/2024/08/30/7715.qmd
+++ b/tests/docs/smoke-all/2024/08/30/7715.qmd
@@ -1,0 +1,17 @@
+---
+title: BulletList in Blockquote should not be fragment 
+format: revealjs
+_quarto:
+  tests:
+    revealjs:
+      ensureHtmlElements:
+        - ['blockquote > ul > li:not([class])']
+        - ['blockquote > ul > li.fragment', 'div.blockquote-list-scaffold']
+---
+
+## Blockquote and incremental
+
+> * Foo
+> * Bar
+
+Using blockquote should not create incremental like Pandoc (https://pandoc.org/MANUAL.html#incremental-lists)


### PR DESCRIPTION
This closes #7715

As discussed, we have a way in Lua to prevent Pandoc Revealjs writer to do this transformation. 

This means we don't support on purpose a Pandoc syntax documented in their doc (https://pandoc.org/MANUAL.html#incremental-lists) but it is really unexpected behavior and their is other means to create incremental list which are documented. 

@cscheid I opened this as a way to keep the solution in a branch somewhere. 

I think it would be worth doing as there is solution to create incremental list and this syntax is really unexpected. I don't think anyone of our users uses it as we don't document it. We have other Pandoc features that don't work by our design choices. I think this is ok for this one too. 

Anyhow, opening for discussion. It is there, we can decide anytime. 