### PR TITLE
handle svg2png rendering error more gracefully

### DIFF
--- a/src/resources/extensions/quarto/placeholder/placeholder.lua
+++ b/src/resources/extensions/quarto/placeholder/placeholder.lua
@@ -13,10 +13,24 @@ return {
     local svg64 = "data:image/svg+xml;base64," .. quarto.base64.encode(svg)
     local result
 
-    if kwargs["format"] == "svg" then
+    local output_format = pandoc.utils.stringify(kwargs["format"])
+    if output_format == "" then
+      if quarto.format.is_typst_output() then
+        output_format = "svg"
+      else 
+        output_format = "png"
+      end
+    end
+
+    if output_format == "svg" then
       result = svg64
     else
       local mt, contents = pandoc.mediabag.fetch("https://svg2png.deno.dev/" .. svg64)
+      if mt ~= "image/png" then
+        error("Expected image/png but got " .. mt)
+        error(contents)
+        return pandoc.Str("Error rendering placeholder")
+      end
       result = "data:" .. mt .. ";base64," .. quarto.base64.encode(contents)
     end
 


### PR DESCRIPTION
This should avoid a crash in situations like https://github.com/quarto-dev/quarto-cli/actions/runs/11395217193/job/31707058333?pr=11100#step:27:615