### PR TITLE
Export TinyTeX bin directory to Lua filter.

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -25,6 +25,7 @@ All changes included in 1.7:
   This also provides a new public function `quarto.utils.is_empty_node`
   that allows to check whether a node is empty, i.e., whether it's an
   empty list, has no child nodes, and contains no text.
+- Expose new `quarto.paths.tinytex_bin_dir` in Quarto's Lua API. If TinyTeX is found by Quarto, this will be set to the path to the `bin` directory of the TinyTeX installation where command line tool are located (e.g., `pdflatex`, `tlmgr`, etc.). If TinyTeX is not found, this will be `nil`, meaning Quarto will use the system PATH to find the command line tools.
 
 ## Other Fixes and Improvements
 

--- a/src/command/render/filters.ts
+++ b/src/command/render/filters.ts
@@ -93,6 +93,7 @@ import { isServerShinyPython } from "../../core/render.ts";
 import { pythonExec } from "../../core/jupyter/exec.ts";
 import { kTocIndent } from "../../config/constants.ts";
 import { isWindows } from "../../deno_ral/platform.ts";
+import { tinyTexBinDir } from "../../tools/impl/tinytex-info.ts";
 
 const kQuartoParams = "quarto-params";
 
@@ -205,6 +206,7 @@ async function quartoEnvironmentParams(_options: PandocOptions) {
   return {
     "paths": {
       "Rscript": await rBinaryPath("Rscript"),
+      "TinyTexBinDir": tinyTexBinDir(), // will be undefined if no tinytex found and quarto will look in PATH
     },
   };
 }

--- a/src/resources/lua-types/quarto/paths.lua
+++ b/src/resources/lua-types/quarto/paths.lua
@@ -7,3 +7,9 @@ Returns the path to the `Rscript` file that Quarto itself would use in its knitr
 ]]
 ---@return string # Path to `Rscript` file
 function quarto.paths.rscript() end
+
+--[[
+Returns the path to the `TinyTeX` bin directory that `quarto install tinytex` installed to, or nil if not found.
+]]
+---@return string|nil # Path to `TinyTeX` bin directory
+function quarto.paths.tinytex_bin_dir() end

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -2093,9 +2093,12 @@ quarto = {
     add_to_blocks = utils.add_to_blocks,
   },
   paths = {
+     -- matches the path from `quartoEnvironmentParams` from src/command/render/filters.ts
     rscript = function()
-      -- matches the path from `quartoEnvironmentParams` from src/command/render/filters.ts
       return param('quarto-environment', nil).paths.Rscript
+    end,
+    tinytex_bin_dir = function()
+      return param('quarto-environment', nil).paths.TinyTexBinDir
     end,
   },
   json = json,


### PR DESCRIPTION
This is useful for a filter to call `tlmgr` or other tools while they are not put on PATH by `quarto install tinytex`

Idea coming from this discussion: 
- https://github.com/quarto-dev/quarto-cli/discussions/11543

We are exposing the bin dir and not the tool path like Rscript because Quarto is not looking to a path like `rBinaryPath()` - we are building the path only for tinytex installed version, and otherwise we call `Deno.run` and rely on tool being on PATH. Also the tool used depends on the configuration.

But bin dir is enough here to be useful