### PR TITLE
Add 2024 to copyright years

### DIFF
--- a/COPYING.md
+++ b/COPYING.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Posit Software, PBC
+Copyright (c) 2020-2024 Posit Software, PBC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,5 +1,5 @@
 Quarto
-Copyright (C) 2020-2023 Posit Software, PBC
+Copyright (C) 2020-2024 Posit Software, PBC
 
 With the exceptions noted below, this code is released under the
 [MIT License](https://opensource.org/license/mit/):


### PR DESCRIPTION
## Description

Include 2024 in the copyright years in the COPYING and COPYRIGHT files.

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
