### PR TITLE
fix: restore HTML escape (`<%-`) for `listing.utilities.localizedString()`

### DIFF
--- a/src/resources/projects/website/listing/_filter.ejs.md
+++ b/src/resources/projects/website/listing/_filter.ejs.md
@@ -14,11 +14,11 @@ const sortUi = listing['sort-ui'];
     <select
       id="listing-<%- listing.id %>-sort"
       class="form-select"
-      aria-label="<%= listing.utilities.localizedString("listing-page-order-by") %>"
+      aria-label="<%- listing.utilities.localizedString("listing-page-order-by") %>"
       onChange="window['quarto-listings']['listing-<%- listing.id %>'].sort(this.options[this.selectedIndex].value, { order: this.options[this.selectedIndex].getAttribute('data-direction')})"
     >
-      <option value="" disabled selected hidden><%= listing.utilities.localizedString("listing-page-order-by") %></option>
-      <option value="index" data-direction="asc"><%= listing.utilities.localizedString("listing-page-order-by-default") %></option>
+      <option value="" disabled selected hidden><%- listing.utilities.localizedString("listing-page-order-by") %></option>
+      <option value="index" data-direction="asc"><%- listing.utilities.localizedString("listing-page-order-by-default") %></option>
       <% for (const sortData of sortableFields) { %>
       <option
         value="<%- sortData.listingSort.field %>"
@@ -32,7 +32,7 @@ const sortUi = listing['sort-ui'];
   <% if (filterUi) { %>
     <div class="input-group input-group-sm quarto-listing-filter">
       <span class="input-group-text"><i class="bi bi-search"></i></span>
-      <input type="text" class="search form-control" placeholder="<%= listing.utilities.localizedString("listing-page-filter") %>" />
+      <input type="text" class="search form-control" placeholder="<%- listing.utilities.localizedString("listing-page-filter") %>" />
     </div>
   <% } %>
 </div>

--- a/src/resources/projects/website/listing/_pagination.ejs.md
+++ b/src/resources/projects/website/listing/_pagination.ejs.md
@@ -1,5 +1,5 @@
 ```{=html}
-<div class="listing-no-matching d-none"><%= listing.utilities.localizedString("listing-page-no-matches") %></div>
+<div class="listing-no-matching d-none"><%- listing.utilities.localizedString("listing-page-no-matches") %></div>
 <% if (listing["page-size"] < items.length) { %>
 <nav id="<%- listing.id %>-pagination" class="listing-pagination" aria-label="Page Navigation">
   <ul class="pagination"></ul>


### PR DESCRIPTION
Restore the use of HTML escape in `listing.utilities.localizedString()` to ensure proper rendering of localized strings in the listing and pagination components.

Markdown cannot be used anyway as each call to this function is in a raw HTML block.

See https://github.com/quarto-dev/quarto-cli/pull/11760#discussion_r1905508436