### PR TITLE
Add tests for revealjs and ipynb with no title

### DIFF
--- a/tests/docs/smoke-all/2024/10/16/8012.qmd
+++ b/tests/docs/smoke-all/2024/10/16/8012.qmd
@@ -1,0 +1,27 @@
+---
+format: revealjs
+_quarto:
+  tests:
+    revealjs:
+      ensureHtmlElements:
+        - ['section:nth-child(2)#python-slide > h2']
+        - ['section#title-slide', 'section#title-slide > h1.title']
+      ensureFileRegexMatches:
+        - ['Custom title[\s\S]+Python slide']
+        - ['Python slide[\s\S]+Custom title']
+engine: jupyter
+---
+
+## 
+
+Custom title slide desired here with custom content and no slide title
+
+There should be no title slide in this presentation, and Python slide should be after this slide. 
+
+rendering through ipynb shouldn't promote title in a way that it messes the slide order. 
+
+## Python slide {#python-slide}
+
+```{python}
+print(2+2)
+```

--- a/tests/new-smoke-all-test.ps1
+++ b/tests/new-smoke-all-test.ps1
@@ -33,6 +33,13 @@ _quarto:
       ensureFileRegexMatches:
         - [] 
         - []
+    revealjs:
+      ensureHtmlElements:
+        - []
+        - []
+      ensureFileRegexMatches:
+        - [] 
+        - []
     latex:
       ensureFileRegexMatches:
         - []

--- a/tests/new-smoke-all-test.sh
+++ b/tests/new-smoke-all-test.sh
@@ -31,6 +31,13 @@ _quarto:
       ensureFileRegexMatches:
         - [] 
         - []
+    revealjs:
+      ensureHtmlElements:
+        - []
+        - []
+      ensureFileRegexMatches:
+        - [] 
+        - []
     latex:
       ensureFileRegexMatches:
         - []


### PR DESCRIPTION
This closes #8012 

The logic of rendering .qmd through ipynb shouldn't mess up with Revealjs structure. 

we add a test for this to check DOM structure of the rendered HTML. Slide order shouldn't be changed by any title promotion