### PR TITLE
Better Handle new chrome

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -103,7 +103,7 @@ All changes included in 1.6:
 
 ## Chromium support
 
-- ([#11135](https://github.com/quarto-dev/quarto-cli/issues/11135)): Use `--headless=old` mode for Chromium to avoid recent issues with the new `--headless` mode. Setting `--headless=new` can be configured with `QUARTO_CHROMIUM_HEADLESS_MODE=new` environment variable, however it is not recommended new headless mode seems to be unstable. Only use to be unblocked of a situation (like `QUARTO_CHROMIUM_HEADLESS_MODE=""` if you use a old chrome version somehow).
+- ([#11135](https://github.com/quarto-dev/quarto-cli/issues/11135)): Use `--headless=old` mode for Chromium to avoid recent issues with the new `--headless` mode. Setting `--headless=new` can be configured with `QUARTO_CHROMIUM_HEADLESS_MODE=new` environment variable, however it is not recommended new headless mode seems to be unstable. Only use to be unblocked of a situation (like `QUARTO_CHROMIUM_HEADLESS_MODE="none"` if you use a old chrome version somehow that don't support `--headless=old`).
 - ([#10170](https://github.com/quarto-dev/quarto-cli/issues/10170)): Quarto should find chrome executable automatically on most OS. If this is does not find it, or a specific version is needed, set `QUARTO_CHROMIUM` environment variable to the executable path.
 
 ## Other Fixes and Improvements

--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -101,6 +101,11 @@ All changes included in 1.6:
 
 - ([#9134](https://github.com/quarto-dev/quarto-cli/issues/9134)): Add proper fix for `multiprocessing` in notebooks with the Python kernel.
 
+## Chromium support
+
+- ([#11135](https://github.com/quarto-dev/quarto-cli/issues/11135)): Use `--headless=old` mode for Chromium to avoid recent issues with the new `--headless` mode. Setting `--headless=new` can be configured with `QUARTO_CHROMIUM_HEADLESS_MODE=new` environment variable, however it is not recommended new headless mode seems to be unstable. Only use to be unblocked of a situation (like `QUARTO_CHROMIUM_HEADLESS_MODE=""` if you use a old chrome version somehow).
+- ([#10170](https://github.com/quarto-dev/quarto-cli/issues/10170)): Quarto should find chrome executable automatically on most OS. If this is does not find it, or a specific version is needed, set `QUARTO_CHROMIUM` environment variable to the executable path.
+
 ## Other Fixes and Improvements
 
 - Upgrade `mermaidjs` to 11.2.0.

--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -103,7 +103,7 @@ All changes included in 1.6:
 
 ## Chromium support
 
-- ([#11135](https://github.com/quarto-dev/quarto-cli/issues/11135)): Use `--headless=old` mode for Chromium to avoid recent issues with the new `--headless` mode. Setting `--headless=new` can be configured with `QUARTO_CHROMIUM_HEADLESS_MODE=new` environment variable, however it is not recommended new headless mode seems to be unstable. Only use to be unblocked of a situation (like `QUARTO_CHROMIUM_HEADLESS_MODE="none"` if you use a old chrome version somehow that don't support `--headless=old`).
+- ([#11135](https://github.com/quarto-dev/quarto-cli/issues/11135)): Use `--headless=old` mode for Chromium to avoid recent issues with the new `--headless` mode. Setting `--headless=new` can be configured with `QUARTO_CHROMIUM_HEADLESS_MODE=new` environment variable, however it is not recommended new headless mode seems to be unstable. Only use to be unblocked of a situation (like `QUARTO_CHROMIUM_HEADLESS_MODE="none"` if you use an old chrome version somehow that don't support `--headless=old`).
 - ([#10170](https://github.com/quarto-dev/quarto-cli/issues/10170)): Quarto should find chrome executable automatically on most OS. If this is does not find it, or a specific version is needed, set `QUARTO_CHROMIUM` environment variable to the executable path.
 
 ## Other Fixes and Improvements

--- a/src/core/cri/cri.ts
+++ b/src/core/cri/cri.ts
@@ -80,7 +80,15 @@ export async function criClient(appPath?: string, port?: number) {
 
   const cmd = [
     app,
-    "--headless",
+    // TODO: Chrome v128 changed the default from --headless=old to --headless=new
+    // in 2024-08. Old headless mode was effectively a separate browser render,
+    // and while more performant did not share the same browser implementation as
+    // headful Chrome. New headless mode will likely be useful to some, but in Quarto use cases
+    // like printing to PDF or screenshoting, we need more work to
+    // move to the new mode. We'll use `--headless=old` as the default for now
+    // until the new mode is more stable, or until we really pin a version as default to be used.
+    // This is also impacting in chromote and pagedown R packages and we could keep syncing with them.
+    "--headless=old",
     "--no-sandbox",
     "--disable-gpu",
     "--renderer-process-limit=1",

--- a/src/core/cri/cri.ts
+++ b/src/core/cri/cri.ts
@@ -14,6 +14,7 @@ import { findOpenPort } from "../port.ts";
 import { getNamedLifetime, ObjectWithLifetime } from "../lifetimes.ts";
 import { sleep } from "../async.ts";
 import { InternalError } from "../lib/error.ts";
+import { getenv } from "../env.ts";
 import { kRenderFileLifetime } from "../../config/constants.ts";
 
 async function waitForServer(port: number, timeout = 3000) {
@@ -78,6 +79,9 @@ export async function criClient(appPath?: string, port?: number) {
   }
   const app: string = appPath || await getBrowserExecutablePath();
 
+  // Allow to adapt the headless mode depending on the Chrome version
+  const headlessMode = getenv("QUARTO_CHROME_HEADLESS_MODE", "old");
+
   const cmd = [
     app,
     // TODO: Chrome v128 changed the default from --headless=old to --headless=new
@@ -88,7 +92,7 @@ export async function criClient(appPath?: string, port?: number) {
     // move to the new mode. We'll use `--headless=old` as the default for now
     // until the new mode is more stable, or until we really pin a version as default to be used.
     // This is also impacting in chromote and pagedown R packages and we could keep syncing with them.
-    "--headless=old",
+    `--headless${headlessMode ? "=" + headlessMode : ""}`,
     "--no-sandbox",
     "--disable-gpu",
     "--renderer-process-limit=1",

--- a/src/core/cri/cri.ts
+++ b/src/core/cri/cri.ts
@@ -16,6 +16,7 @@ import { sleep } from "../async.ts";
 import { InternalError } from "../lib/error.ts";
 import { getenv } from "../env.ts";
 import { kRenderFileLifetime } from "../../config/constants.ts";
+import { debug } from "../../deno_ral/log.ts";
 
 async function waitForServer(port: number, timeout = 3000) {
   const interval = 50;
@@ -104,6 +105,8 @@ export async function criClient(appPath?: string, port?: number) {
     let msg = "Couldn't find open server.";
     // Printing more error information if chrome process errored
     if (!(await browser.status()).success) {
+      debug(`[CHROMIUM path]   : ${app}`);
+      debug(`[CHROMIUM cmd]   : ${cmd}`);
       const rawError = await browser.stderrOutput();
       const errorString = new TextDecoder().decode(rawError);
       msg = msg + "\n" + `Chrome process error: ${errorString}`;

--- a/src/core/cri/cri.ts
+++ b/src/core/cri/cri.ts
@@ -81,7 +81,7 @@ export async function criClient(appPath?: string, port?: number) {
   const app: string = appPath || await getBrowserExecutablePath();
 
   // Allow to adapt the headless mode depending on the Chrome version
-  const headlessMode = getenv("QUARTO_CHROME_HEADLESS_MODE", "old");
+  const headlessMode = getenv("QUARTO_CHROMIUM_HEADLESS_MODE", "old");
 
   const cmd = [
     app,

--- a/src/core/cri/cri.ts
+++ b/src/core/cri/cri.ts
@@ -93,7 +93,7 @@ export async function criClient(appPath?: string, port?: number) {
     // move to the new mode. We'll use `--headless=old` as the default for now
     // until the new mode is more stable, or until we really pin a version as default to be used.
     // This is also impacting in chromote and pagedown R packages and we could keep syncing with them.
-    `--headless${headlessMode ? "=" + headlessMode : ""}`,
+    `--headless${headlessMode == "none" ? "" : "=" + headlessMode}`,
     "--no-sandbox",
     "--disable-gpu",
     "--renderer-process-limit=1",

--- a/src/core/puppeteer.ts
+++ b/src/core/puppeteer.ts
@@ -201,6 +201,12 @@ export async function withHeadlessBrowser<T>(
 
 async function findChrome(): Promise<string | undefined> {
   let path;
+  // First check env var and use this path if specified
+  const envPath = Deno.env.get("QUARTO_CHROMIUM");
+  if (envPath && safeExistsSync(envPath)) {
+    return envPath;
+  }
+  // Otherwise, try to find the path based on OS.
   if (Deno.build.os === "darwin") {
     const programs = [
       "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",


### PR DESCRIPTION
## New headless mode in chrome

Chrome has new headless mode (https://developer.chrome.com/docs/chromium/headless) activated as default since v128. This PR set back to `--headless=old` to revert back to old mode we know is working ok. There is a new `QUARTO_CHROMIUM_HEADLESS_MODE` env var to configure this. This is to fix #11135. 

Tested with 
````markdown
---
title: "Test"
format: typst
---


```{mermaid}
flowchart LR
  A[Hard edge] --> B(Round edge)
  B --> C{Decision}
  C --> D[Result one]
  C --> E[Result two]
```
````

This now renders ok under this PR. 

If `QUARTO_CHROMIUM_HEADLESS_MODE=new` is set and a chrome browser is already opened. Then #11135 will reproduce. close any browser open and keep `QUARTO_CHROMIUM_HEADLESS_MODE=new`, and issue disappear. So definitely some adaptations to make for new headless mode. As long as we can use, `old` then we can wait. 

## Avoid blocking problem by allowing selecting the chromium binary to use

This PR introduce also a new `QUARTO_CHROMIUM` to specify which binary to use and not let Quarto detection applies. closes #10170 (which closes #2980 and closes #4648) 


Currently I am testing our bundled `quarto install chromium` version to see if this still work and if it is ok with this change. This is quite an old pinned version. 


Also, I noticed on windows that chrome opened for screenshot does not close... So investigating that too. 

