### PR TITLE
[backport] Use correct default color for new border config

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -2,6 +2,8 @@
 
 ## In this release
 
+- ([#11561](https://github.com/quarto-dev/quarto-cli/issues/11561)): Fix a regression with `$border-color` that impacted, callouts borders, tabset borders, and table borders of the defaults themes. `$border-color` is now correctly a mixed of `$body-color` and `$body-bg` even for the default theme.
+
 ## In previous releases
 
 - ([#11726](https://github.com/quarto-dev/quarto-cli/issues/11726)) Typst Brand YAML: translate named CSS font weights to Typst.

--- a/src/resources/formats/html/bootstrap/_bootstrap-variables.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-variables.scss
@@ -272,9 +272,12 @@ $link-weight: $font-weight-base !default;
 $link-decoration: null !default;
 
 // border colors
+/// if a theme does not provide body-color or body-bg
+/// defaults to boostrap own default value for theses variables (in _variables.scss)
 $border-color: mix(
-  if(variable-exists(body-color), $body-color, #fff),
-  $body-contrast-bg,
-  30%
+  if(variable-exists(body-color), $body-color, $gray-900),
+  if(variable-exists(body-bg), $body-bg, $white),
+  15%
 ) !default;
+/// Make sure table border are the same as the border color (in case change in bootstrap default)
 $table-border-color: $border-color !default;


### PR DESCRIPTION
> [!IMPORTANT]
> This is a backport PR toward v1.6 

Our default theme use default bootstrap variable and is not a real theme like other bootswatch themes. So be sure to use the default value when we do use variables before defaults bootstrap layer applies

This way we are explicit in the color we are mixing.

Backport to v1.6 from #11828


