### PR TITLE
`quarto check` - add info section

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -117,3 +117,4 @@ All changes included in 1.6:
 - ([#10890](https://github.com/quarto-dev/quarto-cli/issues/10890)): Don't use ports that Firefox considers unsafe.
 - ([#10936](https://github.com/quarto-dev/quarto-cli/issues/10936)): Use `\\` in `meta` shortcode to escape the following character, allowing keys with `.` in them.
 - ([#11068](https://github.com/quarto-dev/quarto-cli/issues/11068)): use standard location when writing to standard output to avoid breakage under `self-contained: true`.
+- ([#11155](https://github.com/quarto-dev/quarto-cli/pull/11155)): Add cache location information to `quarto check`.

--- a/src/command/check/check.ts
+++ b/src/command/check/check.ts
@@ -45,15 +45,25 @@ import { which } from "../../core/path.ts";
 import { dirname } from "../../deno_ral/path.ts";
 import { notebookContext } from "../../render/notebook/notebook-context.ts";
 import { typstBinaryPath } from "../../core/typst.ts";
+import { quartoCacheDir } from "../../core/appdirs.ts";
 
 const kIndent = "      ";
 
-export type Target = "install" | "jupyter" | "knitr" | "versions" | "all";
+export type Target =
+  | "install"
+  | "jupyter"
+  | "knitr"
+  | "versions"
+  | "info"
+  | "all";
 
 export async function check(target: Target): Promise<void> {
   const services = renderServices(notebookContext());
   try {
     info(`Quarto ${quartoConfig.version()}`);
+    if (target === "info" || target === "all") {
+      await checkInfo(services);
+    }
     if (target === "versions" || target === "all") {
       await checkVersions(services);
     }
@@ -69,6 +79,13 @@ export async function check(target: Target): Promise<void> {
   } finally {
     services.cleanup();
   }
+}
+
+// Currently this doesn't check anything, but
+async function checkInfo(_services: RenderServices) {
+  const cacheDir = quartoCacheDir();
+  completeMessage("Checking environment information...");
+  info(kIndent + "Quarto cache location: " + cacheDir);
 }
 
 async function checkVersions(_services: RenderServices) {


### PR DESCRIPTION
This adds a section in `quarto check` where we can provide information for users that might be useful in troubleshooting.