### PR TITLE
fix writeTextFileSyncPreserveMode() to correctly keep mode from a known file

### DIFF
--- a/src/command/render/pandoc-html.ts
+++ b/src/command/render/pandoc-html.ts
@@ -541,7 +541,7 @@ async function processCssIntoExtras(
       } else {
         const hash = await md5HashBytes(new TextEncoder().encode(cleanedCss));
         newCssPath = temp.createFile({ suffix: `-${hash}.css` });
-        writeTextFileSyncPreserveMode(newCssPath, cleanedCss);
+        writeTextFileSyncPreserveMode(cssPath, newCssPath, cleanedCss);
       }
 
       return {

--- a/src/core/sass.ts
+++ b/src/core/sass.ts
@@ -145,7 +145,7 @@ export async function compileSass(
     '// quarto-scss-analysis-annotation { "origin": null }',
   ].join("\n\n");
 
-  const saveScssPrefix = Deno.env.get("QUARTO_SAVE_SCSS")
+  const saveScssPrefix = Deno.env.get("QUARTO_SAVE_SCSS");
   if (saveScssPrefix) {
     // Save the SCSS before compilation
     const counterValue = counter++;
@@ -430,5 +430,5 @@ export function cleanSourceMappingUrl(cssPath: string): void {
     kSourceMappingRegexes[1],
     "",
   );
-  writeTextFileSyncPreserveMode(cssPath, cleaned.trim());
+  writeTextFileSyncPreserveMode(cssPath, cssPath, cleaned.trim());
 }

--- a/src/core/write.ts
+++ b/src/core/write.ts
@@ -5,7 +5,8 @@
  */
 
 export function writeTextFileSyncPreserveMode(
-  path: string,
+  pathWithModeToPreserve: string,
+  pathToWrite: string,
   data: string,
   options?: Deno.WriteFileOptions | undefined,
 ): void {
@@ -13,7 +14,7 @@ export function writeTextFileSyncPreserveMode(
   // See https://github.com/quarto-dev/quarto-cli/issues/660
   let mode;
   if (Deno.build.os !== "windows") {
-    const stat = Deno.statSync(path);
+    const stat = Deno.statSync(pathWithModeToPreserve);
     if (stat.mode !== null) {
       mode = stat.mode;
     }
@@ -23,5 +24,5 @@ export function writeTextFileSyncPreserveMode(
     options = { ...options, mode }; // Merge provided options with mode
   }
 
-  Deno.writeTextFileSync(path, data, options);
+  Deno.writeTextFileSync(pathToWrite, data, options);
 }

--- a/tests/smoke/render/render-html.test.ts
+++ b/tests/smoke/render/render-html.test.ts
@@ -1,0 +1,38 @@
+/*
+* render-html.test.ts
+*
+* Copyright (C) 2024 Posit Software, PBC
+*
+*/
+
+import { existsSync } from "../../../src/deno_ral/fs.ts";
+
+import { testRender } from "./render.ts";
+import { fileLoader } from "../../utils.ts";
+import { join } from "path";
+import { assert } from "testing/asserts";
+
+const testFile = fileLoader()("test.qmd", "html");
+
+// Simple rendering tests
+testRender(testFile.input, "html", false, [], {
+  teardown: async () => {
+    // Bootstrap files should be in the libs folder
+    const bootstrapPath = join(testFile.output.supportPath, "libs", "bootstrap");
+    assert(existsSync(bootstrapPath), `Expected ${bootstrapPath} to exist`);
+    // Check that the bootstrap files have the correct mode
+    // Related to #660, and #11532
+    const files = Deno.readDirSync(bootstrapPath);
+    for (const file of files) {
+      if (file.name.match(/bootstrap-.*\.min\.css$/)) {
+        const fileInfo = Deno.statSync(join(bootstrapPath, file.name));
+        assert(
+          fileInfo.mode?.toString(8) === "100644", 
+          `Expected file mode 100644, got ${fileInfo.mode?.toString(8)}`
+        );
+      }
+    }
+  },
+});
+
+

--- a/tests/smoke/render/render-html.test.ts
+++ b/tests/smoke/render/render-html.test.ts
@@ -11,6 +11,7 @@ import { testRender } from "./render.ts";
 import { fileLoader } from "../../utils.ts";
 import { join } from "path";
 import { assert } from "testing/asserts";
+import { isWindows } from "../../../src/core/platform.ts";
 
 const testFile = fileLoader()("test.qmd", "html");
 
@@ -22,14 +23,16 @@ testRender(testFile.input, "html", false, [], {
     assert(existsSync(bootstrapPath), `Expected ${bootstrapPath} to exist`);
     // Check that the bootstrap files have the correct mode
     // Related to #660, and #11532
-    const files = Deno.readDirSync(bootstrapPath);
-    for (const file of files) {
-      if (file.name.match(/bootstrap-.*\.min\.css$/)) {
-        const fileInfo = Deno.statSync(join(bootstrapPath, file.name));
-        assert(
-          fileInfo.mode?.toString(8) === "100644", 
-          `Expected file mode 100644, got ${fileInfo.mode?.toString(8)}`
-        );
+    if (!isWindows()) {
+      const files = Deno.readDirSync(bootstrapPath);
+      for (const file of files) {
+        if (file.name.match(/bootstrap-.*\.min\.css$/)) {
+          const fileInfo = Deno.statSync(join(bootstrapPath, file.name));
+          assert(
+            fileInfo.mode?.toString(8) === "100644", 
+            `Expected file mode 100644, got ${fileInfo.mode?.toString(8)}`
+          );
+        }
       }
     }
   },

--- a/tests/smoke/render/render.ts
+++ b/tests/smoke/render/render.ts
@@ -16,7 +16,7 @@ import {
 } from "../../verify.ts";
 import { safeRemoveSync } from "../../../src/core/path.ts";
 import { safeExistsSync } from "../../../src/core/path.ts";
-import { assert } from "../../../src/vendor/deno.land/std@0.217.0/assert/assert.ts";
+import { assert } from "testing/asserts";
 
 export function testSimpleIsolatedRender(
   file: string,


### PR DESCRIPTION
This fixes #11532 regression from 1.6 due to #10657 which reverted back to #660

`writeTextFileSyncPreserveMode()` now correctly takes two arguments
- Path with mode to preserve
- Path to write content too

The path could be the same. And this is what it was supposed to be from refactoring in #10657. 