### PR TITLE
feat(brand): Allow named weights and numeric values in `brand-font-weight`

### DIFF
--- a/src/resources/schema/definitions.yml
+++ b/src/resources/schema/definitions.yml
@@ -2791,8 +2791,10 @@
     - ref: brand-font-family
 
 - id: brand-font-weight
-  description: A font weight.
-  enum: [100, 200, 300, 400, 500, 600, 700, 800, 900]
+  description: A font weight as a number between 1 and 1000 (inclusive) or a named weight.
+  anyOf:
+    - number # in [1, 1000]
+    - enum: [normal, bold, bolder, lighter]
   default: 400
 
 - id: brand-font-style


### PR DESCRIPTION
This PR updates the `brand-font-weight` definition to allow named font weight values and to support variable font weights. Currently the definition limits font weight to `1:9 * 100`:

```yaml
- id: brand-font-weight
  description: A font weight.
  enum: [100, 200, 300, 400, 500, 600, 700, 800, 900]
  default: 400
```

but CSS also allows `normal` (400), `bold` (700), `lighter`, and `bolder`. In CSS, the last two are _relative font weights_ and are relative to the element's inherited value. In our case, however, I'd recommend we simply assign these values 100 (`lighter`) and 900 (`bolder`).

Here's the description of `font-weight` as a numeric value from [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#values):

> [`<number>`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#number)
> A [`<number>`](https://developer.mozilla.org/en-US/docs/Web/CSS/number) value between 1 and 1000, both values included. Higher numbers represent weights that are bolder than (or as bold as) lower numbers. This allows fine-grain control for [variable fonts](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#variable_fonts). For non-variable fonts, if the exact specified weight is unavailable, a [fallback weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#fallback_weights) algorithm is used — numeric values that are divisible by 100 correspond to common weight names, as described in the [Common weight name mapping](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#common_weight_name_mapping) section below.

In HTML outputs, we can pass numeric and named values through and let CSS handle the computation. In places where variable or named font weights aren't supported, I propose we round to the nearest named point (using our definition for lighter and bolder):

| Name | Value |
|:-----:|:----:|
| lighter | 100 |
| normal | 400 |
| bold | 700 |
| bolder | 900 |