### PR TITLE
Add a test for the environment variable QUARTO_VERSION_REQUIREMENT

### DIFF
--- a/tests/docs/quarto-required.qmd
+++ b/tests/docs/quarto-required.qmd
@@ -3,6 +3,7 @@ title: Hello Callout!
 format:
   html:
     quarto-required: "<= 0.0.0"
+  html+norequire: default
 ---
 
 This file will not be rendered as it does not respect the quarto version requirement

--- a/tests/smoke/render/render-required.test.ts
+++ b/tests/smoke/render/render-required.test.ts
@@ -18,6 +18,7 @@ testQuartoCmd(
 );
 
 let oldVersionRequirement: string | undefined;
+let originalDenoExit: typeof Deno.exit;
 
 testQuartoCmd(
   "render",
@@ -28,6 +29,12 @@ testQuartoCmd(
       // Save current version of QUARTO_VERSION_REQUIREMENT env var and set it to a value that will not be satisfied
       oldVersionRequirement = Deno.env.get("QUARTO_VERSION_REQUIREMENT");
       Deno.env.set("QUARTO_VERSION_REQUIREMENT", "< 0.0.0");
+      // Mock Deno.exit to throw an error instead of exiting
+      // Otherwise we would not check the error assertion
+      originalDenoExit = Deno.exit;
+      Deno.exit = (code?: number) => {
+        throw new Error(`Deno.exit called with code: ${code}`);
+      };
     },
     teardown: async () => {
       // Restore QUARTO_VERSION_REQUIREMENT
@@ -36,6 +43,8 @@ testQuartoCmd(
       } else {
         Deno.env.delete("QUARTO_VERSION_REQUIREMENT");
       }
+      // Restore Deno.exit
+      Deno.exit = originalDenoExit;
     },
   }
 );

--- a/tests/smoke/render/render-required.test.ts
+++ b/tests/smoke/render/render-required.test.ts
@@ -16,3 +16,26 @@ testQuartoCmd(
   [input],
   [printsMessage("ERROR", /does not satisfy version/)]
 );
+
+let oldVersionRequirement: string | undefined;
+
+testQuartoCmd(
+  "render",
+  [input, "--to", "html+norequire"],
+  [printsMessage("ERROR", /does not meet semver requirement/)],
+  {
+    setup: async () => {
+      // Save current version of QUARTO_VERSION_REQUIREMENT env var and set it to a value that will not be satisfied
+      oldVersionRequirement = Deno.env.get("QUARTO_VERSION_REQUIREMENT");
+      Deno.env.set("QUARTO_VERSION_REQUIREMENT", "< 0.0.0");
+    },
+    teardown: async () => {
+      // Restore QUARTO_VERSION_REQUIREMENT
+      if (oldVersionRequirement) {
+        Deno.env.set("QUARTO_VERSION_REQUIREMENT", oldVersionRequirement);
+      } else {
+        Deno.env.delete("QUARTO_VERSION_REQUIREMENT");
+      }
+    },
+  }
+);


### PR DESCRIPTION
This is a follow up on 00249a46bab6e3e45adb9900677a33e599cb10d3 which closed #10442

It adds a test from the error message when environment variable is set. 

To be working it required to mock Deno.exit() in the test so that it throws an Error()

This is because after using `error()`, `Deno.exit(1)` is called, and it makes `test.execute()` quite with the rest of the test command to verify assertion. 

As a side note, this is possibly a problem as anytime this Deno.exit() happens, our test suite won't fail ! Test is not seen as Failed nor Success 🤷‍♂️ 

Our usual pattern seem to be throwing an error after `error()` so that our hooks trigger (the stack trace for example)

Some examples:

https://github.com/quarto-dev/quarto-cli/blob/60b8e01d36f089882047595ace591ee425462d14/src/command/render/render-files.ts#L512-L516

https://github.com/quarto-dev/quarto-cli/blob/60b8e01d36f089882047595ace591ee425462d14/src/command/render/render-files.ts#L522-L526

https://github.com/quarto-dev/quarto-cli/blob/60b8e01d36f089882047595ace591ee425462d14/src/command/editor-support/crossref.ts#L136-L139

Though it is not the case everywhere. 🤷‍♂️ So probably not applying in this checking of quarto version requirement where we want to fail fast. 

Using `Deno.exit(1)` completely stop execution and `catch()` does not apply 
https://github.com/quarto-dev/quarto-cli/blob/60b8e01d36f089882047595ace591ee425462d14/tests/test.ts#L176-L180

Anyhow, just a PR so that we have a test on the feature; Hopefully this is a good way to do it in our current test status. 
