### PR TITLE
chore(brand): deduplicate font imports

### DIFF
--- a/src/core/sass/brand.ts
+++ b/src/core/sass/brand.ts
@@ -230,7 +230,7 @@ const brandTypographyBundle = (
     "/* typography variables from _brand.yml */",
     '// quarto-scss-analysis-annotation { "action": "push", "origin": "_brand.yml typography" }',
   ];
-  const typographyImports: string[] = [];
+  const typographyImports: Set<string> = new Set();
   const fonts = brand.data?.typography?.fonts ?? [];
 
   const pathCorrection = relative(brand.projectDir, brand.brandDir);
@@ -268,10 +268,10 @@ const brandTypographyBundle = (
         googleFamily = thisFamily;
       } else if (googleFamily !== thisFamily) {
         throw new Error(
-          `Inconsisent Google font families found: ${googleFamily} and ${thisFamily}`,
+          `Inconsistent Google font families found: ${googleFamily} and ${thisFamily}`,
         );
       }
-      typographyImports.push(googleFontImportString(resolvedFont));
+      typographyImports.add(googleFontImportString(resolvedFont));
     }
     if (googleFamily === "") {
       return undefined;
@@ -437,7 +437,7 @@ const brandTypographyBundle = (
     // dependency: "bootstrap",
     quarto: {
       defaults: typographyVariables.join("\n"),
-      uses: typographyImports.join("\n"),
+      uses: Array.from(typographyImports).join("\n"),
       functions: "",
       mixins: "",
       rules: "",


### PR DESCRIPTION
Small change to deduplicate font imports. Prior to this change, a `brand` like

```yaml
typography:
  fonts:
    - family: IBM Plex Mono
      source: google

  monospace:
    family: IBM Plex Mono
  monospace-inline:
    family: IBM Plex Mono
  monospace-block:
    family: IBM Plex Mono
```

Would result in three `@import` statements for "IBM Plex Mono"

```scss
@import"https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap";
@import"https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap";
@import"https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap";
```

After this PR, identical imports are dropped:

```scss
@import"https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap";
```