### PR TITLE
New knitr will support  `#| message: NA` to suppress messages in the output and show in console

### DIFF
--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -8220,9 +8220,18 @@ var require_yaml_intelligence_resources = __commonJS({
           tags: {
             engine: "knitr"
           },
-          schema: "boolean",
+          schema: {
+            enum: [
+              true,
+              false,
+              "NA"
+            ]
+          },
           default: true,
-          description: "Include messages in rendered output."
+          description: {
+            short: "Include messages in rendered output.",
+            long: "Include messages in rendered output. Possible values are `true`, `false`, or `NA`. \nIf `true`, messages are included in the output. If `false`, messages are not included. \nIf `NA`, messages are not included in output but shown in the knitr log to console.\n"
+          }
         },
         {
           name: "results",
@@ -22035,7 +22044,10 @@ var require_yaml_intelligence_resources = __commonJS({
           short: "Location of output relative to the code that generated it\n(<code>default</code>, <code>fragment</code>, <code>slide</code>,\n<code>column</code>, or <code>column-location</code>)",
           long: "Location of output relative to the code that generated it. The\npossible values are as follows:"
         },
-        "Include messages in rendered output.",
+        {
+          short: "Include messages in rendered output.",
+          long: "Include messages in rendered output. Possible values are\n<code>true</code>, <code>false</code>, or <code>NA</code>. If\n<code>true</code>, messages are included in the output. If\n<code>false</code>, messages are not included. If <code>NA</code>,\nmessages are not included in output but shown in the knitr log to\nconsole."
+        },
         {
           short: "How to display text results",
           long: "How to display text results. Note that this option only applies to\nnormal text output (not warnings, messages, or errors). The possible\nvalues are as follows:"
@@ -24134,12 +24146,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 193399,
+        _internalId: 193475,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 193391,
+            _internalId: 193467,
             type: "enum",
             enum: [
               "png",
@@ -24155,7 +24167,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 193398,
+            _internalId: 193474,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -8221,9 +8221,18 @@ try {
             tags: {
               engine: "knitr"
             },
-            schema: "boolean",
+            schema: {
+              enum: [
+                true,
+                false,
+                "NA"
+              ]
+            },
             default: true,
-            description: "Include messages in rendered output."
+            description: {
+              short: "Include messages in rendered output.",
+              long: "Include messages in rendered output. Possible values are `true`, `false`, or `NA`. \nIf `true`, messages are included in the output. If `false`, messages are not included. \nIf `NA`, messages are not included in output but shown in the knitr log to console.\n"
+            }
           },
           {
             name: "results",
@@ -22036,7 +22045,10 @@ try {
             short: "Location of output relative to the code that generated it\n(<code>default</code>, <code>fragment</code>, <code>slide</code>,\n<code>column</code>, or <code>column-location</code>)",
             long: "Location of output relative to the code that generated it. The\npossible values are as follows:"
           },
-          "Include messages in rendered output.",
+          {
+            short: "Include messages in rendered output.",
+            long: "Include messages in rendered output. Possible values are\n<code>true</code>, <code>false</code>, or <code>NA</code>. If\n<code>true</code>, messages are included in the output. If\n<code>false</code>, messages are not included. If <code>NA</code>,\nmessages are not included in output but shown in the knitr log to\nconsole."
+          },
           {
             short: "How to display text results",
             long: "How to display text results. Note that this option only applies to\nnormal text output (not warnings, messages, or errors). The possible\nvalues are as follows:"
@@ -24135,12 +24147,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 193399,
+          _internalId: 193475,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 193391,
+              _internalId: 193467,
               type: "enum",
               enum: [
                 "png",
@@ -24156,7 +24168,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 193398,
+              _internalId: 193474,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -1192,9 +1192,18 @@
       "tags": {
         "engine": "knitr"
       },
-      "schema": "boolean",
+      "schema": {
+        "enum": [
+          true,
+          false,
+          "NA"
+        ]
+      },
       "default": true,
-      "description": "Include messages in rendered output."
+      "description": {
+        "short": "Include messages in rendered output.",
+        "long": "Include messages in rendered output. Possible values are `true`, `false`, or `NA`. \nIf `true`, messages are included in the output. If `false`, messages are not included. \nIf `NA`, messages are not included in output but shown in the knitr log to console.\n"
+      }
     },
     {
       "name": "results",
@@ -15007,7 +15016,10 @@
       "short": "Location of output relative to the code that generated it\n(<code>default</code>, <code>fragment</code>, <code>slide</code>,\n<code>column</code>, or <code>column-location</code>)",
       "long": "Location of output relative to the code that generated it. The\npossible values are as follows:"
     },
-    "Include messages in rendered output.",
+    {
+      "short": "Include messages in rendered output.",
+      "long": "Include messages in rendered output. Possible values are\n<code>true</code>, <code>false</code>, or <code>NA</code>. If\n<code>true</code>, messages are included in the output. If\n<code>false</code>, messages are not included. If <code>NA</code>,\nmessages are not included in output but shown in the knitr log to\nconsole."
+    },
     {
       "short": "How to display text results",
       "long": "How to display text results. Note that this option only applies to\nnormal text output (not warnings, messages, or errors). The possible\nvalues are as follows:"
@@ -17106,12 +17118,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 193399,
+    "_internalId": 193475,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 193391,
+        "_internalId": 193467,
         "type": "enum",
         "enum": [
           "png",
@@ -17127,7 +17139,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 193398,
+        "_internalId": 193474,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/schema/cell-textoutput.yml
+++ b/src/resources/schema/cell-textoutput.yml
@@ -72,9 +72,15 @@
 - name: message
   tags:
     engine: knitr
-  schema: boolean
+  schema:
+    enum: [true, false, NA]
   default: true
-  description: Include messages in rendered output.
+  description:
+    short: Include messages in rendered output.
+    long: |
+      Include messages in rendered output. Possible values are `true`, `false`, or `NA`. 
+      If `true`, messages are included in the output. If `false`, messages are not included. 
+      If `NA`, messages are not included in output but shown in the knitr log to console.
 
 - name: results
   tags:


### PR DESCRIPTION
This is specific support for Quarto as using the R `NA` can't be done in YAML. Knitr will convert `"NA"` to `NA` to set the option correctly.

Related to upstream
- https://github.com/yihui/knitr/issues/2375