### PR TITLE
Add `leveloneanalysis.lua` to bundled lua filter

### DIFF
--- a/package/src/common/prepare-dist.ts
+++ b/package/src/common/prepare-dist.ts
@@ -238,6 +238,7 @@ function inlineFilters(config: Configuration) {
     { name: "crossref" },
     { name: "customwriter" },
     { name: "qmd-reader", dir: "." },
+    { name: "leveloneanalysis", dir: "quarto-internals"}
   ];
 
   filtersToInline.forEach((filter) => {


### PR DESCRIPTION
Follow up on #11841

Otherwise filter is not found by bundled version (but test passes because dev version works)

See example of error below
````
❯ quarto render ./tests/docs/smoke-all/2025/01/10/issue-11835.qmd
Error running filter C:\Users\chris\scoop\apps\quarto-prerelease\current\share\filters\quarto-internals\leveloneanalysis.lua:
cannot open C:\Users\chris\scoop\apps\quarto-prerelease\current\share\filters\quarto-internals\leveloneanalysis.lua: No such file or directory
pandoc
  to: typst
  output-file: issue-11835.typ
  standalone: true
  shift-heading-level-by: -1
  default-image-extension: svg
  wrap: none
  citeproc: false
  number-sections: true

metadata
  section-numbering: 1.1.a
  _quarto:
    tests:
      typst:
        ensurePdfRegexMatches:
          - - 1 Section
          - - 0.1 Section

[typst]: Compiling issue-11835.typ to issue-11835.pdf...DONE

Output created: issue-11835.pdf

````