### PR TITLE
Correctly overwrite _reboot.scss to not apply font-size twice

### DIFF
--- a/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
@@ -2150,15 +2150,26 @@ code.sourceCode a.code-annotation-anchor {
 // override _reboot.scss
 
 // code blocks
-pre code {
+pre {
   font-family: $font-family-monospace-block;
   // I'm really not confident that this is correct
   @include font-size($code-block-font-size);
   font-weight: $font-weight-monospace-block;
+
+  // adding these inherit overrides here
+  // is what `_reboot.scss` does.
+  // we mirror it here for consistency
+  //
+  // Account for some code outputs that place code tags in pre tags
+  code {
+    font-family: inherit;
+    @include font-size(inherit);
+    font-weight: inherit;
+  }
 }
 
 // code inlines
-p code {
+code {
   font-family: $font-family-monospace-inline;
   @include font-size($code-inline-font-size);
   font-weight: $font-weight-monospace-inline;

--- a/tests/docs/playwright/html/code-font-size.qmd
+++ b/tests/docs/playwright/html/code-font-size.qmd
@@ -1,0 +1,8 @@
+---
+title: Testing code font size
+format: html
+---
+
+```python
+1 + 1
+```

--- a/tests/integration/playwright/tests/html-themes.spec.ts
+++ b/tests/integration/playwright/tests/html-themes.spec.ts
@@ -20,3 +20,13 @@ test('Dark theming toggle change to dark background ', async ({ page }) => {
   const locatr2 = await page.locator('div').filter({ hasText: 'Quarto Playground' }).first()
   await expect(locatr2).toHaveCSS('background-color', 'rgb(255, 0, 0)');
 });
+
+test('Code block font size did not change and still equals to pre size', async ({ page }) => {
+  await page.goto('./html/code-font-size.html');
+  const code = page.getByRole('code')
+  const pre = page.locator('pre')
+  const preFontSize = await pre.evaluate((element) =>
+    window.getComputedStyle(element).getPropertyValue('font-size'),
+  );
+  await expect(code).toHaveCSS('font-size', preFontSize);
+});


### PR DESCRIPTION
This follows up on https://github.com/quarto-dev/quarto-cli/pull/11028 to do it differently in similar manner as in `_reboot.scss` so that code inside pre does not apply font-size a second time

closes #11185

I decided that other issue I found with `$code-font-size` being change and how code-annotation behave will be done in 1.7 in another issue. Let's just fix for now what was working in 1.5 and no more in 1.6.

No changelog item because it is fixing a problem from one of the 1.6 new feature. 

I think I'll add a test using playwright about this code font size default change which was the problem for the annotation. Then I'll merge