### PR TITLE
support 'brand' in theme configurations

### DIFF
--- a/src/command/render/pandoc-html.ts
+++ b/src/command/render/pandoc-html.ts
@@ -14,6 +14,8 @@ import {
   kQuartoCssVariables,
   kTextHighlightingMode,
   SassBundle,
+  SassBundleWithBrand,
+  SassLayer,
 } from "../../config/types.ts";
 import { ProjectContext } from "../../project/types.ts";
 
@@ -39,6 +41,8 @@ import { kSassBundles } from "../../config/types.ts";
 import { md5HashBytes } from "../../core/hash.ts";
 import { InternalError } from "../../core/lib/error.ts";
 import { writeTextFileSyncPreserveMode } from "../../core/write.ts";
+import { getStack } from "../../core/deno/debug.ts";
+import { assert } from "testing/asserts";
 
 // The output target for a sass bundle
 // (controls the overall style tag that is emitted)
@@ -57,12 +61,12 @@ export async function resolveSassBundles(
 ) {
   extras = cloneDeep(extras);
 
-  const mergedBundles: Record<string, SassBundle[]> = {};
+  const mergedBundles: Record<string, SassBundleWithBrand[]> = {};
 
   // groups the bundles by dependency name
   const group = (
-    bundles: SassBundle[],
-    groupedBundles: Record<string, SassBundle[]>,
+    bundles: SassBundleWithBrand[],
+    groupedBundles: Record<string, SassBundleWithBrand[]>,
   ) => {
     bundles.forEach((bundle) => {
       if (!groupedBundles[bundle.dependency]) {
@@ -82,19 +86,37 @@ export async function resolveSassBundles(
   let defaultStyle: "dark" | "light" | undefined = undefined;
   for (const dependency of Object.keys(mergedBundles)) {
     // compile the cssPath
-    const bundles = mergedBundles[dependency];
+    const bundlesWithBrand = mergedBundles[dependency];
+    // first, pull out the brand-specific layers
+    //
+    // the brand bundle itself doesn't have any 'brand' entries;
+    // those are used to specify where the brand-specific layers should be inserted
+    // in the final bundle. We filter
+    const brandLayersMaybeBrand = bundlesWithBrand.find((bundle) =>
+      bundle.key === "brand"
+    )?.user || [];
+    assert(!brandLayersMaybeBrand.find((v) => v === "brand"));
+    const brandLayers = brandLayersMaybeBrand as SassLayer[];
+    const bundles: SassBundle[] = bundlesWithBrand.filter((bundle) =>
+      bundle.key !== "brand"
+    ).map((bundle) => {
+      const userBrand = bundle.user?.findIndex((layer) => layer === "brand");
+      if (userBrand && userBrand !== -1) {
+        bundle = cloneDeep(bundle);
+        bundle.user!.splice(userBrand, 1, ...brandLayers);
+      }
+      return bundle as SassBundle;
+    });
 
     // See if any bundles are providing dark specific css
     const hasDark = bundles.some((bundle) => bundle.dark !== undefined);
-    defaultStyle = bundles.some((bundle) =>
-        bundle.dark !== undefined && bundle.dark.default
-      )
-      ? "dark"
-      : "light";
-
+    defaultStyle =
+      bundles.some((bundle) => bundle.dark !== undefined && bundle.dark.default)
+        ? "dark"
+        : "light";
     const targets: SassTarget[] = [{
       name: `${dependency}.min.css`,
-      bundles,
+      bundles: (bundles as any),
       attribs: {
         "append-hash": "true",
       },
@@ -119,7 +141,7 @@ export async function resolveSassBundles(
       });
       targets.push({
         name: `${dependency}-dark.min.css`,
-        bundles: darkBundles,
+        bundles: darkBundles as any,
         attribs: {
           "append-hash": "true",
           ...attribForThemeStyle("dark", defaultStyle),

--- a/src/command/render/pandoc-html.ts
+++ b/src/command/render/pandoc-html.ts
@@ -41,7 +41,6 @@ import { kSassBundles } from "../../config/types.ts";
 import { md5HashBytes } from "../../core/hash.ts";
 import { InternalError } from "../../core/lib/error.ts";
 import { writeTextFileSyncPreserveMode } from "../../core/write.ts";
-import { getStack } from "../../core/deno/debug.ts";
 import { assert } from "testing/asserts";
 
 // The output target for a sass bundle
@@ -163,6 +162,9 @@ export async function resolveSassBundles(
       // it can happen that processing generate an empty css file (e.g quarto-html deps with Quarto CSS variables)
       // in that case, no need to insert the cssPath in the dependency
       if (!cssPath) continue;
+      if (Deno.readTextFileSync(cssPath).length === 0) {
+        continue;
+      }
 
       // Process attributes (forward on to the target)
       for (const bundle of target.bundles) {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -305,9 +305,28 @@ export interface SassLayer {
   rules: string;
 }
 
+export interface SassBundleLayersWithBrand {
+  key: string;
+  user?: (SassLayer | "brand")[];
+  quarto?: SassLayer;
+  framework?: SassLayer;
+  loadPaths?: string[];
+}
+
+export interface SassBundleWithBrand extends SassBundleLayersWithBrand {
+  dependency: string;
+  dark?: {
+    user?: (SassLayer | "brand")[];
+    quarto?: SassLayer;
+    framework?: SassLayer;
+    default?: boolean;
+  };
+  attribs?: Record<string, string>;
+}
+
 export interface SassBundleLayers {
   key: string;
-  user?: SassLayer;
+  user?: SassLayer[];
   quarto?: SassLayer;
   framework?: SassLayer;
   loadPaths?: string[];
@@ -316,7 +335,7 @@ export interface SassBundleLayers {
 export interface SassBundle extends SassBundleLayers {
   dependency: string;
   dark?: {
-    user?: SassLayer;
+    user?: SassLayer[];
     quarto?: SassLayer;
     framework?: SassLayer;
     default?: boolean;
@@ -376,7 +395,7 @@ export interface FormatExtras {
   templateContext?: FormatTemplateContext;
   html?: {
     [kDependencies]?: FormatDependency[];
-    [kSassBundles]?: SassBundle[];
+    [kSassBundles]?: SassBundleWithBrand[];
     [kBodyEnvelope]?: BodyEnvelope;
     [kHtmlPostprocessors]?: Array<HtmlPostProcessor>;
     [kHtmlFinalizers]?: Array<

--- a/src/core/sass.ts
+++ b/src/core/sass.ts
@@ -81,15 +81,19 @@ export async function compileSass(
   );
   const quartoDefaults = bundles.map((bundle) => bundle.quarto?.defaults || "");
   const quartoRules = bundles.map((bundle) => bundle.quarto?.rules || "");
-
   const quartoMixins = bundles.map((bundle) => bundle.quarto?.mixins || "");
 
+  const userLayers = mergeLayers(
+    ...bundles.map((bundle) => bundle.user || []).flat(),
+  );
+  console.log("userLayers", userLayers);
+
   // Gather sasslayer for the user
-  const userUses = bundles.map((bundle) => bundle.user?.uses || "");
-  const userFunctions = bundles.map((bundle) => bundle.user?.functions || "");
-  const userDefaults = bundles.map((bundle) => bundle.user?.defaults || "");
-  const userRules = bundles.map((bundle) => bundle.user?.rules || "");
-  const userMixins = bundles.map((bundle) => bundle.user?.mixins || "");
+  const userUses = userLayers.uses; //bundles.map((bundle) => bundle.user?.uses || "");
+  const userFunctions = userLayers.functions; // bundles.map((bundle) => bundle.user?.functions || "");
+  const userDefaults = userLayers.defaults; // bundles.map((bundle) => bundle.user?.defaults || "");
+  const userRules = userLayers.rules; // bundles.map((bundle) => bundle.user?.rules || "");
+  const userMixins = userLayers.mixins; // bundles.map((bundle) => bundle.user?.mixins || "");
 
   // Set any load paths used to resolve imports
   const loadPaths: string[] = [];
@@ -114,15 +118,15 @@ export async function compileSass(
     '// quarto-scss-analysis-annotation { "origin": "\'use\' section from Quarto" }',
     ...quartoUses,
     '// quarto-scss-analysis-annotation { "origin": "\'use\' section from user-defined SCSS" }',
-    ...userUses,
+    userUses,
     '// quarto-scss-analysis-annotation { "origin": "\'functions\' section from format" }',
     ...frameworkFunctions,
     '// quarto-scss-analysis-annotation { "origin": "\'functions\' section from Quarto" }',
     ...quartoFunctions,
     '// quarto-scss-analysis-annotation { "origin": "\'functions\' section from user-defined SCSS" }',
-    ...userFunctions,
+    userFunctions,
     '// quarto-scss-analysis-annotation { "origin": "Defaults from user-defined SCSS" }',
-    ...userDefaults.reverse(),
+    userDefaults,
     '// quarto-scss-analysis-annotation { "origin": "Defaults from Quarto\'s SCSS" }',
     ...quartoDefaults.reverse(),
     '// quarto-scss-analysis-annotation { "origin": "Defaults from the format SCSS" }',
@@ -138,7 +142,7 @@ export async function compileSass(
     '// quarto-scss-analysis-annotation { "origin": "\'rules\' section from Quarto" }',
     ...quartoRules,
     '// quarto-scss-analysis-annotation { "origin": "\'rules\' section from user-defined SCSS" }',
-    ...userRules,
+    userRules,
     '// quarto-scss-analysis-annotation { "origin": null }',
   ].join("\n\n");
 
@@ -191,7 +195,7 @@ const layoutBoundary =
 const kLayerBoundaryLine = RegExp(layoutBoundary);
 const kLayerBoundaryTest = RegExp(layoutBoundary, "m");
 
-export function mergeLayers(...layers: SassLayer[]) {
+export function mergeLayers(...layers: SassLayer[]): SassLayer {
   const themeUses: string[] = [];
   const themeDefaults: string[] = [];
   const themeRules: string[] = [];
@@ -202,10 +206,7 @@ export function mergeLayers(...layers: SassLayer[]) {
       themeUses.push(theme.uses);
     }
     if (theme.defaults) {
-      // We need to reverse the order of defaults
-      // since defaults override one another by being
-      // set first
-      themeDefaults.unshift(theme.defaults);
+      themeDefaults.push(theme.defaults);
     }
 
     if (theme.rules) {
@@ -223,7 +224,10 @@ export function mergeLayers(...layers: SassLayer[]) {
 
   return {
     uses: themeUses.join("\n"),
-    defaults: themeDefaults.join("\n"),
+    // We need to reverse the order of defaults
+    // since defaults override one another by being
+    // set first
+    defaults: themeDefaults.reverse().join("\n"),
     functions: themeFunctions.join("\n"),
     mixins: themeMixins.join("\n"),
     rules: themeRules.join("\n"),

--- a/src/core/sass.ts
+++ b/src/core/sass.ts
@@ -136,7 +136,7 @@ export async function compileSass(
     '// quarto-scss-analysis-annotation { "origin": "\'mixins\' section from Quarto" }',
     ...quartoMixins,
     '// quarto-scss-analysis-annotation { "origin": "\'mixins\' section from user-defined SCSS" }',
-    ...userMixins,
+    userMixins,
     '// quarto-scss-analysis-annotation { "origin": "\'rules\' section from format" }',
     ...frameworkRules,
     '// quarto-scss-analysis-annotation { "origin": "\'rules\' section from Quarto" }',

--- a/src/core/sass.ts
+++ b/src/core/sass.ts
@@ -422,5 +422,5 @@ export function cleanSourceMappingUrl(cssPath: string): void {
     kSourceMappingRegexes[1],
     "",
   );
-  writeTextFileSyncPreserveMode(cssPath, cleaned);
+  writeTextFileSyncPreserveMode(cssPath, cleaned.trim());
 }

--- a/src/core/sass.ts
+++ b/src/core/sass.ts
@@ -86,7 +86,6 @@ export async function compileSass(
   const userLayers = mergeLayers(
     ...bundles.map((bundle) => bundle.user || []).flat(),
   );
-  console.log("userLayers", userLayers);
 
   // Gather sasslayer for the user
   const userUses = userLayers.uses; //bundles.map((bundle) => bundle.user?.uses || "");

--- a/src/core/sass/brand.ts
+++ b/src/core/sass/brand.ts
@@ -11,9 +11,8 @@ import {
   FormatExtras,
   kSassBundles,
   SassBundle,
-  SassBundleLayers,
+  SassLayer,
 } from "../../config/types.ts";
-import { join, relative } from "../../deno_ral/path.ts";
 import { ProjectContext } from "../../project/types.ts";
 import {
   BrandFont,
@@ -67,49 +66,17 @@ export async function brandBootstrapSassBundles(
   project: ProjectContext,
   key: string,
 ): Promise<SassBundle[]> {
-  return (await brandBootstrapSassBundleLayers(
+  const layers = await brandBootstrapSassLayers(
     fileName,
     project,
-    key,
     defaultColorNameMap,
-  )).map(
-    (layer: SassBundleLayers) => {
-      return {
-        ...layer,
-        dependency: "bootstrap",
-      };
-    },
   );
+  return [{
+    key,
+    dependency: "bootstrap",
+    user: layers,
+  }];
 }
-
-const fontFileFormat = (file: string): string => {
-  const fragments = file.split(".");
-  if (fragments.length < 2) {
-    throw new Error(`Invalid font file ${file}; expected extension.`);
-  }
-  const ext = fragments.pop();
-  // https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src#font_formats
-  switch (ext) {
-    case "otc":
-    case "ttc":
-      return "collection";
-    case "woff":
-      return "woff";
-    case "woff2":
-      return "woff2";
-    case "ttf":
-      return "truetype";
-    case "otf":
-      return "opentype";
-    case "svg":
-    case "svgz":
-      return "svg";
-    case "eot":
-      return "embedded-opentype";
-    default:
-      throw new Error(`Unknown font format ${ext} in ${file}`);
-  }
-};
 
 const bunnyFontImportString = (description: BrandFontCommon) => {
   const bunnyName = (name: string) => name.replace(/ /g, "-");
@@ -175,11 +142,10 @@ const googleFontImportString = (description: BrandFontGoogle) => {
   }:${styleString}wght@${weights}&display=${display}');`;
 };
 
-const brandColorBundle = (
+const brandColorLayer = (
   brand: Brand,
-  key: string,
   nameMap: Record<string, string>,
-): SassBundleLayers => {
+): SassLayer => {
   const colorVariables: string[] = [
     "/* color variables from _brand.yml */",
     '// quarto-scss-analysis-annotation { "action": "push", "origin": "_brand.yml color" }',
@@ -226,24 +192,18 @@ const brandColorBundle = (
     "}",
     '// quarto-scss-analysis-annotation { "action": "pop" }',
   );
-  const colorBundle: SassBundleLayers = {
-    key,
-    // dependency: "bootstrap",
-    quarto: {
-      defaults: colorVariables.join("\n"),
-      uses: "",
-      functions: "",
-      mixins: "",
-      rules: colorCssVariables.join("\n"),
-    },
+  return {
+    defaults: colorVariables.join("\n"),
+    uses: "",
+    functions: "",
+    mixins: "",
+    rules: colorCssVariables.join("\n"),
   };
-  return colorBundle;
 };
 
-const brandBootstrapBundle = (
+const brandDefaultsBootstrapLayer = (
   brand: Brand,
-  key: string,
-): SassBundleLayers => {
+): SassLayer => {
   // Bootstrap Variables from brand.defaults.bootstrap
   const brandBootstrap = brand?.data?.defaults?.bootstrap as unknown as Record<
     string,
@@ -300,42 +260,24 @@ const brandBootstrapBundle = (
 
   bsColors.push('// quarto-scss-analysis-annotation { "action": "pop" }');
 
-  const bsBundle: SassBundleLayers = {
-    key,
-    // dependency: "bootstrap",
-    quarto: {
-      defaults: bsColors.join("\n") + "\n" + bsVariables.join("\n"),
-      uses: "",
-      functions: "",
-      mixins: "",
-      rules: "",
-    },
+  return {
+    defaults: bsColors.join("\n") + "\n" + bsVariables.join("\n"),
+    uses: "",
+    functions: "",
+    mixins: "",
+    rules: "",
   };
-  return bsBundle;
 };
 
-const brandTypographyBundle = (
+const brandTypographyLayer = (
   brand: Brand,
-  key: string,
-): SassBundleLayers => {
+): SassLayer => {
   const typographyVariables: string[] = [
     "/* typography variables from _brand.yml */",
     '// quarto-scss-analysis-annotation { "action": "push", "origin": "_brand.yml typography" }',
   ];
   const typographyImports: Set<string> = new Set();
   const fonts = brand.data?.typography?.fonts ?? [];
-
-  const pathCorrection = relative(brand.projectDir, brand.brandDir);
-  const computePath = (file: string) => {
-    if (file.startsWith("http://") || file.startsWith("https://")) {
-      return file;
-    }
-    // paths in our CSS are always relative to the project directory
-    if (file.startsWith("/")) {
-      return file.slice(1);
-    }
-    return join(pathCorrection, file);
-  };
 
   const getFontFamilies = (family: string | undefined) => {
     return fonts.filter((font) =>
@@ -579,75 +521,61 @@ const brandTypographyBundle = (
   typographyVariables.push(
     '// quarto-scss-analysis-annotation { "action": "pop" }',
   );
-  const typographyBundle: SassBundleLayers = {
-    key,
-    // dependency: "bootstrap",
-    quarto: {
-      defaults: typographyVariables.join("\n"),
-      uses: Array.from(typographyImports).join("\n"),
-      functions: "",
-      mixins: "",
-      rules: "",
-    },
+  return {
+    defaults: typographyVariables.join("\n"),
+    uses: Array.from(typographyImports).join("\n"),
+    functions: "",
+    mixins: "",
+    rules: "",
   };
-  return typographyBundle;
 };
 
-export async function brandSassBundleLayers(
+export async function brandSassLayers(
   fileName: string | undefined,
   project: ProjectContext,
-  key: string,
   nameMap: Record<string, string> = {},
-): Promise<SassBundleLayers[]> {
+): Promise<SassLayer[]> {
   const brand = await project.resolveBrand(fileName);
-  const sassBundles: SassBundleLayers[] = [];
+  const sassLayers: SassLayer[] = [];
 
   if (brand?.data.color) {
-    sassBundles.push(brandColorBundle(brand, key, nameMap));
+    sassLayers.push(brandColorLayer(brand, nameMap));
   }
 
   if (brand?.data.typography) {
-    sassBundles.push(brandTypographyBundle(brand, key));
+    sassLayers.push(brandTypographyLayer(brand));
   }
 
-  return sassBundles;
+  return sassLayers;
 }
 
-export async function brandBootstrapSassBundleLayers(
+export async function brandBootstrapSassLayers(
   fileName: string | undefined,
   project: ProjectContext,
-  key: string,
   nameMap: Record<string, string> = {},
-): Promise<SassBundleLayers[]> {
-  const brand = await project.resolveBrand(fileName);
-  const sassBundles = await brandSassBundleLayers(
+): Promise<SassLayer[]> {
+  const layers = await brandSassLayers(
     fileName,
     project,
-    key,
     nameMap,
   );
 
+  const brand = await project.resolveBrand(fileName);
   if (brand?.data?.defaults?.bootstrap) {
-    const bsBundle = brandBootstrapBundle(brand, key);
-    if (bsBundle) {
-      // Add bsBundle to the beginning of the array so that defaults appear
-      // *after* the rest of the brand variables.
-      sassBundles.unshift(bsBundle);
-    }
+    layers.push(brandDefaultsBootstrapLayer(brand));
   }
 
-  return sassBundles;
+  return layers;
 }
 
-export async function brandRevealSassBundleLayers(
+export async function brandRevealSassLayers(
   input: string | undefined,
   _format: Format,
   project: ProjectContext,
-): Promise<SassBundleLayers[]> {
-  return brandSassBundleLayers(
+): Promise<SassLayer[]> {
+  return brandSassLayers(
     input,
     project,
-    "reveal-theme",
     defaultColorNameMap,
   );
 }
@@ -657,25 +585,20 @@ export async function brandSassFormatExtras(
   _format: Format,
   project: ProjectContext,
 ): Promise<FormatExtras> {
-  const htmlSassBundleLayers = await brandBootstrapSassBundleLayers(
+  const htmlSassBundleLayers = await brandBootstrapSassLayers(
     input,
     project,
-    "brand",
     defaultColorNameMap,
   );
-  const htmlSassBundles: SassBundle[] = htmlSassBundleLayers.map((layer) => {
-    return {
-      ...layer,
-      dependency: "bootstrap",
-    };
-  });
-  if (htmlSassBundles.length === 0) {
-    return {};
-  } else {
-    return {
-      html: {
-        [kSassBundles]: htmlSassBundles,
-      },
-    };
-  }
+  return {
+    html: {
+      [kSassBundles]: [
+        {
+          key: "brand",
+          dependency: "bootstrap",
+          user: htmlSassBundleLayers,
+        },
+      ],
+    },
+  };
 }

--- a/src/core/sass/brand.ts
+++ b/src/core/sass/brand.ts
@@ -24,6 +24,7 @@ import {
 import { Brand } from "../brand/brand.ts";
 
 const defaultColorNameMap: Record<string, string> = {
+  "link-color": "link",
   "pre-color": "foreground",
   "body-bg": "background",
   "body-color": "foreground",

--- a/tests/docs/smoke-all/2022/10/14/invalid-highlight-theme.qmd
+++ b/tests/docs/smoke-all/2022/10/14/invalid-highlight-theme.qmd
@@ -8,7 +8,10 @@ format:
 #    code-fold: true
 #    code-line-numbers: true
     highlight-style: asa
-
+_quarto:
+  tests:
+    html:
+      noErrors: true
 ---
 
 ```r


### PR DESCRIPTION
This is the last `brand` feature we'll get in 1.6: the ability to customize the priority of the `_brand.yml` information inside Quarto theming.

The usage is hopefully intuitive. Our `theme` configuration accepts a new special string `brand`. When present, the string controls the priority of the brand information in the generated theme, following the previous semantics that the array is specified in least-to-most-important order. If unspecified, the behavior is equivalent to `brand` being the very first entry in the array (that is, the least important one)

````
---
title: "brand-order"
format:
  html:
    theme: [cosmo, brand, test.scss]
brand:
  color:
    primary: green
    background: white
---

This is a Quarto website.

To learn more about Quarto websites visit <https://quarto.org/docs/websites>.
````