### PR TITLE
revealjs - Add jumpToSlide support for new revealjs

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -31,6 +31,7 @@ All changes included in 1.6:
 ## `revealjs` Format
 
 - Update to Reveal JS 5.1.0.
+  - Support for a [Jump To Slide](https://revealjs.com/jump-to-slide/) menu to quickly navigate between slides. Set `jump-to-slide: false` to opt out.
 - Prevent empty SASS built css file to be included in header.
 - Remove wrong `sourceMappingUrl` entry in SASS built css.
 - ([#7715](https://github.com/quarto-dev/quarto-cli/issues/7715)): Revealjs don't support anymore special Pandoc syntax making BulletList in Blockquotes become incremental list. This was confusing and unexpected behavior. Supported syntax for incremental list is documented at <https://quarto.org/docs/presentations/revealjs/#incremental-lists>.

--- a/src/format/reveal/constants.ts
+++ b/src/format/reveal/constants.ts
@@ -23,3 +23,4 @@ export const kAutoAnimateDuration = "autoAnimateDuration";
 export const kAutoAnimateUnmatched = "autoAnimateUnmatched";
 export const kAutoStretch = "auto-stretch";
 export const kCodeBlockHeight = "code-block-height";
+export const kJumpToSlide = "jumpToSlide";

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -56,6 +56,7 @@ import {
   kCenterTitleSlide,
   kControlsAuto,
   kHashType,
+  kJumpToSlide,
   kPdfMaxPagesPerSlide,
   kPdfSeparateFragments,
   kPreviewLinksAuto,
@@ -142,6 +143,9 @@ export function revealjsFormat() {
             format.metadata[kAutoAnimateUnmatched] !== undefined
               ? format.metadata[kAutoAnimateUnmatched]
               : true,
+          [kJumpToSlide]: format.metadata[kJumpToSlide] !== undefined
+            ? !!format.metadata[kJumpToSlide]
+            : true,
         };
 
         if (format.metadata[kPdfMaxPagesPerSlide]) {

--- a/src/format/reveal/metadata.ts
+++ b/src/format/reveal/metadata.ts
@@ -6,6 +6,9 @@
 
 import { Metadata } from "../../config/types.ts";
 import { camelToKebab, kebabToCamel } from "../../core/config.ts";
+import {
+  kJumpToSlide,
+} from "./constants.ts";
 
 export function optionsToKebab(options: string[]) {
   return options.reduce(
@@ -111,6 +114,7 @@ const kRevealOptions = [
   "pdfMaxPagesPerSlide",
   "pdfSeparateFragments",
   "pdfPageHeightOffset",
+  kJumpToSlide,
 ];
 
 const kRevealKebabOptions = optionsToKebab(kRevealOptions);

--- a/src/format/reveal/metadata.ts
+++ b/src/format/reveal/metadata.ts
@@ -7,7 +7,12 @@
 import { Metadata } from "../../config/types.ts";
 import { camelToKebab, kebabToCamel } from "../../core/config.ts";
 import {
+  kAutoAnimateDuration,
+  kAutoAnimateEasing,
+  kAutoAnimateUnmatched,
   kJumpToSlide,
+  kPdfMaxPagesPerSlide,
+  kPdfSeparateFragments,
 } from "./constants.ts";
 
 export function optionsToKebab(options: string[]) {
@@ -83,9 +88,9 @@ const kRevealOptions = [
   "preloadIframes",
   "autoAnimate",
   "autoAnimateMatcher",
-  "autoAnimateEasing",
-  "autoAnimateDuration",
-  "autoAnimateUnmatched",
+  kAutoAnimateEasing,
+  kAutoAnimateDuration,
+  kAutoAnimateUnmatched,
   "autoAnimateStyles",
   "autoSlide",
   "autoSlideStoppable",
@@ -111,8 +116,8 @@ const kRevealOptions = [
   "minScale",
   "maxScale",
   "mathjax",
-  "pdfMaxPagesPerSlide",
-  "pdfSeparateFragments",
+  kPdfMaxPagesPerSlide,
+  kPdfSeparateFragments,
   "pdfPageHeightOffset",
   kJumpToSlide,
 ];

--- a/tests/docs/smoke-all/revealjs/jump-to-slide.qmd
+++ b/tests/docs/smoke-all/revealjs/jump-to-slide.qmd
@@ -1,0 +1,17 @@
+---
+title: "Jump to slide"
+format: 
+  revealjs:
+    jump-to-slide: false
+_quarto:
+  test:
+    revealjs:
+      ensureFileRegexMatches:
+        - ["jumpToSlide.*false,"]
+        - ["jumpToSlide.*true,"]
+---
+
+## test
+
+`jump-to-slide` is converted to revealjs option and inserted as `jumpToSlide`. 
+


### PR DESCRIPTION
This feature https://revealjs.com/jump-to-slide/
The config is not yet supported by Pandoc so we need to add the config in Quarto.

Towards #4795
