### PR TITLE
Fix support in PPTX for floatreftarget

### DIFF
--- a/src/resources/filters/customnodes/floatreftarget.lua
+++ b/src/resources/filters/customnodes/floatreftarget.lua
@@ -1082,13 +1082,14 @@ end, function(float)
     return pandoc.Null()
   end
   local im = quarto.utils.match("Plain/[1]/Image")(float.content)
-  if im == nil then
+  if im then
+    decorate_caption_with_crossref(float)
+    im.caption = quarto.utils.as_inlines(float.caption_long)
+    return pandoc.Para({im})
+  else 
     warn("PowerPoint output for FloatRefTargets require a single image as content")
     return pandoc.Null()
   end
-  decorate_caption_with_crossref(float)
-  im.caption = quarto.utils.as_inlines(float.caption_long)
-  return pandoc.Para({im})
 end)
 
 global_table_guid_id = 0

--- a/src/resources/filters/customnodes/floatreftarget.lua
+++ b/src/resources/filters/customnodes/floatreftarget.lua
@@ -1081,15 +1081,17 @@ end, function(float)
     warn("Can't render float without content")
     return pandoc.Null()
   end
-  local im = quarto.utils.match("Plain/[1]/Image")(float.content)
-  if im then
-    decorate_caption_with_crossref(float)
-    im.caption = quarto.utils.as_inlines(float.caption_long)
-    return pandoc.Para({im})
-  else 
+  local im_plain = quarto.utils.match("Plain/[1]/Image")(float.content)
+  local im_para = quarto.utils.match("Para/[1]/Image")(float.content)
+  if not im_plain and not im_para then
     warn("PowerPoint output for FloatRefTargets require a single image as content")
     return pandoc.Null()
   end
+
+  local im = im_plain or im_para
+  decorate_caption_with_crossref(float)
+  im.caption = quarto.utils.as_inlines(float.caption_long)
+  return pandoc.Para({im})
 end)
 
 global_table_guid_id = 0

--- a/tests/docs/smoke-all/2024/06/24/8667.qmd
+++ b/tests/docs/smoke-all/2024/06/24/8667.qmd
@@ -1,5 +1,16 @@
 ---
 format: pptx
+_quarto:
+  tests:
+    pptx:
+      ensurePptxXpath:
+      - 
+        - 1
+        - 
+          - '//p:pic'
+          - '//p:cNvPr[contains(@descr, "existing-image.jpg")]'
+          - '//a:t[contains(text(),"Figure 1")]'
+        - []
 ---
 
 ## Slide Title

--- a/tests/docs/smoke-all/2024/09/30/10931-2.qmd
+++ b/tests/docs/smoke-all/2024/09/30/10931-2.qmd
@@ -1,0 +1,28 @@
+---
+title: Unsupported floatref gives Lua warning and empty content
+format: pptx
+_quarto:
+  tests:
+    pptx:
+      printsMessage:
+        - INFO
+        - 'WARNING.*FloatRefTargets require'
+      ensurePptxXpath:
+      - 
+        - 2
+        - []
+        - ['//a:tbl']
+
+---
+
+## slide with fig div
+
+::: {#fig-table}
+
+| A | B |
+|---|---|
+| C | D |
+
+A table treated like a figure 
+
+:::

--- a/tests/docs/smoke-all/2024/09/30/10931.qmd
+++ b/tests/docs/smoke-all/2024/09/30/10931.qmd
@@ -1,0 +1,27 @@
+---
+title: Testing floatref div in pptx
+format: pptx
+_quarto:
+  tests:
+    pptx:
+      ensurePptxXpath:
+      - 
+        - 2
+        - 
+          - '//p:pic'
+          - '//a:t[contains(text(),"Figure 1")]'
+        - []
+---
+
+## slide with fig div
+
+::: {#fig-graph1}
+
+```{r}
+#| echo: false
+plot(1:10)
+```
+
+A graph
+
+:::


### PR DESCRIPTION
This fixes #10931

- To my knownledge `quarto.utils.match()` returns an element or false, and not nil. So this fixes the problem seen in #10931

- Also I do believe that #10117 can be improved by also supporting the example for #10931 which is CrossRef divs with one image. So I added a conditional on it (it is either inline or block) and then some tests for it

- I also added a test for the currently unsupported behavior which would have catch the #10931 report IMO. 


