### PR TITLE
typst brand yaml: use lightened colors for brand background colors

### DIFF
--- a/src/resources/filters/quarto-post/typst-brand-yaml.lua
+++ b/src/resources/filters/quarto-post/typst-brand-yaml.lua
@@ -65,11 +65,6 @@ function render_typst_brand_yaml()
           end
           local decl = '#let brand-color = ' .. to_typst_dict_indent(colors)
           quarto.doc.include_text('in-header', decl)
-          local BACKGROUND_OPACITY = 0.1
-          local themebk = {}
-          for name, _ in pairs(brandColor) do
-            themebk[name] = _quarto.modules.brand.get_background_color(name, BACKGROUND_OPACITY)
-          end
           if brandColor.background then
             quarto.doc.include_text('in-header', '#set page(fill: brand-color.background)')
           end
@@ -79,7 +74,11 @@ function render_typst_brand_yaml()
             quarto.doc.include_text('in-header', '#set line(stroke: (paint: brand-color.foreground))')
     
           end
-          local decl = '// theme colors at opacity ' .. BACKGROUND_OPACITY .. '\n#let brand-color-background = ' .. to_typst_dict_indent(themebk)
+          local themebk = {}
+          for name, _ in pairs(brandColor) do
+            themebk[name] = 'brand-color.' .. name .. '.lighten(85%)'
+          end
+          local decl = '#let brand-color-background = ' .. to_typst_dict_indent(themebk)
           quarto.doc.include_text('in-header', decl)
         end
         local function quote_string(value)

--- a/tests/docs/smoke-all/typst/brand-yaml/color/posit/brand-color.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/color/posit/brand-color.qmd
@@ -10,7 +10,7 @@ _quarto:
         -
           - 'burgundy: rgb\("#9a4665"\),'
           - 'primary: rgb\("#447099"\),'
-          - 'primary: rgb\("#44709919"\),' # background
+          - 'primary: brand-color\.primary\.lighten\(85%\),'
           - 'title: (\r\n?|\n)\[(\r\n?|\n)Note(\r\n?|\n)\](\r\n?|\n), (\r\n?|\n)background_color: (\r\n?|\n)brand-color-background.primary'
           - 'title: (\r\n?|\n)\[(\r\n?|\n)Warning(\r\n?|\n)\](\r\n?|\n), (\r\n?|\n)background_color: (\r\n?|\n)brand-color-background.warning'
         -


### PR DESCRIPTION
fixes #11485

Instead of using translucent background colors, use lightened background colors, to eliminate blurry callout title bars.

This will be a backport to 1.6 and I'll add the changelog there.


Before | After
--- | ---
<img width="431" alt="image" src="https://github.com/user-attachments/assets/206f94c6-0fe0-4c24-bbf8-ef9366983bcb" /> | <img width="367" alt="image" src="https://github.com/user-attachments/assets/df63d467-28be-4ccb-b915-1436d1d3d5db" />

It is also just a tiny bit lighter. Here are non-branded colors for comparison. 

<img width="504" alt="image" src="https://github.com/user-attachments/assets/1bcdf4b5-8fe8-4e83-a115-89ef672c5ff8" />

(Difficult comparison because Posit colors are less saturated.)