### PR TITLE
serialize and deserialize custom nodes to JSON filters

### DIFF
--- a/tests/docs/smoke-all/2024/10/29/test-shortcode-json-filter-insertion/insert_shortcode.py
+++ b/tests/docs/smoke-all/2024/10/29/test-shortcode-json-filter-insertion/insert_shortcode.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+import json
+import sys
+
+inp = sys.stdin.read()
+doc = json.loads(inp)
+
+#######
+# p_* are a bad version of a micro-panflute
+
+def p_string(string):
+  return {
+    "t": "String",
+    "c": string
+  }
+
+def p_meta_string(string):
+  return {
+    "t": "MetaString",
+    "c": string
+  }
+
+def p_meta_val(val):
+  if type(val) == str:
+    return p_meta_string(val)
+  if type(val) == dict:
+    return p_meta_map(val)
+  if type(val) == list:
+    return p_meta_list(val)
+  raise Exception("Unknown type: " + str(type(val)))
+
+def p_meta_list(list):
+  return {
+    "t": "MetaList",
+    "c": [p_meta_val(v) for v in list]
+  }
+
+def p_meta_map(dict):
+  result = {}
+  for k, v in dict.items():
+    result[k] = p_meta_val(v)
+  return {
+    "t": "MetaMap",
+    "c": result
+  }
+
+def p_attr(id, classes, attrs):
+  return [id, classes, list([k, v] for k, v in attrs.items())]
+
+def p_para(content):
+  return {
+    "t": "Para",
+    "c": content
+  }
+
+#######
+
+max_id = 0
+for node in doc["meta"]["quarto-custom-node-data"]["c"]:
+  if node["t"] == "MetaMap":
+    max_id = max(max_id, int(node["c"]["quarto_custom_meta"]["c"]["id"]["c"]))
+
+def shortcode_data():
+  return {
+    "name": "meta",
+    "params": [ { "type": "param", "value": "baz" } ],
+    "t": "Shortcode",
+    "unparsed_content": r"{{< meta baz >}}",
+    "quarto_custom_meta": {
+      "id": str(max_id + 1) # this needs to be unique!!
+    }
+  }
+
+def shortcode_span():
+  return {
+    "t": "Span",
+    "c": [ 
+      p_attr("", [], {"__quarto_custom": "true", "__quarto_custom_type": "Shortcode", "__quarto_custom_context": "Inline", "__quarto_custom_id": str(max_id + 1)}),
+      [] # no content
+    ]
+  }
+
+doc["meta"]["quarto-custom-node-data"]["c"].append(p_meta_val(shortcode_data()))
+doc["blocks"].append(p_para([shortcode_span()]))
+
+print(json.dumps(doc))

--- a/tests/docs/smoke-all/2024/10/29/test-shortcode-json-filter-insertion/json-filter-shortcode-insertion.qmd
+++ b/tests/docs/smoke-all/2024/10/29/test-shortcode-json-filter-insertion/json-filter-shortcode-insertion.qmd
@@ -1,0 +1,25 @@
+---
+filters:
+  - at: pre-quarto
+    path: insert_shortcode.py
+    type: json
+title: Hello
+foo: bar
+baz: "d79920da-f2a6-4f3e-9c5c-84c9854d5b11"
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - ["d79920da-f2a6-4f3e-9c5c-84c9854d5b11"]
+        - []
+---
+
+{{< meta foo >}}
+
+::: {#fig-1}
+
+This is the content.
+
+This is a caption.
+
+:::


### PR DESCRIPTION
Addresses https://github.com/quarto-dev/quarto-cli/discussions/11235

Custom AST nodes are now serialized to and from JSON. This enables, for example, JSON filters to emit shortcodes, callouts, etc.

In order for JSON filters to do this well, they need to be careful about the way they consume and emit the JSON structure. This will need documentation and ideally library support.

This PR unlocks the core capability.