### PR TITLE
Throw an error if no _quarto.tests in metadata but there is a `_quarto.test` (without s)

### DIFF
--- a/tests/docs/smoke-all/revealjs/jump-to-slide.qmd
+++ b/tests/docs/smoke-all/revealjs/jump-to-slide.qmd
@@ -4,7 +4,7 @@ format:
   revealjs:
     jump-to-slide: false
 _quarto:
-  test:
+  tests:
     revealjs:
       ensureFileRegexMatches:
         - ["jumpToSlide.*false,"]

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -78,8 +78,12 @@ async function guessFormat(fileName: string): Promise<string[]> {
 }
 
 //deno-lint-ignore no-explicit-any
-function hasTestSpecs(metadata: any): boolean {
-  return metadata?.["_quarto"]?.["tests"] != undefined;
+function hasTestSpecs(metadata: any, input: string): boolean {
+  const hasTestSpecs = metadata?.["_quarto"]?.["tests"] != undefined
+  if (!hasTestSpecs && metadata?.["_quarto"]?.["test"] != undefined) {
+    throw new Error(`Test is ${input} is using 'test' in metadata instead of 'tests'. This is probably a typo.`);
+  }
+  return hasTestSpecs
 }
 
 interface QuartoInlineTestSpec {
@@ -231,7 +235,7 @@ for (const { path: fileName } of files) {
 
   const testSpecs: QuartoInlineTestSpec[] = [];
 
-  if (hasTestSpecs(metadata)) {
+  if (hasTestSpecs(metadata, input)) {
     testSpecs.push(...resolveTestSpecs(input, metadata));
   } else {
     const formats = await guessFormat(input);


### PR DESCRIPTION
This will prevent test not running without us knowing like the one I just added. 