### PR TITLE
revealjs - add style for <kbd> in Revealjs format

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -12,6 +12,10 @@ All changes included in 1.6:
 - ([#10328](https://github.com/quarto-dev/quarto-cli/issues/10328)): Interpret subcells as subfloats when subcap count matches subcell count.
 - ([#10624](https://github.com/quarto-dev/quarto-cli/issues/10624)): Don't crash when proof environments are empty in `pdf`.
 
+## `html` Format
+
+- Fix `kbd` element styling on dark themes.
+
 ## `revealjs` Format
 
 - Update to Reveal JS 5.1.0.

--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -19,6 +19,7 @@ All changes included in 1.6:
 - Remove wrong `sourceMappingUrl` entry in SASS built css.
 - ([#7715](https://github.com/quarto-dev/quarto-cli/issues/7715)): Revealjs don't support anymore special Pandoc syntax making BulletList in Blockquotes become incremental list. This was confusing and unexpected behavior. Supported syntax for incremental list is documented at <https://quarto.org/docs/presentations/revealjs/#incremental-lists>.
 - ([#9742](https://github.com/quarto-dev/quarto-cli/issues/9742)): Links to cross-referenced images correctly works.
+- ([#6012](https://github.com/quarto-dev/quarto-cli/issues/6012)): Add styling for `kbd` element in Revealjs slides.
 
 ## `typst` Format
 

--- a/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
@@ -1294,7 +1294,11 @@ $indent: 1.2em;
 kbd,
 .kbd {
   color: $body-color;
-  background-color: $gray-100;
+  @if (quarto-color.blackness($body-bg) > $code-block-theme-dark-threshhold) {
+    background-color: shift-color($gray-100, 70%);
+  } @else {
+    background-color: $gray-100;
+  }
   border: 1px solid;
   border-radius: 5px;
   border-color: $table-border-color;

--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -156,6 +156,13 @@ $overlayElementFgColor: 0, 0, 0 !default;
 
 // -- END setting.scss --
 
+// KBD variables
+$kbd-padding-y: 0.4rem !default;
+$kbd-padding-x: 0.4rem !default;
+$kbd-font-size: $presentation-font-size-root !default;
+$kbd-color: $body-color !default;
+$kbd-bg: $body-bg !default;
+
 /*-- scss:functions --*/
 
 @function colorToRGB($color) {
@@ -737,4 +744,17 @@ div.cell-output-display div.pagedtable-wrapper table.table {
 .reveal .scrollable ol li:first-child:nth-last-child(n + 10),
 .reveal .scrollable ol li:first-child:nth-last-child(n + 10) ~ li {
   margin-left: 1em;
+}
+
+/* kbd rules */
+
+kbd {
+  font-family: $font-family-monospace;
+  font-size: $kbd-font-size;
+  color: $kbd-color;
+  background-color: $kbd-bg;
+  border: 1px solid;
+  border-color: $code-block-border-color;
+  border-radius: 5px;
+  padding: $kbd-padding-y $kbd-padding-x;
 }

--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -18,6 +18,11 @@ $body-bg: #fff !default;
 $body-color: #222 !default;
 $text-muted: lighten($body-color, 30%) !default;
 
+// grey colors (like in bootstrap)
+$gray-200: #e9ecef !default;
+$gray-100: #f8f9fa !default;
+$gray-900: #212529 !default;
+
 // link colors
 $primary: #2a76dd !default;
 $link-color: $primary !default;
@@ -161,7 +166,7 @@ $kbd-padding-y: 0.4rem !default;
 $kbd-padding-x: 0.4rem !default;
 $kbd-font-size: $presentation-font-size-root !default;
 $kbd-color: $body-color !default;
-$kbd-bg: $body-bg !default;
+$kbd-bg: $gray-100 !default; // like in bootstrap style
 
 /*-- scss:functions --*/
 
@@ -170,7 +175,33 @@ $kbd-bg: $body-bg !default;
     ")";
 }
 
+@function tint-color($color, $weight) {
+  @return mix(white, $color, $weight);
+}
+
+@function shade-color($color, $weight) {
+  @return mix(black, $color, $weight);
+}
+
+@function shift-color($color, $weight) {
+  @return if(
+    $weight > 0,
+    shade-color($color, $weight),
+    tint-color($color, -$weight)
+  );
+}
+
 /*-- scss:mixins --*/
+
+@mixin shift_to_dark($property, $color) {
+  @if (
+    sass-color.blackness($backgroundColor) > $code-block-theme-dark-threshhold
+  ) {
+    #{$property}: shift-color($color, 70%);
+  } @else {
+    #{$property}: $color;
+  }
+}
 
 // -- START setting.scss --
 
@@ -752,7 +783,7 @@ kbd {
   font-family: $font-family-monospace;
   font-size: $kbd-font-size;
   color: $kbd-color;
-  background-color: $kbd-bg;
+  @include shift_to_dark("background-color", $kbd-bg);
   border: 1px solid;
   border-color: $code-block-border-color;
   border-radius: 5px;


### PR DESCRIPTION
Closes #6012 

- It adds some styling for kbd element for revealjs. By design, I am choosing the same style than in Bootstrap based document. So it is grey

	- HTML 
		![image](https://github.com/user-attachments/assets/1f6ee0d6-80ad-4b4f-8e7a-8c463db801b7)
	- Revealjs
		![image](https://github.com/user-attachments/assets/fecbc4c8-7bbb-4dc4-b046-e12a5c841181)

- It will change based on dark / light theme where the gray background is made darker. 
	- While trying, I found it was broken for Bootstrap as the color did not adapt while text color was changing. It looks like this now: 
	- HTML with darkly
		![image](https://github.com/user-attachments/assets/dd76ae45-aadf-4e1c-9309-dfac5d2d4492)
	- Revealjs with dark
		![image](https://github.com/user-attachments/assets/20b01275-1ab5-40c4-8c64-f76964f8e13d)

- Some style can be different between HTML and reveal (like border), but this is because it is depend on the theme used, and both format don't have same themes.
	- This is why kbd can be controlled in revealjs with same variable than in bootstrap
		- https://github.com/quarto-dev/quarto-cli/blob/c66d1d38539b0c2dfbb56824d482b107dcf256d3/src/resources/formats/revealjs/quarto.scss#L164-L169

