### PR TITLE
typst brand yaml: make default logo slightly smaller

### DIFF
--- a/src/resources/filters/quarto-post/typst-brand-yaml.lua
+++ b/src/resources/filters/quarto-post/typst-brand-yaml.lua
@@ -278,9 +278,9 @@ function render_typst_brand_yaml()
               inset = _quarto.modules.typst.as_typst_dictionary(pads)
             end
           else
-            inset = '0.5in'
+            inset = '0.75in'
           end
-          logoOptions.width = _quarto.modules.typst.css.translate_length(logoOptions.width or '2in')
+          logoOptions.width = _quarto.modules.typst.css.translate_length(logoOptions.width or '1.5in')
           logoOptions.location = logoOptions.location and
             location_to_typst_align(logoOptions.location) or 'left+top'
           quarto.log.debug('logo options', logoOptions)

--- a/tests/docs/smoke-all/typst/brand-yaml/logo/posit/brand-logo.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/logo/posit/brand-logo.qmd
@@ -9,7 +9,7 @@ _quarto:
     typst:
       ensureTypstFileRegexMatches:
       -
-        - '#set page\(background: align\(left\+top, box\(inset: 0.5in, image\("posit-logo-2024.svg", width: 2in, alt: "Posit Logo"\)\)\)\)'
+        - '#set page\(background: align\(left\+top, box\(inset: 0.75in, image\("posit-logo-2024.svg", width: 1.5in, alt: "Posit Logo"\)\)\)\)'
       - []
 ---
 


### PR DESCRIPTION
As suggested by @cwickham, reduce the default logo size a little (and move it in a little).

Left is current `2in`, center is proposed `1.5in` (this PR), right is `1in`

<img width="2995" alt="image" src="https://github.com/user-attachments/assets/5b05a313-1d1f-444a-9bcb-5e43b4e21c59" />

This will be a backport to 1.6 and I'll add the changelog there.

