### PR TITLE
Extract typst title block into a partial

### DIFF
--- a/src/format/typst/format-typst.ts
+++ b/src/format/typst/format-typst.ts
@@ -92,6 +92,7 @@ export function typstFormat(): Format {
           "definitions.typ",
           "typst-template.typ",
           "typst-show.typ",
+          "typst-title.typ",
           "notes.typ",
           "biblio.typ",
         ].map((partial) => join(templateDir, partial)),

--- a/src/resources/formats/typst/pandoc/quarto/template.typ
+++ b/src/resources/formats/typst/pandoc/quarto/template.typ
@@ -1,5 +1,7 @@
 $definitions.typ()$
 
+$typst-title.typ()$
+
 $typst-template.typ()$
 
 $for(header-includes)$

--- a/src/resources/formats/typst/pandoc/quarto/typst-template.typ
+++ b/src/resources/formats/typst/pandoc/quarto/typst-template.typ
@@ -39,55 +39,21 @@
            font: font,
            size: fontsize)
   set heading(numbering: sectionnumbering)
-  if title != none {
-    align(center)[#block(inset: 2em)[
-      #set par(leading: heading-line-height)
-      #if (heading-family != none or heading-weight != "bold" or heading-style != "normal"
-           or heading-color != black or heading-decoration == "underline"
-           or heading-background-color != none) {
-        set text(font: heading-family, weight: heading-weight, style: heading-style, fill: heading-color)
-        text(size: title-size)[#title]
-        if subtitle != none {
-          parbreak()
-          text(size: subtitle-size)[#subtitle]
-        }
-      } else {
-        text(weight: "bold", size: title-size)[#title]
-        if subtitle != none {
-          parbreak()
-          text(weight: "bold", size: subtitle-size)[#subtitle]
-        }
-      }
-    ]]
-  }
 
-  if authors != none {
-    let count = authors.len()
-    let ncols = calc.min(count, 3)
-    grid(
-      columns: (1fr,) * ncols,
-      row-gutter: 1.5em,
-      ..authors.map(author =>
-          align(center)[
-            #author.name \
-            #author.affiliation \
-            #author.email
-          ]
-      )
-    )
-  }
-
-  if date != none {
-    align(center)[#block(inset: 1em)[
-      #date
-    ]]
-  }
-
-  if abstract != none {
-    block(inset: 2em)[
-    #text(weight: "semibold")[#abstract-title] #h(1em) #abstract
-    ]
-  }
+  title_block(
+    title: title, 
+    subtitle: subtitle, 
+    authors: authors, 
+    date: date, 
+    abstract: abstract,
+    title-size: title-size,
+    subtitle-size: subtitle-size,
+    heading-family: heading-family,
+    heading-weight: heading-weight,
+    heading-style: heading-style,
+    heading-color: heading-color,
+    heading-line-height: heading-line-height
+  )
 
   if toc {
     let title = if toc_title == none {

--- a/src/resources/formats/typst/pandoc/quarto/typst-title.typ
+++ b/src/resources/formats/typst/pandoc/quarto/typst-title.typ
@@ -1,0 +1,65 @@
+#let title_block(
+  title: none,
+  subtitle: none,
+  authors: none,
+  date: none,
+  abstract: none,
+  title-size: none,
+  subtitle-size: none,
+  heading-family: none,
+  heading-weight: none,
+  heading-style: none,
+  heading-color: none,
+  heading-line-height: none
+  ) = {
+  if title != none {
+    align(center)[#block(inset: 2em)[
+      #set par(leading: heading-line-height)
+      #if (heading-family != none or heading-weight != "bold" or heading-style != "normal"
+           or heading-color != black or heading-decoration == "underline"
+           or heading-background-color != none) {
+        set text(font: heading-family, weight: heading-weight, style: heading-style, fill: heading-color)
+        text(size: title-size)[#title]
+        if subtitle != none {
+          parbreak()
+          text(size: subtitle-size)[#subtitle]
+        }
+      } else {
+        text(weight: "bold", size: title-size)[#title]
+        if subtitle != none {
+          parbreak()
+          text(weight: "bold", size: subtitle-size)[#subtitle]
+        }
+      }
+    ]]
+    }
+
+  if authors != none {
+    let count = authors.len()
+    let ncols = calc.min(count, 3)
+    grid(
+      columns: (1fr,) * ncols,
+      row-gutter: 1.5em,
+      ..authors.map(author =>
+          align(center)[
+            #author.name \
+            #author.affiliation \
+            #author.email
+          ]
+      )
+    )
+  }
+
+  if date != none {
+    align(center)[#block(inset: 1em)[
+      #date
+    ]]
+  }
+
+  if abstract != none {
+    block(inset: 2em)[
+    #text(weight: "semibold")[#abstract-title] #h(1em) #abstract
+    ]
+  }
+}
+


### PR DESCRIPTION
## Description

An attempt a implementing https://github.com/quarto-dev/quarto-cli/issues/11709

Adds the `typst-title.typ` template so that users can customize the appearance of the title block in the typst template.

Opening as a place to discuss.

## Checklist

I have (if applicable):

- [X] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
