### PR TITLE
tests, playwright - Some improvements

### DIFF
--- a/quarto-cli.code-workspace
+++ b/quarto-cli.code-workspace
@@ -14,6 +14,7 @@
     "deno.enable": true,
     "deno.unstable": true,
     "deno.path": "./package/dist/bin/tools/deno",
+    "deno.disablePaths": ["./tests/integration/playwright"],
     "deno.suggest.imports.hosts": {
       "https://deno.land": true,
       "https://den.o.land": false

--- a/tests/integration/playwright-tests.test.ts
+++ b/tests/integration/playwright-tests.test.ts
@@ -43,17 +43,6 @@ for (const { path: fileName } of globOutput) {
   fileNames.push(fileName);
 }
 
-// start a web server
-// This is attempt #3
-// attempt #1 through Deno.server causes hangs on repeated requests
-// attempt #2 through http/server causes a deno vendor crash: https://github.com/denoland/deno/issues/16861
-
-// we'll just use python :facepalm:
-
-// const proc = Deno.run({
-//   cmd: ["python", "-m", "http.server", "8080"],
-//   cwd: "docs/playwright",
-// });
 
 try {
   // run playwright
@@ -62,9 +51,6 @@ try {
     cwd: "integration/playwright",
   });
 } finally {
-  // cleanup
-  // proc.kill();
-  // proc.close();
   for (const fileName of fileNames) {
     cleanoutput(fileName, "html");
   }

--- a/tests/integration/playwright-tests.test.ts
+++ b/tests/integration/playwright-tests.test.ts
@@ -50,10 +50,10 @@ for (const { path: fileName } of globOutput) {
 
 // we'll just use python :facepalm:
 
-const proc = Deno.run({
-  cmd: ["python", "-m", "http.server", "8080"],
-  cwd: "docs/playwright",
-});
+// const proc = Deno.run({
+//   cmd: ["python", "-m", "http.server", "8080"],
+//   cwd: "docs/playwright",
+// });
 
 try {
   // run playwright
@@ -63,8 +63,8 @@ try {
   });
 } finally {
   // cleanup
-  proc.kill();
-  proc.close();
+  // proc.kill();
+  // proc.close();
   for (const fileName of fileNames) {
     cleanoutput(fileName, "html");
   }

--- a/tests/integration/playwright/playwright.config.ts
+++ b/tests/integration/playwright/playwright.config.ts
@@ -87,6 +87,7 @@ export default defineConfig({
   // outputDir: 'test-results/',
 
   /* Run your local dev server before starting the tests */
+  /* We use python for this but we could also try using another tool */
   webServer: {
     command: 'python -m http.server 8080',
     url: 'http://127.0.0.1:8080',

--- a/tests/integration/playwright/playwright.config.ts
+++ b/tests/integration/playwright/playwright.config.ts
@@ -1,5 +1,4 @@
-import type { PlaywrightTestConfig } from "@playwright/test";
-import { devices } from "@playwright/test";
+import { defineConfig, devices } from '@playwright/test';
 
 /**
  * Read environment variables from file.
@@ -10,7 +9,8 @@ import { devices } from "@playwright/test";
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
-const config: PlaywrightTestConfig = {
+export default defineConfig({
+  /* Look for test files in the "tests" directory, relative to this configuration file. */
   testDir: "./tests",
   /* Maximum time one test can run for. */
   timeout: 30 * 1000,
@@ -33,36 +33,27 @@ const config: PlaywrightTestConfig = {
   reporter: [["html", { open: "never" }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
-    actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://localhost:3000',
+    baseURL: 'http://127.0.0.1:8080',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
   },
-
   /* Configure projects for major browsers */
   projects: [
     {
       name: "chromium",
-      use: {
-        ...devices["Desktop Chrome"],
-      },
+      use: { ...devices['Desktop Chrome'] },
     },
 
     {
       name: "firefox",
-      use: {
-        ...devices["Desktop Firefox"],
-      },
+      use: {...devices["Desktop Firefox"] },
     },
 
     {
       name: "webkit",
-      use: {
-        ...devices["Desktop Safari"],
-      },
+      use: { ...devices["Desktop Safari"] },
     },
     /* Test against mobile viewports. */
     // {
@@ -96,10 +87,10 @@ const config: PlaywrightTestConfig = {
   // outputDir: 'test-results/',
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   port: 3000,
-  // },
-};
-
-export default config;
+  webServer: {
+    command: 'python -m http.server 8080',
+    url: 'http://127.0.0.1:8080',
+    reuseExistingServer: !process.env.CI,
+    cwd: '../../docs/playwright',
+  },
+});

--- a/tests/integration/playwright/tests/blog-simple-blog.spec.ts
+++ b/tests/integration/playwright/tests/blog-simple-blog.spec.ts
@@ -1,10 +1,8 @@
 import { expect, test } from "@playwright/test";
 
-import { getUrl } from "../src/utils.js";
-
 test('List.js is correctly patch to allow searching with lowercase and uppercase', 
   async ({ page }) => {
-    await page.goto(getUrl('blog/simple-blog/_site/'));
+    await page.goto('./blog/simple-blog/_site/');
     await page.getByPlaceholder('Filter').click();
     await page.getByPlaceholder('Filter').fill('Code');
     await page.getByPlaceholder('Filter').press('Enter');
@@ -23,11 +21,11 @@ test('List.js is correctly patch to allow searching with lowercase and uppercase
 });
 
 test('Categories link are clickable', async ({ page }) => {
-  await page.goto(getUrl('blog/simple-blog/_site/posts/welcome/'));
+  await page.goto('./blog/simple-blog/_site/posts/welcome/');
   await page.locator('div').filter({ hasText: /^news$/ }).click();
   await expect(page).toHaveURL(/_site\/index\.html#category=news$/);
   await expect(page.locator('div.category[data-category="news"]')).toHaveClass(/active/);
-  await page.goto(getUrl('blog/simple-blog/_site/posts/welcome/#img-lst'));
+  await page.goto('./blog/simple-blog/_site/posts/welcome/#img-lst');
   await page.locator('div').filter({ hasText: /^news$/ }).click();
   await expect(page).toHaveURL(/_site\/index\.html#category=news$/);
   await expect(page.locator('div.category[data-category="news"]')).toHaveClass(/active/);


### PR DESCRIPTION
- Update config file to latest version
- use webserver config to run the python server
- Simplify some tests as baseUrl is configured


We also add to `deno.disablePaths` the tests file that are run by playwright directly to avoid Deno language server to apply on those files which are not supposed to be ran by Deno. 

