### PR TITLE
css - don't quote fonts if already quoted

### DIFF
--- a/src/core/css.ts
+++ b/src/core/css.ts
@@ -90,7 +90,9 @@ export function asCssFont(value: unknown): string | undefined {
       .split(",")
       .map((font) => {
         font = font.trim();
-        if (font.includes(" ")) {
+        if (
+          font.includes(" ") && !font.startsWith('"') && !font.startsWith("'")
+        ) {
           font = `"${font}"`;
         }
         return font;

--- a/tests/docs/playwright/html/mainfont/mainfont-1.qmd
+++ b/tests/docs/playwright/html/mainfont/mainfont-1.qmd
@@ -1,0 +1,9 @@
+---
+title: "Code font size"
+format: html
+mainfont: Creepster, "Cascadia Code", Inter
+---
+
+# content
+
+Content

--- a/tests/docs/playwright/html/mainfont/mainfont-2.qmd
+++ b/tests/docs/playwright/html/mainfont/mainfont-2.qmd
@@ -1,0 +1,9 @@
+---
+title: "Code font size"
+format: html
+mainfont: Creepster, Cascadia Code, Inter
+---
+
+# content
+
+Content

--- a/tests/docs/playwright/html/mainfont/mainfont-3.qmd
+++ b/tests/docs/playwright/html/mainfont/mainfont-3.qmd
@@ -1,0 +1,9 @@
+---
+title: "Code font size"
+format: html
+mainfont: Creepster, 'Cascadia Code', Inter
+---
+
+# content
+
+Content

--- a/tests/integration/playwright/tests/html-themes.spec.ts
+++ b/tests/integration/playwright/tests/html-themes.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { getCSSProperty } from '../src/utils';
 
 test('Dark and light theme respect user themes', async ({ page }) => {
   // This document use a custom theme file that change the background color of the title banner
@@ -25,8 +26,15 @@ test('Code block font size did not change and still equals to pre size', async (
   await page.goto('./html/code-font-size.html');
   const code = page.getByRole('code')
   const pre = page.locator('pre')
-  const preFontSize = await pre.evaluate((element) =>
-    window.getComputedStyle(element).getPropertyValue('font-size'),
-  );
+  const preFontSize = await getCSSProperty(pre, 'font-size', false) as string;
   await expect(code).toHaveCSS('font-size', preFontSize);
 });
+
+test('Mainfont can be set to multiple mainfont families', async ({ page }) => {
+  await page.goto('./html/mainfont/mainfont-1.html');
+  expect(await getCSSProperty(page.locator('body'), '--bs-body-font-family', false)).toEqual('Creepster, "Cascadia Code", Inter');
+  await page.goto('./html/mainfont/mainfont-2.html');
+  expect(await getCSSProperty(page.locator('body'), '--bs-body-font-family', false)).toEqual('Creepster, "Cascadia Code", Inter');
+  await page.goto('./html/mainfont/mainfont-3.html');
+  expect(await getCSSProperty(page.locator('body'), '--bs-body-font-family', false)).toEqual('Creepster, "Cascadia Code", Inter');
+})


### PR DESCRIPTION
Related to #11268

We don't want to quote aggressively if the font is already quoted

````
mainfont: Creepster, "Cascadia Code", Inter

mainfont: Creepster, Cascadia Code, Inter

mainfont: Creepster, 'Cascadia Code', Inter
````

It should all work the same and result in same CSS 
````
--bs-body-font-family: Creepster, "Cascadia Code", Inter;
````

Adding playwright test for checking this