### PR TITLE
typst brand yaml: populate brand.typography.headings if brand.typography.base is populated

### DIFF
--- a/src/resources/filters/quarto-post/typst-brand-yaml.lua
+++ b/src/resources/filters/quarto-post/typst-brand-yaml.lua
@@ -307,7 +307,7 @@ function render_typst_brand_yaml()
 
       local headings = _quarto.modules.brand.get_typography('headings')
       local foregroundColor = _quarto.modules.brand.get_color('foreground')
-      if headings and next(headings) or foregroundColor then
+      if headings and next(headings) or base and next(base) or foregroundColor then
         base = base or {}
         headings = headings or {}
         local color = headings.color or foregroundColor

--- a/tests/docs/smoke-all/typst/brand-yaml/typography/title-inherit-base-family.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/typography/title-inherit-base-family.qmd
@@ -1,0 +1,27 @@
+---
+title: "Untitled"
+format:
+  html: default
+  typst:
+    keep-typ: true
+  revealjs:
+    output-file: base-reveal.html
+brand:
+  typography:
+    fonts:
+      - family: Tiny5
+        source: google
+    base: Tiny5
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+      -
+        - 'font: \("Tiny5",\),'
+        - 'heading-family: \("Tiny5",\)'
+
+---
+
+## Section
+
+{{< lipsum 1 >}}


### PR DESCRIPTION
Fix for the Typst side of #11272

All because there is no way to default typst properties to not-set, we must emulate inheritance for base in all cases.