### PR TITLE
Update giscus.ejs to fix giscus color on load

### DIFF
--- a/src/resources/formats/html/giscus/giscus.ejs
+++ b/src/resources/formats/html/giscus/giscus.ejs
@@ -1,11 +1,7 @@
 <input type="hidden" id="giscus-base-theme" value="<%- giscus.baseTheme %>">
 <input type="hidden" id="giscus-alt-theme" value="<%- giscus.altTheme %>">
 <script>
-async function loadGiscusWhenReady() {
-  while (!document.body.classList.contains('quarto-light') && !document.body.classList.contains('quarto-dark')) {
-    await new Promise(resolve => setTimeout(resolve, 50));
-  }
-
+function loadGiscusWhenReady() {
   // Function to get the theme based on body class
   const getTheme = () => {
     const baseTheme = document.getElementById('giscus-base-theme').value;
@@ -14,25 +10,44 @@ async function loadGiscusWhenReady() {
   };
 
   // Create the Giscus script and add it to the desired location
-  const script = document.createElement("script");
-  script.src = "https://giscus.app/client.js";
-  script.async = true;
-  script.dataset.repo = "<%- giscus.repo %>";
-  script.dataset.repoId = "<%- giscus['repo-id'] %>";
-  script.dataset.category = "<%- giscus.category %>";
-  script.dataset.categoryId = "<%- giscus['category-id'] %>";
-  script.dataset.mapping = "<%- giscus.mapping %>";
-  script.dataset.reactionsEnabled = "<%- giscus['reactions-enabled'] ? 1 : 0 %>";
-  script.dataset.emitMetadata = "0";
-  script.dataset.inputPosition = "<%- giscus['input-position'] %>";
-  script.dataset.theme = getTheme();
-  script.dataset.lang = "<%- giscus.language %>";
-  script.crossOrigin = "anonymous";
+  const loadGiscus = () => {
+    const script = document.createElement("script");
+    script.src = "https://giscus.app/client.js";
+    script.async = true;
+    script.dataset.repo = "<%- giscus.repo %>";
+    script.dataset.repoId = "<%- giscus['repo-id'] %>";
+    script.dataset.category = "<%- giscus.category %>";
+    script.dataset.categoryId = "<%- giscus['category-id'] %>";
+    script.dataset.mapping = "<%- giscus.mapping %>";
+    script.dataset.reactionsEnabled = "<%- giscus['reactions-enabled'] ? 1 : 0 %>";
+    script.dataset.emitMetadata = "0";
+    script.dataset.inputPosition = "<%- giscus['input-position'] %>";
+    script.dataset.theme = getTheme();
+    script.dataset.lang = "<%- giscus.language %>";
+    script.crossOrigin = "anonymous";
 
-  // Append the script to the desired div instead of at the end of the body
-  document.getElementById("quarto-content").appendChild(script);
+    // Append the script to the desired div instead of at the end of the body
+    document.getElementById("quarto-content").appendChild(script);
+  };
+
+  // MutationObserver to detect when the 'quarto-light' or 'quarto-dark' class is added to the body
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (mutation.type === "attributes" && mutation.attributeName === "class") {
+        if (document.body.classList.contains('quarto-light') || document.body.classList.contains('quarto-dark')) {
+          loadGiscus();
+          observer.disconnect(); // Stop observing once Giscus is loaded
+          break;
+        }
+      }
+    }
+  });
+
+  // Start observing the body for class attribute changes
+  observer.observe(document.body, {
+    attributes: true,
+    attributeFilter: ["class"],
+  });
 }
-
-// Call the async function to start the loop
 loadGiscusWhenReady();
 </script>

--- a/src/resources/formats/html/giscus/giscus.ejs
+++ b/src/resources/formats/html/giscus/giscus.ejs
@@ -35,28 +35,4 @@ async function loadGiscusWhenReady() {
 
 // Call the async function to start the loop
 loadGiscusWhenReady();
-setTimeout(() => {
-  var bodyClass = window.document.body.classList;
-  const GetTheme = () => {
-    const baseTheme = document.getElementById('giscus-base-theme').value;
-    const altTheme = document.getElementById('giscus-alt-theme').value;
-    return bodyClass.contains('quarto-dark') ? altTheme : baseTheme;
-  };
-  const script = document.createElement("script");
-      script.src = "https://giscus.app/client.js";
-      script.async = true;
-      script.dataset.repo = "<%- giscus.repo %>";
-      script.dataset.repoId = "<%- giscus['repo-id'] %>";
-      script.dataset.category = "<%- giscus.category %>";
-      script.dataset.categoryId = "<%- giscus['category-id'] %>";
-      script.dataset.mapping = "<%- giscus.mapping %>";
-      script.dataset.reactionsEnabled = "<%- giscus['reactions-enabled'] ? 1 : 0 %>";
-      script.dataset.emitMetadata = "0";
-      script.dataset.inputPosition = "<%- giscus['input-position'] %>";
-      script.dataset.theme = GetTheme();
-      script.dataset.lang = "<%- giscus.language %>";
-      script.crossOrigin = "anonymous";
-  // Insert the Giscus script after the current script
-  document.getElementById("quarto-content").appendChild(script);
-}, 50);
 </script>

--- a/src/resources/formats/html/giscus/giscus.ejs
+++ b/src/resources/formats/html/giscus/giscus.ejs
@@ -1,17 +1,28 @@
-<script src="https://giscus.app/client.js"
-        data-repo="<%- giscus.repo %>"
-        data-repo-id="<%- giscus['repo-id'] %>"
-        data-category="<%- giscus.category %>"
-        data-category-id="<%- giscus['category-id'] %>"
-        data-mapping="<%- giscus.mapping %>"
-        data-reactions-enabled="<%- giscus['reactions-enabled'] ? 1 : 0 %>"
-        data-emit-metadata="0"
-        data-input-position="<%- giscus['input-position'] %>"
-        data-theme="<%- giscus.theme %>"
-        data-lang="<%- giscus.language %>"
-        crossorigin="anonymous"
-        <%- giscus.loading ? `data-loading=${giscus.loading}` : '' %>
-        async>
-</script>
 <input type="hidden" id="giscus-base-theme" value="<%- giscus.baseTheme %>">
 <input type="hidden" id="giscus-alt-theme" value="<%- giscus.altTheme %>">
+<script>
+setTimeout(() => {
+  var bodyClass = window.document.body.classList;
+  const GetTheme = () => {
+    const baseTheme = document.getElementById('giscus-base-theme').value;
+    const altTheme = document.getElementById('giscus-alt-theme').value;
+    return bodyClass.contains('quarto-dark') ? altTheme : baseTheme;
+  };
+  const script = document.createElement("script");
+      script.src = "https://giscus.app/client.js";
+      script.async = true;
+      script.dataset.repo = "<%- giscus.repo %>";
+      script.dataset.repoId = "<%- giscus['repo-id'] %>";
+      script.dataset.category = "<%- giscus.category %>";
+      script.dataset.categoryId = "<%- giscus['category-id'] %>";
+      script.dataset.mapping = "<%- giscus.mapping %>";
+      script.dataset.reactionsEnabled = "<%- giscus['reactions-enabled'] ? 1 : 0 %>";
+      script.dataset.emitMetadata = "0";
+      script.dataset.inputPosition = "<%- giscus['input-position'] %>";
+      script.dataset.theme = GetTheme();
+      script.dataset.lang = "<%- giscus.language %>";
+      script.crossOrigin = "anonymous";
+  // Insert the Giscus script after the current script
+  document.getElementById("quarto-content").appendChild(script);
+}, 50);
+</script>

--- a/src/resources/formats/html/giscus/giscus.ejs
+++ b/src/resources/formats/html/giscus/giscus.ejs
@@ -1,28 +1,38 @@
 <input type="hidden" id="giscus-base-theme" value="<%- giscus.baseTheme %>">
 <input type="hidden" id="giscus-alt-theme" value="<%- giscus.altTheme %>">
 <script>
-setTimeout(() => {
-  var bodyClass = window.document.body.classList;
-  const GetTheme = () => {
+async function loadGiscusWhenReady() {
+  while (!document.body.classList.contains('quarto-light') && !document.body.classList.contains('quarto-dark')) {
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+
+  // Function to get the theme based on body class
+  const getTheme = () => {
     const baseTheme = document.getElementById('giscus-base-theme').value;
     const altTheme = document.getElementById('giscus-alt-theme').value;
-    return bodyClass.contains('quarto-dark') ? altTheme : baseTheme;
+    return document.body.classList.contains('quarto-dark') ? altTheme : baseTheme;
   };
+
+  // Create the Giscus script and add it to the desired location
   const script = document.createElement("script");
-      script.src = "https://giscus.app/client.js";
-      script.async = true;
-      script.dataset.repo = "<%- giscus.repo %>";
-      script.dataset.repoId = "<%- giscus['repo-id'] %>";
-      script.dataset.category = "<%- giscus.category %>";
-      script.dataset.categoryId = "<%- giscus['category-id'] %>";
-      script.dataset.mapping = "<%- giscus.mapping %>";
-      script.dataset.reactionsEnabled = "<%- giscus['reactions-enabled'] ? 1 : 0 %>";
-      script.dataset.emitMetadata = "0";
-      script.dataset.inputPosition = "<%- giscus['input-position'] %>";
-      script.dataset.theme = GetTheme();
-      script.dataset.lang = "<%- giscus.language %>";
-      script.crossOrigin = "anonymous";
-  // Insert the Giscus script after the current script
+  script.src = "https://giscus.app/client.js";
+  script.async = true;
+  script.dataset.repo = "<%- giscus.repo %>";
+  script.dataset.repoId = "<%- giscus['repo-id'] %>";
+  script.dataset.category = "<%- giscus.category %>";
+  script.dataset.categoryId = "<%- giscus['category-id'] %>";
+  script.dataset.mapping = "<%- giscus.mapping %>";
+  script.dataset.reactionsEnabled = "<%- giscus['reactions-enabled'] ? 1 : 0 %>";
+  script.dataset.emitMetadata = "0";
+  script.dataset.inputPosition = "<%- giscus['input-position'] %>";
+  script.dataset.theme = getTheme();
+  script.dataset.lang = "<%- giscus.language %>";
+  script.crossOrigin = "anonymous";
+
+  // Append the script to the desired div instead of at the end of the body
   document.getElementById("quarto-content").appendChild(script);
-}, 50);
+}
+
+// Call the async function to start the loop
+loadGiscusWhenReady();
 </script>

--- a/src/resources/formats/html/giscus/giscus.ejs
+++ b/src/resources/formats/html/giscus/giscus.ejs
@@ -1,6 +1,40 @@
 <input type="hidden" id="giscus-base-theme" value="<%- giscus.baseTheme %>">
 <input type="hidden" id="giscus-alt-theme" value="<%- giscus.altTheme %>">
 <script>
+async function loadGiscusWhenReady() {
+  while (!document.body.classList.contains('quarto-light') && !document.body.classList.contains('quarto-dark')) {
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+
+  // Function to get the theme based on body class
+  const getTheme = () => {
+    const baseTheme = document.getElementById('giscus-base-theme').value;
+    const altTheme = document.getElementById('giscus-alt-theme').value;
+    return document.body.classList.contains('quarto-dark') ? altTheme : baseTheme;
+  };
+
+  // Create the Giscus script and add it to the desired location
+  const script = document.createElement("script");
+  script.src = "https://giscus.app/client.js";
+  script.async = true;
+  script.dataset.repo = "<%- giscus.repo %>";
+  script.dataset.repoId = "<%- giscus['repo-id'] %>";
+  script.dataset.category = "<%- giscus.category %>";
+  script.dataset.categoryId = "<%- giscus['category-id'] %>";
+  script.dataset.mapping = "<%- giscus.mapping %>";
+  script.dataset.reactionsEnabled = "<%- giscus['reactions-enabled'] ? 1 : 0 %>";
+  script.dataset.emitMetadata = "0";
+  script.dataset.inputPosition = "<%- giscus['input-position'] %>";
+  script.dataset.theme = getTheme();
+  script.dataset.lang = "<%- giscus.language %>";
+  script.crossOrigin = "anonymous";
+
+  // Append the script to the desired div instead of at the end of the body
+  document.getElementById("quarto-content").appendChild(script);
+}
+
+// Call the async function to start the loop
+loadGiscusWhenReady();
 setTimeout(() => {
   var bodyClass = window.document.body.classList;
   const GetTheme = () => {


### PR DESCRIPTION
Fixes https://github.com/quarto-dev/quarto-cli/issues/8613.

An async while loop check is added to wait for the `quarto-light`/`quarto-dark` body class to load up. The giscus element is then created in the according theme.

The effect:
Before change (using #8613's example):
1. Go to https://ibis-project.org/posts/kedro-ibis/ (light mode giscus loaded)
2. Toggle to dark mode (dark mode giscus loaded)
3. Refresh. Page is in dark mode but giscus is in light mode (bug)

After change:
1. Go to https://rubuky.com/papers/2023-11-30-FemaleOfficer/ (light mode giscus loaded)
2. Toggle to dark mode (dark mode giscus loaded)
3. Refresh. Both page and giscus are in dark mode (desired outcome)
