### PR TITLE
latex - Teach error detection about new fontspec log error for missing font

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -30,6 +30,7 @@ All changes included in 1.6:
   - `latex-auto-install: false` now correctly opt out any missing hyphenation packages detection and installation. Only a warning will be thrown if any detected in the log.
   - For default behavior (`latex-auto-install: true`), detection is still happening and missing packages are installed automatically. If it fails, Quarto does not fail anymore as PDF rendering as succeeded already. Only a warning will be thrown to log the installation failure.
   - Log message about hyphenation package missing for `chinese` or `chinese-hans` languages are now ignored.
+- ([#10655](https://github.com/quarto-dev/quarto-cli/issues/10655)): Missing fonts from fontspec error are correctly detected and looked for to be installed.
 
 ## Projects
 

--- a/src/command/render/latexmk/parse-error.ts
+++ b/src/command/render/latexmk/parse-error.ts
@@ -241,7 +241,11 @@ const packageMatchers = [
     regex: /.*Unable to find TFM file "([^"]+)".*/g,
     filter: formatFontFilter,
   },
-
+  {
+    regex:
+      /.*! Package fontspec Error:\s+\(fontspec\)\s+The font "([^"]+)" cannot be\s+\(fontspec\)\s+found;+/g,
+    filter: formatFontFilter,
+  },
   { regex: /.* File `(.+eps-converted-to.pdf)'.*/g, filter: estoPdfFilter },
   { regex: /.*xdvipdfmx:fatal: pdf_ref_obj.*/g, filter: estoPdfFilter },
 

--- a/tests/docs/smoke-all/2024/09/02/10655.qmd
+++ b/tests/docs/smoke-all/2024/09/02/10655.qmd
@@ -1,0 +1,19 @@
+---
+format:
+  pdf:
+    fontfamily: libertinus
+_quarto:
+  tests:
+    pdf: default
+---
+
+```{r}
+#| include: false
+
+# Remove font that is supposed to be installed automatically
+if (tinytex::check_installed("libertinus-fonts")) {
+  tinytex::tlmgr_remove("libertinus-fonts")
+}
+```
+
+Quarto LaTeX engine should correctly detect the missing font package and install it to render the PDF. 


### PR DESCRIPTION

This way they are correctly detected an installed.

fixes #10655 