### PR TITLE
Fix typo in lua-types file

### DIFF
--- a/src/resources/lua-types/pandoc/pandoc.lua
+++ b/src/resources/lua-types/pandoc/pandoc.lua
@@ -76,7 +76,7 @@ function pandoc.walk_block(element, filter) end
 
 --[[
 -- Apply a filter inside an inline element, walking its contents.
--- Returns a (deep) copy on which the fislter has been applied:
+-- Returns a (deep) copy on which the filter has been applied:
 -- the original element is left untouched.
 ]]
 ---@generic T


### PR DESCRIPTION
Welcome to the quarto GitHub repo!

We are always happy to hear feedback from our users.

To file a _pull request_, please follow these instructions carefully: <https://yihui.org/issue/#bug-reports>

If you're a collaborator from outside `quarto-dev` making changes larger than a typo, please make sure you have filed an [individual](https://posit.co/wp-content/uploads/2023/04/2023-03-13_TC_Indiv_contrib_agreement.pdf) or [corporate](https://posit.co/wp-content/uploads/2023/04/2023-03-13_TC_Corp_contrib_agreement.pdf) contributor agreement. You can send the signed copy to <jj@rstudio.com>.

Also, please complete and keep the checklist below.

## Description

Please describe your PR here.

````md
```py
print("Hello Quarto!")
```
````

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog
