### PR TITLE
port - don't use ports that firefox considers unsafe

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -78,7 +78,6 @@ All changes included in 1.6:
 
 - Upgrade `mermaidjs` to 11.2.0.
 - Upgrade Pandoc to 3.4.
-- ([#10608](https://github.com/quarto-dev/quarto-cli/issues/10608)): Don't overwrite the built-in CSS function `contrast` in Quarto's SCSS.
 - ([#10162](https://github.com/quarto-dev/quarto-cli/issues/10162)): Use Edge on `macOS` as a Chromium browser when available.
 - ([#10235](https://github.com/quarto-dev/quarto-cli/issues/10235)): Configure the CI schedule trigger to activate exclusively for the upstream repository.
 - ([#10295](https://github.com/quarto-dev/quarto-cli/issues/10235)): Fix regression to return error status to shell when `CommandError` is thrown.
@@ -88,3 +87,5 @@ All changes included in 1.6:
 - ([#10552](https://github.com/quarto-dev/quarto-cli/issues/10552)): Add `contents` shortcode.
 - ([#10581](https://github.com/quarto-dev/quarto-cli/issues/10581)): Add `.landscape` div processing to `typst`, `docx` and `pdf` formats to support pages in landscape orientation.
 - ([#10591](https://github.com/quarto-dev/quarto-cli/issues/10591)): Make fenced div syntax slightly more robust by removing spaces around the `=` sign ahead of Pandoc's reader.
+- ([#10608](https://github.com/quarto-dev/quarto-cli/issues/10608)): Don't overwrite the built-in CSS function `contrast` in Quarto's SCSS.
+- ([#10890](https://github.com/quarto-dev/quarto-cli/issues/10890)): Don't use ports that Firefox considers unsafe.

--- a/src/core/port.ts
+++ b/src/core/port.ts
@@ -16,10 +16,13 @@ const kMaxPort = 8000;
 
 function isPortSafe(port: number): boolean {
   // cf https://superuser.com/a/188070
-  // excludes port numbers that chrome considers unsafe
+  // and netwerk/base/nsIOService.cpp in Firefox's source
+  //
+  // excludes port numbers that Chrome or Firefox consider unsafe
   return ![
     3659, // apple-sasl / PasswordServer
     4045, // lockd
+    4160, // sieve
     5060, // sip
     5061, // sips
     6000, // X11
@@ -29,6 +32,7 @@ function isPortSafe(port: number): boolean {
     6667, // Standard IRC [Apple addition]
     6668, // Alternate IRC [Apple addition]
     6669, // Alternate IRC [Apple addition]
+    6679, // osaut
     6697, // IRC + TLS
   ].includes(port);
 }


### PR DESCRIPTION
We need to protect against two more ports. These were found by inspecting Firefox's source code on hg.mozilla.org as of today.