### PR TITLE
Bugfix/remove brand typography base color

### DIFF
--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -11911,6 +11911,7 @@ var require_yaml_intelligence_resources = __commonJS({
             closed: true,
             properties: {
               images: {
+                description: "A dictionary of named logo resources.",
                 schema: {
                   object: {
                     additionalProperties: {
@@ -12095,23 +12096,23 @@ var require_yaml_intelligence_resources = __commonJS({
                 ref: "brand-typography-options-base"
               },
               headings: {
-                description: "Settings for headings\n",
+                description: "Settings for headings, or a string specifying the font family only.",
                 ref: "brand-typography-options-headings"
               },
               monospace: {
-                description: "Settings for monospace text\n",
+                description: "Settings for monospace text, or a string specifying the font family only.",
                 ref: "brand-typography-options-monospace"
               },
               "monospace-inline": {
-                description: "Settings for inline code",
+                description: "Settings for inline code, or a string specifying the font family only.",
                 ref: "brand-typography-options-monospace-inline"
               },
               "monospace-block": {
-                description: "Settings for code blocks",
+                description: "Settings for code blocks, or a string specifying the font family only.",
                 ref: "brand-typography-options-monospace-block"
               },
               link: {
-                description: "Settings for links",
+                description: "Settings for links.",
                 ref: "brand-typography-options-link"
               }
             }
@@ -12119,7 +12120,7 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         {
           id: "brand-typography-options-base",
-          description: "Typographic options.",
+          description: "Base typographic options.",
           anyOf: [
             "string",
             {
@@ -12131,9 +12132,6 @@ var require_yaml_intelligence_resources = __commonJS({
                   weight: {
                     ref: "brand-font-weight"
                   },
-                  color: {
-                    ref: "brand-maybe-named-color"
-                  },
                   "line-height": {
                     ref: "line-height-number-string"
                   }
@@ -12144,7 +12142,7 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         {
           id: "brand-typography-options-headings",
-          description: "Typographic options without a font size.",
+          description: "Typographic options for headings.",
           anyOf: [
             "string",
             {
@@ -22809,6 +22807,7 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         "If <code>true</code>, force the presence of the OJS runtime. If\n<code>false</code>, force the absence instead. If unset, the OJS runtime\nis included only if OJS cells are present in the document.",
         "Use the specified file as a style reference in producing a docx,\npptx, or odt file.",
+        "Branding information to use for this document. If a string, the path\nto a brand file. If false, don\u2019t use branding on this document. If an\nobject, an inline brand definition.",
         "Theme name, theme scss file, or a mix of both.",
         "The light theme name, theme scss file, or a mix of both.",
         "The light theme name, theme scss file, or a mix of both.",
@@ -24131,12 +24130,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 193258,
+        _internalId: 193399,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 193250,
+            _internalId: 193391,
             type: "enum",
             enum: [
               "png",
@@ -24152,7 +24151,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 193257,
+            _internalId: 193398,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -11912,6 +11912,7 @@ try {
               closed: true,
               properties: {
                 images: {
+                  description: "A dictionary of named logo resources.",
                   schema: {
                     object: {
                       additionalProperties: {
@@ -12096,23 +12097,23 @@ try {
                   ref: "brand-typography-options-base"
                 },
                 headings: {
-                  description: "Settings for headings\n",
+                  description: "Settings for headings, or a string specifying the font family only.",
                   ref: "brand-typography-options-headings"
                 },
                 monospace: {
-                  description: "Settings for monospace text\n",
+                  description: "Settings for monospace text, or a string specifying the font family only.",
                   ref: "brand-typography-options-monospace"
                 },
                 "monospace-inline": {
-                  description: "Settings for inline code",
+                  description: "Settings for inline code, or a string specifying the font family only.",
                   ref: "brand-typography-options-monospace-inline"
                 },
                 "monospace-block": {
-                  description: "Settings for code blocks",
+                  description: "Settings for code blocks, or a string specifying the font family only.",
                   ref: "brand-typography-options-monospace-block"
                 },
                 link: {
-                  description: "Settings for links",
+                  description: "Settings for links.",
                   ref: "brand-typography-options-link"
                 }
               }
@@ -12120,7 +12121,7 @@ try {
           },
           {
             id: "brand-typography-options-base",
-            description: "Typographic options.",
+            description: "Base typographic options.",
             anyOf: [
               "string",
               {
@@ -12132,9 +12133,6 @@ try {
                     weight: {
                       ref: "brand-font-weight"
                     },
-                    color: {
-                      ref: "brand-maybe-named-color"
-                    },
                     "line-height": {
                       ref: "line-height-number-string"
                     }
@@ -12145,7 +12143,7 @@ try {
           },
           {
             id: "brand-typography-options-headings",
-            description: "Typographic options without a font size.",
+            description: "Typographic options for headings.",
             anyOf: [
               "string",
               {
@@ -22810,6 +22808,7 @@ try {
           },
           "If <code>true</code>, force the presence of the OJS runtime. If\n<code>false</code>, force the absence instead. If unset, the OJS runtime\nis included only if OJS cells are present in the document.",
           "Use the specified file as a style reference in producing a docx,\npptx, or odt file.",
+          "Branding information to use for this document. If a string, the path\nto a brand file. If false, don\u2019t use branding on this document. If an\nobject, an inline brand definition.",
           "Theme name, theme scss file, or a mix of both.",
           "The light theme name, theme scss file, or a mix of both.",
           "The light theme name, theme scss file, or a mix of both.",
@@ -24132,12 +24131,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 193258,
+          _internalId: 193399,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 193250,
+              _internalId: 193391,
               type: "enum",
               enum: [
                 "png",
@@ -24153,7 +24152,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 193257,
+              _internalId: 193398,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -4883,6 +4883,7 @@
         "closed": true,
         "properties": {
           "images": {
+            "description": "A dictionary of named logo resources.",
             "schema": {
               "object": {
                 "additionalProperties": {
@@ -5067,23 +5068,23 @@
             "ref": "brand-typography-options-base"
           },
           "headings": {
-            "description": "Settings for headings\n",
+            "description": "Settings for headings, or a string specifying the font family only.",
             "ref": "brand-typography-options-headings"
           },
           "monospace": {
-            "description": "Settings for monospace text\n",
+            "description": "Settings for monospace text, or a string specifying the font family only.",
             "ref": "brand-typography-options-monospace"
           },
           "monospace-inline": {
-            "description": "Settings for inline code",
+            "description": "Settings for inline code, or a string specifying the font family only.",
             "ref": "brand-typography-options-monospace-inline"
           },
           "monospace-block": {
-            "description": "Settings for code blocks",
+            "description": "Settings for code blocks, or a string specifying the font family only.",
             "ref": "brand-typography-options-monospace-block"
           },
           "link": {
-            "description": "Settings for links",
+            "description": "Settings for links.",
             "ref": "brand-typography-options-link"
           }
         }
@@ -5091,7 +5092,7 @@
     },
     {
       "id": "brand-typography-options-base",
-      "description": "Typographic options.",
+      "description": "Base typographic options.",
       "anyOf": [
         "string",
         {
@@ -5103,9 +5104,6 @@
               "weight": {
                 "ref": "brand-font-weight"
               },
-              "color": {
-                "ref": "brand-maybe-named-color"
-              },
               "line-height": {
                 "ref": "line-height-number-string"
               }
@@ -5116,7 +5114,7 @@
     },
     {
       "id": "brand-typography-options-headings",
-      "description": "Typographic options without a font size.",
+      "description": "Typographic options for headings.",
       "anyOf": [
         "string",
         {
@@ -15781,6 +15779,7 @@
     },
     "If <code>true</code>, force the presence of the OJS runtime. If\n<code>false</code>, force the absence instead. If unset, the OJS runtime\nis included only if OJS cells are present in the document.",
     "Use the specified file as a style reference in producing a docx,\npptx, or odt file.",
+    "Branding information to use for this document. If a string, the path\nto a brand file. If false, don’t use branding on this document. If an\nobject, an inline brand definition.",
     "Theme name, theme scss file, or a mix of both.",
     "The light theme name, theme scss file, or a mix of both.",
     "The light theme name, theme scss file, or a mix of both.",
@@ -17103,12 +17102,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 193258,
+    "_internalId": 193399,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 193250,
+        "_internalId": 193391,
         "type": "enum",
         "enum": [
           "png",
@@ -17124,7 +17123,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 193257,
+        "_internalId": 193398,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/filters/quarto-post/typst-brand-yaml.lua
+++ b/src/resources/filters/quarto-post/typst-brand-yaml.lua
@@ -96,7 +96,6 @@ function render_typst_brand_yaml()
               '#set text(',
               -- '#show par: set text(', overrules #show heading!
               conditional_entry('weight', base.weight),
-              conditional_entry('fill', base.color, false),
               ')'
             }))
         end

--- a/src/resources/schema/definitions.yml
+++ b/src/resources/schema/definitions.yml
@@ -2538,6 +2538,7 @@
     closed: true
     properties:
       images:
+        description: A dictionary of named logo resources.
         schema:
           object:
             additionalProperties:
@@ -2684,25 +2685,23 @@
           all text.
         ref: brand-typography-options-base
       headings:
-        description: >
-          Settings for headings
+        description: Settings for headings, or a string specifying the font family only.
         ref: brand-typography-options-headings
       monospace:
-        description: >
-          Settings for monospace text
+        description: Settings for monospace text, or a string specifying the font family only. 
         ref: brand-typography-options-monospace
       monospace-inline:
-        description: Settings for inline code
+        description: Settings for inline code, or a string specifying the font family only.
         ref: brand-typography-options-monospace-inline
       monospace-block:
-        description: Settings for code blocks
+        description: Settings for code blocks, or a string specifying the font family only.
         ref: brand-typography-options-monospace-block
       link:
-        description: Settings for links
+        description: Settings for links. 
         ref: brand-typography-options-link
 
 - id: brand-typography-options-base
-  description: Typographic options.
+  description: Base typographic options.
   anyOf:
     - string
     - object:
@@ -2718,7 +2717,7 @@
             ref: line-height-number-string
 
 - id: brand-typography-options-headings
-  description: Typographic options without a font size.
+  description: Typographic options for headings.
   anyOf:
     - string
     - object:

--- a/src/resources/schema/definitions.yml
+++ b/src/resources/schema/definitions.yml
@@ -2711,8 +2711,6 @@
           size: string
           weight:
             ref: brand-font-weight
-          color:
-            ref: brand-maybe-named-color
           line-height:
             ref: line-height-number-string
 

--- a/src/resources/schema/json-schemas.json
+++ b/src/resources/schema/json-schemas.json
@@ -3415,9 +3415,6 @@
               "weight": {
                 "$ref": "#/$defs/BrandFontWeight"
               },
-              "color": {
-                "$ref": "#/$defs/BrandMaybeNamedColor"
-              },
               "line-height": {
                 "$ref": "#/$defs/LineHeightNumberString"
               }

--- a/src/resources/types/schema-types.ts
+++ b/src/resources/types/schema-types.ts
@@ -1349,11 +1349,10 @@ export type BrandTypography = {
 
 export type BrandTypographyOptionsBase = string | {
   "line-height"?: LineHeightNumberString;
-  color?: BrandMaybeNamedColor;
   family?: string;
   size?: string;
   weight?: BrandFontWeight;
-}; /* Typographic options. */
+}; /* Base typographic options. */
 
 export type BrandTypographyOptionsHeadings = string | {
   "line-height"?: LineHeightNumberString;
@@ -1361,7 +1360,7 @@ export type BrandTypographyOptionsHeadings = string | {
   family?: string;
   style?: BrandFontStyle;
   weight?: BrandFontWeight;
-}; /* Typographic options without a font size. */
+}; /* Typographic options for headings. */
 
 export type BrandTypographyOptionsMonospace = string | {
   "background-color"?: BrandMaybeNamedColor;

--- a/tests/docs/brand-yaml/kitchen-sink/_brand.yml
+++ b/tests/docs/brand-yaml/kitchen-sink/_brand.yml
@@ -4,7 +4,7 @@ color:
     black: "#002040"
 
   primary: red
-  foreground: black
+  foreground: "#21f"
   background: "#e6f8ff"
 
 typography:
@@ -26,7 +26,6 @@ typography:
     # sass fails to typecheck
     size: 12pt
     weight: 400
-    color: "#21f"
     line-height: 0.9
   headings:
     family: PT Sans

--- a/tests/docs/brand-yaml/monospace-colors/_brand.yml
+++ b/tests/docs/brand-yaml/monospace-colors/_brand.yml
@@ -1,9 +1,6 @@
 color:
-  ## ERROR: Expecting punctuation: "}" if no palette
-  palette:
-    orangeblue: "#ccc"
   background: "#e6f8ff"
 typography:
   monospace:
     color: "#eee"
-    background-color: "#0a3c07"
+    background-color: "#339d2c"

--- a/tests/docs/brand-yaml/monospace-colors/brand-typography.qmd
+++ b/tests/docs/brand-yaml/monospace-colors/brand-typography.qmd
@@ -13,7 +13,7 @@ format:
 
 We're using only `brand.typography.monospace.color` and `.background-color`.
 
-Raw inlines `3 * fib(5)` and raw blocks will inherit the same colors, off-white and dark green.
+Raw inlines `3 * fib(5)` and raw blocks will inherit the same colors, off-white and green.
 
 :::{.sourceCode}
 ```

--- a/tests/docs/smoke-all/typst/brand-yaml/typography/kitchen-sink-1/_brand.yml
+++ b/tests/docs/smoke-all/typst/brand-yaml/typography/kitchen-sink-1/_brand.yml
@@ -4,7 +4,7 @@ color:
     black: "#002040"
     white: "#FFE0C0"
   primary: red
-  foreground: black
+  foreground: "#080180"
   background: white
 
 typography:
@@ -28,7 +28,6 @@ typography:
     family: Aguafina Script
     size: 14pt
     weight: 200
-    color: "#080180"
     line-height: 1.5
   headings:
     family: Montserrat

--- a/tests/docs/smoke-all/typst/brand-yaml/typography/kitchen-sink-1/brand-typography.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/typography/kitchen-sink-1/brand-typography.qmd
@@ -23,7 +23,8 @@ _quarto:
       -
         - 'font: \("Aguafina Script",\),$'
         - 'fontsize: 14pt,$'
-        - '^#set text\(weight: 200, fill: rgb\("#080180"\), \)$'
+        - '^#set text\(weight: 200, \)$'
+        - '^#set text\(fill: brand-color.foreground\)'
         - '^#set par\(leading: 0\.75em\)$'
 
         - 'heading-family: \("Montserrat",\),$'

--- a/tests/docs/smoke-all/typst/brand-yaml/typography/kitchen-sink-2/_brand.yml
+++ b/tests/docs/smoke-all/typst/brand-yaml/typography/kitchen-sink-2/_brand.yml
@@ -11,7 +11,7 @@ color:
     branded-monospace-block-background: "#0a3c07"
 
   primary: red
-  foreground: black
+  foreground: branded-base-foreground
   background: white
 
 typography:
@@ -36,7 +36,6 @@ typography:
     family: EB Garamond
     size: 16px
     weight: 300
-    color: branded-base-foreground
   headings:
     family: Raleway
     weight: 500

--- a/tests/docs/smoke-all/typst/brand-yaml/typography/kitchen-sink-2/brand-typography.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/typography/kitchen-sink-2/brand-typography.qmd
@@ -23,8 +23,8 @@ _quarto:
       -
         - 'font: \("EB Garamond",\),$'
         - 'fontsize: 12pt,$'
-        - '^#set text\(weight: 300, fill: rgb\("#27262e"\), \)$'
-
+        - '^#set text\(weight: 300, \)$'
+        - '^#set text\(fill: brand-color.foreground\)'
         - 'heading-family: \("Raleway",\),$'
         - 'heading-weight: 500,$'
         - 'heading-style: "normal",$'


### PR DESCRIPTION
A loose end, removing `brand.typography.base.color` from the schema and from the typst implementation.

(The way to control the base font color is with `brand.color.foreground`.)

Ref https://github.com/posit-dev/brand-yml/issues/27