### PR TITLE
configure create themes to have less precedence than brand

### DIFF
--- a/src/resources/projects/book/templates/_quarto.ejs.yml
+++ b/src/resources/projects/book/templates/_quarto.ejs.yml
@@ -15,7 +15,9 @@ bibliography: references.bib
 
 format:
   html:
-    theme: cosmo
+    theme:
+      - cosmo
+      - brand
   pdf:
     documentclass: scrreprt
 

--- a/src/resources/projects/website/templates/_quarto.ejs.yml
+++ b/src/resources/projects/website/templates/_quarto.ejs.yml
@@ -11,7 +11,9 @@ website:
 
 format:
   html:
-    theme: cosmo
+    theme:
+      - cosmo
+      - brand
     css: styles.css
     toc: true
 

--- a/src/resources/projects/website/templates/blog/_quarto-blog.ejs.yml
+++ b/src/resources/projects/website/templates/blog/_quarto-blog.ejs.yml
@@ -12,7 +12,9 @@ website:
         href: https://twitter.com
 format:
   html:
-    theme: cosmo
+    theme:
+      - cosmo
+      - brand
     css: styles.css
 
 <% if(editor){ %>editor: <%= editor %><% } %>


### PR DESCRIPTION
This is something we should have done for 1.6, so that adding a `_brand.yml` file in projects created by `quarto create project` behaves more intuitively.