### PR TITLE
deno - use --allow-all to avoid issues with reading / writing on network drive

### DIFF
--- a/package/launcher/src/main.rs
+++ b/package/launcher/src/main.rs
@@ -87,12 +87,9 @@ fn main() {
         String::from("--no-config"),
         String::from("--cached-only"),
         String::from("--no-lock"),
-        String::from("--allow-read"),
-        String::from("--allow-write"),
-        String::from("--allow-run"),
-        String::from("--allow-env"),
-        String::from("--allow-net"),
-        String::from("--allow-ffi"),      
+        // Using --allow-all as there is otherwise an issue in Deno 1.46.3 with --allow-read and --allow-write with network drives
+        // https://github.com/quarto-dev/quarto-cli/issues/11332
+        String::from("--allow-all"),    
     ];
 
     // # --enable-experimental-regexp-engine is required for /regex/l, https://github.com/quarto-dev/quarto-cli/issues/9737

--- a/package/scripts/common/quarto
+++ b/package/scripts/common/quarto
@@ -169,7 +169,9 @@ fi
 export DENO_TLS_CA_STORE=system,mozilla
 export DENO_NO_UPDATE_CHECK=1
 # Be sure to include any already defined QUARTO_DENO_OPTIONS
-QUARTO_DENO_OPTIONS="--unstable-ffi --unstable-kv --no-config --no-lock ${QUARTO_CACHE_OPTIONS} --allow-read --allow-write --allow-run --allow-env --allow-net --allow-ffi ${QUARTO_DENO_OPTIONS}"
+## Using --allow-all as there is otherwise an issue in Deno 1.46.3 with --allow-read and --allow-write with network drives
+## https://github.com/quarto-dev/quarto-cli/issues/11332
+QUARTO_DENO_OPTIONS="--unstable-ffi --unstable-kv --no-config --no-lock ${QUARTO_CACHE_OPTIONS} --allow-all ${QUARTO_DENO_OPTIONS}"
 
 # --enable-experimental-regexp-engine is required for /regex/l, https://github.com/quarto-dev/quarto-cli/issues/9737
 if [ "$QUARTO_DENO_V8_OPTIONS" != "" ]; then

--- a/package/scripts/windows/quarto.cmd
+++ b/package/scripts/windows/quarto.cmd
@@ -105,7 +105,9 @@ IF NOT DEFINED QUARTO_DENO (
 
 SET "DENO_TLS_CA_STORE=system,mozilla"
 SET "DENO_NO_UPDATE_CHECK=1"
-SET "QUARTO_DENO_OPTIONS=--unstable-kv --unstable-ffi --no-config --no-lock --allow-read --allow-write --allow-run --allow-env --allow-net --allow-ffi !QUARTO_DENO_OPTIONS!"
+REM Using --allow-all as there is otherwise an issue in Deno 1.46.3 with --allow-read and --allow-write with network drives
+REM https://github.com/quarto-dev/quarto-cli/issues/11332
+SET "QUARTO_DENO_OPTIONS=--unstable-kv --unstable-ffi --no-config --no-lock --allow-all !QUARTO_DENO_OPTIONS!"
 
 REM Add expected V8 options to QUARTO_DENO_V8_OPTIONS
 IF DEFINED QUARTO_DENO_V8_OPTIONS (

--- a/package/src/common/compile-quarto-latexmk.ts
+++ b/package/src/common/compile-quarto-latexmk.ts
@@ -68,6 +68,9 @@ export function compileQuartoLatexmkCommand() {
     });
 }
 
+// Using --allow-all as there is otherwise an issue in Deno 1.46.3 with --allow-read and --allow-write with network drives
+// https://github.com/quarto-dev/quarto-cli/issues/11332
+/* 
 const kFlags = [
   "--allow-read",
   "--allow-write",
@@ -75,6 +78,8 @@ const kFlags = [
   "--allow-env",
   "--allow-net",
 ];
+*/
+const kFlags = ["--allow-all"];
 
 export async function installQuartoLatexmk(
   config: Configuration,

--- a/package/src/quarto-bld
+++ b/package/src/quarto-bld
@@ -17,4 +17,4 @@ export DENO_NO_UPDATE_CHECK=1
 
 # TODO: Consider generating a source map or something to get a good stack
 # Create the Deno bundle
-"$QUARTO_DENO" run --no-check --unstable-kv --unstable-ffi --allow-env --allow-read --allow-write --allow-run --allow-net --allow-ffi --v8-flags=--stack-trace-limit=100 --importmap="${SCRIPT_PATH}/../../src/import_map.json" "$SCRIPT_PATH/bld.ts" $@
+"$QUARTO_DENO" run --no-check --unstable-kv --unstable-ffi --allow-all --v8-flags=--stack-trace-limit=100 --importmap="${SCRIPT_PATH}/../../src/import_map.json" "$SCRIPT_PATH/bld.ts" $@

--- a/package/src/quarto-bld.cmd
+++ b/package/src/quarto-bld.cmd
@@ -9,4 +9,4 @@ if NOT DEFINED QUARTO_DENO (
 SET "RUST_BACKTRACE=full"
 SET "DENO_NO_UPDATE_CHECK=1"
 
-"%QUARTO_DENO%" run --unstable-kv --unstable-ffi --allow-read --allow-write --allow-run --allow-env --allow-net --allow-ffi --importmap=%~dp0\..\..\src\dev_import_map.json %~dp0\bld.ts %*
+"%QUARTO_DENO%" run --unstable-kv --unstable-ffi --allow-all --importmap=%~dp0\..\..\src\dev_import_map.json %~dp0\bld.ts %*

--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -56,7 +56,7 @@ $Env:QUARTO_DEBUG = "true"
 # Preparing running Deno with default arguments
 
 $QUARTO_IMPORT_MAP_ARG="--importmap=$(Join-Path $QUARTO_SRC_DIR "import_map.json")"
-$QUARTO_DENO_OPTIONS="--config test-conf.json --v8-flags=--enable-experimental-regexp-engine,--max-old-space-size=8192,--max-heap-size=8192 --unstable-kv --unstable-ffi --no-lock --allow-read --allow-write --allow-run --allow-env --allow-net --check"
+$QUARTO_DENO_OPTIONS="--config test-conf.json --v8-flags=--enable-experimental-regexp-engine,--max-old-space-size=8192,--max-heap-size=8192 --unstable-kv --unstable-ffi --no-lock --allow-all --check"
 
 # Parsing argument passed to the script
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -23,7 +23,7 @@ export QUARTO_BIN_PATH=$DENO_DIR
 export QUARTO_SHARE_PATH="`cd "$QUARTO_ROOT/src/resources/";pwd`"
 export QUARTO_DEBUG=true
 
-QUARTO_DENO_OPTIONS="--config test-conf.json --v8-flags=--enable-experimental-regexp-engine,--max-old-space-size=8192,--max-heap-size=8192 --unstable-kv --unstable-ffi --no-lock --allow-read --allow-write --allow-run --allow-env --allow-net"
+QUARTO_DENO_OPTIONS="--config test-conf.json --v8-flags=--enable-experimental-regexp-engine,--max-old-space-size=8192,--max-heap-size=8192 --unstable-kv --unstable-ffi --no-lock --allow-all"
 
 
 if [[ -z $GITHUB_ACTION ]] && [[ -z $QUARTO_TESTS_NO_CONFIG ]]


### PR DESCRIPTION
This is an issue with Deno 1.46.3 where --allow-read and --allow-write does not give enough permissions to read / write with files on network drive

closes #11332

@cscheid as discussed I replaced with `--allow-all`. I did it everywhere (Linux / Windows) but it seems from deno report the issue is Windows only, so we could also do that only for windows. So for the future, it seems easier to do the same everywhere. I added a comment to remember we could try back using specific flags. 

BTW, by doing `--allow-all`, we are adding two more permissions compared to current situation

````
 -S, --allow-sys[=<API_NAME>...]        Allow access to OS information. Optionally allow specific APIs by function name.
````
````
      --allow-hrtime                     Allow high-resolution time measurement. Note: this can enable timing attacks and fingerprinting.
````

Those two where not activated in our individual flag listing. I tried something like `--allow-all --deny-sys --deny-hrtime` but it seems `--allow-all` always win, so it is not working as expected. 

