### PR TITLE
tests environment - pin pipenv

### DIFF
--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Restore Python Dependencies
         working-directory: tests
         run: |
-          python -m pip install pipenv
+          python -m pip install pipenv==2024.3.0
           pipenv install
 
       - uses: ./.github/workflows/actions/quarto-dev


### PR DESCRIPTION
it seems new version has broke our tests suites so lets try back the previous one

The new 2024.3.1 was released 15hours ago, which match our workflow failing