### PR TITLE
revealjs - set code-font-size as em value for variable default

### DIFF
--- a/src/resources/formats/revealjs/quarto.scss
+++ b/src/resources/formats/revealjs/quarto.scss
@@ -16,7 +16,7 @@ $presentation-line-height: 1.3 !default;
 // and are here to simplify the implementation of _brand.yml and
 // user theming customization in general
 $font-weight-base: 400 !default;
-$code-font-size: $presentation-font-size-root !default;
+$code-font-size: 1em !default;
 $font-family-monospace-block: $font-family-monospace !default;
 $font-family-monospace-inline: $font-family-monospace !default;
 $link-weight: $font-weight-base !default;
@@ -25,7 +25,6 @@ $link-decoration: inherit !default;
 $font-weight-monospace: $font-weight-base !default;
 $font-weight-monospace-block: $font-weight-monospace !default;
 $font-weight-monospace-inline: $font-weight-monospace !default;
-$code-inline-font-size: $code-font-size !default;
 
 // main colors
 $body-bg: #fff !default;
@@ -80,13 +79,14 @@ $presentation-list-bullet-color: $body-color !default;
 // code blocks
 $code-block-bg: $body-bg !default;
 $code-block-border-color: lighten($body-color, 60%) !default;
-$code-block-font-size: ($code-font-size * 0.55) !default;
+$code-block-font-size: $code-font-size * 0.55 !default;
 $code-block-height: 500px !default;
 $code-block-theme-dark-threshhold: 40% !default;
 $code-block-line-height: $presentation-line-height !default;
 $code-block-color: $body-color !default;
 
 // inline code
+$code-inline-font-size: $code-font-size * 0.875 !default;
 $code-color: var(--quarto-hl-fu-color) !default;
 $code-bg: transparent !default;
 
@@ -234,12 +234,17 @@ $overlayElementFgColor: 0, 0, 0 !default;
   }
 }
 
+// Make the font size smaller by a factor of $times
+// Useful for font-size defined in px inside smaller font size controled by em
+// as they would not be impacted by the smaller font size
 @mixin make-smaller-font-size($element, $times: 1) {
   font-size: calc(
     #{$element} * #{quarto-math.pow($presentation-font-smaller, $times)}
   );
 }
 
+// Undo the smaller font size
+// Useful for font-size in em already that should not be impacted by smaller font size controled by em
 @mixin undo-smaller-font-size($element) {
   font-size: calc(#{$element} / #{$presentation-font-smaller});
 }
@@ -505,17 +510,6 @@ $panel-sidebar-padding: 0.5em;
       h3 {
         @include undo-smaller-font-size($revealjs-h3-font-size);
       }
-      // Though we want pre and code to be smaller and they are in px
-      pre {
-        @include make-smaller-font-size($revealjs-code-block-font-size);
-        // Make sure code inside pre use code block font size
-        code {
-          font-size: inherit;
-        }
-      }
-      code {
-        @include make-smaller-font-size($revealjs-code-inline-font-size);
-      }
     }
   }
 
@@ -534,17 +528,6 @@ $panel-sidebar-padding: 0.5em;
       h3 {
         @include undo-smaller-font-size($revealjs-h3-font-size);
       }
-      // Though we want pre and code to be smaller and they are in px
-      pre {
-        @include make-smaller-font-size($revealjs-code-block-font-size);
-        // Make sure code inside pre use code block font size
-        code {
-          font-size: inherit;
-        }
-      }
-      code {
-        @include make-smaller-font-size($revealjs-code-inline-font-size);
-      }
     }
 
     // On callout we want to make the font-size smaller too
@@ -560,32 +543,6 @@ $panel-sidebar-padding: 0.5em;
       }
       h3 {
         @include undo-smaller-font-size($revealjs-h3-font-size);
-      }
-      // Though we want pre and code to be smaller and they are in px
-      pre {
-        @include make-smaller-font-size($revealjs-code-block-font-size);
-        // Make sure code inside pre use code block font size
-        code {
-          font-size: inherit;
-        }
-      }
-      code {
-        @include make-smaller-font-size($revealjs-code-inline-font-size);
-      }
-    }
-    // twice for code / pre inside callout if inside a smaller slide
-    // this is because they are passed in pixels
-    &.smaller div.callout {
-      // Though we want pre and code to be smaller and they are in px
-      pre {
-        @include make-smaller-font-size($revealjs-code-block-font-size, 2);
-        // Make sure code inside pre use code block font size
-        code {
-          font-size: inherit;
-        }
-      }
-      code {
-        @include make-smaller-font-size($revealjs-code-inline-font-size, 2);
       }
     }
   }

--- a/tests/docs/playwright/revealjs/code-font-size.qmd
+++ b/tests/docs/playwright/revealjs/code-font-size.qmd
@@ -23,7 +23,7 @@ Every test is a call to `testthat::test_that()` function.
 
 - And inside a list : `1+1`
 
-## Highlited Cell
+## Highlighted Cell
 
 ````{.python}
 1 + 1

--- a/tests/integration/playwright/src/utils.ts
+++ b/tests/integration/playwright/src/utils.ts
@@ -152,3 +152,9 @@ export async function checkFontSizeIdentical(loc1: Locator, loc2: Locator) {
   const loc1FontSize = await getCSSProperty(loc1, 'font-size', false) as string;
   await expect(loc2).toHaveCSS('font-size', loc1FontSize);
 }
+
+export async function checkFontSizeSimilar(loc1: Locator, loc2: Locator, factor: number = 1) {
+  const loc1FontSize = await getCSSProperty(loc1, 'font-size', true) as number;
+  const loc2FontSize = await getCSSProperty(loc2, 'font-size', true) as number;
+  await expect(loc1FontSize).toBeCloseTo(loc2FontSize * factor);
+}


### PR DESCRIPTION


This fixes #11373 by adapting previous changes in #11028 and then #11237. The changes initially introduced for Brands were making code font size default being pixels, while previous is was set to `em` and so code font size was adapting based on context like headers. 

This PR is making code font size being based on `em` like Quarto 1.5 while keeping the customizable values. Defaults are chosen like this 

- `$code-font-size` in Revealjs is `em` units by default which seems more coherent with its bootstrap counter part, also as `em`. Value is `1em` for revealjs.
- `$code-block-font-size` is set to 0.55em - same as previous Revealjs default, smaller than bootstrap to save some slide space. 
- `$code-inline-font-size` is set to 0.875em - same as bootstrap 

This also simplifies previous logic with smaller context (like callout or smaller slides), and so previous adaptation from previous followed up PR are removed (and test adapted). 

I believe this is closer to default RevealJS and previous Quarto 1.5 style, while keeping the `$code-font-size`

And it is probably better for brand for `size` being passed to `code-font-size` in same units for revealjs and bootstrap. 

Quarto example has been updated with this PR
- https://examples.quarto.pub/revealjs-default-callouts-styles/#/title-slide
