### PR TITLE
use typst raw inline in metadata

### DIFF
--- a/src/resources/filters/quarto-post/typst-brand-yaml.lua
+++ b/src/resources/filters/quarto-post/typst-brand-yaml.lua
@@ -310,12 +310,14 @@ function render_typst_brand_yaml()
       if headings and next(headings) or foregroundColor then
         base = base or {}
         headings = headings or {}
+        local color = headings.color or foregroundColor
+        color = color and pandoc.RawInline('typst', color)
         meta.brand.typography.headings = {
           family = headings.family or base.family,
           weight = headings.weight or base.weight,
           style = headings.style or base.style,
           decoration = headings.decoration or base.decoration,
-          color = headings.color or foregroundColor,
+          color = color,
           ['background-color'] = headings['background-color'] or base['background-color'],
           ['line-height'] = line_height_to_leading(headings['line-height'] or base['line-height']),
         }

--- a/src/resources/formats/typst/pandoc/quarto/definitions.typ
+++ b/src/resources/formats/typst/pandoc/quarto/definitions.typ
@@ -42,10 +42,6 @@
   return block.with(..fields)(new_content)
 }
 
-#let unescape-eval(str) = {
-  return eval(str.replace("\\", ""))
-}
-
 #let empty(v) = {
   if type(v) == "string" {
     // two dollar signs here because we're technically inside

--- a/src/resources/formats/typst/pandoc/quarto/typst-show.typ
+++ b/src/resources/formats/typst/pandoc/quarto/typst-show.typ
@@ -59,10 +59,7 @@ $if(brand.typography.headings.decoration)$
   heading-decoration: "$brand.typography.headings.decoration$",
 $endif$
 $if(brand.typography.headings.color)$
-  heading-color: unescape-eval("$brand.typography.headings.color$"),
-$endif$
-$if(brand.typography.headings.background-color)$
-  heading-background-color: unescape-eval("$brand.typography.headings.background-color$"),
+  heading-color: $brand.typography.headings.color$,
 $endif$
 $if(brand.typography.headings.line-height)$
   heading-line-height: $brand.typography.headings.line-height$,

--- a/tests/docs/smoke-all/typst/brand-yaml/color/foreground-background.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/color/foreground-background.qmd
@@ -18,7 +18,7 @@ _quarto:
         -
           - '#set page\(fill: brand-color\.background\)'
           - '#set text\(fill: brand-color\.foreground\)'
-          - 'heading-color: unescape-eval\("rgb\(\\"\\#ccd2b2\\"\)"\)'
+          - 'heading-color: rgb\("#ccd2b2"\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/typst/brand-yaml/color/foreground-lines.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/color/foreground-lines.qmd
@@ -15,7 +15,7 @@ _quarto:
         -
           - '#set page\(fill: brand-color\.background\)'
           - '#set text\(fill: brand-color\.foreground\)'
-          - 'heading-color: unescape-eval\("rgb\(\\"\\#ccd2b2\\"\)"\)'
+          - 'heading-color: rgb\("#ccd2b2"\)'
           - '#set table.hline\(stroke: \(paint: brand-color\.foreground\)\)'
           - '#set line\(stroke: \(paint: brand-color\.foreground\)\)'
 

--- a/tests/docs/smoke-all/typst/brand-yaml/typography/kitchen-sink-1/brand-typography.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/typography/kitchen-sink-1/brand-typography.qmd
@@ -30,7 +30,7 @@ _quarto:
         - 'heading-family: \("Montserrat",\),$'
         - 'heading-weight: 800,$'
         - 'heading-style: "normal",$'
-        - 'heading-color: unescape-eval\("rgb\(\\"\\#0b8005\\"\)"\),$'
+        - 'heading-color: rgb\("#0b8005"\),$'
         - 'heading-line-height: 0\.25em,$'
         - '^#show heading: set text\(font: "Montserrat", weight: 800, style: "normal", fill: rgb\("#0b8005"\), \)$'
         - '^#show heading: set par\(leading: 0.25em\)$'

--- a/tests/docs/smoke-all/typst/brand-yaml/typography/kitchen-sink-2/brand-typography.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/typography/kitchen-sink-2/brand-typography.qmd
@@ -28,7 +28,7 @@ _quarto:
         - 'heading-family: \("Raleway",\),$'
         - 'heading-weight: 500,$'
         - 'heading-style: "normal",$'
-        - 'heading-color: unescape-eval\("rgb\(\\"\\#042f02\\"\)"\),$'
+        - 'heading-color: rgb\("#042f02"\),$'
         - 'heading-line-height: 0\.25em,$'
         - '^#show heading: set text\(font: "Raleway", weight: 500, style: "normal", fill: rgb\("#042f02"\), \)$'
         - '^#show heading: set par\(leading: 0.25em\)$'


### PR DESCRIPTION
In re https://github.com/quarto-dev/quarto-cli/discussions/11364#discussioncomment-11247298

we can use a raw typst inline in the metadata to avoid escaping and subsequent unescaping and evil eval.

Also remove unused heading `background-color` which is not allowed.