### PR TITLE
A few changes for Deno 2 runtime compatibility

### DIFF
--- a/package/src/util/utils.ts
+++ b/package/src/util/utils.ts
@@ -24,7 +24,7 @@ export async function download(src: string, dest: string): Promise<void> {
 
   const file = await Deno.create(dest);
   await writeAll(file, contents);
-  Deno.close(file.rid);
+  file.close();
 }
 
 export async function unzip(

--- a/src/core/console.ts
+++ b/src/core/console.ts
@@ -173,7 +173,7 @@ export function writeFileToStdout(file: string) {
   const df = Deno.openSync(file, { read: true });
   const contents = readAllSync(df);
   writeAllSync(Deno.stdout, contents);
-  Deno.close(df.rid);
+  df.close();
 }
 
 export function clearLine() {

--- a/src/core/performance/metrics.ts
+++ b/src/core/performance/metrics.ts
@@ -41,37 +41,4 @@ export function reportPeformanceMetrics() {
   console.log("Performance metrics");
   console.log("Quarto:");
   console.log(JSON.stringify(quartoPerformanceMetrics(), null, 2));
-  console.log();
-  // denoMetrics is some kind of fancy object that doesn't respond
-  // to a bunch of the normal methods.  So we have to do this
-  // the JSON-round-trip way.
-  console.log("Deno:");
-  const denoMetrics = JSON.parse(JSON.stringify(Deno.metrics() as any));
-  denoMetrics.ops = Object.fromEntries(
-    Object.entries(denoMetrics.ops).map(
-      ([key, opMetrics]: any) => {
-        for (const key of Object.keys(opMetrics)) {
-          if (opMetrics[key] === 0) {
-            delete opMetrics[key];
-          }
-        }
-        return [key, opMetrics];
-      },
-    ).filter(([_key, opMetrics]: any) => Object.keys(opMetrics).length > 0)
-      .map(([key, opMetrics]: any) => {
-        if (
-          (opMetrics.opsDispatched === opMetrics.opsDispatchedSync &&
-            opMetrics.opsDispatched === opMetrics.opsCompleted &&
-            opMetrics.opsDispatched === opMetrics.opsCompletedSync) ||
-          (opMetrics.opsDispatched === opMetrics.opsDispatchedAsync &&
-            opMetrics.opsDispatched === opMetrics.opsCompleted &&
-            opMetrics.opsDispatched === opMetrics.opsCompletedAsync)
-        ) {
-          return [key, opMetrics.opsDispatched];
-        } else {
-          return [key, opMetrics];
-        }
-      }),
-  );
-  console.log(JSON.stringify(denoMetrics, null, 2));
 }

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -93,7 +93,7 @@ export function jupyterHubServicePrefix() {
 }
 
 export function isInteractiveTerminal() {
-  return Deno.isatty(Deno.stderr.rid);
+  return Deno.stderr.isTerminal();
 }
 
 export function isInteractiveSession() {

--- a/src/core/process.ts
+++ b/src/core/process.ts
@@ -6,6 +6,7 @@
 
 import { MuxAsyncIterator, pooledMap } from "async";
 import { iterateReader } from "io/iterate-reader";
+import { type Closer } from "io/types";
 import { debug, info } from "../deno_ral/log.ts";
 import { onCleanup } from "./cleanup.ts";
 import { ProcessResult } from "./process-types.ts";
@@ -104,7 +105,7 @@ export async function execProcess(
 
       // Add streams to the multiplexer
       const addStream = (
-        stream: (Deno.Reader & Deno.Closer) | null,
+        stream: (Deno.Reader & Closer) | null,
         filter?: (output: string) => string,
       ) => {
         if (stream !== null) {
@@ -131,7 +132,7 @@ export async function execProcess(
       }
 
       // Close the streams
-      const closeStream = (stream: (Deno.Reader & Deno.Closer) | null) => {
+      const closeStream = (stream: (Deno.Reader & Closer) | null) => {
         if (stream) {
           stream.close();
         }

--- a/src/core/process.ts
+++ b/src/core/process.ts
@@ -6,7 +6,7 @@
 
 import { MuxAsyncIterator, pooledMap } from "async";
 import { iterateReader } from "io/iterate-reader";
-import { type Closer } from "io/types";
+import { type Closer, type Reader } from "io/types";
 import { debug, info } from "../deno_ral/log.ts";
 import { onCleanup } from "./cleanup.ts";
 import { ProcessResult } from "./process-types.ts";
@@ -105,7 +105,7 @@ export async function execProcess(
 
       // Add streams to the multiplexer
       const addStream = (
-        stream: (Deno.Reader & Closer) | null,
+        stream: (Reader & Closer) | null,
         filter?: (output: string) => string,
       ) => {
         if (stream !== null) {
@@ -132,7 +132,7 @@ export async function execProcess(
       }
 
       // Close the streams
-      const closeStream = (stream: (Deno.Reader & Closer) | null) => {
+      const closeStream = (stream: (Reader & Closer) | null) => {
         if (stream) {
           stream.close();
         }

--- a/src/project/types/website/listing/website-listing-feed.ts
+++ b/src/project/types/website/listing/website-listing-feed.ts
@@ -513,7 +513,7 @@ async function generateFeed(
         escape,
       },
     );
-    await Deno.write(feedFile.rid, textEncoder.encode(preamble));
+    await feedFile.write(textEncoder.encode(preamble));
 
     for (const feedItem of feedItems) {
       const item = renderEjs(
@@ -523,7 +523,7 @@ async function generateFeed(
           escape,
         },
       );
-      await Deno.write(feedFile.rid, textEncoder.encode(item));
+      await feedFile.write(textEncoder.encode(item));
     }
 
     // Render the postamble
@@ -534,7 +534,7 @@ async function generateFeed(
         escape,
       },
     );
-    await Deno.write(feedFile.rid, textEncoder.encode(postamble));
+    await feedFile.write(textEncoder.encode(postamble));
   } finally {
     feedFile.close();
   }

--- a/src/project/types/website/listing/website-listing-feed.ts
+++ b/src/project/types/website/listing/website-listing-feed.ts
@@ -536,7 +536,7 @@ async function generateFeed(
     );
     await Deno.write(feedFile.rid, textEncoder.encode(postamble));
   } finally {
-    Deno.close(feedFile.rid);
+    feedFile.close();
   }
 }
 

--- a/src/publish/common/publish.ts
+++ b/src/publish/common/publish.ts
@@ -267,7 +267,7 @@ function stageDocumentPublish(title: string, publishFiles: PublishFiles) {
   const publishDir = globalTempContext().createDir();
 
   // copy all files to it
-  const stagedFiles = window.structuredClone(publishFiles) as PublishFiles;
+  const stagedFiles = globalThis.structuredClone(publishFiles) as PublishFiles;
   stagedFiles.baseDir = publishDir;
   for (const file of publishFiles.files) {
     const src = join(publishFiles.baseDir, file);


### PR DESCRIPTION
## Description

This PR moves a few method calls that were deprecated and removed in Deno 2 to their replacements (except for `Deno.metrics()`, which was removed without replacement).

This is not a complete set of changes: some dependencies also need to be updated or patched (xmlp is the main one that I'm aware of right now), but testing the waters here with this smaller and simpler one since this is my first contribution.

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
