### PR TITLE
fix: change code block syntax as no longer rendered properly

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,31 +29,29 @@ body:
         You can share a Quarto document using the following syntax, _i.e._, using more backticks than you have in your document (usually four ` ```` `).
         For example with Quarto CLI >=1.5:
 
-        `````md
-        ````qmd
-        ---
-        title: "Reproducible Quarto Document"
-        format: html
-        engine: jupyter
-        ---
-
-        This is a reproducible Quarto document using `format: html`.
-        It is written in Markdown and contains embedded Python code.
-        When you run the code, it will produce a message.
-
-        ```{python}
-        print("Hello, world!")
-        ```
-
-        ![An image]({{< placeholder 600 400 >}}){#fig-placeholder}
-
-        {{< lipsum 1 >}}
-
-        A reference to @fig-placeholder.
-
-        The end.
-        ````
-        `````
+            ````qmd
+            ---
+            title: "Reproducible Quarto Document"
+            format: html
+            engine: jupyter
+            ---
+            
+            This is a reproducible Quarto document using `format: html`.
+            It is written in Markdown and contains embedded Python code.
+            When you run the code, it will produce a message.
+            
+            ```{python}
+            print("Hello, world!")
+            ```
+            
+            ![An image]({{< placeholder 600 400 >}}){#fig-placeholder}
+            
+            {{< lipsum 1 >}}
+            
+            A reference to @fig-placeholder.
+            
+            The end.
+            ````
 
   - type: textarea
     attributes:


### PR DESCRIPTION
For some reason, the code block is no longer rendered properly in issue template.
This PR switches to use the indented code block syntax.

| Before | After |
|--------|--------|
| <img width="1003" alt="image" src="https://github.com/user-attachments/assets/7bd7f741-4056-4831-a57b-485c7dde2900" /> | <img width="892" alt="image" src="https://github.com/user-attachments/assets/72f4cf97-7865-4302-a056-65cc27b0bdbd" /> | 

