### PR TITLE
Feature/brand default font sources

### DIFF
--- a/src/core/sass/brand.ts
+++ b/src/core/sass/brand.ts
@@ -378,7 +378,13 @@ const brandTypographyBundle = (
     for (const _resolvedFont of font) {
       const resolvedFont =
         _resolvedFont as (BrandFont | BrandFontGoogle | BrandFontBunny);
-      if ((resolvedFont as any).source && resolvedFont.source !== "bunny") {
+      // Typescript's type checker doesn't understand that it's ok to attempt
+      // to access a property that might not exist on a type when you're
+      // only testing for its existence.
+
+      // deno-lint-ignore no-explicit-any
+      const source = (resolvedFont as any).source;
+      if (source && source !== "bunny") {
         return undefined;
       }
       const thisFamily = resolvedFont.family;

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -12301,6 +12301,9 @@ var require_yaml_intelligence_resources = __commonJS({
             },
             {
               ref: "brand-font-system"
+            },
+            {
+              ref: "brand-font-common"
             }
           ]
         },
@@ -21778,6 +21781,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "A link or path to the brand\u2019s dark-colored logo or icon.",
         "Alternative text for the logo, used for accessibility.",
         "Provide definitions and defaults for brand\u2019s logo in various formats\nand sizes.",
+        "A dictionary of named logo resources.",
         "A link or path to the brand\u2019s small-sized logo or icon, or a link or\npath to both the light and dark versions.",
         "A link or path to the brand\u2019s medium-sized logo, or a link or path to\nboth the light and dark versions.",
         "A link or path to the brand\u2019s large- or full-sized logo, or a link or\npath to both the light and dark versions.",
@@ -21801,13 +21805,13 @@ var require_yaml_intelligence_resources = __commonJS({
         "Typography definitions for the brand.",
         "Font files and definitions for the brand.",
         "The base font settings for the brand. These are used as the default\nfor all text.",
-        "Settings for headings",
-        "Settings for monospace text",
-        "Settings for inline code",
-        "Settings for code blocks",
-        "Settings for links",
-        "Typographic options.",
-        "Typographic options without a font size.",
+        "Settings for headings, or a string specifying the font family\nonly.",
+        "Settings for monospace text, or a string specifying the font family\nonly.",
+        "Settings for inline code, or a string specifying the font family\nonly.",
+        "Settings for code blocks, or a string specifying the font family\nonly.",
+        "Settings for links.",
+        "Base typographic options.",
+        "Typographic options for headings.",
         "Typographic options for monospace elements.",
         "Typographic options for inline monospace elements.",
         "Line height",

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -12302,6 +12302,9 @@ try {
               },
               {
                 ref: "brand-font-system"
+              },
+              {
+                ref: "brand-font-common"
               }
             ]
           },
@@ -21779,6 +21782,7 @@ try {
           "A link or path to the brand\u2019s dark-colored logo or icon.",
           "Alternative text for the logo, used for accessibility.",
           "Provide definitions and defaults for brand\u2019s logo in various formats\nand sizes.",
+          "A dictionary of named logo resources.",
           "A link or path to the brand\u2019s small-sized logo or icon, or a link or\npath to both the light and dark versions.",
           "A link or path to the brand\u2019s medium-sized logo, or a link or path to\nboth the light and dark versions.",
           "A link or path to the brand\u2019s large- or full-sized logo, or a link or\npath to both the light and dark versions.",
@@ -21802,13 +21806,13 @@ try {
           "Typography definitions for the brand.",
           "Font files and definitions for the brand.",
           "The base font settings for the brand. These are used as the default\nfor all text.",
-          "Settings for headings",
-          "Settings for monospace text",
-          "Settings for inline code",
-          "Settings for code blocks",
-          "Settings for links",
-          "Typographic options.",
-          "Typographic options without a font size.",
+          "Settings for headings, or a string specifying the font family\nonly.",
+          "Settings for monospace text, or a string specifying the font family\nonly.",
+          "Settings for inline code, or a string specifying the font family\nonly.",
+          "Settings for code blocks, or a string specifying the font family\nonly.",
+          "Settings for links.",
+          "Base typographic options.",
+          "Typographic options for headings.",
           "Typographic options for monospace elements.",
           "Typographic options for inline monospace elements.",
           "Line height",

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -5273,6 +5273,9 @@
         },
         {
           "ref": "brand-font-system"
+        },
+        {
+          "ref": "brand-font-common"
         }
       ]
     },
@@ -14750,6 +14753,7 @@
     "A link or path to the brand’s dark-colored logo or icon.",
     "Alternative text for the logo, used for accessibility.",
     "Provide definitions and defaults for brand’s logo in various formats\nand sizes.",
+    "A dictionary of named logo resources.",
     "A link or path to the brand’s small-sized logo or icon, or a link or\npath to both the light and dark versions.",
     "A link or path to the brand’s medium-sized logo, or a link or path to\nboth the light and dark versions.",
     "A link or path to the brand’s large- or full-sized logo, or a link or\npath to both the light and dark versions.",
@@ -14773,13 +14777,13 @@
     "Typography definitions for the brand.",
     "Font files and definitions for the brand.",
     "The base font settings for the brand. These are used as the default\nfor all text.",
-    "Settings for headings",
-    "Settings for monospace text",
-    "Settings for inline code",
-    "Settings for code blocks",
-    "Settings for links",
-    "Typographic options.",
-    "Typographic options without a font size.",
+    "Settings for headings, or a string specifying the font family\nonly.",
+    "Settings for monospace text, or a string specifying the font family\nonly.",
+    "Settings for inline code, or a string specifying the font family\nonly.",
+    "Settings for code blocks, or a string specifying the font family\nonly.",
+    "Settings for links.",
+    "Base typographic options.",
+    "Typographic options for headings.",
     "Typographic options for monospace elements.",
     "Typographic options for inline monospace elements.",
     "Line height",

--- a/src/resources/schema/definitions.yml
+++ b/src/resources/schema/definitions.yml
@@ -2688,7 +2688,7 @@
         description: Settings for headings, or a string specifying the font family only.
         ref: brand-typography-options-headings
       monospace:
-        description: Settings for monospace text, or a string specifying the font family only. 
+        description: Settings for monospace text, or a string specifying the font family only.
         ref: brand-typography-options-monospace
       monospace-inline:
         description: Settings for inline code, or a string specifying the font family only.
@@ -2697,7 +2697,7 @@
         description: Settings for code blocks, or a string specifying the font family only.
         ref: brand-typography-options-monospace-block
       link:
-        description: Settings for links. 
+        description: Settings for links.
         ref: brand-typography-options-link
 
 - id: brand-typography-options-base
@@ -2811,7 +2811,12 @@
     - ref: brand-font-bunny
     - ref: brand-font-file
     - ref: brand-font-system
-
+    # a font definition missing source information,
+    # from which we will assume a default source
+    #
+    # in Quarto, the default source for typst is `google`
+    # and the default source for html formats is `bunny`
+    - ref: brand-font-common
 - id: brand-font-weight
   description: A font weight.
   enum:

--- a/src/resources/schema/json-schemas.json
+++ b/src/resources/schema/json-schemas.json
@@ -3593,6 +3593,9 @@
         },
         {
           "$ref": "#/$defs/BrandFontSystem"
+        },
+        {
+          "$ref": "#/$defs/BrandFontCommon"
         }
       ]
     },

--- a/src/resources/types/schema-types.ts
+++ b/src/resources/types/schema-types.ts
@@ -1405,7 +1405,8 @@ export type BrandFont =
   | BrandFontGoogle
   | BrandFontBunny
   | BrandFontFile
-  | BrandFontSystem; /* Font files and definitions for the brand. */
+  | BrandFontSystem
+  | BrandFontCommon; /* Font files and definitions for the brand. */
 
 export type BrandFontWeight =
   | 100


### PR DESCRIPTION
This PR makes it so that font sources don't need to be specified.

In Quarto, default font sources behave differently depending on formats:

- `html` formats get the privacy-friendly [bunny](https://fonts.bunny.net/) CDN
- `typst` formats get Google fonts. This does mean that Google Fonts's CDN is accessed, but since this is in Typst, that access only happens at render time, instead of being used at every document read.