### PR TITLE
listing - Correctly handle non ASCII category and special characters

### DIFF
--- a/src/command/render/pandoc.ts
+++ b/src/command/render/pandoc.ts
@@ -207,6 +207,7 @@ import {
   BrandFontFile,
   BrandFontGoogle,
 } from "../../resources/types/schema-types.ts";
+import { kFieldCategories } from "../../project/types/website/listing/website-listing-shared.ts";
 
 // in case we are running multiple pandoc processes
 // we need to make sure we capture all of the trace files
@@ -1018,6 +1019,10 @@ export async function runPandoc(
       // don't process some format specific metadata that may have been processed already
       // - theme is handled specifically already for revealjs with a metadata override and should not be overridden by user input
       if (key === kTheme && isRevealjsOutput(options.format.pandoc)) {
+        continue;
+      }
+      // - categories are handled specifically already for website projects with a metadata override and should not be overridden by user input
+      if (key === kFieldCategories && projectIsWebsite(options.project)) {
         continue;
       }
       // perform the override

--- a/src/core/base64.ts
+++ b/src/core/base64.ts
@@ -1,0 +1,7 @@
+export function b64EncodeUnicode(str: string) {
+  return btoa(encodeURIComponent(str));
+}
+
+export function UnicodeDecodeB64(str: string) {
+  return decodeURIComponent(atob(str));
+}

--- a/src/core/base64.ts
+++ b/src/core/base64.ts
@@ -2,6 +2,6 @@ export function b64EncodeUnicode(str: string) {
   return btoa(encodeURIComponent(str));
 }
 
-export function UnicodeDecodeB64(str: string) {
+export function unicodeDecodeB64(str: string) {
   return decodeURIComponent(atob(str));
 }

--- a/src/project/types/website/listing/website-listing-categories.ts
+++ b/src/project/types/website/listing/website-listing-categories.ts
@@ -17,6 +17,7 @@ import {
   ListingDescriptor,
   ListingSharedOptions,
 } from "./website-listing-shared.ts";
+import { b64EncodeUnicode } from "../../../../core/base64.ts";
 
 export function categorySidebar(
   doc: Document,
@@ -117,7 +118,7 @@ function categoryElement(
   categoryEl.classList.add("category");
   categoryEl.setAttribute(
     "data-category",
-    value !== undefined ? btoa(value) : btoa(category),
+    value !== undefined ? b64EncodeUnicode(value) : b64EncodeUnicode(category),
   );
   categoryEl.innerHTML = contents;
   return categoryEl;

--- a/src/project/types/website/listing/website-listing-template.ts
+++ b/src/project/types/website/listing/website-listing-template.ts
@@ -44,7 +44,7 @@ import { formatDate, parsePandocDate } from "../../../../core/date.ts";
 import { truncateText } from "../../../../core/text.ts";
 import { encodeAttributeValue } from "../../../../core/html.ts";
 import { imagePlaceholder, isPlaceHolder } from "./website-listing-read.ts";
-import { b64EncodeUnicode, UnicodeDecodeB64 } from "../../../../core/base64.ts";
+import { b64EncodeUnicode, unicodeDecodeB64 } from "../../../../core/base64.ts";
 
 export const kDateFormat = "date-format";
 
@@ -164,7 +164,7 @@ export function templateMarkdownHandler(
     // some custom utils function
     ejsParams["utils"] = {
       b64encode: b64EncodeUnicode,
-      b64decode: UnicodeDecodeB64,
+      b64decode: unicodeDecodeB64,
     };
 
     return ejsParams;

--- a/src/project/types/website/listing/website-listing-template.ts
+++ b/src/project/types/website/listing/website-listing-template.ts
@@ -44,6 +44,7 @@ import { formatDate, parsePandocDate } from "../../../../core/date.ts";
 import { truncateText } from "../../../../core/text.ts";
 import { encodeAttributeValue } from "../../../../core/html.ts";
 import { imagePlaceholder, isPlaceHolder } from "./website-listing-read.ts";
+import { b64EncodeUnicode, UnicodeDecodeB64 } from "../../../../core/base64.ts";
 
 export const kDateFormat = "date-format";
 
@@ -160,6 +161,12 @@ export function templateMarkdownHandler(
       ejsParams["metadataAttrs"] = reshapedListing.utilities.metadataAttrs;
       ejsParams["templateParams"] = reshapedListing["template-params"];
     }
+    // some custom utils function
+    ejsParams["utils"] = {
+      b64encode: b64EncodeUnicode,
+      b64decode: UnicodeDecodeB64,
+    };
+
     return ejsParams;
   };
 
@@ -455,7 +462,7 @@ export function reshapeListing(
     attr["index"] = (index++).toString();
     if (item.categories) {
       const str = (item.categories as string[]).join(",");
-      attr["categories"] = btoa(str);
+      attr["categories"] = b64EncodeUnicode(str);
     }
 
     // Add magic attributes for the sortable values

--- a/src/project/types/website/website.ts
+++ b/src/project/types/website/website.ts
@@ -86,6 +86,9 @@ import { formatDate } from "../../../core/date.ts";
 import { projectExtensionPathResolver } from "../../../extension/extension.ts";
 import { websiteDraftPostProcessor } from "./website-draft.ts";
 import { projectDraftMode } from "./website-utils.ts";
+import { kFieldCategories } from "./listing/website-listing-shared.ts";
+import { pandocNativeStr } from "../../../core/pandoc/codegen.ts";
+import { asArray } from "../../../core/array.ts";
 
 export const kSiteTemplateDefault = "default";
 export const kSiteTemplateBlog = "blog";
@@ -157,6 +160,7 @@ export const websiteProjectType: ProjectType = {
       // add some title related variables
       extras.pandoc = extras.pandoc || {};
       extras.metadata = extras.metadata || {};
+      extras.metadataOverride = extras.metadataOverride || {};
 
       // Resolve any giscus information
       resolveFormatForGiscus(project, format);
@@ -194,6 +198,18 @@ export const websiteProjectType: ProjectType = {
         title
       ) {
         extras.metadata[kPageTitle] = title;
+      }
+
+      // categories metadata needs to be escaped from Markdown processing to
+      // avoid +smart applying to it. Categories are expected to be non markdown.
+      // So we provide an override to ensure they are not processed.
+      if (format.metadata[kFieldCategories]) {
+        extras.metadataOverride[kFieldCategories] = asArray(
+          format.metadata[kFieldCategories],
+        ).map(
+          (category) =>
+            pandocNativeStr(category as string).mappedString().value,
+        );
       }
 
       // html metadata

--- a/src/resources/projects/website/listing/item-default.ejs.md
+++ b/src/resources/projects/website/listing/item-default.ejs.md
@@ -56,7 +56,7 @@ print(`<div class="metadata-value listing-${field}">${listing.utilities.outputLi
 <% if (fields.includes('categories') && item.categories) { %> 
 <div class="listing-categories">
 <% for (const category of item.categories) { %>
-<div class="listing-category" onclick="window.quartoListingCategory('<%=btoa(category)%>'); return false;"><%= category %></div>
+<div class="listing-category" onclick="window.quartoListingCategory('<%=utils.b64encode(category)%>'); return false;"><%= category %></div>
 <% } %>
 </div>
 <% } %> 

--- a/src/resources/projects/website/listing/item-grid.ejs.md
+++ b/src/resources/projects/website/listing/item-grid.ejs.md
@@ -64,7 +64,7 @@ return !["title", "image", "image-alt", "date", "author", "subtitle", "descripti
 
 <div class="listing-categories">
   <% for (const category of item.categories) { %>
-<div class="listing-category" onclick="window.quartoListingCategory('<%=btoa(category)%>'); return false;"><%= category %></div>
+<div class="listing-category" onclick="window.quartoListingCategory('<%=utils.b64encode(category)%>'); return false;"><%= category %></div>
   <% } %>
 </div>
 

--- a/src/resources/projects/website/listing/listing-default.ejs.md
+++ b/src/resources/projects/website/listing/listing-default.ejs.md
@@ -1,5 +1,5 @@
 :::{.list .quarto-listing-default}
 <% for (const item of items) { %>
-<% partial('item-default.ejs.md', {listing, item }) %>
+<% partial('item-default.ejs.md', {listing, item, utils }) %>
 <% } %>
 :::

--- a/src/resources/projects/website/listing/listing-grid.ejs.md
+++ b/src/resources/projects/website/listing/listing-grid.ejs.md
@@ -4,6 +4,6 @@ const cols = listing['grid-columns'];
 
 :::{.list .grid .quarto-listing-cols-<%=cols%>}
 <% for (const item of items) { %>
-<% partial('item-grid.ejs.md', {listing, item }) %>
+<% partial('item-grid.ejs.md', {listing, item, utils }) %>
 <% } %>
 :::

--- a/src/resources/projects/website/listing/quarto-listing.js
+++ b/src/resources/projects/website/listing/quarto-listing.js
@@ -59,7 +59,10 @@ window.document.addEventListener("DOMContentLoaded", function (_event) {
   );
 
   for (const categoryEl of categoryEls) {
-    const category = atob(categoryEl.getAttribute("data-category"));
+    // category needs to support non ASCII characters
+    const category = decodeURIComponent(
+      atob(categoryEl.getAttribute("data-category"))
+    );
     categoryEl.onclick = () => {
       activateCategory(category);
       setCategoryHash(category);
@@ -209,7 +212,9 @@ function activateCategory(category) {
 
   // Activate this category
   const categoryEl = window.document.querySelector(
-    `.quarto-listing-category .category[data-category='${btoa(category)}']`
+    `.quarto-listing-category .category[data-category='${btoa(
+      encodeURIComponent(category)
+    )}']`
   );
   if (categoryEl) {
     categoryEl.classList.add("active");
@@ -232,7 +237,9 @@ function filterListingCategory(category) {
         list.filter(function (item) {
           const itemValues = item.values();
           if (itemValues.categories !== null) {
-            const categories = atob(itemValues.categories).split(",");
+            const categories = decodeURIComponent(
+              atob(itemValues.categories)
+            ).split(",");
             return categories.includes(category);
           } else {
             return false;

--- a/src/resources/projects/website/listing/quarto-listing.js
+++ b/src/resources/projects/website/listing/quarto-listing.js
@@ -16,7 +16,9 @@ window["quarto-listing-loaded"] = () => {
   if (hash) {
     // If there is a category, switch to that
     if (hash.category) {
-      activateCategory(hash.category);
+      // category hash are URI encoded so we need to decode it before processing
+      // so that we can match it with the category element processed in JS
+      activateCategory(decodeURIComponent(hash.category));
     }
     // Paginate a specific listing
     const listingIds = Object.keys(window["quarto-listings"]);

--- a/tests/docs/playwright/blog/simple-blog/posts/post-with-code/index.qmd
+++ b/tests/docs/playwright/blog/simple-blog/posts/post-with-code/index.qmd
@@ -2,7 +2,7 @@
 title: "Post With Code"
 author: "Harlow Malloc"
 date: "2024-09-06"
-categories: [news, code, analysis]
+categories: [news, code, analysis, apos'trophe]
 image: "image.jpg"
 ---
 

--- a/tests/docs/playwright/blog/simple-blog/posts/welcome/index.qmd
+++ b/tests/docs/playwright/blog/simple-blog/posts/welcome/index.qmd
@@ -2,7 +2,7 @@
 title: "Welcome To My Blog"
 author: "Tristan O'Malley"
 date: "2024-09-03"
-categories: [news]
+categories: [news, 'euros (€)', 免疫]
 ---
 
 This is the first post in a Quarto blog. Welcome!

--- a/tests/docs/smoke-all/2024/10/23/issue-10829/.gitignore
+++ b/tests/docs/smoke-all/2024/10/23/issue-10829/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+_site/

--- a/tests/integration/playwright/tests/blog-simple-blog.spec.ts
+++ b/tests/integration/playwright/tests/blog-simple-blog.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { getUrl } from "../src/utils";
 
 test('List.js is correctly patch to allow searching with lowercase and uppercase', 
   async ({ page }) => {
@@ -25,6 +26,25 @@ test('Categories link are clickable', async ({ page }) => {
   await page.locator('div').filter({ hasText: /^news$/ }).click();
   await expect(page).toHaveURL(/_site\/index\.html#category=news$/);
   await expect(page.locator(`div.category[data-category="${btoa('news')}"]`)).toHaveClass(/active/);
+  await page.goto('./blog/simple-blog/_site/posts/welcome/#img-lst');
+  await page.locator('div').filter({ hasText: /^news$/ }).click();
+  await expect(page).toHaveURL(/_site\/index\.html#category=news$/);
+  await expect(page.locator(`div.category[data-category="${btoa('news')}"]`)).toHaveClass(/active/);
+});
+
+test('Categories link with special chars are clickable', async ({ page }) => {
+  await page.goto('./blog/simple-blog/_site/posts/welcome/');
+  await page.getByRole('link', { name: 'news' }).click();
+  await expect(page).toHaveURL(/_site\/index\.html#category=news$/);
+  await expect(page.locator(`div.category[data-category="${btoa('news')}"]`)).toHaveClass(/active/);
+  await page.getByRole('link', { name: 'Welcome To My Blog' }).click(); 
+  await page.getByRole('link', { name: 'euros (€)' }).click();
+  await expect(page).toHaveURL(getUrl(`blog/simple-blog/_site/index.html#category=${encodeURIComponent('euros (€)')}`));
+  await expect(page.locator(`div.category[data-category="${btoa(encodeURIComponent('euros (€)'))}"]`)).toHaveClass(/active/);
+  await page.getByRole('link', { name: 'Welcome To My Blog' }).click(); 
+  await page.getByRole('link', { name: '免疫' }).click();
+  await expect(page).toHaveURL(getUrl(`blog/simple-blog/_site/index.html#category=${encodeURIComponent('免疫')}`));
+  await expect(page.locator(`div.category[data-category="${btoa(encodeURIComponent('免疫'))}"]`)).toHaveClass(/active/);
   await page.goto('./blog/simple-blog/_site/posts/welcome/#img-lst');
   await page.locator('div').filter({ hasText: /^news$/ }).click();
   await expect(page).toHaveURL(/_site\/index\.html#category=news$/);

--- a/tests/integration/playwright/tests/blog-simple-blog.spec.ts
+++ b/tests/integration/playwright/tests/blog-simple-blog.spec.ts
@@ -45,6 +45,10 @@ test('Categories link with special chars are clickable', async ({ page }) => {
   await page.getByRole('link', { name: '免疫' }).click();
   await expect(page).toHaveURL(getUrl(`blog/simple-blog/_site/index.html#category=${encodeURIComponent('免疫')}`));
   await expect(page.locator(`div.category[data-category="${btoa(encodeURIComponent('免疫'))}"]`)).toHaveClass(/active/);
+  await page.goto('./blog/simple-blog/_site/posts/post-with-code/');  
+  await page.getByRole('link', { name: "apos'trophe" }).click();
+  await expect(page).toHaveURL(getUrl(`blog/simple-blog/_site/index.html#category=${encodeURIComponent("apos'trophe")}`));
+  await expect(page.locator(`div.category[data-category="${btoa(encodeURIComponent("apos'trophe"))}"]`)).toHaveClass(/active/);
   await page.goto('./blog/simple-blog/_site/posts/welcome/#img-lst');
   await page.locator('div').filter({ hasText: /^news$/ }).click();
   await expect(page).toHaveURL(/_site\/index\.html#category=news$/);

--- a/tests/integration/playwright/tests/blog-simple-blog.spec.ts
+++ b/tests/integration/playwright/tests/blog-simple-blog.spec.ts
@@ -32,25 +32,23 @@ test('Categories link are clickable', async ({ page }) => {
   await expect(page.locator(`div.category[data-category="${btoa('news')}"]`)).toHaveClass(/active/);
 });
 
-test('Categories link with special chars are clickable', async ({ page }) => {
+test('Categories links are clickable', async ({ page }) => {
+  const checkCategoryLink = async (category: string) => {
+    await page.getByRole('link', { name: category }).click();
+    await expect(page).toHaveURL(getUrl(`blog/simple-blog/_site/index.html#category=${encodeURIComponent(category)}`));
+    await expect(page.locator(`div.category[data-category="${btoa(encodeURIComponent(category))}"]`)).toHaveClass(/active/);
+  };
+  // Checking link is working
   await page.goto('./blog/simple-blog/_site/posts/welcome/');
-  await page.getByRole('link', { name: 'news' }).click();
-  await expect(page).toHaveURL(/_site\/index\.html#category=news$/);
-  await expect(page.locator(`div.category[data-category="${btoa('news')}"]`)).toHaveClass(/active/);
-  await page.getByRole('link', { name: 'Welcome To My Blog' }).click(); 
-  await page.getByRole('link', { name: 'euros (€)' }).click();
-  await expect(page).toHaveURL(getUrl(`blog/simple-blog/_site/index.html#category=${encodeURIComponent('euros (€)')}`));
-  await expect(page.locator(`div.category[data-category="${btoa(encodeURIComponent('euros (€)'))}"]`)).toHaveClass(/active/);
-  await page.getByRole('link', { name: 'Welcome To My Blog' }).click(); 
-  await page.getByRole('link', { name: '免疫' }).click();
-  await expect(page).toHaveURL(getUrl(`blog/simple-blog/_site/index.html#category=${encodeURIComponent('免疫')}`));
-  await expect(page.locator(`div.category[data-category="${btoa(encodeURIComponent('免疫'))}"]`)).toHaveClass(/active/);
-  await page.goto('./blog/simple-blog/_site/posts/post-with-code/');  
-  await page.getByRole('link', { name: "apos'trophe" }).click();
-  await expect(page).toHaveURL(getUrl(`blog/simple-blog/_site/index.html#category=${encodeURIComponent("apos'trophe")}`));
-  await expect(page.locator(`div.category[data-category="${btoa(encodeURIComponent("apos'trophe"))}"]`)).toHaveClass(/active/);
+  await checkCategoryLink('news');
+  // Including for special characters
+  await page.getByRole('link', { name: 'Welcome To My Blog' }).click();
+  await checkCategoryLink('euros (€)');
+  await page.getByRole('link', { name: 'Welcome To My Blog' }).click();
+  await checkCategoryLink('免疫');
+  await page.goto('./blog/simple-blog/_site/posts/post-with-code/');
+  await checkCategoryLink("apos'trophe");
+  // special check for when a page is not loaded from non root path
   await page.goto('./blog/simple-blog/_site/posts/welcome/#img-lst');
-  await page.locator('div').filter({ hasText: /^news$/ }).click();
-  await expect(page).toHaveURL(/_site\/index\.html#category=news$/);
-  await expect(page.locator(`div.category[data-category="${btoa('news')}"]`)).toHaveClass(/active/);
+  await checkCategoryLink('news');
 });


### PR DESCRIPTION
This is additional fix to #11177 so that category with special characters, and UTF-8 characters are correctly handled.

It fixes first #11358 and then add to #11177 to fix #8517. A category with apostrophe does not cause issue anymore (#10829) but cliking on them was still not working. 

### About UTF-8 in category

Using base64 encoding works, in the limite of ASCII character range. For content with UTF-8 characters, we need to take extra measure. 

This PR uses `encodeURIComponent` and `decodeURIComponent` to get into that range of characters. It seems UTF-8 stream can be used, so we could switch to that. 

### About clicking on category with special char

It took me a while to find the problem but the issue was that 

- `categories` are metadata processed by us in JS, but also passed to Pandoc to use in title-block template. 
- Pandoc parses any string value in metadata as Markdown, and we default to `markdown+smart` for the readers. This smart extension applies and so `'` was transformed to another character. 
- This lead to our JS script not being able to find the right category to activate because they are not the same when base64 encoded. 

	<details>
	<summary>Example </summary>
	
	````markdown
	---
	title: "Font test"
	categories: "apos'trophe"
	---
	
	test
	````
	
	Render to native
	````
	Pandoc
	  Meta
	    { unMeta =
	        fromList
	          [ ( "categories" , MetaInlines [ Str "apos\8217trophe" ] )
	          , ( "title"
	            , MetaInlines [ Str "Font" , Space , Str "test" ]
	            )
	          ]
	    }
	  [ Para [ Str "test" ] ]
	````

	`\8217` is not `'`
	
	</details>

We had such issues in the past with `revealjs-url` metadata, so I am using same "trick" by wrapping in `pandocNativeStr()` so that it can be passed unparsed as a metadata to Pandoc. 

This requires processing the format metadata to override the existing one. To do that
- it is using `projectExtras` as this really apply to website project. 
- it is using a `metadataOverride` though because currently `mergeConfigs` is appending arrays together otherwise. 
- There needs to be a special handle in the (again) problematic `engineMetadata` override. As discussed in the past, I think this should be removed, but that it is not the place to discuss. Fact is `categories` is not listed as a `isQuartoMetadata()` so, it does get identified as possible engine metadata override, but it can't happen here as we are processing it. So like revealjs `theme` key, there is an exception now. **This whole part will need to be reconsider when we'll deal with `mergeConfig` and this code piece**

Hopefully this explains clearly what I tried. Happy to discuss and consider another solution if you think of one. 

Consequence of this change: `categories` can only be raw string, as in non-markdown string. Which I think is what we currently expect (but not enforced until now)

