### PR TITLE
shortcodes - allow `\\.` in shortcode key resolution

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -93,3 +93,4 @@ All changes included in 1.6:
 - ([#10608](https://github.com/quarto-dev/quarto-cli/issues/10608)): Don't overwrite the built-in CSS function `contrast` in Quarto's SCSS.
 - ([#10821](https://github.com/quarto-dev/quarto-cli/issues/10821)): Be more conservative in stripping `echo: fenced` from fenced output.
 - ([#10890](https://github.com/quarto-dev/quarto-cli/issues/10890)): Don't use ports that Firefox considers unsafe.
+- ([#10936](https://github.com/quarto-dev/quarto-cli/issues/10936)): Use `\\` in `meta` shortcode to escape the following character, allowing keys with `.` in them.

--- a/src/resources/filters/quarto-pre/options.lua
+++ b/src/resources/filters/quarto-pre/options.lua
@@ -38,10 +38,13 @@ function var(name, def)
   end
 end
 
-function parseOption(name, options, def) 
+function parseOption(name, options, def)
+  print(name)
+  name = name:gsub("%\\%.", string.char(1))
   local keys = split(name, ".")
   local value = nil
   for i, key in ipairs(keys) do
+    key = key:gsub(string.char(1), "."):gsub("%\\(.)", "%1")
     if value == nil then
       value = readOption(options, key, nil)
     else

--- a/tests/docs/smoke-all/2024/09/30/issue-10936.qmd
+++ b/tests/docs/smoke-all/2024/09/30/issue-10936.qmd
@@ -1,0 +1,16 @@
+---
+nested:
+  a.b.c:
+    key: cb593803d9d65583347959fd848b5536
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - ['cb593803d9d65583347959fd848b5536']
+---
+
+I would like to show the "Show me" using a shortcode.
+
+E.g. {{< meta nested.a\\.b\\.c.key >}}
+
+but it fails.


### PR DESCRIPTION
Closes #10936.
