### PR TITLE
fix(brand): Resolve colors in typography before sending to Sass vars

### DIFF
--- a/src/core/sass/brand.ts
+++ b/src/core/sass/brand.ts
@@ -422,8 +422,12 @@ const brandTypographyBundle = (
       const source = variable[0];
       const target = variable[1];
       if (fontInformation[source]) {
+        let value = fontInformation[source];
+        if (["color", "background-color"].includes(source)) {
+          value = brand.getColor(value as string);
+        }
         typographyVariables.push(
-          `$${target}: ${fontInformation[source]} !default;`,
+          `$${target}: ${value} !default;`,
         );
       }
     }


### PR DESCRIPTION
Small fix to resolve colors in `brand.typography.*.{color,background-color}` before sending them to Sass.

Prior to this change the following yaml

```yaml
color:
  palette:
    bright_pink: "#FF3D7F"
    orange: "#FF6F20"
    gray_light: "#E0E0E0"
  primary: orange
  danger: bright_pink

typography:
  headings:
    color: primary
  monospace-inline:
    color: bright_pink
  monospace-block:
    background-color: gray_light
```

would set

```scss
$headings-color: primary !default;
$code-color: bright_pink !default;
$pre-color: bright_pink !default;
$pre-bg: gray_light !default;
```

This PR calls `brand.getColor()` on the value of `color` or `background-color` properties before passing to Sass.