### PR TITLE
gha - `save-always` is deprecated in actions/cache@v4

### DIFF
--- a/.github/actions/cache-typst/action.yml
+++ b/.github/actions/cache-typst/action.yml
@@ -1,10 +1,21 @@
-name: "Cache Typst package"
+name: "Restore any Typst package cache"
 description: "Configures the caching for Typst packages"
+outputs:
+  cache-hit:
+    description: "Is there a cache restored ?"
+    value: ${{ steps.cache-typst-restore.outputs.cache-hit }}
+  cache-key:
+    description: "Key of the cache considered"
+    value: ${{ steps.cache-typst-restore.outputs.cache-primary-key }}
+  cache-path:
+    description: "where is the packages cache for typst ?"
+    value: ${{ steps.cache-typst-path.outputs.TYPST_CACHE }}
 
 runs:
   using: "composite"
   steps:
     - name: Typst Cache path
+      id: cache-typst-path
       run: |
         case $RUNNER_OS in
           "Linux")
@@ -21,13 +32,12 @@ runs:
               exit 1
               ;;
         esac
+        echo "TYPST_CACHE=${TYPST_CACHE}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Cache Typst package folder
-      uses: actions/cache@v4
+      id: cache-typst-restore
+      uses: actions/cache/restore@v4
       with:
         path: ${{ env.TYPST_CACHE }}
-        key: ${{ runner.os }}-typst-1-${{ github.run_id }}
-        restore-keys: |
-          ${{ runner.os }}-typst-1-
-        save-always: true
+        key: ${{ runner.os }}-typst-1

--- a/.github/actions/cache-typst/action.yml
+++ b/.github/actions/cache-typst/action.yml
@@ -2,10 +2,13 @@ name: "Restore any Typst package cache"
 description: "Configures the caching for Typst packages"
 outputs:
   cache-hit:
-    description: "Is there a cache restored ?"
+    description: "Was a cache found with primary key ?"
     value: ${{ steps.cache-typst-restore.outputs.cache-hit }}
-  cache-key:
-    description: "Key of the cache considered"
+  cache-primary-key:
+    description: "Key of the cache to find and save"
+    value: ${{ steps.cache-typst-restore.outputs.cache-primary-key }}
+  cache-matched-key:
+    description: "Key of the cache found and used."
     value: ${{ steps.cache-typst-restore.outputs.cache-primary-key }}
   cache-path:
     description: "where is the packages cache for typst ?"
@@ -41,3 +44,5 @@ runs:
       with:
         path: ${{ env.TYPST_CACHE }}
         key: ${{ runner.os }}-typst-1
+        restore-keys: |
+          ${{ runner.os }}-typst-

--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -294,7 +294,8 @@ jobs:
         if: always()
         uses: actions/cache/save@v4
         with:
-          key: ${{ steps.cache-typst.outputs.cache-key }}
+          key: ${{ steps.cache-typst.outputs.cache-primary-key }}
+          path: ${{ steps.cache-typst.outputs.cache-path }}
 
       - uses: actions/upload-artifact@v4
         # PLaywright test only runs on Linux for now

--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -161,6 +161,7 @@ jobs:
           quarto install tinytex
 
       - name: Cache Typst packages
+        id: cache-typst
         uses: ./.github/actions/cache-typst
 
       - name: Install Chrome
@@ -288,6 +289,12 @@ jobs:
         with:
           name: timed test file
           path: tests/timing-for-ci.txt
+
+      - name: Save Typst cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          key: ${{ steps.cache-typst.outputs.cache-key }}
 
       - uses: actions/upload-artifact@v4
         # PLaywright test only runs on Linux for now


### PR DESCRIPTION
So use restore and save steps correctly

This is needed to remove the deprecation warning we have in CI, and so that it keeps working when it will be removed. 

Follow up on initial PR https://github.com/quarto-dev/quarto-cli/pull/7573
