### PR TITLE
css - don't define functions that override existing css functions

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -65,6 +65,7 @@ All changes included in 1.6:
 
 ## Other Fixes and Improvements
 
+- ([#10608](https://github.com/quarto-dev/quarto-cli/issues/10608)): Don't overwrite the built-in CSS function `contrast` in Quarto's SCSS.
 - ([#10162](https://github.com/quarto-dev/quarto-cli/issues/10162)): Use Edge on `macOS` as a Chromium browser when available.
 - ([#10235](https://github.com/quarto-dev/quarto-cli/issues/10235)): Configure the CI schedule trigger to activate exclusively for the upstream repository.
 - ([#10295](https://github.com/quarto-dev/quarto-cli/issues/10235)): Fix regression to return error status to shell when `CommandError` is thrown.

--- a/src/resources/formats/html/bootstrap/_bootstrap-functions.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-functions.scss
@@ -45,7 +45,7 @@
       $mixColor,
       percentage(quarto-math.div($percentMix, 100))
     );
-    $contrastRatio: contrast($contrastColor, $bgColor);
+    $contrastRatio: quarto-contrast($contrastColor, $bgColor);
     $percentMix: $percentMix - 1;
   }
 
@@ -343,7 +343,7 @@
 
 // Calculate the contrast ratio between two colors.
 // See https://www.w3.org/TR/WCAG20-TECHS/G17.html#G17-tests
-@function contrast($back, $front) {
+@function quarto-contrast($back, $front) {
   $backLum: luminance($back) + 0.05;
   $foreLum: luminance($front) + 0.05;
 
@@ -361,8 +361,8 @@
 
   $minimumContrast: 3.1;
 
-  $lightContrast: contrast($color, white);
-  $darkContrast: contrast($color, rgba(black, 0.87));
+  $lightContrast: quarto-contrast($color, white);
+  $darkContrast: quarto-contrast($color, rgba(black, 0.87));
 
   @if ($lightContrast < $minimumContrast) and ($darkContrast > $lightContrast) {
     @return "light";


### PR DESCRIPTION
Closes #10608.

@gadenbuie We still have `color-contrast`, but that appears to come from bootstrap itself. What should we do in this case?

