### PR TITLE
typst css: div color, background-color; translation of named brand colors

### DIFF
--- a/src/resources/filters/modules/brand/brand.lua
+++ b/src/resources/filters/modules/brand/brand.lua
@@ -38,6 +38,7 @@ local function get_typography(fontName)
   local typography = brand.typography and brand.typography[fontName]
   if not typography then return nil end
   local typsted = {}
+  if type(typography) == 'string' then typography = {family = typography} end
   for k, v in pairs(typography) do
     if k == 'color' or k == 'background-color' then
       typsted[k] = get_color(v) or _quarto.format.typst.css.output_color(_quarto.format.typst.css.parse_color(v))

--- a/src/resources/filters/modules/brand/brand.lua
+++ b/src/resources/filters/modules/brand/brand.lua
@@ -1,11 +1,16 @@
 -- brand.lua
 -- Copyright (C) 2020-2024 Posit Software, PBC
 
-local function get_color(name)
+local function get_color_css(name)
   local brand = param("brand")
   brand = brand and brand.processedData -- from src/core/brand/brand.ts
   if not brand then return nil end
   local cssColor = brand.color[name]
+  return cssColor
+end
+
+local function get_color(name)
+  local cssColor = get_color_css(name)
   if not cssColor then return nil end
   if _quarto.format.isTypstOutput() then
     return _quarto.format.typst.css.output_color(_quarto.format.typst.css.parse_color(cssColor))
@@ -32,9 +37,6 @@ local function get_typography(fontName)
   if not brand then return nil end
   local typography = brand.typography and brand.typography[fontName]
   if not typography then return nil end
-  if type(typography) == 'string' then
-    typography = { family = typography }
-  end
   local typsted = {}
   for k, v in pairs(typography) do
     if k == 'color' or k == 'background-color' then
@@ -63,6 +65,7 @@ local function get_logo(name)
 end
 
 return {
+  get_color_css = get_color_css,
   get_color = get_color,
   get_background_color = get_background_color,
   get_typography = get_typography,

--- a/src/resources/filters/quarto-post/typst-css-property-processing.lua
+++ b/src/resources/filters/quarto-post/typst-css-property-processing.lua
@@ -330,9 +330,12 @@ function render_typst_css_property_processing()
           local k, v = to_kv(clause)
           if k == 'font-family' then
             div.attributes['typst:text:font'] = translate_string_list(v)
-          end
-          if k == 'font-size' then
+          elseif k == 'font-size' then
             div.attributes['typst:text:size'] = _quarto.format.typst.css.translate_length(v, _warnings)
+          elseif k == 'background-color' then
+            div.attributes['typst:fill'] = _quarto.format.typst.css.output_color(_quarto.format.typst.css.parse_color(v, _warnings), nil, _warnings)
+          elseif k == 'color' then
+            div.attributes['typst:text:fill'] = _quarto.format.typst.css.output_color(_quarto.format.typst.css.parse_color(v, _warnings), nil, _warnings)
           end
         end
       end

--- a/tests/docs/smoke-all/typst/brand-yaml/color/typst-css-named-brand-color.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/color/typst-css-named-brand-color.qmd
@@ -1,0 +1,30 @@
+---
+title: Translate brand named color references from CSS to Typst
+format:
+  typst:
+    keep-typ: true
+brand:
+  color:
+    palette:
+      dark-grey: "#222"
+      blue: "#82aeef"
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - '#block\(fill: brand-color\.dark-grey\)\[\s*#set text\(fill: brand-color\.blue\);'
+        - []
+---
+
+
+```{=typst}
+// stopgap to make this look ok
+#set block(inset: 6pt)
+```
+
+:::{style="background-color: var(--brand-dark-grey); color: var(--brand-blue)"}
+This div is blue on dark grey.
+:::
+
+{{< lipsum 2 >}}


### PR DESCRIPTION
This allows

```markdown
:::{style="background-color: var(--brand-dark-grey); color: var(--brand-blue)"}
This div is blue on dark grey.
:::
```

producing

```typst
#block(fill: brand-color.dark-grey)[
#set text(fill: brand-color.blue); This div is blue on dark grey.

]
```

or produces a warning if the named brand color does not exist.

Parsing variable references isn't worse than parsing rgb, right?

cc @cwickham 