### PR TITLE
typst brand yaml: translate named css font weights to typst

### DIFF
--- a/src/resources/filters/modules/typst_css.lua
+++ b/src/resources/filters/modules/typst_css.lua
@@ -593,6 +593,47 @@ local function quote(s)
   return '"' .. s .. '"'
 end
 
+local same_weights = {
+  'thin',
+  'light',
+  'normal',
+  'regular',
+  'medium',
+  'bold',
+  'black',
+}
+
+local weight_synonyms = {
+  ['ultra-light'] = 'extra-light',
+  ['demi-bold'] = 'semi-bold',
+  ['ultra-bold'] = 'extra-bold',
+}
+
+local dashed_weights = {
+  'extra-light',
+  'ultra-light',
+  'semi-bold',
+  'demi-bold',
+  'extra-bold',
+  'ultra-bold',
+}
+
+local function translate_font_weight(w, warnings)
+  if not w then return nil end
+  local num = tonumber(w)
+  if num and 1 <= num and num <= 1000 then
+    return num
+  elseif tcontains(same_weights, w) then
+    return w
+  elseif tcontains(dashed_weights, w) then
+    w = weight_synonyms[w] or w
+    return w:gsub('-', '')
+  else
+    output_warning(warnings, 'invalid font weight ' .. tostring(w))
+    return nil
+  end
+end
+
 local function translate_border_style(v, _warnings)
   local dash
   if v == 'none' then
@@ -718,6 +759,7 @@ return {
   translate_border_width = translate_border_width,
   translate_border_style = translate_border_style,
   translate_border_color = translate_border_color,
+  translate_font_weight = translate_font_weight,
   consume_width = consume_width,
   consume_style = consume_style,
   consume_color = consume_color

--- a/tests/docs/smoke-all/typst/brand-yaml/typography/dashed-font-weights.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/typography/dashed-font-weights.qmd
@@ -1,0 +1,44 @@
+---
+title: "Dashed font weights"
+format:
+  typst:
+    keep-typ: true
+brand:
+  typography:
+    base:
+      weight: ultra-light
+    headings:
+      weight: ultra-bold
+    monospace-inline:
+      weight: light
+    monospace-block:
+      weight: semi-bold
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+      -
+        - '#set text\(weight: "extralight", \)'
+        - 'heading-weight: "extrabold",'
+        - '#show raw.where\(block: false\): set text\(weight: "light", \)'
+        - '#show raw.where\(block: true\): set text\(weight: "semibold", \)'
+      - []
+      ensurePdfRegexMatches:
+      -
+        - 'base is extralight'
+        - 'heading-2 is extrabold'
+      - []
+
+---
+
+## heading-2 is `#context text.weight`{=typst}
+
+```
+def fact n:
+  if n == 1:
+    return 1
+  return n * fact(n-1)
+```
+
+base is `#context text.weight`{=typst} \
+{{< lipsum 1 >}}


### PR DESCRIPTION
fixes #11726

CSS has synonyms and it also uses dashes, so map and remove.

Also, we were previously failing if `brand.typography.headings.weight` was a string because it wouldn't be quoted. So use a raw typst inline (as with color).

This will be a backport to 1.6 and I'll add the changelog there.