### PR TITLE
windows, zip - Correctly quote path arguments to handle special characters (like space)

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -49,9 +49,13 @@ All changes included in 1.6:
 
 - ([#10616](https://github.com/quarto-dev/quarto-cli/issues/10268)): Add a `z-index` setting to the 'back to top' button to ensure it is always visible.
 
-## Quarto Blog
+### Quarto Blog
 
 - ([#10710](https://github.com/quarto-dev/quarto-cli/issues/10710)): Fix an issue with categorie badges as links in the blog post header.
+
+### Manuscript
+
+- Fix an issue on Windows when creating MECA bundles containing special file name like space in the path ([quarto-ext/manuscript-template-rstudio#3](https://github.com/quarto-ext/manuscript-template-rstudio/issues/3)).
 
 ## Engines
 

--- a/src/core/zip.ts
+++ b/src/core/zip.ts
@@ -65,7 +65,7 @@ export function zip(
         "PowerShell",
         "Compress-Archive",
         "-Path",
-        filesArr.join(", "),
+        filesArr.map((x) => `"${x}"`).join(", "),
         "-DestinationPath",
         archive,
         "-Force",

--- a/tests/docs/manuscript/qmd-single/dummy resource with space in name.txt
+++ b/tests/docs/manuscript/qmd-single/dummy resource with space in name.txt
@@ -1,0 +1,1 @@
+Should be in bundle

--- a/tests/docs/manuscript/qmd-single/index.qmd
+++ b/tests/docs/manuscript/qmd-single/index.qmd
@@ -34,6 +34,8 @@ citation:
 draft: false
 bibliography: references.bib
 echo: false
+resources: 
+  - "dummy resource with space in name.txt"
 ---
 
 ## Introduction

--- a/tests/smoke/manuscript/render-manuscript.test.ts
+++ b/tests/smoke/manuscript/render-manuscript.test.ts
@@ -63,6 +63,7 @@ const qmdSingleOutputs = [
   "images/reservoirs.png",
   "index-preview.html",
   "index.out.ipynb",
+  "dummy resource with space in name.txt"
 ];
 
 testManuscriptRender(


### PR DESCRIPTION
This fix MECA bundle problem in project with special filename

closes https://github.com/quarto-ext/manuscript-template-rstudio/issues/3
