### PR TITLE
feat(brand): Add `brand.meta.link.bluesky`

### DIFF
--- a/src/resources/schema/definitions.yml
+++ b/src/resources/schema/definitions.yml
@@ -2487,6 +2487,9 @@
                 mastodon:
                   string:
                     description: The brand's Mastodon URL.
+                bluesky:
+                  string:
+                    description: The brand's Bluesky URL.
                 github:
                   string:
                     description: The brand's GitHub URL.


### PR DESCRIPTION
Adds `brand.meta.link.bluesky` to the brand definitions.

For https://github.com/posit-dev/brand-yml/issues/46