### PR TITLE
feat(html): `--quarto-border-radius` follows Bootstrap's `$enable-rounded`

### DIFF
--- a/src/resources/formats/html/_quarto-rules.scss
+++ b/src/resources/formats/html/_quarto-rules.scss
@@ -587,13 +587,11 @@ div.ansi-escaped-output {
   --quarto-text-muted: #{$text-muted};
   --quarto-border-color: #{$table-border-color};
   --quarto-border-width: #{$border-width};
-}
-
-@if not variable-exists(enable-rounded) or $enable-rounded == true {
-  :root {
+  @if not variable-exists(enable-rounded) or $enable-rounded == true {
     --quarto-border-radius: #{$border-radius};
   }
 }
+
 
 /* rules to support GT table styling */
 table.gt_table {

--- a/src/resources/formats/html/_quarto-rules.scss
+++ b/src/resources/formats/html/_quarto-rules.scss
@@ -587,7 +587,12 @@ div.ansi-escaped-output {
   --quarto-text-muted: #{$text-muted};
   --quarto-border-color: #{$table-border-color};
   --quarto-border-width: #{$border-width};
-  --quarto-border-radius: #{if($enable-rounded == true, $border-radius, 0)};
+}
+
+@if not variable-exists(enable-rounded) or $enable-rounded == true {
+  :root {
+    --quarto-border-radius: #{$border-radius};
+  }
 }
 
 /* rules to support GT table styling */

--- a/src/resources/formats/html/_quarto-rules.scss
+++ b/src/resources/formats/html/_quarto-rules.scss
@@ -587,7 +587,7 @@ div.ansi-escaped-output {
   --quarto-text-muted: #{$text-muted};
   --quarto-border-color: #{$table-border-color};
   --quarto-border-width: #{$border-width};
-  --quarto-border-radius: #{if($enable-rounded == true, $border-rounded, 0)};
+  --quarto-border-radius: #{if($enable-rounded == true, $border-radius, 0)};
 }
 
 /* rules to support GT table styling */

--- a/src/resources/formats/html/_quarto-rules.scss
+++ b/src/resources/formats/html/_quarto-rules.scss
@@ -587,7 +587,7 @@ div.ansi-escaped-output {
   --quarto-text-muted: #{$text-muted};
   --quarto-border-color: #{$table-border-color};
   --quarto-border-width: #{$border-width};
-  --quarto-border-radius: #{$border-radius};
+  --quarto-border-radius: #{if($enable-rounded == true, $border-rounded, 0)};
 }
 
 /* rules to support GT table styling */

--- a/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
@@ -835,7 +835,7 @@ div.sourceCode {
   @if $code-block-bg {
     background-color: $code-block-bg-color;
     border: 1px solid $code-block-bg-color;
-    border-radius: $border-radius;
+    border-radius: var(--quarto-border-radius);
   } @else {
     background-color: $body-bg !important;
     border: none;

--- a/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
@@ -835,7 +835,9 @@ div.sourceCode {
   @if $code-block-bg {
     background-color: $code-block-bg-color;
     border: 1px solid $code-block-bg-color;
-    border-radius: var(--quarto-border-radius);
+    @if $enable-rounded {
+      border-radius: $border-radius;
+    }
   } @else {
     background-color: $body-bg !important;
     border: none;


### PR DESCRIPTION
Updates Quarto's Sass rules to set `--quarto-border-radius` following Bootstrap's `$enable-rounded` option flag, i.e. not setting Quarto's CSS var if `$enable-rounded` is not `true`.

I was wanting hard edges for code blocks and noticed that `div.sourceCode` uses `$border-radius` instead of `--quarto-border-radius`, so I updated that rule as well.