### PR TITLE
typst brand yaml: link color defaults to brand primary color

### DIFF
--- a/src/resources/filters/quarto-post/typst-brand-yaml.lua
+++ b/src/resources/filters/quarto-post/typst-brand-yaml.lua
@@ -182,11 +182,13 @@ function render_typst_brand_yaml()
         end
 
         local link = _quarto.modules.brand.get_typography('link')
-        if link and next(link) then
+        local primaryColor = _quarto.modules.brand.get_color('primary')
+        if link and next(link) or primaryColor then
+          link = link or {}
           quarto.doc.include_text('in-header', table.concat({
             '#show link: set text(',
             conditional_entry('weight', link.weight),
-            conditional_entry('fill', link.color, false),
+            conditional_entry('fill', link.color or primaryColor, false),
             ')'
           }))
         end
@@ -304,7 +306,8 @@ function render_typst_brand_yaml()
       end
 
       local headings = _quarto.modules.brand.get_typography('headings')
-      if headings and next(headings) or _quarto.modules.brand.get_color('foreground') then
+      local foregroundColor = _quarto.modules.brand.get_color('foreground')
+      if headings and next(headings) or foregroundColor then
         base = base or {}
         headings = headings or {}
         meta.brand.typography.headings = {
@@ -312,7 +315,7 @@ function render_typst_brand_yaml()
           weight = headings.weight or base.weight,
           style = headings.style or base.style,
           decoration = headings.decoration or base.decoration,
-          color = headings.color or _quarto.modules.brand.get_color('foreground'),
+          color = headings.color or foregroundColor,
           ['background-color'] = headings['background-color'] or base['background-color'],
           ['line-height'] = line_height_to_leading(headings['line-height'] or base['line-height']),
         }

--- a/tests/docs/smoke-all/typst/brand-yaml/color/link-primary-brand-color.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/color/link-primary-brand-color.qmd
@@ -1,0 +1,21 @@
+---
+title: Foreground and background colors
+format:
+  typst:
+    keep-typ: true
+brand:
+  color:
+    palette:
+      fire: "#dd571c"
+    primary: fire
+
+_quarto:
+  tests:
+    typst:
+      ensurePdfRegexMatches:
+        -
+          - 'a link in rgb\("#dd571c"\)'
+        - []
+---
+
+Here is [a link in `#context text.fill`{=typst}](http://example.com).


### PR DESCRIPTION
Typst currently uses the following [theme colors](https://posit-dev.github.io/brand-yml/brand/color.html#theme-colors):

* `background` - page color
* `foreground` - text and lines
* `primary` - links, this PR

In addition, Typst callouts use `primary`, `warning`, `danger`, and `success`.

Happy to add more as we find them.