### PR TITLE
fix(brand): Fix and improve Bootstrap variable handling

### DIFF
--- a/src/core/sass/brand.ts
+++ b/src/core/sass/brand.ts
@@ -266,6 +266,8 @@ const brandBootstrapBundle = (
   if (Number(brandBootstrap?.version ?? 5) === 5) {
     // https://getbootstrap.com/docs/5.3/customize/color/#color-sass-maps
     bootstrapColorVariables = [
+      "black",
+      "white",
       "blue",
       "indigo",
       "purple",
@@ -276,10 +278,6 @@ const brandBootstrapBundle = (
       "green",
       "teal",
       "cyan",
-      "black",
-      "white",
-      "gray",
-      "gray-dark"
     ]
   }
 

--- a/src/core/sass/brand.ts
+++ b/src/core/sass/brand.ts
@@ -192,7 +192,7 @@ const brandColorBundle = (
 
   // Create `brand-` prefixed Sass and CSS variables from color.palette
   for (const colorKey of Object.keys(brand.data?.color?.palette ?? {})) {
-    const colorVar = colorKey.replace(/[^a-zA-Z0-9_-]+/, "-");
+    const colorVar = colorKey.replace(/[^a-zA-Z0-9_-]+/g, "-");
     colorVariables.push(
       `$brand-${colorVar}: ${brand.getColor(colorKey)} !default;`,
     );

--- a/src/core/sass/brand.ts
+++ b/src/core/sass/brand.ts
@@ -262,24 +262,21 @@ const brandBootstrapBundle = (
   bsVariables.push('// quarto-scss-analysis-annotation { "action": "pop" }');
 
   // Bootstrap Colors from color.palette
-  let bootstrapColorVariables: string[] = [];
-  if (Number(brandBootstrap?.version ?? 5) === 5) {
-    // https://getbootstrap.com/docs/5.3/customize/color/#color-sass-maps
-    bootstrapColorVariables = [
-      "black",
-      "white",
-      "blue",
-      "indigo",
-      "purple",
-      "pink",
-      "red",
-      "orange",
-      "yellow",
-      "green",
-      "teal",
-      "cyan",
-    ]
-  }
+  // https://getbootstrap.com/docs/5.3/customize/color/#color-sass-maps
+  const bootstrapColorVariables = [
+    "black",
+    "white",
+    "blue",
+    "indigo",
+    "purple",
+    "pink",
+    "red",
+    "orange",
+    "yellow",
+    "green",
+    "teal",
+    "cyan",
+  ]
 
   const bsColors: string[] = [
     "/* Bootstrap color variables from _brand.yml */",


### PR DESCRIPTION
1. Adding missing `g` flag in the regex that sanitizes `brand.color.palette` names for use in Sass and CSS variables.

2. Drop `gray` and `gray-dark` from Bootstrap color variables list. These appear in [Bootstrap's `$colors` map](https://github.com/twbs/bootstrap/blob/6e1f75f420f68e1d52733b8e407fc7c3766c9dba/scss/_variables.scss#L65-L66) but are derived from the gray color palette, and are not [top-level color Sass variables](https://github.com/twbs/bootstrap/blob/6e1f75f420f68e1d52733b8e407fc7c3766c9dba/scss/_variables.scss#L38-L49).

3. Drop the `brand.defaults.bootstrap.version` check. On second thought, I imagine Quarto plans to support at most one version of Bootstrap at a time. You _might_ want to throw a warning if someone asks for BS 5 after Quarto moves to BS 6 (in some distant future), but we don't need the version check now.

    Furthermore, in the `defaults` layer there's very little risk in setting Sass variables across Boostrap versions. Since they're all defined with `${var}: {value} !default;`, either they'll be used by Bootstrap or they won't. So the chance of breakage is small.