### PR TITLE
run - remove --cached-only by default, see #11219

### DIFF
--- a/src/core/run/deno.ts
+++ b/src/core/run/deno.ts
@@ -36,6 +36,11 @@ export const denoRunHandler: RunHandler = {
 
     const importMap = normalize(join(denoDir, "../run_import_map.json"));
 
+    const noNet = Deno.env.get("QUARTO_RUN_NO_NETWORK") === "true";
+
+    // --cached-only can only be used in bundles as vendoring is not done anymore in dev mode
+    const cachedOnly = noNet;
+
     return await execProcess(
       {
         cmd: [
@@ -43,8 +48,7 @@ export const denoRunHandler: RunHandler = {
           "run",
           "--import-map",
           importMap,
-          // --cached-only can only be used in bundles as vendoring is not done anymore in dev mode
-          ...(quartoConfig.isDebug() ? [] : ["--cached-only"]),
+          ...(cachedOnly ? ["--cached-only"] : []),
           "--allow-all",
           "--unstable-kv",
           "--unstable-ffi",


### PR DESCRIPTION
This might allow us to close #11219. We can restore the old behavior when we migrate to Deno 2, where they've presumably fixed the `jsr` + loose range specifier issues.