### PR TITLE
Add support for linking to CC0 1.0 license 

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -15,6 +15,7 @@ All changes included in 1.6:
 ## `html` Format
 
 - Fix `kbd` element styling on dark themes.
+- ([#10761](https://github.com/quarto-dev/quarto-cli/issues/10761)): Add support for `licence: CC0` to automatically link to Creative Commons licence [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/).
 
 ## `revealjs` Format
 

--- a/src/format/html/format-html-appendix.ts
+++ b/src/format/html/format-html-appendix.ts
@@ -46,6 +46,8 @@ const kAppendixCreativeCommonsLic = [
   "CC BY-NC-ND",
 ];
 
+const kAppendixCCZero = "CC0";
+
 const kStylePlain = "plain";
 const kStyleDefault = "default";
 
@@ -455,9 +457,13 @@ function creativeCommonsLicense(
             | "CC BY-NC-SA",
           version: version || "4.0",
         };
-      } else {
-        return undefined;
       }
+    } else if (license === kAppendixCCZero) {
+      // special case for this creative commons license
+      return {
+        base: kAppendixCCZero,
+        version: "1.0",
+      };
     } else {
       return undefined;
     }
@@ -467,6 +473,14 @@ function creativeCommonsLicense(
 }
 
 function creativeCommonsUrl(license: string, lang?: string, version?: string) {
+  // Special case for CC0 as different URL
+  if (license === kAppendixCCZero) {
+    return {
+      url: `https://creativecommons.org/publicdomain/zero/${version}/`,
+      text: `CC0 ${version}`,
+      inlineLink: true,
+    };
+  }
   const licenseType = license.substring(3);
   if (lang && lang !== "en") {
     return {

--- a/tests/docs/appendix/license.qmd
+++ b/tests/docs/appendix/license.qmd
@@ -1,0 +1,56 @@
+---
+format:
+  html+zero:
+    license: "CC0"
+  html+cc: 
+    license: "CC BY"
+  html+text: 
+    license: "This work is dedicated to the Public Domain"
+  html+custom: 
+    license:
+      text: > 
+        Permission is granted to copy, distribute and/or 
+        modify this document under the terms of the GNU Free 
+        Documentation License, Version 1.3 or any later version 
+        published by the Free Software Foundation; with no 
+        Invariant Sections, no Front-Cover Texts, and no 
+        Back-Cover Texts. A copy of the license is included in 
+        the section entitled "GNU Free Documentation License
+      type: open-access
+      url: https://www.gnu.org/licenses/fdl-1.3-standalone.html
+_quarto:
+  tests:
+    html+zero:
+      ensureHtmlElements:
+        - ['a[rel="license"][href="https://creativecommons.org/publicdomain/zero/1.0/"]']
+        - []
+      ensureFileRegexMatches:
+        - ['CC0 1.0'] 
+        - []
+    html+cc:
+      ensureHtmlElements:
+        - ['a[rel="license"][href="https://creativecommons.org/licenses/by/4.0/"]']
+        - []
+      ensureFileRegexMatches:
+        - ['CC BY 4.0'] 
+        - []
+    html+text:
+      ensureHtmlElements:
+        - ['h2 + div.quarto-appendix-contents']
+        - []
+      ensureFileRegexMatches:
+        - ['This work is dedicated to the Public Domain'] 
+        - []
+    html+custom:
+      ensureHtmlElements:
+        - ['a[rel="license"][href="https://www.gnu.org/licenses/fdl-1.3-standalone.html"]']
+        - []
+      ensureFileRegexMatches:
+        - ['GNU Free Documentation License'] 
+        - []
+---
+
+
+## Title
+
+This doc will have an appendix part with a licence as a link to the right creative common url


### PR DESCRIPTION
This add CC0 1.0 (https://creativecommons.org/publicdomain/zero/1.0/) support. It is a special creative commons license with different naming and link that this other CC BY.

This PR also add tests for the various form of licence filed possible