### PR TITLE
Use correct default color for new border config

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -7,6 +7,7 @@ All changes included in 1.7:
 - ([#11549](https://github.com/quarto-dev/quarto-cli/issues/11549)): Fix regression in rendering `dashboard` tabsets into cards without titles.
 - ([#11580](https://github.com/quarto-dev/quarto-cli/issues/11580)): Fix regression with documents containing `categories` fields that are not strings.
 - ([#11752](https://github.com/quarto-dev/quarto-cli/issues/11752)): Fix regression with non-alphanumeric characters in `categories` preventing correct filtering of listing.
+- ([#11561](https://github.com/quarto-dev/quarto-cli/issues/11561)): Fix a regression with `$border-color` that impacted, callouts borders, tabset borders, and table borders of the defaults themes. `$border-color` is now correctly a mixed of `$body-color` and `$body-bg` even for the default theme.
 
 ## YAML validation
 

--- a/src/resources/formats/html/bootstrap/_bootstrap-variables.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-variables.scss
@@ -272,5 +272,12 @@ $link-weight: $font-weight-base !default;
 $link-decoration: null !default;
 
 // border colors
-$border-color: mix($body-contrast-color, $body-contrast-bg, 30%) !default;
+/// if a theme does not provide body-color or body-bg
+/// defaults to boostrap own default value for theses variables (in _variables.scss)
+$border-color: mix(
+  if(variable-exists(body-color), $body-color, $gray-900),
+  if(variable-exists(body-bg), $body-bg, $white),
+  15%
+) !default;
+/// Make sure table border are the same as the border color (in case change in bootstrap default)
 $table-border-color: $border-color !default;

--- a/src/resources/formats/html/bootstrap/_bootstrap-variables.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-variables.scss
@@ -272,9 +272,5 @@ $link-weight: $font-weight-base !default;
 $link-decoration: null !default;
 
 // border colors
-$border-color: mix(
-  if(variable-exists(body-color), $body-color, #fff),
-  $body-contrast-bg,
-  30%
-) !default;
+$border-color: mix($body-contrast-color, $body-contrast-bg, 30%) !default;
 $table-border-color: $border-color !default;

--- a/tests/docs/playwright/html/default-border-color.qmd
+++ b/tests/docs/playwright/html/default-border-color.qmd
@@ -1,0 +1,33 @@
+---
+title: "Checking that border color for default does not change"
+format: 
+  html:
+    theme: litera
+---
+
+::: callout-note
+
+Content
+
+:::
+
+::: {.panel-tabset}
+
+## Tab 1
+
+This is a playground for Quarto.
+
+## Tab 2
+
+Another Tab
+
+## Tab 3
+
+![An image]({{< placeholder 600 400 >}}){#fig-placeholder}
+
+:::
+
+|              | mpg| cyl|
+|:-------------|---:|---:|
+|Mazda RX4     |  21|   6|
+|Mazda RX4 Wag |  21|   6|

--- a/tests/integration/playwright/src/utils.ts
+++ b/tests/integration/playwright/src/utils.ts
@@ -125,14 +125,18 @@ export type RGBColor = {
   red: number;
   green: number;
   blue: number;
+  alpha?: number;
 };
 
 export async function checkColor(element, cssProperty, rgbColors: RGBColor) {
-  await expect(element).toHaveCSS(cssProperty, `rgb(${rgbColors.red}, ${rgbColors.green}, ${rgbColors.blue})`);
+  const colorString = rgbColors.alpha !== undefined 
+    ? `rgba(${rgbColors.red}, ${rgbColors.green}, ${rgbColors.blue}, ${rgbColors.alpha})`
+    : `rgb(${rgbColors.red}, ${rgbColors.green}, ${rgbColors.blue})`;
+  await expect(element).toHaveCSS(cssProperty, colorString);
 }
 
-export function asRGB(red: number, green: number, blue: number): RGBColor {
-  return { red, green, blue };
+export function asRGB(red: number, green: number, blue: number, alpha?: number): RGBColor {
+  return { red, green, blue, alpha };
 }
 
 export async function getCSSProperty(loc: Locator, variable: string, asNumber = false): Promise<string | number> {
@@ -147,7 +151,6 @@ export async function getCSSProperty(loc: Locator, variable: string, asNumber = 
   }
 }
 
-
 export async function checkFontSizeIdentical(loc1: Locator, loc2: Locator) {
   const loc1FontSize = await getCSSProperty(loc1, 'font-size', false) as string;
   await expect(loc2).toHaveCSS('font-size', loc1FontSize);
@@ -157,4 +160,9 @@ export async function checkFontSizeSimilar(loc1: Locator, loc2: Locator, factor:
   const loc1FontSize = await getCSSProperty(loc1, 'font-size', true) as number;
   const loc2FontSize = await getCSSProperty(loc2, 'font-size', true) as number;
   await expect(loc1FontSize).toBeCloseTo(loc2FontSize * factor);
+}
+
+export async function checkBorderProperties(element: Locator, side: string, color: RGBColor, width: string) {
+  await checkColor(element, `border-${side}-color`, color);
+  await expect(element).toHaveCSS(`border-${side}-width`, width);
 }

--- a/tests/integration/playwright/tests/html-themes.spec.ts
+++ b/tests/integration/playwright/tests/html-themes.spec.ts
@@ -43,19 +43,24 @@ test('border color from default theme does not change (like disappearing)', asyn
   await page.goto('./html/default-border-color.html');
 
   // callout border
-  for (const side of ['bottom', 'right', 'top']) {
-    await checkBorderProperties(page.getByText('Note Content'), side, asRGB(0, 0, 0, 0.1), '1px');
-  }
+  const calloutNote = page.locator('div.callout-note');
+  const calloutBorderColor = asRGB(0, 0, 0, 0.1);
+  await checkBorderProperties(calloutNote, 'bottom', calloutBorderColor, '1px');
+  await checkBorderProperties(calloutNote, 'right', calloutBorderColor, '1px');
+  await checkBorderProperties(calloutNote, 'top', calloutBorderColor, '1px');
   
   // tabset border
-  for (const side of ['bottom', 'right', 'left']) {
-    await checkBorderProperties(
-      page.getByText('This is a playground for Quarto. Another Tab'),
-      side,
-      asRGB(225, 225, 226),
-      '1px'
-    );
-  }
+  const tabContent = page.locator('div.tab-content');
+  const tabBorderColor = asRGB(225, 225, 226);
+  await checkBorderProperties(tabContent, 'bottom', tabBorderColor, '1px');
+  await checkBorderProperties(tabContent, 'right', tabBorderColor, '1px');
+  await checkBorderProperties(tabContent, 'left', tabBorderColor, '1px');
+
+  const activeNavLink = page.locator('li.nav-item > a.nav-link.active');
+  await checkBorderProperties(activeNavLink, 'top', tabBorderColor, '1px');
+  await checkBorderProperties(activeNavLink, 'right', tabBorderColor, '1px');
+  await checkBorderProperties(activeNavLink, 'left', tabBorderColor, '1px');
+  await checkBorderProperties(activeNavLink, 'bottom', asRGB(255, 255, 255), '1px');
 
   // table borders
   const table = page.locator('table');

--- a/tests/integration/playwright/tests/html-themes.spec.ts
+++ b/tests/integration/playwright/tests/html-themes.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { getCSSProperty } from '../src/utils';
+import { asRGB, checkBorderProperties, checkColor, getCSSProperty } from '../src/utils';
 
 test('Dark and light theme respect user themes', async ({ page }) => {
   // This document use a custom theme file that change the background color of the title banner
@@ -38,3 +38,38 @@ test('Mainfont can be set to multiple mainfont families', async ({ page }) => {
   await page.goto('./html/mainfont/mainfont-3.html');
   expect(await getCSSProperty(page.locator('body'), '--bs-body-font-family', false)).toEqual('Creepster, "Cascadia Code", Inter');
 })
+
+test('border color from default theme does not change (like disappearing)', async ({ page }) => {
+  await page.goto('./html/default-border-color.html');
+
+  // callout border
+  for (const side of ['bottom', 'right', 'top']) {
+    await checkBorderProperties(page.getByText('Note Content'), side, asRGB(0, 0, 0, 0.1), '1px');
+  }
+  
+  // tabset border
+  for (const side of ['bottom', 'right', 'left']) {
+    await checkBorderProperties(
+      page.getByText('This is a playground for Quarto. Another Tab'),
+      side,
+      asRGB(225, 225, 226),
+      '1px'
+    );
+  }
+
+  // table borders
+  const table = page.locator('table');
+  const headerColor = asRGB(154, 157, 160);
+  const borderColor = asRGB(214, 216, 217);
+  // table defines top and bottom borders
+  await checkBorderProperties(table, 'top', borderColor, '1px');
+  await checkBorderProperties(table, 'bottom', borderColor, '1px');
+    
+  // table header row have a specific bottom row, other are colorized but hidden (width 0)
+  const thead = table.locator('> thead');
+  await checkBorderProperties(thead, 'bottom', headerColor, '1px');
+  await checkBorderProperties(thead, 'top', borderColor, '0px');
+  await checkBorderProperties(thead, 'left', asRGB(0, 0, 0, 0.1), '0px');
+  await checkBorderProperties(thead, 'right', asRGB(0, 0, 0, 0.1), '0px');
+
+});


### PR DESCRIPTION
fix #11561 and fix #11816

As discussed, the problem here seems to the wrong color for mixing. 

When `$body-color` and `$body-bg` are not defined, we should use the same values as Bootstrap default variables, which are the ones used for default theme (i.e `theme: default`)

However, we need to try get back a nice default. Previously `$border-color` used was bootstrap default
https://github.com/quarto-dev/quarto-cli/blob/768e540f9762985509299c7521914e4731e9483f/src/resources/formats/html/bootstrap/dist/scss/_variables.scss#L550
https://github.com/quarto-dev/quarto-cli/blob/768e540f9762985509299c7521914e4731e9483f/src/resources/formats/html/bootstrap/dist/scss/_variables.scss#L12

![image](https://github.com/user-attachments/assets/8073a1ec-f4bc-43a1-9478-d132798ad09a)

One way to fix is the following: 

* We still follow the `mix()` idea for `$border-color` introduced in 
	- https://github.com/quarto-dev/quarto-cli/pull/11283
* But we use the default values if `body-color` or `body-bg` is not defined. 

So 
https://github.com/quarto-dev/quarto-cli/blob/768e540f9762985509299c7521914e4731e9483f/src/resources/formats/html/bootstrap/_bootstrap-variables.scss#L277-L281

This way we get 
![image](https://github.com/user-attachments/assets/23dd4740-fa11-4675-a6ed-6a5b8fc62aae)

Which is quite close. 

If we want to keep default theme the same, we could just `mix()` when variable exists. 

````scss
@if variable-exists(body-color) and variable-exists(body-bg) {
  $border-color: mix($body-color, $body-bg, 10%) !default;
  $table-border-color: $border-color !default;
}
````

But I don't think we want to make use of those `@if` because our SCSS -> CSS exposer logic. 

This PR aims to fix the default theme. Then we need to fix 
- https://github.com/quarto-dev/quarto-cli/issues/11816 
before we can do thorough testing with various theme. 

Right now this is some examples after this PR

* Vapor
	![image](https://github.com/user-attachments/assets/e7e595e4-6681-4a9b-935c-c46450ed1a17)
* Darkly
	![image](https://github.com/user-attachments/assets/be9df3ab-95f0-4e23-afad-a26f0245b9bb)
* Cyborg
	![image](https://github.com/user-attachments/assets/4a428e5b-ec32-4c91-bb83-c812118fa502)
* litera
	![image](https://github.com/user-attachments/assets/bab948ff-915e-4dde-acb2-cdc4b60e147d)
* lux
	![image](https://github.com/user-attachments/assets/8bb1649b-fb64-4231-9fab-30426dcfdced)


So I think we get good mix with this. 





