### PR TITLE
Remove creation of temp scss file

### DIFF
--- a/src/core/sass/analyzer/parse.ts
+++ b/src/core/sass/analyzer/parse.ts
@@ -27,7 +27,6 @@ export const makeParserModule = (
         /(^\s*[A-Za-z0-9-]+):([^ \n])/mg,
         "$1: $2",
       );
-      Deno.writeTextFileSync(`temp-${counter++}.scss`, contents);
 
       // This is relatively painful, because unfortunately the error message of scss-parser
       // is not helpful.


### PR DESCRIPTION
Reported in 
- https://github.com/quarto-dev/quarto-cli/discussions/10901

@cscheid this is to be removed, isn't it ? I believe it was useful for debugging right ? 