### PR TITLE
theme - export two more css variable about code block color

### DIFF
--- a/src/resources/formats/html/_quarto-rules.scss
+++ b/src/resources/formats/html/_quarto-rules.scss
@@ -588,12 +588,6 @@ div.ansi-escaped-output {
   --quarto-border-color: #{$table-border-color};
   --quarto-border-width: #{$border-width};
   --quarto-border-radius: #{$border-radius};
-  @if $code-block-bg {
-    --quarto-code-block-bg-color: #{$code-block-bg-color};
-  }
-  @if variable-exists(code-block-color) {
-    --quarto-code-block-color: #{$code-block-color};
-  }
 }
 
 /* rules to support GT table styling */

--- a/src/resources/formats/html/_quarto-rules.scss
+++ b/src/resources/formats/html/_quarto-rules.scss
@@ -588,6 +588,12 @@ div.ansi-escaped-output {
   --quarto-border-color: #{$table-border-color};
   --quarto-border-width: #{$border-width};
   --quarto-border-radius: #{$border-radius};
+  @if $code-block-bg {
+    --quarto-code-block-bg-color: #{$code-block-bg-color};
+  }
+  @if variable-exists(code-block-color) {
+    --quarto-code-block-color: #{$code-block-color};
+  }
 }
 
 /* rules to support GT table styling */

--- a/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
@@ -762,6 +762,10 @@ $code-block-bg-color: quarto-color.adjust(
 ) !default;
 @if type_of($code-block-bg) == color {
   $code-block-bg-color: $code-block-bg;
+  // export as CSS variable
+  :root {
+    --quarto-code-block-bg-color: #{$code-block-bg-color};
+  }
 }
 
 // stack layout panels on mobile devices
@@ -850,6 +854,10 @@ div.sourceCode {
 @if variable-exists(code-block-color) {
   div.sourceCode pre.sourceCode {
     color: $code-block-color;
+  }
+  // export this one as a CSS variable
+  :root {
+    --quarto-code-block-color: #{$code-block-color};
   }
 }
 


### PR DESCRIPTION
This PR just export two more CSS variables to pass the information about color used for code blocks. 
This complements the other variables already defined for extension. 

closes #10717 for quarto side. `quarto-live` will need to do the rest. cc @georgestagg

This needs to be checked against various example to see if that is enough to handle all themes. 
So opening as a draft