### PR TITLE
Re-enable change to markdown highlighting from previous quarto version

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -17,3 +17,7 @@ All changes included in 1.7:
   This also provides a new public function `quarto.utils.is_empty_node`
   that allows to check whether a node is empty, i.e., whether it's an
   empty list, has no child nodes, and contains no text.
+
+## Other Fixes and Improvements
+
+- ([#11643](https://github.com/quarto-dev/quarto-cli/issues/11643)): Improve highlighting of nested code block inside markdown code block, i.e. using ` ```{{python}} ` or ` ```python ` inside ` ````markdown` fenced code block.

--- a/src/resources/pandoc/syntax-definitions/markdown.xml
+++ b/src/resources/pandoc/syntax-definitions/markdown.xml
@@ -22,6 +22,11 @@
           Example: **bold text and _italic and bold text_**
                    __bold and ~~strikeout and bold~~__
 -->
+<!--
+    Quarto specific adaptations to keep upon updates:
+      - Support for ```{language} code block syntax, specific to quarto computation code blocks
+      - Add explicit support for language julia and dot in code blocks as they are available in skylighting
+-->
 <!DOCTYPE language
 [
 <!-- NOTE: To correctly detect bold, italic or strike out text, use minimal="true" in RegExpr rules -->

--- a/src/resources/pandoc/syntax-definitions/markdown.xml
+++ b/src/resources/pandoc/syntax-definitions/markdown.xml
@@ -358,11 +358,12 @@
         <RegExpr attribute="Fenced Code" context="#pop!javascript-code" String="&fcode;\s*\{?\.?(?:javascript|[mo]?js|es6|kwinscript|julius).*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!jsx-code" String="&fcode;\s*\{?\.?(?:jsx|tsx|(?:java|type)script\-react).*&end;" insensitive="true" beginRegion="code-block"/> <!-- Included in the HTML definition. Also apply for TSX. -->
         <RegExpr attribute="Fenced Code" context="#pop!json-code" String="&fcode;\s*\{?\.?(?:json5?|gltf).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!julia-code" String="&fcode;\s*\{?\.?(?:julia|jl).*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!yaml-code" String="&fcode;\s*\{?\.?(?:ya?ml).*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!matlab-code" String="&fcode;\s*\{?\.?matlab.*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!markdown-code" String="&fcode;\s*\{?\.?(?:markdown|m?md).*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!mustache-code" String="&fcode;\s*\{?\.?(?:handlebars|hbs|mustache|mst|ractive|hogan|hulk).*&end;" insensitive="true" beginRegion="code-block"/> <!-- Included in the HTML definition -->
-        <RegExpr attribute="Fenced Code" context="#pop!perl-code" String="&fcode;\s*\{?\.?(?:julia|mermaid|dot|perl|p[lm]|pod|psgi|vcl).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!perl-code" String="&fcode;\s*\{?\.?(?:mermaid|dot|perl|p[lm]|pod|psgi|vcl).*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!php-code" String="&fcode;\s*\{?\.?(?:php[3457t]?|wml|phtml?|aw|ctp).*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!python-code" String="&fcode;\s*\{?\.?(?:python[23]?|py[23w]?|[rc]py|sconstruct|gypi?).*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!qml-code" String="&fcode;\s*\{?\.?qml(?:types)?.*&end;" insensitive="true" beginRegion="code-block"/>
@@ -446,6 +447,10 @@
       <context attribute="Normal Text" lineEndContext="#stay" name="json-code">
         <IncludeRules context="code"/>
         <IncludeRules context="##JSON" includeAttrib="true"/>
+      </context>
+      <context attribute="Normal Text" lineEndContext="#stay" name="julia-code">
+        <IncludeRules context="code"/>
+        <IncludeRules context="##Julia" includeAttrib="true"/>
       </context>
       <context attribute="Normal Text" lineEndContext="#stay" name="yaml-code">
         <IncludeRules context="code"/>

--- a/src/resources/pandoc/syntax-definitions/markdown.xml
+++ b/src/resources/pandoc/syntax-definitions/markdown.xml
@@ -349,6 +349,7 @@
         <RegExpr attribute="Fenced Code" context="#pop!css-code" String="&fcode;\s*\{?\.?css.*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!c-code" String="&fcode;\s*\{?\.?[ch].*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!doxygen-code" String="&fcode;\s*\{?\.?doxygen.*&end;" insensitive="true" beginRegion="code-block"/> <!-- Block comment of Doxygen -->
+        <RegExpr attribute="Fenced Code" context="#pop!dot-code" String="&fcode;\s*\{?\.?dot.*&end;" insensitive="true" beginRegion="code-block"/> <!-- Block comment of Doxygen -->
         <RegExpr attribute="Fenced Code" context="#pop!email-code" String="&fcode;\s*\{?\.?(?:email|emlx?|mbo?x).*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!go-code" String="&fcode;\s*\{?\.?go(?:lang)?.*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!hamlet-code" String="&fcode;\s*\{?\.?[wxs]?hamlet.*&end;" insensitive="true" beginRegion="code-block"/> <!-- Included in the Haskell definition -->
@@ -363,7 +364,7 @@
         <RegExpr attribute="Fenced Code" context="#pop!matlab-code" String="&fcode;\s*\{?\.?matlab.*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!markdown-code" String="&fcode;\s*\{?\.?(?:markdown|m?md).*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!mustache-code" String="&fcode;\s*\{?\.?(?:handlebars|hbs|mustache|mst|ractive|hogan|hulk).*&end;" insensitive="true" beginRegion="code-block"/> <!-- Included in the HTML definition -->
-        <RegExpr attribute="Fenced Code" context="#pop!perl-code" String="&fcode;\s*\{?\.?(?:mermaid|dot|perl|p[lm]|pod|psgi|vcl).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!perl-code" String="&fcode;\s*\{?\.?(?:mermaid|perl|p[lm]|pod|psgi|vcl).*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!php-code" String="&fcode;\s*\{?\.?(?:php[3457t]?|wml|phtml?|aw|ctp).*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!python-code" String="&fcode;\s*\{?\.?(?:python[23]?|py[23w]?|[rc]py|sconstruct|gypi?).*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!qml-code" String="&fcode;\s*\{?\.?qml(?:types)?.*&end;" insensitive="true" beginRegion="code-block"/>
@@ -411,6 +412,10 @@
       <context attribute="Normal Text" lineEndContext="#stay" name="doxygen-code">
         <IncludeRules context="code"/>
         <IncludeRules context="BlockComment##Doxygen" includeAttrib="true"/>
+      </context>
+      <context attribute="Normal Text" lineEndContext="#stay" name="dot-code">
+        <IncludeRules context="code"/>
+        <IncludeRules context="##dot" includeAttrib="true"/>
       </context>
       <context attribute="Normal Text" lineEndContext="#stay" name="email-code">
         <IncludeRules context="code"/>

--- a/src/resources/pandoc/syntax-definitions/markdown.xml
+++ b/src/resources/pandoc/syntax-definitions/markdown.xml
@@ -72,6 +72,10 @@
 <!ENTITY linebreakregex "  $">
 <!-- strikethrough text, pandoc style -->
 <!ENTITY strikeoutregex "[~]{2}[^~](?:.*[^~])?[~]{2}">
+<!-- highlight text -->
+<!ENTITY highlightregex "[=]{2}[^=](?:.*[^=])?[=]{2}">
+<!-- emoji -->
+<!ENTITY emojiregex ":([-+]1|\w+):">
 <!-- start of fenced code block -->
 <!ENTITY fcode "(`{3,}|~{3,})">
 <!-- end of line & empty line -->
@@ -88,15 +92,9 @@
 <!ENTITY startcomment "&lt;!--">
 <!ENTITY endcomment "--&gt;">
 <!ENTITY checkbox "\[[ x]\](?=\s)">
-
-<!-- html stuff -->
-	<!ENTITY name          "[A-Za-z_:][\w.:_-]*">
-	<!ENTITY attributeName "[A-Za-z_:*#\(\[][\)\]\w.:_-]*">
-	<!ENTITY entref        "&amp;(?:#[0-9]+|#[xX][0-9A-Fa-f]+|&name;);">
-
 ]>
 
-<language name="Markdown" version="27" kateversion="5.79" section="Markup" extensions="*.md;*.mmd;*.markdown" mimetype="text/markdown" priority="15" author="Darrin Yeager, Claes Holmerson" license="GPL,BSD">
+<language name="Markdown" version="30" kateversion="5.79" section="Markup" extensions="*.md;*.mmd;*.markdown;*.md.html" mimetype="text/markdown" priority="15" author="Darrin Yeager, Claes Holmerson" license="GPL,BSD">
   <highlighting>
     <contexts>
       <!-- Start of the Markdown document: find metadata or code block -->
@@ -143,15 +141,28 @@
         <DetectChar context="find-strong-normal" char="*" lookAhead="true"/>
         <DetectChar context="find-emphasis-normal" char="_" lookAhead="true"/>
         <RegExpr attribute="Strikethrough Text" minimal="true" String="&strikeoutregex;"/>
+        <RegExpr attribute="Highlight Text" minimal="true" String="&highlightregex;"/>
         <!-- Common -->
         <IncludeRules context="inc"/>
         <RegExpr attribute="Normal Text: Link" String="&implicitlink;"/>
+        <!-- Table -->
+        <DetectChar attribute="Table" char="|" context="table" firstNonSpace="true" lookAhead="1"/>
       </context>
       <!-- Find indented code blocks. These are only allowed after an empty line or on the first line -->
       <context name="find-code-block" attribute="Normal Text" lineEndContext="#stay" lineEmptyContext="#stay" fallthroughContext="#pop">
         <RegExpr attribute="Code" String="^&indentedcodeblock;" column="0"/>
         <RegExpr attribute="Normal Text" String="&end;" />
         <RegExpr attribute="Comment" context="comment" String="^\s*&startcomment;|\s*&startcomment;(?=.*&endcomment;)" beginRegion="comment"/>
+      </context>
+
+      <!-- Table in Normal Text Document -->
+      <context name="table" attribute="Normal Text" lineEndContext="#pop" lineEmptyContext="#pop!find-code-block">
+        <IncludeRules context="find-table-element"/>
+        <IncludeRules context="Normal Text"/>
+      </context>
+
+      <context name="find-table-element" attribute="Normal Text" lineEndContext="#pop">
+        <RegExpr attribute="Table" String="(\|(\s*:?---+:?)?)++"/>
       </context>
 
       <context name="find-header" attribute="Normal Text" lineEndContext="#pop">
@@ -213,6 +224,7 @@
         <RegExpr attribute="Normal Text" context="#pop!find-code-block" String="&emptyline;" column="0"/>
         <StringDetect attribute="Comment" context="#pop!find-code-block" String="&startcomment;" column="0" lookAhead="true"/>
         <IncludeRules context="default-blockquote-2"/>
+        <IncludeRules context="find-table-element"/>
       </context>
       <!-- Blockquote within a list -->
       <context name="blockquote-list" attribute="Blockquote: Normal Text" lineEndContext="#stay" lineEmptyContext="#pop">
@@ -232,6 +244,7 @@
         <!-- Strong, emphasis, strong-emphasis and strikethrough text -->
         <AnyChar context="find-strong-emphasis-blockquote" String="*_" lookAhead="true"/>
         <RegExpr attribute="Blockquote: Strikethrough Text" minimal="true" String="&strikeoutregex;"/>
+        <RegExpr attribute="Blockquote: Highlight Text" minimal="true" String="&highlightregex;"/>
         <!-- Common -->
         <IncludeRules context="inc"/>
         <RegExpr attribute="Blockquote: Link" String="&implicitlink;"/>
@@ -260,6 +273,8 @@
         <RegExpr context="#pop" String="^\s*\S" column="0" lookAhead="true"/>
         <!-- Highlight checkbox at the start of the item (task list) -->
         <RegExpr attribute="List: Checkbox" context="content-list" String="\s*&checkbox;"/>
+        <!-- Highlight checkbox at the start of the item (task list) -->
+        <RegExpr attribute="Table" context="content-list-table" String="\s*\|"/>
       </context>
       <!-- 1. numlist (one digit) -->
       <context name="numlist" attribute="List: Normal Text" lineEndContext="#stay" fallthroughContext="content-list">
@@ -290,13 +305,14 @@
            to check the indentation of the text and determine if the content of the list ends. -->
       <context name="content-list" attribute="List: Normal Text" lineEndContext="#stay" lineEmptyContext="#pop">
         <RegExpr context="#pop" String="&emptyline;" column="0"/>
-        <!-- Blockquote and horzontal rule (check indentation) -->
+        <!-- Blockquote and horizontal rule (check indentation) -->
         <RegExpr context="#pop" String="^\s*(?:&gt;|&rulerregex;)" column="0" lookAhead="true"/>
         <!-- End with header or new list/numlist -->
         <RegExpr context="#pop#pop" String="^(?:\s*(?:&listbullet;|[\d]+\.)\s|#{1,6}\s)" column="0" lookAhead="true"/>
         <!-- Strong, emphasis, strong-emphasis and strikethrough text -->
         <AnyChar context="find-strong-emphasis-list" String="*_" lookAhead="true"/>
         <RegExpr attribute="List: Strikethrough Text" minimal="true" String="&strikeoutregex;"/>
+        <RegExpr attribute="List: Highlight Text" minimal="true" String="&highlightregex;"/>
         <!-- Common -->
         <IncludeRules context="inc"/>
         <RegExpr attribute="List: Link" String="&implicitlink;"/>
@@ -307,6 +323,12 @@
         <RegExpr attribute="List: Strong-Emphasis Text" context="#pop" minimal="true" String="&strongemphasisregex_ast;|&strongemphasisregex_und;"/>
         <RegExpr attribute="List: Emphasis Text" context="#pop" minimal="true" String="&emphasisregex_ast;|&emphasisregex_und;"/>
         <AnyChar attribute="List: Normal Text" context="#pop" String="*_"/>
+      </context>
+
+      <!-- Table in List -->
+      <context name="content-list-table" attribute="List: Normal Text" lineEndContext="#stay" lineEmptyContext="#pop">
+        <IncludeRules context="find-table-element"/>
+        <IncludeRules context="content-list"/>
       </context>
 
       <!-- Comments -->
@@ -345,7 +367,6 @@
         <RegExpr attribute="Fenced Code" context="#pop!python-code" String="&fcode;\s*\{?\.?(?:python[23]?|py[23w]?|[rc]py|sconstruct|gypi?).*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!qml-code" String="&fcode;\s*\{?\.?qml(?:types)?.*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!r-code" String="&fcode;\s*\{?\.?(?:r|rprofile|rscript).*&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!raku-code" String="&fcode;\s*\{?\.?(?:raku(?:mod|doc|test)?|perl6|p[lm]?6|pod6|nqp).*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!rest-code" String="&fcode;\s*\{?\.?(?:rst|rest|restructuredtext).*&end;" insensitive="true" beginRegion="code-block"/> <!-- Included in the CMake definition -->
         <RegExpr attribute="Fenced Code" context="#pop!ruby-code" String="&fcode;\s*\{?\.?(?:ruby|rbx?|rjs|rake|f?cgi|gemspec|irbrc|ru|prawn|Appraisals|(?:Rake|Cap|Chef|Gem|Guard|Hobo|Vagrant||Rant|Berks|Thor|Puppet)file|rxml|(?:xml|js)\.erb).*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!rust-code" String="&fcode;\s*\{?\.?(?:rust|rs).*&end;" insensitive="true" beginRegion="code-block"/>
@@ -462,7 +483,7 @@
         <IncludeRules context="code"/>
         <IncludeRules context="##R Script" includeAttrib="true"/>
       </context>
-      <context attribute="Normal Text" lineEndContext="#stay" name="raku-code">
+      <context attribute="Normal Text" lineEndContext="#stay" name="raku-code" fallthroughContext="term##Raku">
         <IncludeRules context="code"/>
         <IncludeRules context="base##Raku" includeAttrib="true"/>
       </context>
@@ -511,6 +532,8 @@
         <RegExpr attribute="Reference Image" String="&refimageregex;"/>
         <RegExpr attribute="Auto-Link" context="autolink" String="&autolinkregex;" lookAhead="true"/>
         <RegExpr attribute="Mailto-Link" context="mailtolink" String="&mailtolinkregex;"/>
+        <!-- Emoji -->
+        <RegExpr attribute="Emoji" String="&emojiregex;"/>
         <!-- Line Break -->
         <RegExpr attribute="Line Break" minimal="true" String="&linebreakregex;"/>
         <!-- Backslash Escapes -->
@@ -529,6 +552,7 @@
         <Detect2Chars attribute="Backslash Escape" char="\" char1="-"/>
         <Detect2Chars attribute="Backslash Escape" char="\" char1="."/>
         <Detect2Chars attribute="Backslash Escape" char="\" char1="!"/>
+        <Detect2Chars attribute="Backslash Escape" char="\" char1="|"/>
         <Detect2Chars attribute="Backslash Escape" char="\" char1="&lt;"/>
         <Detect2Chars attribute="Backslash Escape" char="\" char1="&gt;"/>
         <Detect2Chars attribute="Backslash Escape" char="\" char1="&amp;"/>
@@ -537,7 +561,7 @@
         <RegExpr context="find-html-block" String="&lt;/?&htmlname;(?:[\s&gt;]|/&gt;|$)" lookAhead="true"/>
       </context>
       <context name="find-html-block" attribute="Normal Text" lineEndContext="#pop" fallthroughContext="#pop">
-        <IncludeRules context="FindElements"/>
+        <IncludeRules context="FindElements##HTML"/>
       </context>
 
       <!-- Links and email: <https://example.com>, <example@kde.org> -->
@@ -604,302 +628,6 @@
         <Detect2Chars attribute="Inline Image" char="\" char1=")"/>
         <RegExpr attribute="Inline Image: Link" String="\b&startlink;(?:\\.|[^&quot;&gt;\s\)\\])+"/>
       </context>
-
-  <context name="FindHTML" attribute="Normal Text" lineEndContext="#stay">
-    <DetectSpaces/>
-    <DetectIdentifier/>
-    <StringDetect attribute="Comment" context="Comment" String="&lt;!--" beginRegion="comment" />
-    <StringDetect attribute="CDATA" context="CDATA" String="&lt;![CDATA[" beginRegion="cdata" />
-    <RegExpr attribute="Doctype" context="Doctype" String="&lt;!DOCTYPE\s+" insensitive="true" beginRegion="doctype" />
-    <IncludeRules context="FindElements" />
-    <RegExpr attribute="Processing Instruction" context="PI" String="&lt;\?[\w:-]*" beginRegion="pi" />
-
-    <!-- as long as kde gives DTDs the text/html mimetype--><IncludeRules context="FindDTDRules" />
-    <IncludeRules context="FindEntityRefs" />
-  </context>
-
-  <context name="FindElements" attribute="Other Text" lineEndContext="#pop">
-    <RegExpr attribute="Element Symbols" context="ElementTagName" String="&lt;(?=(&name;))" />
-    <RegExpr attribute="Element Symbols" context="ElementTagNameClose" String="&lt;/(?=(&name;))" />
-  </context>
-
-  <context name="ElementTagName" attribute="Other Text" lineEndContext="#pop">
-    <IncludeRules context="FindHTMLTags" />
-    <IncludeRules context="FindSpecialHTMLTags" />
-    <StringDetect attribute="Element" context="#pop!El Open" String="%1" dynamic="true" />
-  </context>
-
-  <context name="ElementTagNameClose" attribute="Other Text" lineEndContext="#pop">
-    <IncludeRules context="FindHTMLTagsClose" />
-    <StringDetect attribute="Element" context="#pop!El Close" String="%1" dynamic="true" />
-  </context>
-
-  <!-- This allows you to insert HTML tags in other syntax definitions -->
-  <context name="FindSpecialHTMLTags" attribute="Normal Text" lineEndContext="#stay">
-    <WordDetect attribute="Element" context="#pop!CSS" String="style" insensitive="true" beginRegion="style" />
-    <WordDetect attribute="Element" context="#pop!JS" String="script" insensitive="true" beginRegion="script" />
-  </context>
-
-  <context name="FindHTMLTags" attribute="Normal Text" lineEndContext="#stay">
-    <WordDetect attribute="Element" context="#pop!El Open" String="pre" insensitive="true" beginRegion="pre" />
-    <WordDetect attribute="Element" context="#pop!El Open" String="div" insensitive="true" beginRegion="div" />
-    <WordDetect attribute="Element" context="#pop!El Open" String="table" insensitive="true" beginRegion="table" />
-    <WordDetect attribute="Element" context="#pop!El Open" String="ul" insensitive="true" beginRegion="ul" />
-    <WordDetect attribute="Element" context="#pop!El Open" String="ol" insensitive="true" beginRegion="ol" />
-    <WordDetect attribute="Element" context="#pop!El Open" String="dl" insensitive="true" beginRegion="dl" />
-    <WordDetect attribute="Element" context="#pop!El Open" String="article" insensitive="true" beginRegion="article" />
-    <WordDetect attribute="Element" context="#pop!El Open" String="aside" insensitive="true" beginRegion="aside" />
-    <WordDetect attribute="Element" context="#pop!El Open" String="details" insensitive="true" beginRegion="details" />
-    <WordDetect attribute="Element" context="#pop!El Open" String="figure" insensitive="true" beginRegion="figure" />
-    <WordDetect attribute="Element" context="#pop!El Open" String="footer" insensitive="true" beginRegion="footer" />
-    <WordDetect attribute="Element" context="#pop!El Open" String="header" insensitive="true" beginRegion="header" />
-    <WordDetect attribute="Element" context="#pop!El Open" String="main" insensitive="true" beginRegion="main" />
-    <WordDetect attribute="Element" context="#pop!El Open" String="nav" insensitive="true" beginRegion="nav" />
-    <WordDetect attribute="Element" context="#pop!El Open" String="section" insensitive="true" beginRegion="section" />
-  </context>
-
-  <context name="FindHTMLTagsClose" attribute="Normal Text" lineEndContext="#stay">
-    <WordDetect attribute="Element" context="#pop!El Close" String="pre" insensitive="true" endRegion="pre" />
-    <WordDetect attribute="Element" context="#pop!El Close" String="div" insensitive="true" endRegion="div" />
-    <WordDetect attribute="Element" context="#pop!El Close" String="table" insensitive="true" endRegion="table" />
-    <WordDetect attribute="Element" context="#pop!El Close" String="ul" insensitive="true" endRegion="ul" />
-    <WordDetect attribute="Element" context="#pop!El Close" String="ol" insensitive="true" endRegion="ol" />
-    <WordDetect attribute="Element" context="#pop!El Close" String="dl" insensitive="true" endRegion="dl" />
-    <WordDetect attribute="Element" context="#pop!El Close" String="article" insensitive="true" endRegion="article" />
-    <WordDetect attribute="Element" context="#pop!El Close" String="aside" insensitive="true" endRegion="aside" />
-    <WordDetect attribute="Element" context="#pop!El Close" String="details" insensitive="true" endRegion="details" />
-    <WordDetect attribute="Element" context="#pop!El Close" String="figure" insensitive="true" endRegion="figure" />
-    <WordDetect attribute="Element" context="#pop!El Close" String="footer" insensitive="true" endRegion="footer" />
-    <WordDetect attribute="Element" context="#pop!El Close" String="header" insensitive="true" endRegion="header" />
-    <WordDetect attribute="Element" context="#pop!El Close" String="main" insensitive="true" endRegion="main" />
-    <WordDetect attribute="Element" context="#pop!El Close" String="nav" insensitive="true" endRegion="nav" />
-    <WordDetect attribute="Element" context="#pop!El Close" String="section" insensitive="true" endRegion="section" />
-  </context>
-
-  <context name="FindEntityRefs" attribute="Other Text" lineEndContext="#stay">
-    <RegExpr attribute="EntityRef" context="#stay" String="&entref;" />
-    <AnyChar attribute="Error" context="#stay" String="&amp;&lt;" />
-  </context>
-
-  <context name="FindPEntityRefs" attribute="Other Text" lineEndContext="#stay">
-    <RegExpr attribute="EntityRef" context="#stay" String="&entref;" />
-    <RegExpr attribute="PEntityRef" context="#stay" String="%&name;;" />
-    <AnyChar attribute="Error" context="#stay" String="&amp;%" />
-  </context>
-
-  <context name="FindAttributes" attribute="Other Text" lineEndContext="#stay">
-    <RegExpr attribute="Attribute" context="#stay" String="^&attributeName;|\s+&attributeName;" />
-    <DetectChar attribute="Attribute Separator" context="Value" char="=" />
-  </context>
-
-  <context name="FindDTDRules" attribute="Other Text" lineEndContext="#stay">
-    <RegExpr attribute="Doctype" context="Doctype Markupdecl" String="&lt;!(?:ELEMENT|ENTITY|ATTLIST|NOTATION)\b" />
-  </context>
-
-
-  <context name="Comment" attribute="Comment" lineEndContext="#stay">
-    <DetectSpaces/>
-    <StringDetect attribute="Comment" context="#pop" String="--&gt;" endRegion="comment" />
-    <IncludeRules context="##Comments" />
-    <DetectIdentifier/>
-    <RegExpr attribute="Error" context="#stay" String="-(?:-(?!-&gt;))+" />
-  </context>
-
-  <context name="CDATA" attribute="Other Text" lineEndContext="#stay">
-    <DetectSpaces/>
-    <DetectIdentifier/>
-    <StringDetect attribute="CDATA" context="#pop" String="]]&gt;" endRegion="cdata" />
-    <StringDetect attribute="EntityRef" context="#stay" String="]]&amp;gt;" />
-  </context>
-
-  <context name="PI" attribute="Other Text" lineEndContext="#stay">
-    <Detect2Chars attribute="Processing Instruction" context="#pop" char="?" char1="&gt;" endRegion="pi" />
-  </context>
-
-  <context name="Doctype" attribute="Other Text" lineEndContext="#stay">
-    <DetectChar attribute="Doctype" context="#pop" char="&gt;" endRegion="doctype" />
-    <DetectChar attribute="Doctype" context="Doctype Internal Subset" char="[" beginRegion="int_subset" />
-  </context>
-
-  <context name="Doctype Internal Subset" attribute="Other Text" lineEndContext="#stay">
-    <DetectChar attribute="Doctype" context="#pop" char="]" endRegion="int_subset" />
-    <IncludeRules context="FindDTDRules" />
-    <StringDetect attribute="Comment" context="Comment" String="&lt;!--" beginRegion="comment" />
-    <RegExpr attribute="Processing Instruction" context="PI" String="&lt;\?[\w:-]*" beginRegion="pi" />
-    <IncludeRules context="FindPEntityRefs" />
-  </context>
-
-  <context name="Doctype Markupdecl" attribute="Other Text" lineEndContext="#stay">
-    <DetectChar attribute="Doctype" context="#pop" char="&gt;" />
-    <DetectChar attribute="Value" context="Doctype Markupdecl DQ" char="&quot;" />
-    <DetectChar attribute="Value" context="Doctype Markupdecl SQ" char="&apos;" />
-  </context>
-
-  <context name="Doctype Markupdecl DQ" attribute="Value" lineEndContext="#stay">
-    <DetectChar attribute="Value" context="#pop" char="&quot;" />
-    <IncludeRules context="FindPEntityRefs" />
-  </context>
-
-  <context name="Doctype Markupdecl SQ" attribute="Value" lineEndContext="#stay">
-    <DetectChar attribute="Value" context="#pop" char="&apos;" />
-    <IncludeRules context="FindPEntityRefs" />
-  </context>
-
-  <context name="El Open" attribute="Other Text" lineEndContext="#stay">
-    <Detect2Chars attribute="Element Symbols" context="#pop" char="/" char1="&gt;" />
-    <DetectChar attribute="Element Symbols" context="#pop" char="&gt;" />
-    <IncludeRules context="FindAttributes" />
-    <RegExpr attribute="Error" context="#stay" String="\S" />
-  </context>
-
-  <context name="El Close" attribute="Other Text" lineEndContext="#stay">
-    <DetectChar attribute="Element Symbols" context="#pop" char="&gt;" />
-    <RegExpr attribute="Error" context="#stay" String="\S" />
-  </context>
-
-  <context name="CSS" attribute="Other Text" lineEndContext="#stay">
-    <Detect2Chars attribute="Element Symbols" context="#pop" char="/" char1="&gt;" endRegion="style" />
-    <DetectChar attribute="Element Symbols" context="CSS content" char="&gt;" />
-    <IncludeRules context="FindAttributes" />
-    <RegExpr attribute="Error" context="#stay" String="\S" />
-  </context>
-
-  <context name="CSS content" attribute="Other Text" lineEndContext="#stay">
-    <RegExpr attribute="Element Symbols" context="CSS content Close" String="&lt;/(?=style\b)" insensitive="true" />
-    <IncludeRules context="##CSS" includeAttrib="true"/>
-  </context>
-  <context name="CSS content Close" attribute="Other Text" lineEndContext="#stay">
-    <DetectIdentifier attribute="Element" context="#pop#pop#pop!El Close" endRegion="style" />
-  </context>
-
-  <context name="JS" attribute="Other Text" lineEndContext="#stay">
-    <RegExpr attribute="Attribute" context="Script-Type" String="(?:\s+|^)type(?=\=|\s|$)" insensitive="true"/>
-    <DetectChar attribute="Element Symbols" context="JS content" char="&gt;" />
-    <IncludeRules context="DefaultJS" />
-  </context>
-  <context name="DefaultJS" attribute="Other Text" lineEndContext="#stay">
-    <Detect2Chars attribute="Element Symbols" context="#pop" char="/" char1="&gt;" endRegion="script" />
-    <IncludeRules context="FindAttributes" />
-    <RegExpr attribute="Error" context="#stay" String="\S" />
-  </context>
-
-  <context name="JS content" attribute="Other Text" lineEndContext="#stay">
-    <IncludeRules context="Default JS content"/>
-    <IncludeRules context="Normal##JavaScript" includeAttrib="true"/>
-  </context>
-  <context name="Default JS content" attribute="Other Text" lineEndContext="#stay">
-    <IncludeRules context="FindScriptTagClose" />
-    <RegExpr attribute="Comment" context="JS comment close" String="//(?=.*&lt;/script\b)" insensitive="true" />
-  </context>
-
-  <context name="FindScriptTagClose" attribute="Other Text" lineEndContext="#stay">
-    <RegExpr attribute="Element Symbols" context="ScriptTagClose" String="&lt;/(?=script\b)" insensitive="true" />
-  </context>
-  <context name="ScriptTagClose" attribute="Other Text" lineEndContext="#stay">
-    <DetectIdentifier attribute="Element" context="#pop#pop#pop!El Close" endRegion="script" />
-  </context>
-
-  <context name="JS comment close" attribute="Comment" lineEndContext="#pop">
-    <RegExpr attribute="Element Symbols" context="#pop!ScriptTagClose" String="&lt;/(?=script\b)" insensitive="true" />
-    <DetectSpaces />
-    <IncludeRules context="##Comments" />
-  </context>
-
-  <context name="Value" attribute="Other Text" lineEndContext="#stay" fallthrough="true" fallthroughContext="Value NQ">
-    <DetectChar attribute="Value" context="Value DQ" char="&quot;" />
-    <DetectChar attribute="Value" context="Value SQ" char="&apos;" />
-    <DetectSpaces />
-  </context>
-
-  <context name="Value NQ" attribute="Other Text" lineEndContext="#pop#pop" fallthrough="true" fallthroughContext="#pop#pop">
-    <IncludeRules context="FindEntityRefs" />
-    <RegExpr attribute="Value" context="#stay" String="/(?!&gt;)|[^/&gt;&lt;&quot;&apos;\s]" />
-  </context>
-
-  <context name="Value DQ" attribute="Value" lineEndContext="#stay">
-    <DetectChar attribute="Value" context="#pop#pop" char="&quot;" />
-    <IncludeRules context="FindEntityRefs" />
-  </context>
-
-  <context name="Value SQ" attribute="Value" lineEndContext="#stay">
-    <DetectChar attribute="Value" context="#pop#pop" char="&apos;" />
-    <IncludeRules context="FindEntityRefs" />
-  </context>
-
-  <!-- Read content from the "type" attribute to change the language to
-       highlight in the <script> tag. The default language is JavaScript. -->
-
-  <context name="Script-Type" attribute="Other Text" lineEndContext="#stay" fallthrough="true" fallthroughContext="#pop">
-    <DetectSpaces />
-    <DetectChar attribute="Attribute" context="#pop!Script-Type Value" char="=" />
-  </context>
-  <context name="Script-Type Value" attribute="Other Text" lineEndContext="#stay" fallthrough="true" fallthroughContext="#pop!Value">
-    <DetectSpaces />
-    <!-- TypeScript -->
-    <StringDetect attribute="Value" context="#pop#pop!TypeScript" String="&quot;text/typescript&quot;"/>
-    <StringDetect attribute="Value" context="#pop#pop!TypeScript" String="&apos;text/typescript&apos;"/>
-    <!-- JSX (JavaScript React) -->
-    <StringDetect attribute="Value" context="#pop#pop!JSX" String="&quot;text/jsx&quot;"/>
-    <StringDetect attribute="Value" context="#pop#pop!JSX" String="&apos;text/jsx&apos;"/>
-    <StringDetect attribute="Value" context="#pop#pop!JSX" String="&quot;text/babel&quot;"/>
-    <StringDetect attribute="Value" context="#pop#pop!JSX" String="&apos;text/babel&apos;"/>
-    <!-- MustacheJS / HandlebarsJS / RactiveJS -->
-    <StringDetect attribute="Value" context="#pop#pop!MustacheJS" String="&quot;x-tmpl-mustache&quot;"/>
-    <StringDetect attribute="Value" context="#pop#pop!MustacheJS" String="&apos;x-tmpl-mustache&apos;"/>
-    <StringDetect attribute="Value" context="#pop#pop!MustacheJS" String="&quot;text/mustache&quot;"/>
-    <StringDetect attribute="Value" context="#pop#pop!MustacheJS" String="&apos;text/mustache&apos;"/>
-    <StringDetect attribute="Value" context="#pop#pop!MustacheJS" String="&quot;text/x-mustache-template&quot;"/>
-    <StringDetect attribute="Value" context="#pop#pop!MustacheJS" String="&apos;text/x-mustache-template&apos;"/>
-    <StringDetect attribute="Value" context="#pop#pop!MustacheJS" String="&quot;text/x-handlebars-template&quot;"/>
-    <StringDetect attribute="Value" context="#pop#pop!MustacheJS" String="&apos;text/x-handlebars-template&apos;"/>
-    <StringDetect attribute="Value" context="#pop#pop!MustacheJS" String="&quot;text/ractive&quot;"/>
-    <StringDetect attribute="Value" context="#pop#pop!MustacheJS" String="&apos;text/ractive&apos;"/>
-    <!-- HTML templates -->
-    <StringDetect attribute="Value" context="#pop#pop!Script HTML template" String="&quot;text/html&quot;"/>
-    <StringDetect attribute="Value" context="#pop#pop!Script HTML template" String="&apos;text/html&apos;"/>
-  </context>
-
-  <context name="JSX" attribute="Other Text" lineEndContext="#stay">
-    <DetectChar attribute="Element Symbols" context="JSX content" char="&gt;" />
-    <IncludeRules context="DefaultJS" />
-  </context>
-  <context name="JSX content" attribute="Other Text" lineEndContext="#stay">
-    <IncludeRules context="Default JS content"/>
-    <IncludeRules context="Normal##JavaScript React (JSX)" includeAttrib="true"/>
-  </context>
-
-  <context name="TypeScript" attribute="Other Text" lineEndContext="#stay">
-    <DetectChar attribute="Element Symbols" context="TypeScript content" char="&gt;" />
-    <IncludeRules context="DefaultJS" />
-  </context>
-  <context name="TypeScript content" attribute="Other Text" lineEndContext="#stay">
-    <IncludeRules context="Default JS content"/>
-    <IncludeRules context="Normal##TypeScript" includeAttrib="true"/>
-  </context>
-
-  <context name="MustacheJS" attribute="Other Text" lineEndContext="#stay">
-    <DetectChar attribute="Element Symbols" context="MustacheJS content" char="&gt;" />
-    <IncludeRules context="DefaultJS" />
-  </context>
-  <context name="MustacheJS content" attribute="Other Text" lineEndContext="#stay">
-    <IncludeRules context="FindScriptTagClose" />
-    <StringDetect attribute="Error" context="#stay" String="&lt;script&gt;" insensitive="true" />
-    <RegExpr attribute="Error" context="#stay" String="&lt;script\b" insensitive="true" />
-    <IncludeRules context="Base##Mustache/Handlebars (HTML)" includeAttrib="true"/>
-  </context>
-
-  <context name="Script HTML template" attribute="Other Text" lineEndContext="#stay">
-    <DetectChar attribute="Element Symbols" context="Script HTML template content" char="&gt;" />
-    <IncludeRules context="DefaultJS" />
-  </context>
-  <context name="Script HTML template content" attribute="Other Text" lineEndContext="#stay">
-    <IncludeRules context="FindScriptTagClose" />
-    <StringDetect attribute="Error" context="#stay" String="&lt;script&gt;" insensitive="true" />
-    <RegExpr attribute="Error" context="#stay" String="&lt;script\b" insensitive="true" />
-    <IncludeRules context="FindHTML" />
-  </context>
-
-
     </contexts>
     <itemDatas>
       <itemData name="Normal Text" defStyleNum="dsNormal"/>
@@ -907,6 +635,7 @@
       <itemData name="Strong Text" defStyleNum="dsNormal" bold="true"/>
       <itemData name="Strong-Emphasis Text" defStyleNum="dsNormal" italic="true" bold="true"/>
       <itemData name="Strikethrough Text" defStyleNum="dsNormal" strikeOut="true"/>
+      <itemData name="Highlight Text" defStyleNum="dsAlert"/>
       <itemData name="Normal Text: Link" defStyleNum="dsNormal" underline="true" spellChecking="false"/>
       <itemData name="Horizontal Rule" defStyleNum="dsNormal" bold="true" spellChecking="false"/>
       <itemData name="Line Break" defStyleNum="dsNormal" underline="true" color="#999999" spellChecking="false"/>
@@ -922,6 +651,7 @@
       <itemData name="Blockquote: Strong Text" defStyleNum="dsAttribute" bold="true"/>
       <itemData name="Blockquote: Strong-Emphasis Text" defStyleNum="dsAttribute" italic="true" bold="true"/>
       <itemData name="Blockquote: Strikethrough Text" defStyleNum="dsAttribute" strikeOut="true"/>
+      <itemData name="Blockquote: Highlight Text" defStyleNum="dsAlert"/>
       <itemData name="Blockquote: Link" defStyleNum="dsAttribute" underline="true" spellChecking="false"/>
       <itemData name="List" defStyleNum="dsSpecialString" bold="1" spellChecking="false"/>
       <itemData name="Number List" defStyleNum="dsSpecialString" spellChecking="false"/>
@@ -930,11 +660,14 @@
       <itemData name="List: Strong Text" defStyleNum="dsNormal" bold="true"/>
       <itemData name="List: Strong-Emphasis Text" defStyleNum="dsNormal" italic="true" bold="true"/>
       <itemData name="List: Strikethrough Text" defStyleNum="dsNormal" strikeOut="true"/>
+      <itemData name="List: Highlight Text" defStyleNum="dsAlert"/>
       <itemData name="List: Link" defStyleNum="dsNormal" underline="true" spellChecking="false"/>
       <itemData name="List: Checkbox" defStyleNum="dsVariable" spellChecking="false"/>
       <itemData name="Comment" defStyleNum="dsComment"/>
       <itemData name="Code" defStyleNum="dsInformation"/>
       <itemData name="Fenced Code" defStyleNum="dsInformation" spellChecking="false"/>
+      <itemData name="Table" defStyleNum="dsPreprocessor"/>
+      <itemData name="Emoji" defStyleNum="dsSpecialChar" spellChecking="false"/>
       <itemData name="Auto-Link" defStyleNum="dsOthers" spellChecking="false"/>
       <itemData name="Link" defStyleNum="dsOthers" underline="true" spellChecking="false"/>
       <itemData name="Mailto-Link" defStyleNum="dsOthers" spellChecking="false"/>

--- a/src/resources/pandoc/syntax-definitions/markdown.xml
+++ b/src/resources/pandoc/syntax-definitions/markdown.xml
@@ -319,40 +319,40 @@
       <context name="find-lang-fenced-code" attribute="Normal Text" lineEndContext="#pop">
         <!-- Apply syntax highlighting to fenced code blocks for some languages -->
         <RegExpr attribute="Fenced Code" context="#pop!code" String="&fcode;&end;" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!bash-code" String="&fcode;\s*(?:bash(?:rc|_profile|_login|_logout)?|shell|sh|profile|PKGBUILD|APKBUILD|ebuild|eclass|nix)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!zsh-code" String="&fcode;\s*(?:zsh)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!cpp-code" String="&fcode;\s*(?:[ch]pp|[ch]\+\+|[ch]xx|h?cc|hh|cuh?|ino|pde|moc)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!csharp-code" String="&fcode;\s*(?:cs|csharp|c\#)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!cmake-code" String="&fcode;\s*(?:cmake|CMakeLists(?:\.txt)?)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!css-code" String="&fcode;\s*css&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!c-code" String="&fcode;\s*[ch]&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!doxygen-code" String="&fcode;\s*doxygen&end;" insensitive="true" beginRegion="code-block"/> <!-- Block comment of Doxygen -->
-        <RegExpr attribute="Fenced Code" context="#pop!email-code" String="&fcode;\s*(?:email|emlx?|mbo?x)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!go-code" String="&fcode;\s*go(?:lang)?&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!hamlet-code" String="&fcode;\s*[wxs]?hamlet&end;" insensitive="true" beginRegion="code-block"/> <!-- Included in the Haskell definition -->
-        <RegExpr attribute="Fenced Code" context="#pop!haskell-code" String="&fcode;\s*(?:haskell|c?hs|hs\-boot)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!html-code" String="&fcode;\s*(?:[sx]?html?|inc|tmpl|tpl)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!java-code" String="&fcode;\s*(?:java|bsh)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!javascript-code" String="&fcode;\s*(?:javascript|m?js|es6|kwinscript|julius)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!jsx-code" String="&fcode;\s*(?:jsx|tsx|(?:java|type)script\-react)&end;" insensitive="true" beginRegion="code-block"/> <!-- Included in the HTML definition. Also apply for TSX. -->
-        <RegExpr attribute="Fenced Code" context="#pop!json-code" String="&fcode;\s*(?:json5?|gltf)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!yaml-code" String="&fcode;\s*(?:ya?ml)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!matlab-code" String="&fcode;\s*matlab&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!markdown-code" String="&fcode;\s*(?:markdown|m?md)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!mustache-code" String="&fcode;\s*(?:handlebars|hbs|mustache|mst|ractive|hogan|hulk)&end;" insensitive="true" beginRegion="code-block"/> <!-- Included in the HTML definition -->
-        <RegExpr attribute="Fenced Code" context="#pop!perl-code" String="&fcode;\s*(?:perl|p[lm]|pod|psgi|vcl)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!php-code" String="&fcode;\s*(?:php[3457t]?|wml|phtml?|aw|ctp)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!python-code" String="&fcode;\s*(?:python[23]?|py[23w]?|[rc]py|sconstruct|gypi?)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!qml-code" String="&fcode;\s*qml(?:types)?&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!r-code" String="&fcode;\s*(?:r|rprofile|rscript)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!raku-code" String="&fcode;\s*(?:raku(?:mod|doc|test)?|perl6|p[lm]?6|pod6|nqp)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!rest-code" String="&fcode;\s*(?:rst|rest|restructuredtext)&end;" insensitive="true" beginRegion="code-block"/> <!-- Included in the CMake definition -->
-        <RegExpr attribute="Fenced Code" context="#pop!ruby-code" String="&fcode;\s*(?:ruby|rbx?|rjs|rake|f?cgi|gemspec|irbrc|ru|prawn|Appraisals|(?:Rake|Cap|Chef|Gem|Guard|Hobo|Vagrant||Rant|Berks|Thor|Puppet)file|rxml|(?:xml|js)\.erb)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!rust-code" String="&fcode;\s*(?:rust|rs)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!mysql-code" String="&fcode;\s*(?:mysql|sql|ddl)&end;" insensitive="true" beginRegion="code-block"/> <!-- Included in the PHP definition -->
-        <RegExpr attribute="Fenced Code" context="#pop!nim-code" String="&fcode;\s*(?:nims?)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!typescript-code" String="&fcode;\s*(?:typescript|ts)&end;" insensitive="true" beginRegion="code-block"/>
-        <RegExpr attribute="Fenced Code" context="#pop!xml-code" String="&fcode;\s*(?:xml|xsd|xspf|tld|jsp|c?pt|dtml|rss|opml|svg|daml|rdf|ui|kcfg|qrc|wsdl|scxml|xbel|dae|sch|brd|docbook)&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!bash-code" String="&fcode;\s*\{?\.?(?:bash(?:rc|_profile|_login|_logout)?|shell|sh|profile|PKGBUILD|APKBUILD|ebuild|eclass|nix).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!zsh-code" String="&fcode;\s*\{?\.?(?:zsh).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!cpp-code" String="&fcode;\s*\{?\.?(?:[ch]pp|[ch]\+\+|[ch]xx|h?cc|hh|cuh?|ino|pde|moc).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!csharp-code" String="&fcode;\s*\{?\.?(?:cs|csharp|c\#).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!cmake-code" String="&fcode;\s*\{?\.?(?:cmake|CMakeLists(?:\.txt)?).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!css-code" String="&fcode;\s*\{?\.?css.*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!c-code" String="&fcode;\s*\{?\.?[ch].*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!doxygen-code" String="&fcode;\s*\{?\.?doxygen.*&end;" insensitive="true" beginRegion="code-block"/> <!-- Block comment of Doxygen -->
+        <RegExpr attribute="Fenced Code" context="#pop!email-code" String="&fcode;\s*\{?\.?(?:email|emlx?|mbo?x).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!go-code" String="&fcode;\s*\{?\.?go(?:lang)?.*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!hamlet-code" String="&fcode;\s*\{?\.?[wxs]?hamlet.*&end;" insensitive="true" beginRegion="code-block"/> <!-- Included in the Haskell definition -->
+        <RegExpr attribute="Fenced Code" context="#pop!haskell-code" String="&fcode;\s*\{?\.?(?:haskell|c?hs|hs\-boot).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!html-code" String="&fcode;\s*\{?\.?(?:[sx]?html?|inc|tmpl|tpl).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!java-code" String="&fcode;\s*\{?\.?(?:java|bsh).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!javascript-code" String="&fcode;\s*\{?\.?(?:javascript|[mo]?js|es6|kwinscript|julius).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!jsx-code" String="&fcode;\s*\{?\.?(?:jsx|tsx|(?:java|type)script\-react).*&end;" insensitive="true" beginRegion="code-block"/> <!-- Included in the HTML definition. Also apply for TSX. -->
+        <RegExpr attribute="Fenced Code" context="#pop!json-code" String="&fcode;\s*\{?\.?(?:json5?|gltf).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!yaml-code" String="&fcode;\s*\{?\.?(?:ya?ml).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!matlab-code" String="&fcode;\s*\{?\.?matlab.*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!markdown-code" String="&fcode;\s*\{?\.?(?:markdown|m?md).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!mustache-code" String="&fcode;\s*\{?\.?(?:handlebars|hbs|mustache|mst|ractive|hogan|hulk).*&end;" insensitive="true" beginRegion="code-block"/> <!-- Included in the HTML definition -->
+        <RegExpr attribute="Fenced Code" context="#pop!perl-code" String="&fcode;\s*\{?\.?(?:julia|mermaid|dot|perl|p[lm]|pod|psgi|vcl).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!php-code" String="&fcode;\s*\{?\.?(?:php[3457t]?|wml|phtml?|aw|ctp).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!python-code" String="&fcode;\s*\{?\.?(?:python[23]?|py[23w]?|[rc]py|sconstruct|gypi?).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!qml-code" String="&fcode;\s*\{?\.?qml(?:types)?.*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!r-code" String="&fcode;\s*\{?\.?(?:r|rprofile|rscript).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!raku-code" String="&fcode;\s*\{?\.?(?:raku(?:mod|doc|test)?|perl6|p[lm]?6|pod6|nqp).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!rest-code" String="&fcode;\s*\{?\.?(?:rst|rest|restructuredtext).*&end;" insensitive="true" beginRegion="code-block"/> <!-- Included in the CMake definition -->
+        <RegExpr attribute="Fenced Code" context="#pop!ruby-code" String="&fcode;\s*\{?\.?(?:ruby|rbx?|rjs|rake|f?cgi|gemspec|irbrc|ru|prawn|Appraisals|(?:Rake|Cap|Chef|Gem|Guard|Hobo|Vagrant||Rant|Berks|Thor|Puppet)file|rxml|(?:xml|js)\.erb).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!rust-code" String="&fcode;\s*\{?\.?(?:rust|rs).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!mysql-code" String="&fcode;\s*\{?\.?(?:mysql|sql|ddl).*&end;" insensitive="true" beginRegion="code-block"/> <!-- Included in the PHP definition -->
+        <RegExpr attribute="Fenced Code" context="#pop!nim-code" String="&fcode;\s*\{?\.?(?:nims?).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!typescript-code" String="&fcode;\s*\{?\.?(?:typescript|ts).*&end;" insensitive="true" beginRegion="code-block"/>
+        <RegExpr attribute="Fenced Code" context="#pop!xml-code" String="&fcode;\s*\{?\.?(?:xml|xsd|xspf|tld|jsp|c?pt|dtml|rss|opml|svg|daml|rdf|ui|kcfg|qrc|wsdl|scxml|xbel|dae|sch|brd|docbook).*&end;" insensitive="true" beginRegion="code-block"/>
         <RegExpr attribute="Fenced Code" context="#pop!code" String="&fcode;.*$" beginRegion="code-block"/>
       </context>
       <context name="code" attribute="Code" lineEndContext="#stay"> <!-- Unknown language -->

--- a/tests/docs/smoke-all/2024/09/24/issue-10821-b.qmd
+++ b/tests/docs/smoke-all/2024/09/24/issue-10821-b.qmd
@@ -5,7 +5,7 @@ _quarto:
   tests:
     html:
       ensureFileRegexMatches:
-        - ['<span class="in">#\| fig-cap: ''This figure will have ''''echo: fenced'''' in its caption.''</span>']
+        - ['<span class="co">#\| fig-cap: ''This figure will have ''''echo: fenced'''' in its caption.''</span>']
         - []
         # - ['fig-cap']
 ---

--- a/tests/docs/smoke-all/2024/09/24/issue-10821.qmd
+++ b/tests/docs/smoke-all/2024/09/24/issue-10821.qmd
@@ -5,7 +5,7 @@ _quarto:
   tests:
     html:
       ensureFileRegexMatches:
-        - ['<span class="in">#\| fig-cap: "This figure will have ''echo: fenced'' in its caption."</span>']
+        - ['<span class="co">#\| fig-cap: "This figure will have ''echo: fenced'' in its caption."</span>']
         - []
 ---
 

--- a/tests/docs/text-highlighting/markdown-quarto-syntax.qmd
+++ b/tests/docs/text-highlighting/markdown-quarto-syntax.qmd
@@ -1,0 +1,36 @@
+---
+title: Markdown block with quarto syntax
+format: html
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - ['client <span class="op">=</span> <span class="ex">connect</span>\.Client\(\)</span>']
+        - ['<span class="in">client = connect\.Client\(\)</span>']
+---
+
+## Nested highlight
+
+This is a quarto document example
+
+```` markdown
+---
+title: "Client Credentials Using the Python SDK"
+format: html
+---
+
+# Example Client Credentials Exchange
+
+This Quarto document is able to acquire an OAuth access token 
+from a Service Account OAuth integration.
+
+```{{python}}
+from posit import connect
+
+client = connect.Client()
+# NOTE: get_content_credentials reads the `CONNECT_CONTENT_SESSION_TOKEN`
+# from the environment to complete the credential exchange.
+print(client.oauth.get_content_credentials().get("access_token"))
+```
+
+````

--- a/tests/docs/text-highlighting/markdown-quarto-syntax.qmd
+++ b/tests/docs/text-highlighting/markdown-quarto-syntax.qmd
@@ -4,12 +4,29 @@ format: html
 _quarto:
   tests:
     html:
-      ensureFileRegexMatches:
-        - ['client <span class="op">=</span> <span class="ex">connect</span>\.Client\(\)</span>']
-        - ['<span class="in">client = connect\.Client\(\)</span>']
+      ensureHtmlElements:
+        - 
+          - '#python pre.sourceCode.markdown'
+          - '#python span#cb1-14 span.op'
+          - '#ojs pre.sourceCode.markdown'
+          - '#ojs span#cb2-2 span.co'
+          - '#ojs span#cb2-7 span.op'
+          - '#julia pre.sourceCode.markdown'
+          - '#julia span#cb3-2 span.co'
+          - '#julia span#cb3-7 span.fu'
+          - '#mermaid pre.sourceCode.markdown'
+          - '#mermaid span#cb4-3 *:not(span)'
+          - '#dot pre.sourceCode.markdown'
+          - '#dot span#cb5-4 *:not(span)'
+        - 
+           - '#python span#cb1-14 span.in'
+           - '#ojs span#cb2-7 span.in'
+           - '#julia span#cb3-7 span.in'
+           - '#mermaid span#cb4-3 span.in'
+           - '#dot span#cb5-4 span.in'
 ---
 
-## Nested highlight
+## Nested markdown with highlight python {#python}
 
 This is a quarto document example
 
@@ -33,4 +50,61 @@ client = connect.Client()
 print(client.oauth.get_content_credentials().get("access_token"))
 ```
 
+````
+## embedded ojs highlight {#ojs}
+
+````markdown
+```{{ojs}}
+// Comment
+viewof bill_length_min = Inputs.range(
+  [32, 50], 
+  {value: 35, step: 1, label: "Bill length (min):"}
+)
+viewof islands = Inputs.checkbox(
+  ["Torgersen", "Biscoe", "Dream"], 
+  { value: ["Torgersen", "Biscoe"], 
+    label: "Islands:"
+  }
+)
+```
+````
+
+## embedded julia highlight {#julia}
+
+````markdown
+```{{julia}}
+#| label: fig-parametric
+#| fig-cap: "Parametric Plots"
+
+using Plots
+
+plot(sin, 
+     x->sin(2x), 
+     0, 
+     2π, 
+     leg=false, 
+     fill=(0,:lavender))
+```
+````
+## Embedded mermaid {#mermaid}
+
+````markdown
+```{{mermaid}}
+%%| fig-width: 6.5
+flowchart LR
+  A[Hard edge] --> B(Round edge)
+  B --> C{Decision}
+```
+````
+
+## Embedded dot {#dot}
+
+````markdown
+```{{dot}}
+//| label: fig-linux-kernel
+//| fig-cap: "A diagram of the Linux kernel."
+graph {
+  A -- B
+}
+```
 ````

--- a/tests/docs/text-highlighting/markdown-quarto-syntax.qmd
+++ b/tests/docs/text-highlighting/markdown-quarto-syntax.qmd
@@ -86,6 +86,7 @@ plot(sin,
      fill=(0,:lavender))
 ```
 ````
+
 ## Embedded mermaid {#mermaid}
 
 ````markdown

--- a/tests/docs/text-highlighting/markdown-quarto-syntax.qmd
+++ b/tests/docs/text-highlighting/markdown-quarto-syntax.qmd
@@ -17,7 +17,8 @@ _quarto:
           - '#mermaid pre.sourceCode.markdown'
           - '#mermaid span#cb4-3 *:not(span)'
           - '#dot pre.sourceCode.markdown'
-          - '#dot span#cb5-4 *:not(span)'
+          - '#dot span#cb5-2 span.co'
+          - '#dot span#cb5-4 span.va'
         - 
            - '#python span#cb1-14 span.in'
            - '#ojs span#cb2-7 span.in'


### PR DESCRIPTION
This PR is fixing all the highlighting issue in markdown block and adds some improvement. 

For the context, quarto embeds a `markdown.xml` that is tweaked to support special quarto syntax for computation code block. However, the tweaked file was overwritten in c47753cf5d5733e7b433cab63b3a4083e87f2e63 while updating `markdown.xml` from upstream. 

So this PR first re-enable everything:

- enable markdown highlighting to correctly identify pandoc and rmd/qmd style code blocks (83e587e)
- ensure that markdown highlights embedded ojs (f56363d)
- embedded highlight for julia (a5d07f6)
- add minimal highlighting to dot and mermaid (e135a14)

All this was lost several Quarto version ago, and we did not notice while our website lost its highligting for julia, ojs and diagram example. 🤦 

This PR also adds some better support for `julia` and `dot` which are both supported language by skylighting already. So the `markdown.xml` is further customized so that it defer to those language highlighting for embedded code block. 

This fixes part of https://github.com/quarto-dev/quarto-cli/issues/1453 as now `dot` will correctly be highlighed. 

For `mermaid`, it will require creating or finding a `mermaid.xml` as KDE doesn't have one. 

This PR also add tests so that we don't break this again.
