### PR TITLE
typst brand yaml logo: use mediabag

### DIFF
--- a/src/resources/filters/quarto-finalize/mediabag.lua
+++ b/src/resources/filters/quarto-finalize/mediabag.lua
@@ -9,16 +9,8 @@ function mediabag_filter()
     Image = function(el)
       if not _quarto.format.isWordProcessorOutput() and
          not _quarto.format.isPowerPointOutput() then
-        local mt, contents = pandoc.mediabag.lookup(el.src)
-        if contents ~= nil then
-          
-          local mediabagDir = param("mediabag-dir", nil)
-          local mediaFile = pandoc.path.join{mediabagDir, el.src}
-
-          local file = _quarto.file.write(mediaFile, contents)
-          if not file then
-            warn('failed to write mediabag entry: ' .. mediaFile)
-          end
+        local mediaFile = _quarto.modules.mediabag.write_mediabag_entry(el.src)
+        if mediaFile then
           el.src = mediaFile
           return el
         end

--- a/src/resources/filters/quarto-post/typst-brand-yaml.lua
+++ b/src/resources/filters/quarto-post/typst-brand-yaml.lua
@@ -57,7 +57,7 @@ function render_typst_brand_yaml()
   end
 
   return {
-    Pandoc = function(pandoc)
+    Pandoc = function(pandoc0)
       local brand = param('brand')
       local raw_block_shown = false
       if brand and brand.processedData then
@@ -285,9 +285,16 @@ function render_typst_brand_yaml()
             location_to_typst_align(logoOptions.location) or 'left+top'
           quarto.log.debug('logo options', logoOptions)
           local altProp = logoOptions.alt and (', alt: "' .. logoOptions.alt .. '"') or ''
-          local dblbackslash = string.gsub(logoOptions.path, '\\', '\\\\') -- double backslash?
+          local imageFilename = logoOptions.path
+          if _quarto.modules.mediabag.should_mediabag(imageFilename) then
+            imageFilename = _quarto.modules.mediabag.resolved_url_cache[logoOptions.path] or _quarto.modules.mediabag.fetch_and_store_image(logoOptions.path)
+            imageFilename = _quarto.modules.mediabag.write_mediabag_entry(imageFilename) or imageFilename
+          else
+            -- backslashes need to be doubled for Windows
+            imageFilename = string.gsub(imageFilename, '\\', '\\\\')
+          end
           quarto.doc.include_text('in-header',
-            '#set page(background: align(' .. logoOptions.location .. ', box(inset: ' .. inset .. ', image("' .. dblbackslash .. '", width: ' .. logoOptions.width .. altProp .. '))))')
+            '#set page(background: align(' .. logoOptions.location .. ', box(inset: ' .. inset .. ', image("' .. imageFilename .. '", width: ' .. logoOptions.width .. altProp .. '))))')
         end  
       end
     end,

--- a/tests/docs/smoke-all/typst/brand-yaml/logo/online-logo.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/logo/online-logo.qmd
@@ -1,0 +1,17 @@
+---
+title: "Untitled"
+format:
+  typst:
+    keep-typ: true
+brand:
+  logo:
+    medium: https://quarto.org/quarto.png
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+      -
+        - '#set page\(background: align\(left\+top, box\(inset: 0.75in, image\("online-logo_files(/|\\)mediabag(/|\\)quarto.png", width: 1.5in\)\)\)\)'
+      - []
+---
+


### PR DESCRIPTION
Fixes #11438 

This is a rather complex change because this image is written straight to Typst and I don't think we could put a Pandoc image inside `include-in-headers`

So instead we add two new mediabag APIs

* `_quarto.modules.mediabag.write_mediabag_entry()` contains the heart of `quarto-finalize/mediabag.lua`
* `_quarto.modules.mediabag.should_mediabag()` tests an url or path to see if it should go in the mediabag

(Recently I found out about putting Typst raw blocks in metadata - could an image go in there? Would that solution be less ugly?)
