### PR TITLE
Bugfix/brand typography family string

### DIFF
--- a/src/resources/filters/modules/brand/brand.lua
+++ b/src/resources/filters/modules/brand/brand.lua
@@ -32,6 +32,9 @@ local function get_typography(fontName)
   if not brand then return nil end
   local typography = brand.typography and brand.typography[fontName]
   if not typography then return nil end
+  if type(typography) == 'string' then
+    typography = { family = typography }
+  end
   local typsted = {}
   for k, v in pairs(typography) do
     if k == 'color' or k == 'background-color' then

--- a/tests/docs/smoke-all/2024/10/28/brand-typography-family-string/_brand.yml
+++ b/tests/docs/smoke-all/2024/10/28/brand-typography-family-string/_brand.yml
@@ -1,0 +1,11 @@
+color: 
+  palette: 
+    white: "#eeddcc"
+    black: "#112233"
+  foreground: black
+  background: white
+typography:
+  fonts:
+    - family: "Roboto Slab"
+      source: google
+  base: "Roboto Slab"

--- a/tests/docs/smoke-all/2024/10/28/brand-typography-family-string/test.qmd
+++ b/tests/docs/smoke-all/2024/10/28/brand-typography-family-string/test.qmd
@@ -1,0 +1,16 @@
+---
+format: typst
+title: Hello
+---
+
+## This is a section
+
+This is a paragraph.
+
+## This is another section
+
+This is another paragraph.
+
+```
+some code.
+```


### PR DESCRIPTION
Adds support for `string`-typed shortcuts in font family declarations in Lua. Specifically:

```yml
typography:
  fonts:
    - family: "Roboto Slab"
      source: google
  base: "Roboto Slab" # <- this
```