### PR TITLE
ensure that a chromium process started by Quarto is always closed

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -111,6 +111,7 @@ All changes included in 1.6:
 
 - ([#11135](https://github.com/quarto-dev/quarto-cli/issues/11135)): Use `--headless=old` mode for Chromium to avoid recent issues with the new `--headless` mode. Setting `--headless=new` can be configured with `QUARTO_CHROMIUM_HEADLESS_MODE=new` environment variable, however it is not recommended new headless mode seems to be unstable. Only use to be unblocked of a situation (like `QUARTO_CHROMIUM_HEADLESS_MODE="none"` if you use an old chrome version somehow that don't support `--headless=old`).
 - ([#10170](https://github.com/quarto-dev/quarto-cli/issues/10170)): Quarto should find chrome executable automatically on most OS. If this is does not find it, or a specific version is needed, set `QUARTO_CHROMIUM` environment variable to the executable path.
+- Quarto now makes sure that all started chromium instances are closed when the process ends, no matter how it ends (success, error, or interruption).
 
 ## Other Fixes and Improvements
 


### PR DESCRIPTION
Follow up on #11135 and #11187 as they surfaced a problem where Chromium processed where not closed after rendering. 

The real issue is there 
https://github.com/quarto-dev/quarto-cli/blob/c8a3e7c046884f8cb4bac8d96d73204baaa6328a/src/core/cri/cri.ts#L129-L130

where somehow `await client.close()` does not return and so `browser.close()` never happens. This was confirmed by debugging interactively in VSCODE on Windows. 

**This PR is not solving the issue which is tracked at https://github.com/quarto-dev/quarto-cli/issues/11196** - it is only improving current logic for 1.6 releases to make sure we do clean after ourselves in all cases, like we do with other processed. 

So for that aim, this PR adds `browser` Deno process to the same cleanupHandler for processes for quarto `exitWithCleanup()` logic. This cleanupHandler has all processes started with `execProcess()` already, but we can't use `execProcess()` here as we want to start the process in background, do HTML printing, then close. 