### PR TITLE
fix(brand): Set `$theme: "brand"` when `brand` is included

### DIFF
--- a/src/core/sass/brand.ts
+++ b/src/core/sass/brand.ts
@@ -567,6 +567,16 @@ export async function brandSassLayers(
   const brand = await project.resolveBrand(fileName);
   const sassLayers: SassLayer[] = [];
 
+  sassLayers.push(
+    {
+      defaults: '$theme: "brand" !default;',
+      uses: "",
+      functions: "",
+      mixins: "",
+      rules: "",
+    }
+  )
+
   if (brand?.data.color) {
     sassLayers.push(brandColorLayer(brand, nameMap));
   }


### PR DESCRIPTION
Fixes #11471

Sets `$theme: "brand" !default` in the brand Sass layers to achieve this desired behavior:

> I think the best we can do is to use the name that the configuration deemed to be "the most important", eg `theme: [brand, cosmo]` gets `$theme: "cosmo"` and `theme: [cosmo, brand]` gets `$theme: "brand"`.

Test with the example in #11471 and use this `_quarto.yml`:

```yml
project:
  type: website

website:
  title: "Brand navbar-bg default"
  navbar:
    left:
      - index.qmd

format:
  html:
    theme: [brand, cosmo]
    # theme: [cosmo, brand]
    # theme: brand
```