### PR TITLE
fix(layout-typst): Use fraction type for width to prevent overflow

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -4,3 +4,7 @@ All changes included in 1.7:
 
 - ([#11532](https://github.com/quarto-dev/quarto-cli/issues/11532)): Fix regression for [#660](https://github.com/quarto-dev/quarto-cli/issues/660), which causes files to have incorrect permissions when Quarto is installed in a location not writable by the current user.
 - ([#11509](https://github.com/quarto-dev/quarto-cli/issues/11509)): Fix link-decoration regression in HTML formats.
+
+## `typst` Format
+
+- ([#11578](https://github.com/quarto-dev/quarto-cli/issues/11578): Use fraction type for width to prevent overflow in layout.

--- a/src/resources/filters/layout/typst.lua
+++ b/src/resources/filters/layout/typst.lua
@@ -50,7 +50,11 @@ local function render_floatless_typst_layout(panel)
     -- synthesize column spec from row
     local col_spec = {}
     for j, col in ipairs(row) do
-      table.insert(col_spec, col.attributes["width"])
+      local width = col.attributes["width"]
+      if width:sub(-1) == "%" then
+        width = width:sub(1, -2) .. "fr"
+      end
+      table.insert(col_spec, width)
     end
     -- TODO allow configurable gutter
     local col_spec_str = "columns: (" .. table.concat(col_spec, ", ") .. "), gutter: 1em, rows: 1,"

--- a/tests/docs/smoke-all/typst/layout.qmd
+++ b/tests/docs/smoke-all/typst/layout.qmd
@@ -1,0 +1,30 @@
+---
+title: "Fraction layout"
+format:
+  typst:
+    keep-typ: true
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          ['#grid\((\r\n?|\n)columns: \(9.1fr, 18.2fr, 18.2fr, 9.1fr, 27.3fr, 9.1fr, 9.1fr\), gutter: 1em, rows: 1,']
+---
+
+::: {layout="[1, 2, 2, 1, 3, 1, 1]"}
+
+![Placeholder]({{< placeholder 200 >}})
+
+![Placeholder]({{< placeholder 200 >}})
+
+![Placeholder]({{< placeholder 200 >}})
+
+![Placeholder]({{< placeholder 200 >}})
+
+![Placeholder]({{< placeholder 200 >}})
+
+![Placeholder]({{< placeholder 200 >}})
+
+![Placeholder]({{< placeholder 200 >}})
+
+:::


### PR DESCRIPTION
Switch from using percentage to fraction type for column widths to avoid overflow issues in Typst.

Fixes #11578

<table>
<tr><th>Input</th><th>1.6.39</th><th>This PR</th></tr>
<tr><td>

````qmd
---
title: "Quarto Playground"
format: typst
---

::: {layout="[1, 2, 2, 1, 3, 1, 1]"}

![]({{< placeholder format=svg >}})

![]({{< placeholder format=svg >}})

![]({{< placeholder format=svg >}})

![]({{< placeholder format=svg >}})

![]({{< placeholder format=svg >}})

![]({{< placeholder format=svg >}})

![]({{< placeholder format=svg >}})
:::

````

</td><td>

<img width="701" alt="image" src="https://github.com/user-attachments/assets/60cdc316-1af6-423b-a21c-bba5fd36630d">

</td><td>

<img width="705" alt="image" src="https://github.com/user-attachments/assets/ee6aa9d9-f9d5-4b6d-9b2c-c35d9fd01e91">

</td></tr>

</table>