### PR TITLE
fix: Markdown support in listings templates

### DIFF
--- a/src/resources/projects/website/listing/_filter.ejs.md
+++ b/src/resources/projects/website/listing/_filter.ejs.md
@@ -23,7 +23,7 @@ const sortUi = listing['sort-ui'];
       <option
         value="<%- sortData.listingSort.field %>"
         data-direction="<%- sortData.listingSort.direction %>">
-        <%- sortData.description %>
+        <%= sortData.description %>
       </option>
       <% } %>
     </select>

--- a/src/resources/projects/website/listing/_filter.ejs.md
+++ b/src/resources/projects/website/listing/_filter.ejs.md
@@ -10,32 +10,29 @@ const sortUi = listing['sort-ui'];
   <% const sortableFields = listing.utilities.sortableFieldData(); %>
   <% if (sortUi && sortableFields.length > 0) { %>
    <div class="input-group input-group-sm quarto-listing-sort">
-     <span class="input-group-text"><i class="bi bi-sort-down"></i></span>
-     <select
+    <span class="input-group-text"><i class="bi bi-sort-down"></i></span>
+    <select
       id="listing-<%- listing.id %>-sort"
       class="form-select"
-      aria-label="<%- listing.utilities.localizedString("listing-page-order-by")%>"
+      aria-label="<%- listing.utilities.localizedString("listing-page-order-by") %>"
       onChange="window['quarto-listings']['listing-<%- listing.id %>'].sort(this.options[this.selectedIndex].value, { order: this.options[this.selectedIndex].getAttribute('data-direction')})"
     >
-       <option value="" disabled selected hidden><%- listing.utilities.localizedString("listing-page-order-by")%></option>
-       <option value="index" data-direction="asc"><%- listing.utilities.localizedString("listing-page-order-by-default")%></option>
-       <% for (const sortData of sortableFields) { %>
-         <option
-          value="<%- sortData.listingSort.field %>"
-          data-direction="<%- sortData.listingSort.direction %>">
-          <%= sortData.description %>
-        </option>
-       <% } %>
-     </select>
+      <option value="" disabled selected hidden><%- listing.utilities.localizedString("listing-page-order-by") %></option>
+      <option value="index" data-direction="asc"><%- listing.utilities.localizedString("listing-page-order-by-default") %></option>
+      <% for (const sortData of sortableFields) { %>
+      <option
+        value="<%- sortData.listingSort.field %>"
+        data-direction="<%- sortData.listingSort.direction %>">
+        <%- sortData.description %>
+      </option>
+      <% } %>
+    </select>
   </div>
-
-
   <% } %>
-
   <% if (filterUi) { %>
     <div class="input-group input-group-sm quarto-listing-filter">
       <span class="input-group-text"><i class="bi bi-search"></i></span>
-      <input type="text" class="search form-control" placeholder="<%- listing.utilities.localizedString("listing-page-filter")%>" />
+      <input type="text" class="search form-control" placeholder="<%- listing.utilities.localizedString("listing-page-filter") %>" />
     </div>
   <% } %>
 </div>

--- a/src/resources/projects/website/listing/_filter.ejs.md
+++ b/src/resources/projects/website/listing/_filter.ejs.md
@@ -14,11 +14,11 @@ const sortUi = listing['sort-ui'];
     <select
       id="listing-<%- listing.id %>-sort"
       class="form-select"
-      aria-label="<%- listing.utilities.localizedString("listing-page-order-by") %>"
+      aria-label="<%= listing.utilities.localizedString("listing-page-order-by") %>"
       onChange="window['quarto-listings']['listing-<%- listing.id %>'].sort(this.options[this.selectedIndex].value, { order: this.options[this.selectedIndex].getAttribute('data-direction')})"
     >
-      <option value="" disabled selected hidden><%- listing.utilities.localizedString("listing-page-order-by") %></option>
-      <option value="index" data-direction="asc"><%- listing.utilities.localizedString("listing-page-order-by-default") %></option>
+      <option value="" disabled selected hidden><%= listing.utilities.localizedString("listing-page-order-by") %></option>
+      <option value="index" data-direction="asc"><%= listing.utilities.localizedString("listing-page-order-by-default") %></option>
       <% for (const sortData of sortableFields) { %>
       <option
         value="<%- sortData.listingSort.field %>"
@@ -32,7 +32,7 @@ const sortUi = listing['sort-ui'];
   <% if (filterUi) { %>
     <div class="input-group input-group-sm quarto-listing-filter">
       <span class="input-group-text"><i class="bi bi-search"></i></span>
-      <input type="text" class="search form-control" placeholder="<%- listing.utilities.localizedString("listing-page-filter") %>" />
+      <input type="text" class="search form-control" placeholder="<%= listing.utilities.localizedString("listing-page-filter") %>" />
     </div>
   <% } %>
 </div>

--- a/src/resources/projects/website/listing/_metadata.ejs.md
+++ b/src/resources/projects/website/listing/_metadata.ejs.md
@@ -2,7 +2,9 @@
 const categories = item.categories !== undefined ? item.categories.join(',') : undefined;
 %>
 
+```{=html}
 <div class="quarto-listing-item-metadata" style-"display:none;">
 <span class="original-value" data-original-value="${itemNumber}" style="display:none;"></span>
 <% if (categories !== undefined) { %><span class="categories" data-categories="${categories}" style="display:none;"></span><% } %>
 </div>
+```

--- a/src/resources/projects/website/listing/_metadata.ejs.md
+++ b/src/resources/projects/website/listing/_metadata.ejs.md
@@ -2,9 +2,9 @@
 const categories = item.categories !== undefined ? item.categories.join(',') : undefined;
 %>
 
-::: {.quarto-listing-item-metadata" style-"display:none;"}
-[]{.original-value data-original-value="${itemNumber}" style="display:none;"}
-<% if (categories !== undefined) { %>
-[]{.categories data-categories="${categories}" style="display:none;"}
-<% } %>
-:::
+```{=html}
+<div class="quarto-listing-item-metadata" style-"display:none;">
+<span class="original-value" data-original-value="${itemNumber}" style="display:none;"></span>
+<% if (categories !== undefined) { %><span class="categories" data-categories="${categories}" style="display:none;"></span><% } %>
+</div>
+```

--- a/src/resources/projects/website/listing/_metadata.ejs.md
+++ b/src/resources/projects/website/listing/_metadata.ejs.md
@@ -2,9 +2,9 @@
 const categories = item.categories !== undefined ? item.categories.join(',') : undefined;
 %>
 
-```{=html}
-<div class="quarto-listing-item-metadata" style-"display:none;">
-<span class="original-value" data-original-value="${itemNumber}" style="display:none;"></span>
-<% if (categories !== undefined) { %><span class="categories" data-categories="${categories}" style="display:none;"></span><% } %>
-</div>
-```
+::: {.quarto-listing-item-metadata" style-"display:none;"}
+[]{.original-value data-original-value="${itemNumber}" style="display:none;"}
+<% if (categories !== undefined) { %>
+[]{.categories data-categories="${categories}" style="display:none;"}
+<% } %>
+:::

--- a/src/resources/projects/website/listing/_metadata.ejs.md
+++ b/src/resources/projects/website/listing/_metadata.ejs.md
@@ -3,7 +3,7 @@ const categories = item.categories !== undefined ? item.categories.join(',') : u
 %>
 
 ```{=html}
-<div class="quarto-listing-item-metadata" style-"display:none;">
+<div class="quarto-listing-item-metadata" style="display:none;">
 <span class="original-value" data-original-value="${itemNumber}" style="display:none;"></span>
 <% if (categories !== undefined) { %><span class="categories" data-categories="${categories}" style="display:none;"></span><% } %>
 </div>

--- a/src/resources/projects/website/listing/_pagination.ejs.md
+++ b/src/resources/projects/website/listing/_pagination.ejs.md
@@ -1,8 +1,5 @@
-::: {.listing-no-matching .d-none}
-<%- listing.utilities.localizedString("listing-page-no-matches") %>
-:::
-
 ```{=html}
+<div class="listing-no-matching d-none"><%= listing.utilities.localizedString("listing-page-no-matches") %></div>
 <% if (listing["page-size"] < items.length) { %>
 <nav id="<%- listing.id %>-pagination" class="listing-pagination" aria-label="Page Navigation">
   <ul class="pagination"></ul>

--- a/src/resources/projects/website/listing/_pagination.ejs.md
+++ b/src/resources/projects/website/listing/_pagination.ejs.md
@@ -2,12 +2,10 @@
 <%- listing.utilities.localizedString("listing-page-no-matches") %>
 :::
 
-<% if (listing["page-size"] < items.length) { %>
-
 ```{=html}
+<% if (listing["page-size"] < items.length) { %>
 <nav id="<%- listing.id %>-pagination" class="listing-pagination" aria-label="Page Navigation">
   <ul class="pagination"></ul>
 </nav>
-```
-
 <% } %>
+```

--- a/src/resources/projects/website/listing/_pagination.ejs.md
+++ b/src/resources/projects/website/listing/_pagination.ejs.md
@@ -1,10 +1,13 @@
-```{=html}
-<div class="listing-no-matching d-none">
+::: {.listing-no-matching .d-none}
 <%- listing.utilities.localizedString("listing-page-no-matches") %>
-</div>
+:::
+
 <% if (listing["page-size"] < items.length) { %>
+
+```{=html}
 <nav id="<%- listing.id %>-pagination" class="listing-pagination" aria-label="Page Navigation">
   <ul class="pagination"></ul>
 </nav>
-<% } %>
 ```
+
+<% } %>

--- a/src/resources/projects/website/listing/_pagination.ejs.md
+++ b/src/resources/projects/website/listing/_pagination.ejs.md
@@ -1,8 +1,10 @@
-<div class="listing-no-matching d-none"><%- listing.utilities.localizedString("listing-page-no-matches")%></div>
-<% if (listing["page-size"] < items.length) { %>
 ```{=html}
+<div class="listing-no-matching d-none">
+<%- listing.utilities.localizedString("listing-page-no-matches") %>
+</div>
+<% if (listing["page-size"] < items.length) { %>
 <nav id="<%- listing.id %>-pagination" class="listing-pagination" aria-label="Page Navigation">
   <ul class="pagination"></ul>
 </nav>
-```
 <% } %>
+```

--- a/src/resources/projects/website/listing/item-default.ejs.md
+++ b/src/resources/projects/website/listing/item-default.ejs.md
@@ -31,44 +31,64 @@ return value;
 
 let value = readField(item, field);
 if (value !== undefined) {
-print(`<div class="metadata-value listing-${field}">${listing.utilities.outputLink(item, field, value)}</div>`);  
+print(`<div class="metadata-value listing-${field}">${listing.utilities.outputLink(item, field, value)}</div>`);
  }
 }
 %>
 
-<div class="quarto-post image-<%= imageAlign %>" <%= listing.utilities.metadataAttrs(item) %>>
+::: {.quarto-post .image-<%= imageAlign %> <%= listing.utilities.metadataAttrs(item) %>}
+
 <% if (fields.includes('image')) { %>
-<div class="thumbnail">
-<a href="<%- item.path %>" class="no-external">
+`<div class="thumbnail"><a href="<%- item.path %>" class="no-external">`{=html}
 <% if (item.image) { %>
 <%= listing.utilities.img(itemNumber, item.image, "thumbnail-image", item['image-alt'], item['image-lazy-loading'] ?? listing['image-lazy-loading']) %>
 <% } else { %>
 <%= listing.utilities.imgPlaceholder(listing.id, itemNumber, item.outputHref) %>
 <% } %>
-</a>
-</div>
+`</a></div>`{=html}
 <% } %>
-<div class="body">
-<% if (fields.includes('title')) { %>
-<h3 class="no-anchor listing-title"><a href="<%- item.path %>" class="no-external"><%= item.title %></a></h3>
-<div class="listing-subtitle"><a href="<%- item.path %>" class="no-external"><%= item.subtitle %></a></div>
-<% } %>
-<% if (fields.includes('categories') && item.categories) { %> 
-<div class="listing-categories">
-<% for (const category of item.categories) { %>
-<div class="listing-category" onclick="window.quartoListingCategory('<%=utils.b64encode(category)%>'); return false;"><%= category %></div>
-<% } %>
-</div>
-<% } %> 
-<% if (fields.includes('description')) { %>
-<div class="delink listing-description"><a href="<%- item.path %>" class="no-external"><%= item.description %></a></div>
-<% } %>
-</div>
-<div class="metadata"><a href="<%- item.path %>" class="no-external">
-<% if (fields.includes('date') && item.date) { %><div class="listing-date"><%= item.date %></div><% } %>
-<% if (fields.includes('author') && item.author) { %><div class="listing-author"><%= item.author %></div><% } %>
-<% if (fields.includes('reading-time') && item['reading-time']) { %> <div class="listing-reading-time"><%= item['reading-time'] %></div> <% } %>
-<% for (const field of otherFields) { %>
-<% outputMetadata(item, field) %><% } %></a></div>
 
-</div>
+::: {.body}
+
+<% if (fields.includes('title')) { %>
+`<h3 class="no-anchor listing-title"><a href="<%- item.path %>" class="no-external">`{=html} <%= item.title %> `</a></h3>`{=html}
+<% if (fields.includes('subtitle')) { %>
+`<div class="listing-subtitle"><a href="<%- item.path %>" class="no-external">`{=html} <%= item.subtitle %> `</a></div>`{=html}
+<% } %>
+<% } %>
+
+<% if (fields.includes('categories') && item.categories) { %>
+`<div class="listing-categories">`{=html}
+<% for (const category of item.categories) { %>
+`<div class="listing-category" onclick="window.quartoListingCategory('<%- utils.b64encode(category) %>'); return false;">`{=html} <%= category %> `</div>`{=html}
+<% } %>
+`</div>`{=html}
+<% } %>
+
+<% if (fields.includes('description')) { %>
+`<div class="delink listing-description"><a href="<%- item.path %>" class="no-external">`{=html} <%= item.description %> `</a></div>`{=html}
+<% } %>
+
+:::
+
+::: {.metadata}
+`<a href="<%- item.path %>" class="no-external">`{=html}
+<% if (fields.includes('date') && item.date) { %>
+`<div class="listing-date">`{=html} <%= item.date %> `</div>`{=html}
+<% } %>
+
+<% if (fields.includes('author') && item.author) { %>
+`<div class="listing-author">`{=html} <%= item.author %> `</div>`{=html}
+<% } %>
+
+<% if (fields.includes('reading-time') && item['reading-time']) { %>
+`<div class="listing-reading-time">`{=html} <%= item['reading-time'] %> `</div>`{=html}
+<% } %>
+
+<% for (const field of otherFields) { %>
+<% outputMetadata(item, field) %>
+<% } %>
+`</a>`{=html}
+:::
+
+:::

--- a/src/resources/projects/website/listing/item-default.ejs.md
+++ b/src/resources/projects/website/listing/item-default.ejs.md
@@ -39,56 +39,86 @@ print(`<div class="metadata-value listing-${field}">${listing.utilities.outputLi
 ::: {.quarto-post .image-<%= imageAlign %> <%= listing.utilities.metadataAttrs(item) %>}
 
 <% if (fields.includes('image')) { %>
-`<div class="thumbnail"><a href="<%- item.path %>" class="no-external">`{=html}
+
+```{=html}
+<div class="thumbnail"><a href="<%- item.path %>" class="no-external">
 <% if (item.image) { %>
 <%= listing.utilities.img(itemNumber, item.image, "thumbnail-image", item['image-alt'], item['image-lazy-loading'] ?? listing['image-lazy-loading']) %>
 <% } else { %>
 <%= listing.utilities.imgPlaceholder(listing.id, itemNumber, item.outputHref) %>
 <% } %>
-`</a></div>`{=html}
+</a></div>
+```
+
 <% } %>
 
 ::: {.body}
 
 <% if (fields.includes('title')) { %>
-`<h3 class="no-anchor listing-title"><a href="<%- item.path %>" class="no-external">`{=html} <%= item.title %> `</a></h3>`{=html}
+<h3 class="no-anchor listing-title"><a href="<%- item.path %>" class="no-external"><%= item.title %></a></h3>
 <% if (fields.includes('subtitle')) { %>
-`<div class="listing-subtitle"><a href="<%- item.path %>" class="no-external">`{=html} <%= item.subtitle %> `</a></div>`{=html}
+<div class="listing-subtitle"><a href="<%- item.path %>" class="no-external"><%= item.subtitle %></a></div>
 <% } %>
 <% } %>
 
 <% if (fields.includes('categories') && item.categories) { %>
-`<div class="listing-categories">`{=html}
+
+```{=html}
+<div class="listing-categories">
 <% for (const category of item.categories) { %>
-`<div class="listing-category" onclick="window.quartoListingCategory('<%- utils.b64encode(category) %>'); return false;">`{=html} <%= category %> `</div>`{=html}
+<div class="listing-category" onclick="window.quartoListingCategory('<%- utils.b64encode(category) %>'); return false;"><%= category %></div>
 <% } %>
-`</div>`{=html}
+</div>
+```
+
 <% } %>
 
 <% if (fields.includes('description')) { %>
-`<div class="delink listing-description"><a href="<%- item.path %>" class="no-external">`{=html} <%= item.description %> `</a></div>`{=html}
+
+```{=html}
+<div class="delink listing-description"><a href="<%- item.path %>" class="no-external">
+```
+
+<%= item.description %>
+
+```{=html}
+</a></div>
+```
+
 <% } %>
 
 :::
 
 ::: {.metadata}
-`<a href="<%- item.path %>" class="no-external">`{=html}
+
+```{=html}
+<a href="<%- item.path %>" class="no-external">
+```
+
 <% if (fields.includes('date') && item.date) { %>
-`<div class="listing-date">`{=html} <%= item.date %> `</div>`{=html}
+<div class="listing-date"><%= item.date %></div>
 <% } %>
 
 <% if (fields.includes('author') && item.author) { %>
-`<div class="listing-author">`{=html} <%= item.author %> `</div>`{=html}
+<div class="listing-author"><%= item.author %></div>
 <% } %>
 
 <% if (fields.includes('reading-time') && item['reading-time']) { %>
-`<div class="listing-reading-time">`{=html} <%= item['reading-time'] %> `</div>`{=html}
+
+```{=html}
+<div class="listing-reading-time"><%= item['reading-time'] %></div>
+```
+
 <% } %>
 
 <% for (const field of otherFields) { %>
 <% outputMetadata(item, field) %>
 <% } %>
-`</a>`{=html}
+
+```{=html}
+</a>
+```
+
 :::
 
 :::

--- a/src/resources/projects/website/listing/item-default.ejs.md
+++ b/src/resources/projects/website/listing/item-default.ejs.md
@@ -66,7 +66,7 @@ print(`<div class="metadata-value listing-${field}">${listing.utilities.outputLi
 ```{=html}
 <div class="listing-categories">
 <% for (const category of item.categories) { %>
-<div class="listing-category" onclick="window.quartoListingCategory('<%- utils.b64encode(category) %>'); return false;"><%= category %></div>
+<div class="listing-category" onclick="window.quartoListingCategory('<%= utils.b64encode(category) %>'); return false;"><%= category %></div>
 <% } %>
 </div>
 ```

--- a/src/resources/projects/website/listing/item-grid.ejs.md
+++ b/src/resources/projects/website/listing/item-grid.ejs.md
@@ -141,8 +141,12 @@ const flexJustify = showField('author') && showField('date') ? "justify" : showF
 let value = readField(item, field);
 %>
 <tr>
+```
+
 <td><%= listing.utilities.fieldName(field) %></td>
 <td class="<%- field %>"><%= listing.utilities.outputLink(item, field, value) %></td>
+
+```{=html}
 </tr>
 <% } %>
 </table>

--- a/src/resources/projects/website/listing/item-grid.ejs.md
+++ b/src/resources/projects/website/listing/item-grid.ejs.md
@@ -45,43 +45,68 @@ return !["title", "image", "image-alt", "date", "author", "subtitle", "descripti
 ```
 
 <% if (fields.includes('image')) { %>
+
 <% if (item.image) { %>
-`<p class="card-img-top">`{=html}
+
+```{=html}
+<p class="card-img-top">
 <%= listing.utilities.img(itemNumber, item.image, "thumbnail-image card-img", item['image-alt'], item['image-lazy-loading'] ?? listing['image-lazy-loading']) %>
-`</p>`{=html}
+</p>
+```
+
 <% } else { %>
+
+```{=html}
 <%= listing.utilities.imgPlaceholder(listing.id, itemNumber, item.outputHref) %>
-<% } %>
+```
 
 <% } %>
+<% } %>
+
 <% if (showField('title') || showField('subtitle') || showField('description') || showField('author') || showField('date') || otherFields.length > 0) { %>
 
-`<div class="card-body post-contents">`{=html}
+::: {.card-body .post-contents}
 
 <% if (showField('title')) { %>
-`<h5 class="no-anchor card-title listing-title">`{=html} <%= item.title %> `</h5>`{=html}
+<h5 class="no-anchor card-title listing-title"><%= item.title %></h5>
 <% } %>
 
 <% if (showField('subtitle')) { %>
-`<div class="card-subtitle listing-subtitle">`{=html} <%= item.subtitle %> `</div>`{=html}
+<div class="card-subtitle listing-subtitle"><%= item.subtitle %></div>
 <% } %>
 
 <% if (showField('reading-time')) { %>
-`<div class="listing-reading-time card-text text-muted">`{=html} <%= item['reading-time'] %> `</div>`{=html}
+
+```{=html}
+<div class="listing-reading-time card-text text-muted"><%= item['reading-time'] %></div>
+```
+
 <% } %>
 
 <% if (fields.includes('categories') && item.categories) { %>
-`<div class="listing-categories">`{=html}
 
+```{=html}
+<div class="listing-categories">
 <% for (const category of item.categories) { %>
-`<div class="listing-category" onclick="window.quartoListingCategory('<%- utils.b64encode(category ) %>'); return false;">`{=html} <%= category %> `</div>`{=html}
+<div class="listing-category" onclick="window.quartoListingCategory('<%- utils.b64encode(category ) %>'); return false;"><%= category %></div>
 <% } %>
+</div>
+```
 
-`</div>`{=html}
 <% } %>
 
 <% if (showField('description')) { %>
-`<div class="card-text listing-description delink">`{=html} <%= item.description %> `</div>`{=html}
+
+```{=html}
+<div class="card-text listing-description delink">
+```
+
+<%= item.description %>
+
+```{=html}
+</div>
+```
+
 <% } %>
 
 <%
@@ -89,49 +114,70 @@ const flexJustify = showField('author') && showField('date') ? "justify" : showF
 %>
 
 <% if (showField('author') || showField('date')) { %>
-`<div class="card-attribution card-text-small <%- flexJustify %>">`{=html}
+
+```{=html}
+<div class="card-attribution card-text-small <%- flexJustify %>">
+```
 
 <% if (showField('author')) { %>
-`<div class="listing-author">`{=html} <%= item.author %> `</div>`{=html}
+<div class="listing-author"><%= item.author %></div>
 <% } %>
 
 <% if (showField('date')) { %>
-`<div class="listing-date">`{=html} <%= item.date %> `</div>`{=html}
+<div class="listing-date"><%= item.date %></div>
 <% } %>
 
-`</div>`{=html}
+```{=html}
+</div>
+```
+
 <% } %>
 
 <% if (otherFields.length > 0) { %>
-`<table class="card-other-values">`{=html}
+
+```{=html}
+<table class="card-other-values">
 <% for (const field of otherFields) {
 let value = readField(item, field);
 %>
-`<tr>`{=html}
-`<td>`{=html} <%= listing.utilities.fieldName(field) %> `</td>`{=html}
-`<td class="<%- field %>">`{=html} <%= listing.utilities.outputLink(item, field, value) %> `</td>`{=html}
-`</tr>`{=html}
+<tr>
+<td><%= listing.utilities.fieldName(field) %></td>
+<td class="<%- field %>"><%= listing.utilities.outputLink(item, field, value) %></td>
+</tr>
 <% } %>
-`</table>`{=html}
+</table>
+```
+
 <% } %>
 
-`</div>`{=html}
+:::
 <% } %>
 
 <% if (fields.includes('filename') || fields.includes('file-modified')) { %>
 
-`<div class="card-footer">`{=html}
+::: {.card-footer}
 
 <% if (fields.includes('filename')) { %>
-`<div class="card-filename listing-filename">`{=html} <%= item.filename ? item.filename : "&nbsp;" %> `</div>`{=html}
+
+```{=html}
+<div class="card-filename listing-filename"><%= item.filename ? item.filename : "&nbsp;" %></div>
+```
+
 <% } %>
 
 <% if (fields.includes('file-modified')) { %>
-`<div class="card-file-modified listing-file-modified">`{=html} <%= item['file-modified'] ? item['file-modified'] : "&nbsp;" %> `</div>`{=html}
+
+```{=html}
+<div class="card-file-modified listing-file-modified"><%= item['file-modified'] ? item['file-modified'] : "&nbsp;" %></div>
+```
+
 <% } %>
 
-`</div>`{=html}
+:::
 <% } %>
-`</div></a>`{=html}
+
+```{=html}
+</div></a>
+```
 
 :::

--- a/src/resources/projects/website/listing/item-grid.ejs.md
+++ b/src/resources/projects/website/listing/item-grid.ejs.md
@@ -41,7 +41,7 @@ return !["title", "image", "image-alt", "date", "author", "subtitle", "descripti
 
 ```{=html}
 <a href="<%- item.path %>" class="quarto-grid-link">
-<div class="quarto-grid-item card h-100 <%- `card-${align}` %><%- hideBorders ? ' borderless' : '' %>">
+<div class="quarto-grid-item card h-100 <%= `card-${align}` %><%= hideBorders ? ' borderless' : '' %>">
 ```
 
 <% if (fields.includes('image')) { %>

--- a/src/resources/projects/website/listing/item-grid.ejs.md
+++ b/src/resources/projects/website/listing/item-grid.ejs.md
@@ -88,7 +88,7 @@ return !["title", "image", "image-alt", "date", "author", "subtitle", "descripti
 ```{=html}
 <div class="listing-categories">
 <% for (const category of item.categories) { %>
-<div class="listing-category" onclick="window.quartoListingCategory('<%- utils.b64encode(category ) %>'); return false;"><%= category %></div>
+<div class="listing-category" onclick="window.quartoListingCategory('<%= utils.b64encode(category ) %>'); return false;"><%= category %></div>
 <% } %>
 </div>
 ```

--- a/src/resources/projects/website/listing/item-grid.ejs.md
+++ b/src/resources/projects/website/listing/item-grid.ejs.md
@@ -37,17 +37,18 @@ return !["title", "image", "image-alt", "date", "author", "subtitle", "descripti
 });
 %>
 
-<div class="g-col-1" <%= listing.utilities.metadataAttrs(item) %>>
+::: {.g-col-1 <%= listing.utilities.metadataAttrs(item) %> }
+
+```{=html}
 <a href="<%- item.path %>" class="quarto-grid-link">
-<div class="quarto-grid-item card h-100 <%-`card-${align}`%><%= hideBorders ? ' borderless' : '' %>">
+<div class="quarto-grid-item card h-100 <%- `card-${align}` %><%- hideBorders ? ' borderless' : '' %>">
+```
 
 <% if (fields.includes('image')) { %>
-
 <% if (item.image) { %>
-
-<p class="card-img-top">
+`<p class="card-img-top">`{=html}
 <%= listing.utilities.img(itemNumber, item.image, "thumbnail-image card-img", item['image-alt'], item['image-lazy-loading'] ?? listing['image-lazy-loading']) %>
-</p>
+`</p>`{=html}
 <% } else { %>
 <%= listing.utilities.imgPlaceholder(listing.id, itemNumber, item.outputHref) %>
 <% } %>
@@ -55,65 +56,82 @@ return !["title", "image", "image-alt", "date", "author", "subtitle", "descripti
 <% } %>
 <% if (showField('title') || showField('subtitle') || showField('description') || showField('author') || showField('date') || otherFields.length > 0) { %>
 
-<div class="card-body post-contents">
-<% if (showField('title')) { %><h5 class="no-anchor card-title listing-title"><%= item.title %></h5><% } %>
-<% if (showField('subtitle')) { %><div class="card-subtitle listing-subtitle"><%= item.subtitle %></div><% } %>
-<% if (showField('reading-time')) { %><div class="listing-reading-time card-text text-muted"><%= item['reading-time'] %></div> <% } %>
+`<div class="card-body post-contents">`{=html}
+
+<% if (showField('title')) { %>
+`<h5 class="no-anchor card-title listing-title">`{=html} <%= item.title %> `</h5>`{=html}
+<% } %>
+
+<% if (showField('subtitle')) { %>
+`<div class="card-subtitle listing-subtitle">`{=html} <%= item.subtitle %> `</div>`{=html}
+<% } %>
+
+<% if (showField('reading-time')) { %>
+`<div class="listing-reading-time card-text text-muted">`{=html} <%= item['reading-time'] %> `</div>`{=html}
+<% } %>
 
 <% if (fields.includes('categories') && item.categories) { %>
+`<div class="listing-categories">`{=html}
 
-<div class="listing-categories">
-  <% for (const category of item.categories) { %>
-<div class="listing-category" onclick="window.quartoListingCategory('<%=utils.b64encode(category)%>'); return false;"><%= category %></div>
-  <% } %>
-</div>
-
+<% for (const category of item.categories) { %>
+`<div class="listing-category" onclick="window.quartoListingCategory('<%- utils.b64encode(category ) %>'); return false;">`{=html} <%= category %> `</div>`{=html}
 <% } %>
+
+`</div>`{=html}
+<% } %>
+
 <% if (showField('description')) { %>
-
-<div class="card-text listing-description delink"><%= item.description %></div>
+`<div class="card-text listing-description delink">`{=html} <%= item.description %> `</div>`{=html}
 <% } %>
-<% 
+
+<%
 const flexJustify = showField('author') && showField('date') ? "justify" : showField('author') ? "start" : "end";
 %>
+
 <% if (showField('author') || showField('date')) { %>
-<div class="card-attribution card-text-small <%-flexJustify%>">
-<% if (showField('author')) { %><div class="listing-author"><%= item.author %></div><% } %>
-<% if (showField('date')) { %><div class="listing-date"><%= item.date %></div><% } %>
-</div>
+`<div class="card-attribution card-text-small <%- flexJustify %>">`{=html}
+
+<% if (showField('author')) { %>
+`<div class="listing-author">`{=html} <%= item.author %> `</div>`{=html}
+<% } %>
+
+<% if (showField('date')) { %>
+`<div class="listing-date">`{=html} <%= item.date %> `</div>`{=html}
+<% } %>
+
+`</div>`{=html}
 <% } %>
 
 <% if (otherFields.length > 0) { %>
-
-<table class="card-other-values">
-<% for (const field of otherFields) { 
-let value = readField(item, field);  
+`<table class="card-other-values">`{=html}
+<% for (const field of otherFields) {
+let value = readField(item, field);
 %>
-<tr>
-<td><%= listing.utilities.fieldName(field) %></td>
-<td class="<%-field%>"><%= listing.utilities.outputLink(item, field, value) %></td>
-</tr>
+`<tr>`{=html}
+`<td>`{=html} <%= listing.utilities.fieldName(field) %> `</td>`{=html}
+`<td class="<%- field %>">`{=html} <%= listing.utilities.outputLink(item, field, value) %> `</td>`{=html}
+`</tr>`{=html}
 <% } %>
-</table>
-
+`</table>`{=html}
 <% } %>
 
-</div>
+`</div>`{=html}
 <% } %>
 
 <% if (fields.includes('filename') || fields.includes('file-modified')) { %>
 
-<div class="card-footer">
+`<div class="card-footer">`{=html}
+
 <% if (fields.includes('filename')) { %>
-<div class="card-filename listing-filename">
-<%= item.filename ? item.filename : "&nbsp;" %>
-</div>
+`<div class="card-filename listing-filename">`{=html} <%= item.filename ? item.filename : "&nbsp;" %> `</div>`{=html}
 <% } %>
+
 <% if (fields.includes('file-modified')) { %>
-<div class="card-file-modified listing-file-modified">
-<%= item['file-modified'] ? item['file-modified'] : "&nbsp;"%>
-</div>
+`<div class="card-file-modified listing-file-modified">`{=html} <%= item['file-modified'] ? item['file-modified'] : "&nbsp;" %> `</div>`{=html}
 <% } %>
-</div>
+
+`</div>`{=html}
 <% } %>
-</div></a></div>
+`</div></a>`{=html}
+
+:::

--- a/src/resources/projects/website/listing/listing-default.ejs.md
+++ b/src/resources/projects/website/listing/listing-default.ejs.md
@@ -1,7 +1,7 @@
-:::{.list .quarto-listing-default}
-``````{=html}
+::: {.list .quarto-listing-default}
+
 <% for (const item of items) { %>
 <% partial('item-default.ejs.md', {listing, item, utils }) %>
 <% } %>
-``````
+
 :::

--- a/src/resources/projects/website/listing/listing-grid.ejs.md
+++ b/src/resources/projects/website/listing/listing-grid.ejs.md
@@ -2,10 +2,10 @@
 const cols = listing['grid-columns'];
 %>
 
-:::{.list .grid .quarto-listing-cols-<%=cols%>}
-```{=html}
+::: {.list .grid .quarto-listing-cols-<%= cols %>}
+
 <% for (const item of items) { %>
 <% partial('item-grid.ejs.md', {listing, item, utils }) %>
 <% } %>
-```
+
 :::

--- a/src/resources/projects/website/listing/listing-table.ejs.md
+++ b/src/resources/projects/website/listing/listing-table.ejs.md
@@ -84,7 +84,9 @@ return listing.utilities.outputLink(item, field, value, `listing-${field}`);
 <tr <%= listing.utilities.metadataAttrs(item) %><%= onclick(item) %>>
 <% for (const field of fields){ %>
 <td>
+```
 <%= outputValue(itemNumber, field) %>
+```{=html}
 </td>
 <% } %>
 </tr>

--- a/src/resources/projects/website/listing/listing-table.ejs.md
+++ b/src/resources/projects/website/listing/listing-table.ejs.md
@@ -82,13 +82,14 @@ return listing.utilities.outputLink(item, field, value, `listing-${field}`);
 %>
 
 <tr <%= listing.utilities.metadataAttrs(item) %><%= onclick(item) %>>
-<% for (const field of fields){ %>
-<td>
 ```
-<%= outputValue(itemNumber, field) %>
-```{=html}
-</td>
+
+<% for (const field of fields){ %>
+<td><%= outputValue(itemNumber, field) %></td>
 <% } %>
+
+```{=html}
+
 </tr>
 <% } %>
 </tbody>

--- a/src/resources/projects/website/listing/listing-table.ejs.md
+++ b/src/resources/projects/website/listing/listing-table.ejs.md
@@ -70,7 +70,7 @@ return listing.utilities.outputLink(item, field, value, `listing-${field}`);
 <tr>
 <% for (const field of fields) { %>
 <th>
-<% if (sortUi && hasSort(field)) { %><a class="sort" data-sort="<%-listing.utilities.sortTarget(field)%>" onclick="if (this.classList.contains('sort-asc')) { this.classList.add('sort-desc'); this.classList.remove('sort-asc') } else { this.classList.add('sort-asc'); this.classList.remove('sort-desc')} return false;"><% } %><%= listing.utilities.fieldName(field) %><% if (sortUi && hasSort(field)) { %></a><% } %>
+<% if (sortUi && hasSort(field)) { %><a class="sort" data-sort="<%- listing.utilities.sortTarget(field) %>" onclick="if (this.classList.contains('sort-asc')) { this.classList.add('sort-desc'); this.classList.remove('sort-asc') } else { this.classList.add('sort-asc'); this.classList.remove('sort-desc')} return false;"><% } %><%= listing.utilities.fieldName(field) %><% if (sortUi && hasSort(field)) { %></a><% } %>
 </th>
 <% } %>
 </tr>

--- a/tests/docs/listings/_quarto.yml
+++ b/tests/docs/listings/_quarto.yml
@@ -5,4 +5,4 @@ website:
   title: "Listing Test"
 format:
   html:
-    theme: [litera, styles.scss]
+    theme: [litera]


### PR DESCRIPTION
The changes restore Markdown support in the default listings templates after the introduction of `{=html}` in version 1.7.5. This update ensures that Markdown formatting is correctly rendered in listings.

Fixes #11758.

This PR also adds a check for `subtitle` field in the default listing. Previously it was adding subtitle even when not provided as long as `title` was.

Tested on: https://m.canouil.dev/quarto-issues-experiments/issue11758/
Source: https://github.com/mcanouil/quarto-issues-experiments/tree/main/quarto-cli-11758

To do:

- [x] check that the fix for #11701 still works.
