### PR TITLE
Bugfix/11860

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -25,13 +25,17 @@ All changes included in 1.7:
 
 - ([#11608](https://github.com/quarto-dev/quarto-cli/pull/11608)): Do not issue error message when calling `quarto check info`.
 
-## `typst` Format
+## `html` format
 
-- ([#11578](https://github.com/quarto-dev/quarto-cli/issues/11578)): Typst column layout widths use fractional `fr` units instead of percent `%` units for unitless and default widths in order to fill the enclosing block and not spill outside it.
+- ([#11860])(https://github.com/quarto-dev/quarto-cli/issues/11860)): ES6 modules that import other local JS modules in documents with `embed-resources: true` are now correctly embedded.
+
+## `pdf` format
+
 - ([#11835](https://github.com/quarto-dev/quarto-cli/issues/11835)): Take markdown structure into account when detecting minimum heading level.
 
-## `pdf` Format
+## `typst` format
 
+- ([#11578](https://github.com/quarto-dev/quarto-cli/issues/11578)): Typst column layout widths use fractional `fr` units instead of percent `%` units for unitless and default widths in order to fill the enclosing block and not spill outside it.
 - ([#11835](https://github.com/quarto-dev/quarto-cli/issues/11835)): Take markdown structure into account when detecting minimum heading level.
 
 ## Lua Filters and extensions

--- a/src/core/data-url.ts
+++ b/src/core/data-url.ts
@@ -1,4 +1,4 @@
-import { encode as base64Encode } from "encoding/base64";
+import { encodeBase64 as base64Encode } from "encoding/base64";
 
 export function asDataUrl(
   content: string | ArrayBuffer,

--- a/src/core/esbuild.ts
+++ b/src/core/esbuild.ts
@@ -106,6 +106,8 @@ export async function esbuildCommand(
   if (result.success) {
     return result.stdout;
   } else {
+    console.error(result.stderr);
+
     throw new Error("esbuild command failed");
   }
 }

--- a/tests/docs/playwright/embed-resources/issue-11860/.gitignore
+++ b/tests/docs/playwright/embed-resources/issue-11860/.gitignore
@@ -1,0 +1,2 @@
+inner
+/.quarto/

--- a/tests/docs/playwright/embed-resources/issue-11860/hello.js
+++ b/tests/docs/playwright/embed-resources/issue-11860/hello.js
@@ -1,0 +1,2 @@
+export const hello = 'world';
+alert("We're here!");

--- a/tests/docs/playwright/embed-resources/issue-11860/main.js
+++ b/tests/docs/playwright/embed-resources/issue-11860/main.js
@@ -1,0 +1,1 @@
+import { hello } from './hello.js';

--- a/tests/docs/playwright/embed-resources/issue-11860/main.qmd
+++ b/tests/docs/playwright/embed-resources/issue-11860/main.qmd
@@ -1,0 +1,11 @@
+---
+format:
+  html:
+    embed-resources: true
+---
+
+```{=html}
+<script type="module" src="./main.js"></script>
+```
+
+## oh oh

--- a/tests/integration/playwright-tests.test.ts
+++ b/tests/integration/playwright-tests.test.ts
@@ -32,15 +32,27 @@ await initState();
 
 // const promises = [];
 const fileNames: string[] = [];
+const extraOpts = [
+  {
+    pathSuffix: "docs/playwright/embed-resources/issue-11860/main.qmd",
+    options: ["--output-dir=inner"],
+  }
+]
 
 for (const { path: fileName } of globOutput) {
   const input = fileName;
+  const options: string[] = [];
+  for (const extraOpt of extraOpts) {
+    if (fileName.endsWith(extraOpt.pathSuffix)) {
+      options.push(...extraOpt.options);
+    }
+  }
 
   // sigh, we have a race condition somewhere in
   // mediabag inspection if we don't wait all renders
   // individually. This is very slow..
   await execProcess({
-    cmd: [quartoDevCmd(), "render", input],
+    cmd: [quartoDevCmd(), "render", input, ...options],
   });
   fileNames.push(fileName);
 }

--- a/tests/integration/playwright/tests/html-embed-resources-es6-modules.spec.ts
+++ b/tests/integration/playwright/tests/html-embed-resources-es6-modules.spec.ts
@@ -1,0 +1,15 @@
+import { expect, Page, test } from "@playwright/test";
+
+test("es6 modules to be bundled correctly in documents with embed-resources=true", async ({ page }) => {
+  const messages: string[] = [];
+  page.on('response', (response) => {
+    if (!response.ok()) {
+      messages.push(`[${response.status()}] ${response.url()}`);
+    }
+  });
+  page.on('pageerror', (error) => {
+    messages.push(`[${error.name}] ${error.message}`);
+  });
+  await page.goto('./embed-resources/issue-11860/inner/main.html');
+  expect(messages).toStrictEqual([]); 
+});


### PR DESCRIPTION
Closes #11860. This implements the "dynamic" solution for the bug, where we now bundle linked ES6 modules with `esbuild` and replace them with data URLs. This is a more comprehensive solution than Pandoc's, which stops at the first include, breaking ES6 scripts that have import statements in them.

cc @cderv :D