### PR TITLE
Typst line brand colors

### DIFF
--- a/src/resources/filters/quarto-post/typst-brand-yaml.lua
+++ b/src/resources/filters/quarto-post/typst-brand-yaml.lua
@@ -75,6 +75,9 @@ function render_typst_brand_yaml()
           end
           if brandColor.foreground then
             quarto.doc.include_text('in-header', '#set text(fill: brand-color.foreground)')
+            quarto.doc.include_text('in-header', '#set table.hline(stroke: (paint: brand-color.foreground))')
+            quarto.doc.include_text('in-header', '#set line(stroke: (paint: brand-color.foreground))')
+    
           end
           local decl = '// theme colors at opacity ' .. BACKGROUND_OPACITY .. '\n#let brand-color-background = ' .. to_typst_dict_indent(themebk)
           quarto.doc.include_text('in-header', decl)

--- a/tests/docs/smoke-all/typst/brand-yaml/color/foreground-lines.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/color/foreground-lines.qmd
@@ -1,0 +1,35 @@
+---
+title: Foreground and background colors
+format:
+  typst:
+    keep-typ: true
+brand:
+  color:
+    foreground: "#ccd2b2"
+    background: "#30104f"
+
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - '#set page\(fill: brand-color\.background\)'
+          - '#set text\(fill: brand-color\.foreground\)'
+          - 'heading-color: unescape-eval\("rgb\(\\"\\#ccd2b2\\"\)"\)'
+          - '#set table.hline\(stroke: \(paint: brand-color\.foreground\)\)'
+          - '#set line\(stroke: \(paint: brand-color\.foreground\)\)'
+
+        - []
+---
+
+
+
+| Col1 | Col2 |
+|------|------|
+| A    | B    |
+
+------------------------------------------------------------------------
+
+See footnote [^1]
+
+[^1]: Here's a footnote


### PR DESCRIPTION
Fixes #11273 

Use brand foreground color for Typst lines and table horizontal lines.

Not implemented for table vertical lines because we don't use them, but users can enable with

```typst
#set table.vline(stroke: (paint: brand-color.foreground))
```
