### PR TITLE
Fix powershell ArgumentList bug

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -22,6 +22,12 @@ All changes included in 1.7:
   that allows to check whether a node is empty, i.e., whether it's an
   empty list, has no child nodes, and contains no text.
 
+## Engines
+
+### `julia`
+
+- ([#11659](https://github.com/quarto-dev/quarto-cli/pull/11659)): Fix escaping bug where paths containing spaces or backslashes break server startup on Windows.
+
 ## Other Fixes and Improvements
 
 - ([#11643](https://github.com/quarto-dev/quarto-cli/issues/11643)): Improve highlighting of nested code block inside markdown code block, i.e. using ` ```{{python}} ` or ` ```python ` inside ` ````markdown` fenced code block.

--- a/src/execute/julia.ts
+++ b/src/execute/julia.ts
@@ -34,7 +34,7 @@ import {
 } from "../config/format.ts";
 import { resourcePath } from "../core/resources.ts";
 import { quartoRuntimeDir } from "../core/appdirs.ts";
-import { normalizePath } from "../core/path.ts";
+import { normalizePath, pathWithForwardSlashes } from "../core/path.ts";
 import { isInteractiveSession } from "../core/platform.ts";
 import { runningInCI } from "../core/ci-info.ts";
 import { sleep } from "../core/async.ts";
@@ -271,6 +271,7 @@ async function startOrReuseJuliaServer(
       await ensureQuartoNotebookRunnerEnvironment(options);
       juliaProject = juliaRuntimeDir();
     } else {
+      juliaProject = pathWithForwardSlashes(juliaProject);
       trace(
         options,
         `Custom julia project set via QUARTO_JULIA_PROJECT="${juliaProject}". Checking if QuartoNotebookRunner can be loaded.`,

--- a/src/execute/julia.ts
+++ b/src/execute/julia.ts
@@ -248,6 +248,12 @@ export const juliaEngine: ExecutionEngine = {
   },
 };
 
+function powershell_argument_list_to_string(...args: string[]): string {
+  // formats as '"arg 1" "arg 2" "arg 3"'
+  const inner = args.map((arg) => `"${arg}"`).join(" ");
+  return `'${inner}'`;
+}
+
 async function startOrReuseJuliaServer(
   options: JuliaExecuteOptions,
 ): Promise<{ reused: boolean }> {
@@ -310,15 +316,12 @@ async function startOrReuseJuliaServer(
             "Start-Process",
             options.julia_cmd,
             "-ArgumentList",
-            // string array argument list, each element but the last must have a "," element after
-            "--startup-file=no",
-            ",",
-            `--project=${juliaProject}`,
-            ",",
-            resourcePath("julia/quartonotebookrunner.jl"),
-            ",",
-            transportFile,
-            // end of string array
+            powershell_argument_list_to_string(
+              "--startup-file=no",
+              `--project=${juliaProject}`,
+              resourcePath("julia/quartonotebookrunner.jl"),
+              transportFile,
+            ),
             "-WindowStyle",
             "Hidden",
           ],


### PR DESCRIPTION
Should fix https://github.com/quarto-dev/quarto-cli/issues/10111 with the technique reported to work in https://github.com/quarto-dev/quarto-cli/issues/10489#issuecomment-2288922426 which seems to match one of the syntax options mentioned in the official docs https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/start-process?view=powershell-7.4#example-7-specifying-arguments-to-the-process

I don't have a Windows machine so I could not separately test this. For a test of the bug, one of the passed paths would need a space inside it which I can't control easily on CI. The only path amenable to that would be the project path which can be controlled with the ENV variable QUARTO_JULIA_PROJECT (but only if no server process is running yet, and the order of tests seems to be automatically decided by the CI script, so I'm not sure how to control that).