### PR TITLE
use brand schema for brand.yml files

### DIFF
--- a/src/core/lib/yaml-intelligence/yaml-intelligence.ts
+++ b/src/core/lib/yaml-intelligence/yaml-intelligence.ts
@@ -75,6 +75,7 @@ import {
 import { loadDefaultSchemaDefinitions } from "../yaml-schema/definitions.ts";
 import { patchMarkdownDescriptions } from "./descriptions.ts";
 import { hover } from "./hover.ts";
+import { getBrandConfigSchema } from "../yaml-schema/brand.ts";
 
 interface IDEContext {
   formats: string[];
@@ -1098,7 +1099,24 @@ const determineSchema = async (context: YamlIntelligenceContext): Promise<{
       schema: extensionConfigSchema,
       schemaName: "extension-config",
     };
-  } else {
+  }
+
+  const brandYamlNames = [
+    "_brand.yml",
+    "_brand.yaml",
+  ];
+  if (
+    context.path &&
+    brandYamlNames.some((name) => context.path!.endsWith(name))
+  ) {
+    const brandYamlSchema = await getBrandConfigSchema();
+    return {
+      schema: brandYamlSchema,
+      schemaName: "brand",
+    };
+  }
+
+  {
     const projectConfigSchema = await getProjectConfigSchema();
     return {
       schema: projectConfigSchema,

--- a/src/core/lib/yaml-schema/brand.ts
+++ b/src/core/lib/yaml-schema/brand.ts
@@ -1,0 +1,17 @@
+/*
+ * brand.ts
+ *
+ * Schema for _brand.yml
+ *
+ * Copyright (C) 2024 Posit Software, PBC
+ */
+
+import { refSchema } from "./common.ts";
+import { ConcreteSchema } from "./types.ts";
+
+// deno-lint-ignore require-await
+export const getBrandConfigSchema: () => Promise<
+  ConcreteSchema
+> = async () => {
+  return refSchema("brand", "");
+};

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -22944,6 +22944,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "Monitor the hash and change slides accordingly",
         "Include the current fragment in the URL",
         "Play a subtle sound when changing slides",
+        "Deactivate jump to slide feature.",
         {
           short: "Slides that are too tall to fit within a single page will expand onto\nmultiple pages",
           long: "Slides that are too tall to fit within a single page will expand onto\nmultiple pages. You can limit how many pages a slide may expand to using\nthis option."
@@ -23781,8 +23782,7 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
         "Manuscript configuration",
-        "internal-schema-hack",
-        "Deactivate jump to slide feature."
+        "internal-schema-hack"
       ],
       "schema/external-schemas.yml": [
         {
@@ -24011,12 +24011,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 190204,
+        _internalId: 190350,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 190196,
+            _internalId: 190342,
             type: "enum",
             enum: [
               "png",
@@ -24032,7 +24032,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 190203,
+            _internalId: 190349,
             type: "anyOf",
             anyOf: [
               {
@@ -33935,6 +33935,11 @@ async function locateCellWithCursor(context) {
   return foundCell;
 }
 
+// ../yaml-schema/brand.ts
+var getBrandConfigSchema = async () => {
+  return refSchema("brand", "");
+};
+
 // yaml-intelligence.ts
 function getTagValue(schema2, tag) {
   if (schema2 === true || schema2 === false) {
@@ -34663,7 +34668,19 @@ var determineSchema = async (context) => {
       schema: extensionConfigSchema,
       schemaName: "extension-config"
     };
-  } else {
+  }
+  const brandYamlNames = [
+    "_brand.yml",
+    "_brand.yaml"
+  ];
+  if (context.path && brandYamlNames.some((name) => context.path.endsWith(name))) {
+    const brandYamlSchema = await getBrandConfigSchema();
+    return {
+      schema: brandYamlSchema,
+      schemaName: "brand"
+    };
+  }
+  {
     const projectConfigSchema = await getProjectConfigSchema();
     return {
       schema: projectConfigSchema,

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -22945,6 +22945,7 @@ try {
           "Monitor the hash and change slides accordingly",
           "Include the current fragment in the URL",
           "Play a subtle sound when changing slides",
+          "Deactivate jump to slide feature.",
           {
             short: "Slides that are too tall to fit within a single page will expand onto\nmultiple pages",
             long: "Slides that are too tall to fit within a single page will expand onto\nmultiple pages. You can limit how many pages a slide may expand to using\nthis option."
@@ -23782,8 +23783,7 @@ try {
           },
           "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
           "Manuscript configuration",
-          "internal-schema-hack",
-          "Deactivate jump to slide feature."
+          "internal-schema-hack"
         ],
         "schema/external-schemas.yml": [
           {
@@ -24012,12 +24012,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 190204,
+          _internalId: 190350,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 190196,
+              _internalId: 190342,
               type: "enum",
               enum: [
                 "png",
@@ -24033,7 +24033,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 190203,
+              _internalId: 190349,
               type: "anyOf",
               anyOf: [
                 {
@@ -33789,6 +33789,11 @@ ${tidyverseInfo(
     }
   }
 
+  // ../yaml-schema/brand.ts
+  var getBrandConfigSchema = async () => {
+    return refSchema("brand", "");
+  };
+
   // yaml-intelligence.ts
   function getTagValue(schema2, tag) {
     if (schema2 === true || schema2 === false) {
@@ -34517,7 +34522,19 @@ ${tidyverseInfo(
         schema: extensionConfigSchema,
         schemaName: "extension-config"
       };
-    } else {
+    }
+    const brandYamlNames = [
+      "_brand.yml",
+      "_brand.yaml"
+    ];
+    if (context.path && brandYamlNames.some((name) => context.path.endsWith(name))) {
+      const brandYamlSchema = await getBrandConfigSchema();
+      return {
+        schema: brandYamlSchema,
+        schemaName: "brand"
+      };
+    }
+    {
       const projectConfigSchema = await getProjectConfigSchema();
       return {
         schema: projectConfigSchema,

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -15916,6 +15916,7 @@
     "Monitor the hash and change slides accordingly",
     "Include the current fragment in the URL",
     "Play a subtle sound when changing slides",
+    "Deactivate jump to slide feature.",
     {
       "short": "Slides that are too tall to fit within a single page will expand onto\nmultiple pages",
       "long": "Slides that are too tall to fit within a single page will expand onto\nmultiple pages. You can limit how many pages a slide may expand to using\nthis option."
@@ -16753,8 +16754,7 @@
     },
     "Disambiguating year suffix in author-date styles (e.g.&nbsp;“a” in “Doe,\n1999a”).",
     "Manuscript configuration",
-    "internal-schema-hack",
-    "Deactivate jump to slide feature."
+    "internal-schema-hack"
   ],
   "schema/external-schemas.yml": [
     {
@@ -16983,12 +16983,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 190204,
+    "_internalId": 190350,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 190196,
+        "_internalId": 190342,
         "type": "enum",
         "enum": [
           "png",
@@ -17004,7 +17004,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 190203,
+        "_internalId": 190349,
         "type": "anyOf",
         "anyOf": [
           {


### PR DESCRIPTION
Towards #10249.

This changes quarto's yaml intelligence to recognize and validate brand.yml files on IDEs, in addition to the `quarto` command.