### PR TITLE
Bump QuartoNotebookRunner.jl to 0.11.5

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -92,6 +92,7 @@ All changes included in 1.6:
 ### `julia`
 
 - ([#10225](https://github.com/quarto-dev/quarto-cli/issues/10225)): Handle API change in `is_manifest_current` in Julia 1.11.
+- ([#11013](https://github.com/quarto-dev/quarto-cli/issues/11013)): Fix QuartoNotebookRunner.jl precompilation failure on Julia 1.11.
 
 ### `jupyter`
 

--- a/src/resources/julia/Project.toml
+++ b/src/resources/julia/Project.toml
@@ -2,4 +2,4 @@
 QuartoNotebookRunner = "4c0109c6-14e9-4c88-93f0-2b974d3468f4"
 
 [compat]
-QuartoNotebookRunner = "=0.11.2"
+QuartoNotebookRunner = "=0.11.5"


### PR DESCRIPTION
## Description

Updates the QuartoNotebookRunner.jl package (used by the `julia` engine) to 0.11.5 to take advantage of bugfixes / updates.

## Checklist

None of the below seemed relevant for such a trivial change, but please let me know if you want me to do anything else

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [x] updated the appropriate changelog
