### PR TITLE
fix(revealjs): Empty title slide element shouldn't be shown in TOC

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -45,6 +45,7 @@ All changes included in 1.6:
 - ([#6012](https://github.com/quarto-dev/quarto-cli/issues/6012)): Add styling for `kbd` element in Revealjs slides.
 - ([#10887](https://github.com/quarto-dev/quarto-cli/issues/10887)): Updating default Mathjax used from 2.7.0 to 2.7.9.
 - ([#9999](https://github.com/quarto-dev/quarto-cli/issues/9999)): Fix spacing problems of different size elements in columns.
+- ([#11146](https://github.com/quarto-dev/quarto-cli/issues/11146)): Fix issue with slide created with `---` and having no title showing up in TOC. Now they don't show up as slide created with empty header e.g. `## `.
 
 ## `typst` Format
 

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -379,7 +379,7 @@ export function revealjsFormat() {
 const determineRevealLogo = (format: Format): string | undefined => {
   const brandData = format.render.brand?.processedData;
   if (brandData?.logo) {
-    const keys: ("medium" | "small" | "large")[] = ["medium", "small", "large"]
+    const keys: ("medium" | "small" | "large")[] = ["medium", "small", "large"];
     // add slide logo if we have one
     for (const size of keys) {
       const logoInfo = brandData.logo[size];
@@ -582,12 +582,12 @@ const handleInvisibleSlides = (doc: Document) => {
 const handleUntitledSlidesInToc = (doc: Document) => {
   // remove from toc all slides that have no title
   const tocEntries = Array.from(doc.querySelectorAll(
-    'nav[role="doc-toc"] a[href^="#/"]',
+    'nav[role="doc-toc"] ul > li',
   ));
   for (const tocEntry of tocEntries) {
     const tocEntryEl = tocEntry as Element;
     if (tocEntryEl.textContent.trim() === "") {
-      tocEntryEl.parentElement?.remove();
+      tocEntryEl.remove();
     }
   }
 };

--- a/tests/docs/smoke-all/2024/10/22/11146.qmd
+++ b/tests/docs/smoke-all/2024/10/22/11146.qmd
@@ -1,0 +1,29 @@
+---
+format: revealjs
+toc: true
+_quarto:
+  tests:
+    revealjs:
+      ensureHtmlElements:
+        - 
+          - 'nav[role="doc-toc"] ul > li:nth-child(1) > a[href$="section-1"]'
+          - 'nav[role="doc-toc"] ul > li:nth-child(2) > a[href$="section-2"]'
+        - 
+          - 'nav[role="doc-toc"] ul > li:nth-child(3)'
+---
+
+## Section 1
+
+Should show up in the TOC as a bullet point.
+
+---
+
+No title and should not be
+
+## Section 2
+
+Should show up in the TOC as a bullet point.
+
+## 
+
+No title and should not be in the TOC


### PR DESCRIPTION
This complements initial fix from #3671 to support `---` as a slide separator. 

I believe it is safe to check for the whole `li` element which creates the bullet point, and removed if it is empty.

closes #11146
