### PR TITLE
brand.typography.headings must take foreground color

### DIFF
--- a/src/resources/filters/quarto-post/typst-brand-yaml.lua
+++ b/src/resources/filters/quarto-post/typst-brand-yaml.lua
@@ -301,14 +301,15 @@ function render_typst_brand_yaml()
       end
 
       local headings = _quarto.modules.brand.get_typography('headings')
-      if headings and next(headings) then
+      if headings and next(headings) or _quarto.modules.brand.get_color('foreground') then
         base = base or {}
+        headings = headings or {}
         meta.brand.typography.headings = {
           family = headings.family or base.family,
           weight = headings.weight or base.weight,
           style = headings.style or base.style,
           decoration = headings.decoration or base.decoration,
-          color = headings.color or base.color,
+          color = headings.color or _quarto.modules.brand.get_color('foreground'),
           ['background-color'] = headings['background-color'] or base['background-color'],
           ['line-height'] = line_height_to_leading(headings['line-height'] or base['line-height']),
         }

--- a/tests/docs/smoke-all/typst/brand-yaml/color/foreground-background.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/color/foreground-background.qmd
@@ -1,0 +1,36 @@
+---
+title: Foreground and background colors
+format:
+  typst:
+    keep-typ: true
+brand:
+  color:
+    foreground: "#ccd2b2"
+    background: "#0d0519"
+  typography:
+    monospace-block:
+      background-color: "#ccd2b250"
+
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - '#set page\(fill: brand-color\.background\)'
+          - '#set text\(fill: brand-color\.foreground\)'
+          - 'heading-color: unescape-eval\("rgb\(\\"\\#ccd2b2\\"\)"\)'
+        - []
+---
+
+# Just double checking...
+
+That simple background and foreground colors work everywhere.
+
+Here is some `inline code`.
+
+```
+You are going to need to customize
+your code blocks for dark mode!
+```
+
+{{< lipsum 2 >}}


### PR DESCRIPTION
Partial fix for #11273

When I removed support for `brand.typography.base.color` in #11253 I did not apprehend that because of Typst's limitation where you can't not-set optional properties,

```typst
#set text(fill: x)
```

at the root level of the document will not propagate to the title.

So we must populate `brand.typography.headings.color` for `typst-show.typ` even when there is not otherwise any `brand.typography.headings`. (And test that it is populated.)