### PR TITLE
fix: Typo in callout docs (YAML)

### DIFF
--- a/src/resources/editor/tools/attrs.yml
+++ b/src/resources/editor/tools/attrs.yml
@@ -88,7 +88,7 @@
     - value: .callout-note
       doc: "Include additional explanation or context."
     - value: .callout-tip
-      doc: "Provide a productivity tip or other helpful guideance. "
+      doc: "Provide a productivity tip or other helpful guidance. "
     - value: .callout-important
       doc: "Emphasize content that readers should be sure to read."
     - value: .callout-caution


### PR DESCRIPTION
Corrected the spelling of "guideance" to "guidance" in the callout documentation.

Fixes #11504