### PR TITLE
Bugfix/improve brand defaults validation

### DIFF
--- a/src/core/lib/errors.ts
+++ b/src/core/lib/errors.ts
@@ -9,7 +9,6 @@
 import * as colors from "./external/colors.ts";
 import { MappedString } from "./text-types.ts";
 import { ErrorLocation, TidyverseError } from "./errors-types.ts";
-import { isWindows } from "../../deno_ral/platform.ts";
 
 // tidyverse error message styling
 // https://style.tidyverse.org/error-messages.html
@@ -25,9 +24,19 @@ import { isWindows } from "../../deno_ral/platform.ts";
 
 function platformHasNonAsciiCharacters(): boolean {
   try {
-    return !isWindows;
+    // we can't import from deno_ral directly here
+    // because it's outside of core/lib, which
+    // gets imported by code that runs in the browser
+    //
+    // Then, we need to guard against Deno being undefined
+    // there as well
+    return Deno.build.os !== "windows";
   } catch (_e) {
-    return false;
+    //
+    // But if deno is undefined, we can assume that we're
+    // running in the browser, where non-ascii characters
+    // are supported
+    return true;
   }
 }
 

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -11839,6 +11839,11 @@ var require_yaml_intelligence_resources = __commonJS({
                             description: "The brand's Mastodon URL."
                           }
                         },
+                        bluesky: {
+                          string: {
+                            description: "The brand's Bluesky URL."
+                          }
+                        },
                         github: {
                           string: {
                             description: "The brand's GitHub URL."
@@ -12526,7 +12531,42 @@ var require_yaml_intelligence_resources = __commonJS({
                 ref: "brand-typography"
               },
               defaults: {
+                ref: "brand-defaults"
+              }
+            }
+          }
+        },
+        {
+          id: "brand-defaults",
+          object: {
+            properties: {
+              bootstrap: {
+                ref: "brand-defaults-bootstrap"
+              },
+              quarto: {
                 schema: "object"
+              }
+            }
+          }
+        },
+        {
+          id: "brand-defaults-bootstrap",
+          object: {
+            properties: {
+              defaults: {
+                schema: {
+                  object: {
+                    additionalProperties: {
+                      schema: {
+                        anyOf: [
+                          "string",
+                          "boolean",
+                          "number"
+                        ]
+                      }
+                    }
+                  }
+                }
               }
             }
           }
@@ -21782,6 +21822,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "Important links for the brand, including social media links. If a\nsingle string, it is the brand\u2019s home page or website. Additional fields\nare allowed for internal use.",
         "The brand\u2019s home page or website.",
         "The brand\u2019s Mastodon URL.",
+        "The brand\u2019s Bluesky URL.",
         "The brand\u2019s GitHub URL.",
         "The brand\u2019s LinkedIn URL.",
         "The brand\u2019s Twitter URL.",
@@ -24146,12 +24187,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 193475,
+        _internalId: 193524,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 193467,
+            _internalId: 193516,
             type: "enum",
             enum: [
               "png",
@@ -24167,7 +24208,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 193474,
+            _internalId: 193523,
             type: "anyOf",
             anyOf: [
               {
@@ -24301,9 +24342,9 @@ var ANSI_PATTERN = new RegExp(
 // ../errors.ts
 function platformHasNonAsciiCharacters() {
   try {
-    return !isWindows;
+    return Deno.build.os !== "windows";
   } catch (_e) {
-    return false;
+    return true;
   }
 }
 function tidyverseInfo(msg) {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -11840,6 +11840,11 @@ try {
                               description: "The brand's Mastodon URL."
                             }
                           },
+                          bluesky: {
+                            string: {
+                              description: "The brand's Bluesky URL."
+                            }
+                          },
                           github: {
                             string: {
                               description: "The brand's GitHub URL."
@@ -12527,7 +12532,42 @@ try {
                   ref: "brand-typography"
                 },
                 defaults: {
+                  ref: "brand-defaults"
+                }
+              }
+            }
+          },
+          {
+            id: "brand-defaults",
+            object: {
+              properties: {
+                bootstrap: {
+                  ref: "brand-defaults-bootstrap"
+                },
+                quarto: {
                   schema: "object"
+                }
+              }
+            }
+          },
+          {
+            id: "brand-defaults-bootstrap",
+            object: {
+              properties: {
+                defaults: {
+                  schema: {
+                    object: {
+                      additionalProperties: {
+                        schema: {
+                          anyOf: [
+                            "string",
+                            "boolean",
+                            "number"
+                          ]
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -21783,6 +21823,7 @@ try {
           "Important links for the brand, including social media links. If a\nsingle string, it is the brand\u2019s home page or website. Additional fields\nare allowed for internal use.",
           "The brand\u2019s home page or website.",
           "The brand\u2019s Mastodon URL.",
+          "The brand\u2019s Bluesky URL.",
           "The brand\u2019s GitHub URL.",
           "The brand\u2019s LinkedIn URL.",
           "The brand\u2019s Twitter URL.",
@@ -24147,12 +24188,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 193475,
+          _internalId: 193524,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 193467,
+              _internalId: 193516,
               type: "enum",
               enum: [
                 "png",
@@ -24168,7 +24209,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 193474,
+              _internalId: 193523,
               type: "anyOf",
               anyOf: [
                 {
@@ -24317,7 +24358,7 @@ try {
     try {
       return Deno.build.os !== "windows";
     } catch (_e) {
-      return false;
+      return true;
     }
   }
   function tidyverseInfo(msg) {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -4811,6 +4811,11 @@
                         "description": "The brand's Mastodon URL."
                       }
                     },
+                    "bluesky": {
+                      "string": {
+                        "description": "The brand's Bluesky URL."
+                      }
+                    },
                     "github": {
                       "string": {
                         "description": "The brand's GitHub URL."
@@ -5498,7 +5503,42 @@
             "ref": "brand-typography"
           },
           "defaults": {
+            "ref": "brand-defaults"
+          }
+        }
+      }
+    },
+    {
+      "id": "brand-defaults",
+      "object": {
+        "properties": {
+          "bootstrap": {
+            "ref": "brand-defaults-bootstrap"
+          },
+          "quarto": {
             "schema": "object"
+          }
+        }
+      }
+    },
+    {
+      "id": "brand-defaults-bootstrap",
+      "object": {
+        "properties": {
+          "defaults": {
+            "schema": {
+              "object": {
+                "additionalProperties": {
+                  "schema": {
+                    "anyOf": [
+                      "string",
+                      "boolean",
+                      "number"
+                    ]
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -14754,6 +14794,7 @@
     "Important links for the brand, including social media links. If a\nsingle string, it is the brand’s home page or website. Additional fields\nare allowed for internal use.",
     "The brand’s home page or website.",
     "The brand’s Mastodon URL.",
+    "The brand’s Bluesky URL.",
     "The brand’s GitHub URL.",
     "The brand’s LinkedIn URL.",
     "The brand’s Twitter URL.",
@@ -17118,12 +17159,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 193475,
+    "_internalId": 193524,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 193467,
+        "_internalId": 193516,
         "type": "enum",
         "enum": [
           "png",
@@ -17139,7 +17180,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 193474,
+        "_internalId": 193523,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/schema/definitions.yml
+++ b/src/resources/schema/definitions.yml
@@ -2977,4 +2977,25 @@
       typography:
         ref: brand-typography
       defaults:
+        ref: brand-defaults
+
+- id: brand-defaults
+  object:
+    properties:
+      bootstrap:
+        ref: brand-defaults-bootstrap
+      quarto:
         schema: object
+
+- id: brand-defaults-bootstrap
+  object:
+    properties:
+      defaults:
+        schema:
+          object:
+            additionalProperties:
+              schema:
+                anyOf:
+                  - string
+                  - boolean
+                  - number

--- a/src/resources/schema/json-schemas.json
+++ b/src/resources/schema/json-schemas.json
@@ -3204,6 +3204,9 @@
                     "mastodon": {
                       "type": "string"
                     },
+                    "bluesky": {
+                      "type": "string"
+                    },
                     "github": {
                       "type": "string"
                     },
@@ -3767,7 +3770,30 @@
             "$ref": "#/$defs/BrandTypography"
           },
           "defaults": {
+            "$ref": "#/$defs/BrandDefaults"
+          }
+        }
+      }
+    },
+    "BrandDefaults": {
+      "object": {
+        "properties": {
+          "bootstrap": {
+            "$ref": "#/$defs/BrandDefaultsBootstrap"
+          },
+          "quarto": {
             "type": "object"
+          }
+        }
+      }
+    },
+    "BrandDefaultsBootstrap": {
+      "object": {
+        "properties": {
+          "defaults": {
+            "object": {
+              "properties": {}
+            }
           }
         }
       }

--- a/src/resources/types/schema-types.ts
+++ b/src/resources/types/schema-types.ts
@@ -1266,6 +1266,7 @@ export type ManuscriptSchema = {
 
 export type BrandMeta = {
   link?: string | {
+    bluesky?: string /* The brand's Bluesky URL. */;
     facebook?: string /* The brand's Facebook URL. */;
     github?: string /* The brand's GitHub URL. */;
     home?: string /* The brand's home page or website. */;
@@ -1475,10 +1476,19 @@ export type BrandFontFamily = string;
 
 export type Brand = {
   color?: BrandColor;
-  defaults?: JsonObject;
+  defaults?: BrandDefaults;
   logo?: BrandLogo;
   meta?: BrandMeta;
   typography?: BrandTypography;
+};
+
+export type BrandDefaults = {
+  bootstrap?: BrandDefaultsBootstrap;
+  quarto?: JsonObject;
+};
+
+export type BrandDefaultsBootstrap = {
+  defaults?: { [key: string]: string | boolean | number };
 };
 
 export type ProjectConfig = {


### PR DESCRIPTION
This catches typos on `brand.defaults.bootstrap.defaults`, and fixes a bug where we were accidentally importing deno-specific code from our core/lib directory, which needs to be safe to run in browser settings.