### PR TITLE
Resolve inputs files in the order of the render list

### DIFF
--- a/src/project/project-context.ts
+++ b/src/project/project-context.ts
@@ -802,16 +802,18 @@ export async function projectInputFiles(
     const resolved = resolvePathGlobs(dir, renderFiles, exclude, {
       mode: "auto",
     });
-    await Promise.all(
-      (ld.difference(resolved.include, resolved.exclude) as string[])
-        .map((file) => {
-          if (Deno.statSync(file).isDirectory) {
-            return addDir(file);
-          } else {
-            return addFile(file);
-          }
-        }),
-    );
+    for (
+      const file of ld.difference(
+        resolved.include,
+        resolved.exclude,
+      ) as string[]
+    ) {
+      if (Deno.statSync(file).isDirectory) {
+        await addDir(file);
+      } else {
+        await addFile(file);
+      }
+    }
   } else {
     await addDir(dir);
   }

--- a/src/project/project-context.ts
+++ b/src/project/project-context.ts
@@ -317,7 +317,7 @@ export async function projectContext(
           result,
           projectConfig,
         );
-        // if we are attemping to get the projectConext for a file and the
+        // if we are attemping to get the projectContext for a file and the
         // file isn't in list of input files then return a single-file project
         const fullPath = normalizePath(path);
         if (Deno.statSync(fullPath).isFile && !files.includes(fullPath)) {


### PR DESCRIPTION
Using Promise.all() with current `addFile()` logic without keeping track of index does not allow us to comply with render list order

This creates various problem, including breaking the promise of render target config controlling the order of rendering.

- fixes https://github.com/quarto-dev/quarto-cli/issues/10463
- fixes https://github.com/quarto-dev/quarto-cli/issues/11039
- fixes https://github.com/quarto-dev/quarto-cli/issues/10714


_Creating this as a Draft PR for now to discuss, and see if we can keep the Promise logic for performance while keeping track of the order_