### PR TITLE
Improved SCSS for revealjs - part 1

### DIFF
--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -104,6 +104,21 @@ $dark-bg-link-color: #42affa !default;
 $light-bg-code-color: #4758ab !default;
 $dark-bg-code-color: #ffa07a !default;
 
+// KBD variables
+$kbd-padding-y: 0.4rem !default;
+$kbd-padding-x: 0.4rem !default;
+$kbd-font-size: $presentation-font-size-root !default;
+$kbd-color: $body-color !default;
+$kbd-bg: $gray-100 !default; // like in bootstrap style
+
+// variables required by _brand.yml
+$font-family-monospace-block: $font-family-monospace !default;
+$font-family-monospace-inline: $font-family-monospace !default;
+$font-weight-monospace: $font-weight-base !default;
+$font-weight-monospace-block: $font-weight-monospace !default;
+$font-weight-monospace-inline: $font-weight-monospace !default;
+$code-inline-font-size: $code-font-size !default;
+
 // --- derive reveal versions of presentation variables for finer-grained override ---
 
 $revealjs-font-size-root: $presentation-font-size-root !default;
@@ -172,21 +187,6 @@ $overlayElementBgColor: 240, 240, 240 !default;
 $overlayElementFgColor: 0, 0, 0 !default;
 
 // -- END setting.scss --
-
-// KBD variables
-$kbd-padding-y: 0.4rem !default;
-$kbd-padding-x: 0.4rem !default;
-$kbd-font-size: $presentation-font-size-root !default;
-$kbd-color: $body-color !default;
-$kbd-bg: $gray-100 !default; // like in bootstrap style
-
-// variables required by _brand.yml
-$font-family-monospace-block: $font-family-monospace !default;
-$font-family-monospace-inline: $font-family-monospace !default;
-$font-weight-monospace: $font-weight-base !default;
-$font-weight-monospace-block: $font-weight-monospace !default;
-$font-weight-monospace-inline: $font-weight-monospace !default;
-$code-inline-font-size: $code-font-size !default;
 
 /*-- scss:functions --*/
 

--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -321,6 +321,14 @@ div.reveal div.slides section.quarto-title-block {
     color: $code-block-color;
     font-family: inherit;
   }
+
+  &.sourceCode code {
+    color: $code-block-color;
+    background-color: $code-block-bg;
+    padding: 6px 9px;
+    max-height: $code-block-height;
+    white-space: pre;
+  }
 }
 
 // Inside code-file-name div, we want to use the same background color as decorated codeblock header
@@ -335,14 +343,6 @@ div.reveal div.slides section.quarto-title-block {
   background-color: $code-bg;
   white-space: pre-wrap;
   font-family: $font-family-monospace-inline;
-}
-
-.reveal pre.sourceCode code {
-    color: $code-block-color;
-  background-color: $code-block-bg;
-  padding: 6px 9px;
-  max-height: $code-block-height;
-  white-space: pre;
 }
 
 .reveal .column-output-location {

--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -338,9 +338,7 @@ div.reveal div.slides section.quarto-title-block {
 }
 
 .reveal pre.sourceCode code {
-  @if variable-exists(code-block-color) {
     color: $code-block-color;
-  }
   background-color: $code-block-bg;
   padding: 6px 9px;
   max-height: $code-block-height;

--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -139,6 +139,9 @@ $revealjs-block-margin: $presentation-block-margin !default;
 $revealjs-line-height: $presentation-line-height !default;
 $revealjs-list-bullet-color: $presentation-list-bullet-color !default;
 
+$revealjs-code-inline-font-size: $code-inline-font-size !default;
+$revealjs-code-block-font-size: $code-block-font-size !default;
+
 // ---- map to reveal scss variables ---
 // ---- This is based from the revealjs setting.scss
 // -- START setting.scss --
@@ -310,7 +313,7 @@ div.reveal div.slides section.quarto-title-block {
   background-color: $code-block-bg;
   border: none;
   margin: 0;
-  font-size: $code-block-font-size;
+  font-size: $revealjs-code-block-font-size;
   line-height: $code-block-line-height;
 }
 
@@ -322,7 +325,7 @@ div.reveal div.slides section.quarto-title-block {
 
 .reveal code {
   color: $code-color;
-  font-size: $code-inline-font-size;
+  font-size: $revealjs-code-inline-font-size;
   background-color: $code-bg;
   white-space: pre-wrap;
 }
@@ -339,7 +342,7 @@ div.reveal div.slides section.quarto-title-block {
 
 .reveal pre code {
   background-color: $body-bg;
-  font-size: $code-block-font-size;
+  font-size: $revealjs-code-block-font-size;
   color: $code-block-color;
 }
 

--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -315,6 +315,14 @@ div.reveal div.slides section.quarto-title-block {
   margin: 0;
   font-size: $revealjs-code-block-font-size;
   line-height: $code-block-line-height;
+  font-family: $blockCodeFont;
+
+  code {
+    background-color: $body-bg;
+    font-size: inherit;
+    color: $code-block-color;
+    font-family: inherit;
+  }
 }
 
 // Inside code-file-name div, we want to use the same background color as decorated codeblock header
@@ -328,6 +336,7 @@ div.reveal div.slides section.quarto-title-block {
   font-size: $revealjs-code-inline-font-size;
   background-color: $code-bg;
   white-space: pre-wrap;
+  font-family: $inlineCodeFont;
 }
 
 .reveal pre.sourceCode code {
@@ -819,12 +828,4 @@ kbd {
 :root {
   --r-inline-code-font: #{$inlineCodeFont};
   --r-block-code-font: #{$blockCodeFont};
-}
-
-.reveal code {
-  font-family: var(--r-inline-code-font);
-}
-
-.reveal pre code {
-	font-family: var(--r-block-code-font);
 }

--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -224,6 +224,14 @@ $overlayElementFgColor: 0, 0, 0 !default;
   }
 }
 
+@mixin make-smaller-font-size($element) {
+  font-size: calc(#{$element} * #{$presentation-font-smaller});
+}
+
+@mixin undo-smaller-font-size($element) {
+  font-size: calc(#{$element} / #{$presentation-font-smaller});
+}
+
 // -- START setting.scss --
 
 // Generates the presentation background, can be overridden
@@ -460,29 +468,88 @@ $panel-sidebar-padding: 0.5em;
   line-height: $revealjs-line-height;
 }
 
-.reveal.smaller .slides section,
-.reveal .slides section.smaller,
-.reveal .slides section .callout {
-  font-size: #{$presentation-font-smaller}em;
-}
-// avoid applying twice the reduction when using nested section
-.reveal.smaller .slides section section {
-  font-size: inherit;
-}
+// Smaller font size logic
+.reveal {
+  // When smaller is set globally
+  &.smaller {
+    .slides {
+      // We make the all slide font-size smaller by a factor of $presentation-font-smaller
+      section {
+        font-size: #{$presentation-font-smaller}em;
 
-.reveal.smaller .slides h1,
-.reveal .slides section.smaller h1 {
-  font-size: calc(#{$revealjs-h1-font-size} / #{$presentation-font-smaller});
-}
+        // avoid applying twice the reduction when using nested section
+        section {
+          font-size: inherit;
+        }
+      }
 
-.reveal.smaller .slides h2,
-.reveal .slides section.smaller h2 {
-  font-size: calc(#{$revealjs-h2-font-size} / #{$presentation-font-smaller});
-}
+      // But we don't want headers to change size and they are in em
+      h1 {
+        @include undo-smaller-font-size($revealjs-h1-font-size);
+      }
+      h2 {
+        @include undo-smaller-font-size($revealjs-h2-font-size);
+      }
+      h3 {
+        @include undo-smaller-font-size($revealjs-h3-font-size);
+      }
+      // Though we want pre and code to be smaller and they are in px
+      pre {
+        @include make-smaller-font-size($revealjs-code-block-font-size);
+      }
+      code {
+        @include make-smaller-font-size($revealjs-code-inline-font-size);
+      }
+    }
+  }
 
-.reveal.smaller .slides h3,
-.reveal .slides section.smaller h3 {
-  font-size: calc(#{$revealjs-h3-font-size} / #{$presentation-font-smaller});
+  .slides section {
+    // when  smaller is set on slide
+    &.smaller {
+      font-size: #{$presentation-font-smaller}em;
+
+      // But we don't want headers to change size and they are in em
+      h1 {
+        @include undo-smaller-font-size($revealjs-h1-font-size);
+      }
+      h2 {
+        @include undo-smaller-font-size($revealjs-h2-font-size);
+      }
+      h3 {
+        @include undo-smaller-font-size($revealjs-h3-font-size);
+      }
+      // Though we want pre and code to be smaller and they are in px
+      pre {
+        @include make-smaller-font-size($revealjs-code-block-font-size);
+      }
+      code {
+        @include make-smaller-font-size($revealjs-code-inline-font-size);
+      }
+    }
+
+    // On callout we want to make the font-size smaller too
+    .callout {
+      font-size: #{$presentation-font-smaller}em;
+
+      // But we don't want headers to change size and they are in em
+      h1 {
+        @include undo-smaller-font-size($revealjs-h1-font-size);
+      }
+      h2 {
+        @include undo-smaller-font-size($revealjs-h2-font-size);
+      }
+      h3 {
+        @include undo-smaller-font-size($revealjs-h3-font-size);
+      }
+      // Though we want pre and code to be smaller and they are in px
+      pre {
+        @include make-smaller-font-size($revealjs-code-block-font-size);
+      }
+      code {
+        @include make-smaller-font-size($revealjs-code-inline-font-size);
+      }
+    }
+  }
 }
 
 .reveal .columns > .column > :not(ul, ol) {

--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -173,8 +173,6 @@ $heading3Size: $revealjs-h3-font-size !default;
 $heading4Size: $revealjs-h4-font-size !default;
 
 $codeFont: $font-family-monospace !default;
-$inlineCodeFont: $font-family-monospace-inline !default;
-$blockCodeFont: $font-family-monospace-block !default;
 
 // Links and actions
 $linkColor: $link-color !default;
@@ -315,7 +313,7 @@ div.reveal div.slides section.quarto-title-block {
   margin: 0;
   font-size: $revealjs-code-block-font-size;
   line-height: $code-block-line-height;
-  font-family: $blockCodeFont;
+  font-family: $font-family-monospace-block;
 
   code {
     background-color: $body-bg;
@@ -336,7 +334,7 @@ div.reveal div.slides section.quarto-title-block {
   font-size: $revealjs-code-inline-font-size;
   background-color: $code-bg;
   white-space: pre-wrap;
-  font-family: $inlineCodeFont;
+  font-family: $font-family-monospace-inline;
 }
 
 .reveal pre.sourceCode code {
@@ -826,6 +824,6 @@ kbd {
 }
 
 :root {
-  --r-inline-code-font: #{$inlineCodeFont};
-  --r-block-code-font: #{$blockCodeFont};
+  --r-inline-code-font: #{$font-family-monospace-inline};
+  --r-block-code-font: #{$font-family-monospace-block};
 }

--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -316,7 +316,7 @@ div.reveal div.slides section.quarto-title-block {
   font-family: $font-family-monospace-block;
 
   code {
-    background-color: $body-bg;
+    background-color: $body-bg; // Insure we color output and code cell differently
     font-size: inherit;
     color: $code-block-color;
     font-family: inherit;
@@ -324,10 +324,12 @@ div.reveal div.slides section.quarto-title-block {
 
   &.sourceCode code {
     color: $code-block-color;
-    background-color: $code-block-bg;
+    font-size: inherit;
+    background-color: inherit;
+    white-space: pre;
+    font-family: inherit;
     padding: 6px 9px;
     max-height: $code-block-height;
-    white-space: pre;
   }
 }
 

--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -654,30 +654,34 @@ $panel-sidebar-padding: 0.5em;
   z-index: 1;
 }
 
-.reveal .callout.callout-style-simple .callout-body,
-.reveal .callout.callout-style-default .callout-body,
-.reveal .callout.callout-style-simple div.callout-title,
-.reveal .callout.callout-style-default div.callout-title {
-  font-size: inherit;
-}
+/* Callout styles */
+.reveal .callout {
+  &.callout-style-simple,
+  &.callout-style-default {
+    .callout-body,
+    div.callout-title {
+      font-size: inherit;
+    }
+    .callout-icon::before {
+      height: 2rem;
+      width: 2rem;
+      background-size: 2rem 2rem;
+    }
+  }
 
-.reveal .callout.callout-style-default .callout-icon::before,
-.reveal .callout.callout-style-simple .callout-icon::before {
-  height: 2rem;
-  width: 2rem;
-  background-size: 2rem 2rem;
-}
+  &.callout-titled {
+    .callout-title p {
+      margin-top: 0.5em;
+    }
 
-.reveal .callout.callout-titled .callout-title p {
-  margin-top: 0.5em;
-}
+    .callout-icon::before {
+      margin-top: 1rem;
+    }
 
-.reveal .callout.callout-titled .callout-icon::before {
-  margin-top: 1rem;
-}
-
-.reveal .callout.callout-titled .callout-body > .callout-content > :last-child {
-  margin-bottom: 1rem;
+    .callout-body > .callout-content > :last-child {
+      margin-bottom: 1rem;
+    }
+  }
 }
 
 .reveal .panel-tabset [role="tab"] {

--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -496,6 +496,10 @@ $panel-sidebar-padding: 0.5em;
       // Though we want pre and code to be smaller and they are in px
       pre {
         @include make-smaller-font-size($revealjs-code-block-font-size);
+        // Make sure code inside pre use code block font size
+        code {
+          font-size: inherit;
+        }
       }
       code {
         @include make-smaller-font-size($revealjs-code-inline-font-size);
@@ -521,6 +525,10 @@ $panel-sidebar-padding: 0.5em;
       // Though we want pre and code to be smaller and they are in px
       pre {
         @include make-smaller-font-size($revealjs-code-block-font-size);
+        // Make sure code inside pre use code block font size
+        code {
+          font-size: inherit;
+        }
       }
       code {
         @include make-smaller-font-size($revealjs-code-inline-font-size);
@@ -544,6 +552,10 @@ $panel-sidebar-padding: 0.5em;
       // Though we want pre and code to be smaller and they are in px
       pre {
         @include make-smaller-font-size($revealjs-code-block-font-size);
+        // Make sure code inside pre use code block font size
+        code {
+          font-size: inherit;
+        }
       }
       code {
         @include make-smaller-font-size($revealjs-code-inline-font-size);

--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -903,4 +903,6 @@ kbd {
 :root {
   --r-inline-code-font: #{$font-family-monospace-inline};
   --r-block-code-font: #{$font-family-monospace-block};
+  --r-inline-code-font-size: #{$revealjs-code-inline-font-size};
+  --r-block-code-font-size: #{$revealjs-code-block-font-size};
 }

--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -347,12 +347,6 @@ div.reveal div.slides section.quarto-title-block {
   white-space: pre;
 }
 
-.reveal pre code {
-  background-color: $body-bg;
-  font-size: $revealjs-code-block-font-size;
-  color: $code-block-color;
-}
-
 .reveal .column-output-location {
   display: flex;
   align-items: stretch;

--- a/tests/docs/playwright/revealjs/code-font-size.qmd
+++ b/tests/docs/playwright/revealjs/code-font-size.qmd
@@ -1,0 +1,50 @@
+---
+title: "Code font size"
+format: revealjs
+---
+
+## Callouts
+
+:::{.callout-tip}
+
+## Example test file
+
+- Every test is a call to `testthat::test_that()` function.
+
+````{.python}
+1 + 1
+````
+
+:::
+
+## No callout inline 
+
+Every test is a call to `testthat::test_that()` function.
+
+- And inside a list : `1+1`
+
+## Highlited Cell
+
+````{.python}
+1 + 1
+````
+
+## Non Highligted
+
+````
+1 + 1
+````
+
+## Smaller slide {.smaller}
+
+### With a h3 
+
+Some inline code: `1 + 1`
+
+And block code:
+
+```{.r}
+1 + 1
+```
+
+

--- a/tests/integration/playwright/tests/revealjs-themes.spec.ts
+++ b/tests/integration/playwright/tests/revealjs-themes.spec.ts
@@ -1,29 +1,97 @@
 import { test, expect, Locator } from '@playwright/test';
 
-async function getCSSProperty(loc: Locator, variable: string) {
-  return await loc.evaluate((element) =>
-    window.getComputedStyle(element).getPropertyValue(variable)
+async function getCSSProperty(loc: Locator, variable: string, asNumber = false): Promise<string | number> {
+  const property = await loc.evaluate((element, variable) =>
+    window.getComputedStyle(element).getPropertyValue(variable),
+    variable
   );
+  if (asNumber) {
+    return parseFloat(property);
+  } else {
+    return property;
+  }
 }
 
 async function checkFontSizeIdentical(loc1: Locator, loc2: Locator) {
-  const loc1FontSize = await getCSSProperty(loc1, 'font-size');
+  const loc1FontSize = await getCSSProperty(loc1, 'font-size', false) as string;
   await expect(loc2).toHaveCSS('font-size', loc1FontSize);
 }
 
-test('Code block font size did not change and still equals to pre size', async ({ page }) => {
+async function getRevealMainFontSize(page: any): Promise<number> {
+  return await getCSSProperty(page.locator('body'), "--r-main-font-size", true) as number;
+}
+
+async function getRevealCodeBlockFontSize(page: any): Promise<number> {
+  return await getCSSProperty(page.locator('body'), "--r-block-code-font-size", true) as number;
+}
+
+async function getRevealCodeInlineFontSize(page: any): Promise<number> {
+  return await getCSSProperty(page.locator('body'), "--r-inline-code-font-size", true) as number;
+}
+
+test('Code font size in callouts and smaller slide is scaled down', async ({ page }) => {
   await page.goto('./revealjs/code-font-size.html');
   await page.locator('body').press('ArrowRight');
+  // Get smaller slide scale factor
+  const calloutsFontSize = await getCSSProperty(page.locator('#callouts div.callout'), "font-size", true) as number;
+  const mainFontSize = await getRevealMainFontSize(page);
+  const scaleFactor = calloutsFontSize / mainFontSize;
+  expect(scaleFactor).toBeLessThan(1);
+  // Font size in callout for inline code should be scaled smaller than default inline code
+  const codeInlineFontSize = await getRevealCodeInlineFontSize(page);
+  const computedInlineFontSize = scaleFactor * codeInlineFontSize;
+  expect(await getCSSProperty(page.locator('#callouts').getByText('testthat::test_that()'), 'font-size', true)).toBeCloseTo(computedInlineFontSize);
   // Font size in callout for inline code should be same size as text by default
   await checkFontSizeIdentical(
     page.locator('#callouts').getByText('Every test is a call to'), 
     page.locator('#callouts').getByText('testthat::test_that()')
   );
   // Font size for code block in callout should be scaled smaller that default code block
-  const calloutsFontSize = parseFloat(await getCSSProperty(page.locator('#callouts'), "font-size"));
-  const bodyFontSize = parseFloat(await getCSSProperty(page.locator('body'), "font-size"));
-  const scaleFactor = calloutsFontSize / bodyFontSize;
-  const codeBlockFontSize = await getCSSProperty(page.locator('body'), "--r-block-code-font-size");
-  const computedCodeFont = `${scaleFactor * parseFloat(codeBlockFontSize)}px`;
-  await expect(page.locator('#callout pre code')).toHaveCSS('font-size', computedCodeFont);
+  const codeBlockFontSize = await getRevealCodeBlockFontSize(page)
+  const computedBlockFontSize = scaleFactor * codeBlockFontSize;
+  expect(await getCSSProperty(page.locator('.callout pre code'), 'font-size', true)).toBeCloseTo(computedBlockFontSize);
+});
+
+test('Code font size in smaller slide is scaled down', async ({ page }) => {
+  await page.goto('./revealjs/code-font-size.html#/smaller-slide');
+  // Get smaller slide scale factor
+  const smallerFontSize = await getCSSProperty(page.getByText('And block code:', { exact: true }), "font-size", true) as number;
+  const mainFontSize = await getRevealMainFontSize(page);
+  const scaleFactor = smallerFontSize / mainFontSize;
+  expect(scaleFactor).toBeLessThan(1);
+  // Code Font size in smaller slide for inline code should be scaled smaller than default inline code
+  const codeInlineFontSize = await getRevealCodeInlineFontSize(page);
+  const computedInlineFontSize = scaleFactor * codeInlineFontSize;
+  expect(
+    await getCSSProperty(
+      page.locator('#smaller-slide p').filter({ hasText: 'Some inline code' }).getByRole('code'),
+       'font-size', true
+    )
+  ).toBeCloseTo(computedInlineFontSize);
+  // Font size for code block in callout should be scaled smaller that default code block
+  const codeBlockFontSize = await getRevealCodeBlockFontSize(page)
+  const computedBlockFontSize = scaleFactor * codeBlockFontSize;
+  expect(await getCSSProperty(page.locator('#smaller-slide pre').getByRole('code'), 'font-size', true)).toBeCloseTo(computedBlockFontSize);
+});
+
+test('Code font size is correctly set', async ({ page }) => {
+  await page.goto('./revealjs/code-font-size.html');
+  await page.locator('body').press('ArrowRight');
+  await page.locator('body').press('ArrowRight');
+  const codeInlineFontSize = await getRevealCodeInlineFontSize(page);
+  expect(
+    await getCSSProperty(page.locator('#no-callout-inline').getByText('testthat::test_that()'), 'font-size', true)
+  ).toBeCloseTo(codeInlineFontSize);
+  expect(
+    await getCSSProperty(page.getByText('1+1', { exact: true }), 'font-size', true)
+  ).toBeCloseTo(codeInlineFontSize);
+  await page.locator('body').press('ArrowRight');
+  const codeBlockFontSize = await getRevealCodeBlockFontSize(page);
+  expect(
+    await getCSSProperty(page.locator("#highlited-cell div.sourceCode pre code"), 'font-size', true)
+  ).toBeCloseTo(codeBlockFontSize);
+  await page.locator('body').press('ArrowRight');
+  expect(
+    await getCSSProperty(page.locator("#non-highligted pre code"), 'font-size', true)
+  ).toBeCloseTo(codeBlockFontSize);
 });

--- a/tests/integration/playwright/tests/revealjs-themes.spec.ts
+++ b/tests/integration/playwright/tests/revealjs-themes.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect, Locator } from '@playwright/test';
+
+async function getCSSProperty(loc: Locator, variable: string) {
+  return await loc.evaluate((element) =>
+    window.getComputedStyle(element).getPropertyValue(variable)
+  );
+}
+
+async function checkFontSizeIdentical(loc1: Locator, loc2: Locator) {
+  const loc1FontSize = await getCSSProperty(loc1, 'font-size');
+  await expect(loc2).toHaveCSS('font-size', loc1FontSize);
+}
+
+test('Code block font size did not change and still equals to pre size', async ({ page }) => {
+  await page.goto('./revealjs/code-font-size.html');
+  await page.locator('body').press('ArrowRight');
+  // Font size in callout for inline code should be same size as text by default
+  await checkFontSizeIdentical(
+    page.locator('#callouts').getByText('Every test is a call to'), 
+    page.locator('#callouts').getByText('testthat::test_that()')
+  );
+  // Font size for code block in callout should be scaled smaller that default code block
+  const calloutsFontSize = parseFloat(await getCSSProperty(page.locator('#callouts'), "font-size"));
+  const bodyFontSize = parseFloat(await getCSSProperty(page.locator('body'), "font-size"));
+  const scaleFactor = calloutsFontSize / bodyFontSize;
+  const codeBlockFontSize = await getCSSProperty(page.locator('body'), "--r-block-code-font-size");
+  const computedCodeFont = `${scaleFactor * parseFloat(codeBlockFontSize)}px`;
+  await expect(page.locator('#callout pre code')).toHaveCSS('font-size', computedCodeFont);
+});


### PR DESCRIPTION
This PR does various improvement 

- Refactor some SCSS code for better understanding what it is doing
- Move definition and variables in different places to group with other related rules
- Fixes #11215 so that new `$code-block-font-size` and  `$code-inline-font-size` from brand #11028 correctly works with smaller size content (like callouts and `.smaller` class
	- It also exports them as CSS var `--r-inline-code-font-size` and `--r-block-code-font-size`, to complement `--r-inline-code-font` and `--r-block-code-font`. This is useful for testing too.
	- Remove `$inlineCodeFont` and `$blockCodeFont` which are intermediates not in `settings.scss` from revealjs. This part of the file is for variables from revealjs itself (for themes). 
- New revealjs specific variable `$revealjs-code-inline-font-size` and `$revealjs-code-block-font-size` to match other `$revealjs-*` export (at https://github.com/quarto-dev/quarto-cli/blob/570fb4410d054068984a9c91948a2e0687a5c620/src/resources/formats/revealjs/quarto.scss#L122)
- It also adds some playwright test to compute font-size and check this is what we expect. This should help detect in advanced problem like #11215 

It seems a lot of changes, but it is only some reorganization to help fix issues like https://github.com/quarto-dev/quarto-cli/issues/5832 and other on callout (which are coming next)
