### PR TITLE
Sort keys when encoding tables as JSON

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -19,6 +19,7 @@ All changes included in 1.6:
 - ([#10858](https://github.com/quarto-dev/quarto-cli/issues/10858)): Don't crash in `gfm` when `content` of a `FloatRefTarget` is of type `Blocks`.
 - ([#10894](https://github.com/quarto-dev/quarto-cli/issues/10894)): Fix configuration of title and prefix in callouts for `html`, `revealjs`, `pdf`, and `typst`.
 - ([#10999](https://github.com/quarto-dev/quarto-cli/issues/10999)): New API entry point: `quarto.paths.rscript()` to resolve `Rscript` path in Lua filters and extensions consistently with Quarto itself.
+- ([#11124](https://github.com/quarto-dev/quarto-cli/pull/11124)): Sort keys when encoding tables as JSON
 
 ## `dashboard` Format
 
@@ -29,6 +30,7 @@ All changes included in 1.6:
 - Fix `kbd` element styling on dark themes.
 - ([#10761](https://github.com/quarto-dev/quarto-cli/issues/10761)): Add support for `licence: CC0` to automatically link to Creative Commons licence [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/).
 - ([#10817](https://github.com/quarto-dev/quarto-cli/issues/10817)): Ensure that user provided SCSS has precedent over quarto generated scss also for dark theme.
+- ([#11124](https://github.com/quarto-dev/quarto-cli/pull/11124)): Use stable order of GLightbox options
 
 ## `revealjs` Format
 

--- a/src/resources/pandoc/datadir/_json.lua
+++ b/src/resources/pandoc/datadir/_json.lua
@@ -5,6 +5,7 @@
 -- https://github.com/rxi/json.lua
 --
 -- includes unreleased upstream changes: https://github.com/rxi/json.lua/blob/dbf4b2dd2eb7c23be2773c89eb059dadd6436f94/json.lua
+-- includes unmerged upstream pull request: https://github.com/rxi/json.lua/pull/51
 --
 -- Permission is hereby granted, free of charge, to any person obtaining a copy of
 -- this software and associated documentation files (the "Software"), to deal in
@@ -26,6 +27,21 @@
 --
 
 local json = { _version = "0.1.2-quarto" }
+
+-- taken from https://www.lua.org/pil/19.3.html
+function pairsByKeys (t, f)
+  local a = {}
+  for n in pairs(t) do table.insert(a, n) end
+  table.sort(a, f)
+  local i = 0      -- iterator variable
+  local iter = function ()   -- iterator function
+    i = i + 1
+    if a[i] == nil then return nil
+    else return a[i], t[a[i]]
+    end
+  end
+  return iter
+end
 
 -------------------------------------------------------------------------------
 -- Encode
@@ -89,7 +105,7 @@ local function encode_table(val, stack)
 
   else
     -- Treat as an object
-    for k, v in pairs(val) do
+    for k, v in pairsByKeys(val) do
       if type(k) ~= "string" then
         error("invalid table: mixed or invalid key types")
       end

--- a/src/resources/pandoc/datadir/_json.lua
+++ b/src/resources/pandoc/datadir/_json.lua
@@ -101,7 +101,7 @@ local function encode_table(val, stack)
     return "[" .. table.concat(res, ",") .. "]"
   elseif types["string"] then
     -- Treat as object
-    for k, v in pairs(val) do
+    for k, v in _quarto.utils.table.sortedPairs(val) do
       table.insert(res, encode_string(k) .. ":" .. encode(v, stack))
     end
     stack[val] = nil


### PR DESCRIPTION
## Description

Sorts object keys when encoding a table as JSON. This makes JSON objects deterministic which is especially useful for the GLightbox parameters which are part of the rendered HTML. This change may have unintended side effects such as performance degradation which I hope will be revealed by a review.

closes https://github.com/quarto-dev/quarto-cli/issues/11122

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [x] updated the appropriate changelog
