### PR TITLE
Compatibility with the latest patches to xmlp.

### DIFF
--- a/src/project/types/website/website-sitemap.ts
+++ b/src/project/types/website/website-sitemap.ts
@@ -165,8 +165,7 @@ async function readSitemap(sitemapPath: string): Promise<Urlset> {
     }
   });
   const reader = await Deno.open(sitemapPath);
-  await parser.parse(reader);
-  reader.close();
+  await parser.parse(reader.readable);
   return urlset;
 }
 


### PR DESCRIPTION
## Description

In https://github.com/clipcrow/xmlp/pull/3 and https://github.com/clipcrow/xmlp/commit/d215ffa6b3509b95e0b53aead4bbc96716704657, xmlp was changed to support Deno 2. This PR adapts the usage in website-sitemap.ts to those changes.

1. SAXParser.parse now expects a ReadableStream.
2. SAXParser.parse now works on the input stream directly and closes it at the end

xmlp hasn't released a new version with these changes despite my ask for it in https://github.com/clipcrow/xmlp/issues/5. Would love to get some thoughts on how to handle this case.

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
