### PR TITLE
Adding a test for svg embedding when used in logo

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -52,6 +52,7 @@ All changes included in 1.6:
 - ([#9999](https://github.com/quarto-dev/quarto-cli/issues/9999)): Fix spacing problems of different size elements in columns.
 - ([#11146](https://github.com/quarto-dev/quarto-cli/issues/11146)): Fix issue with slide created with `---` and having no title showing up in TOC. Now they don't show up as slide created with empty header e.g. `## `.
 - ([#7142](https://github.com/quarto-dev/quarto-cli/issues/7142)): Fix issue in slides with `incremental: true` not working as expected when `code-annotation: hover` or `code-annotation: select`.
+- ([#9803](https://github.com/quarto-dev/quarto-cli/issues/9803)): Using url for `logo` to an online svg is now working correctly with `embed-resources: true`.
 
 ## `typst` Format
 

--- a/tests/docs/smoke-all/2024/10/29/9803.qmd
+++ b/tests/docs/smoke-all/2024/10/29/9803.qmd
@@ -1,0 +1,19 @@
+---
+title: Revealjs logo svg
+format:
+  revealjs:
+    logo: https://raw.githubusercontent.com/mcanouil/hex-stickers/main/SVG/rlille.svg
+    embed-resources: true
+_quarto:
+  tests:
+    revealjs:
+      ensureHtmlElements:
+        - ['img.slide-logo']
+        - []
+---
+
+## Slide
+
+This is a playground for Quarto.
+
+![An image](https://placehold.co/600x400.png)


### PR DESCRIPTION
closes #9803 - it is solved by 1.6 (probably pandoc's update). This PR adds a test to be sure we don't regress

And a changelog entry
