### PR TITLE
Don't use deno cache with Quarto run when using dev version

### DIFF
--- a/src/core/run/deno.ts
+++ b/src/core/run/deno.ts
@@ -12,6 +12,7 @@ import { architectureToolsPath, resourcePath } from "../resources.ts";
 import { RunHandler, RunHandlerOptions } from "./types.ts";
 import { removeIfExists } from "../path.ts";
 import { copyTo } from "../copy.ts";
+import { quartoConfig } from "../quarto.ts";
 
 export const denoRunHandler: RunHandler = {
   canHandle: (script: string) => {
@@ -42,7 +43,8 @@ export const denoRunHandler: RunHandler = {
           "run",
           "--import-map",
           importMap,
-          "--cached-only",
+          // --cached-only can only be used in bundles as vendoring is not done anymore in dev mode
+          ...(quartoConfig.isDebug() ? [] : ["--cached-only"]),
           "--allow-all",
           "--unstable-kv",
           "--unstable-ffi",

--- a/tests/docs/run/test-stdlib.ts
+++ b/tests/docs/run/test-stdlib.ts
@@ -1,2 +1,1 @@
-// Temporarily turn this off.
-// import { readLines } from "stdlib/io";
+import { readLines } from "stdlib/io";

--- a/tests/smoke/run/stdlib-run-version.test.ts
+++ b/tests/smoke/run/stdlib-run-version.test.ts
@@ -19,6 +19,4 @@ unitTest("stdlib-run-version", async () => {
   });
   console.log({result})
   assert(result.success);
-}, {
-  ignore: Deno.build.os == "windows",
 });

--- a/tests/smoke/run/stdlib-run-version.test.ts
+++ b/tests/smoke/run/stdlib-run-version.test.ts
@@ -19,4 +19,6 @@ unitTest("stdlib-run-version", async () => {
   });
   console.log({result})
   assert(result.success);
+}, {
+  ignore: Deno.build.os == "windows",
 });


### PR DESCRIPTION
Follow up on 
- https://github.com/quarto-dev/quarto-cli/pull/10940

we deactivated a failing test, and this solves it. 

`quarto run` with dev version needs to not set `--cached-only` as we don't vendor anymore in dev version. 

BTW, I used what we consider to be the mark of dev mode which is `QUARTO_DEBUG`. See comments 
https://github.com/quarto-dev/quarto-cli/blob/5c38d77c240f3eb2a6ebf5239a31cf7c7ea9be07/src/core/quarto.ts#L64-L67
https://github.com/quarto-dev/quarto-cli/blob/5c38d77c240f3eb2a6ebf5239a31cf7c7ea9be07/src/core/quarto.ts#L94-L95

We do set `QUARTO_DEBUG` in 
- `quarto.cmd` for windows
- `quarto` for UNIX
- our `run-tests` scripts
