### PR TITLE
try to add duplicate warning definition only for knitr

### DIFF
--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -8216,6 +8216,24 @@ var require_yaml_intelligence_resources = __commonJS({
           }
         },
         {
+          name: "warning",
+          tags: {
+            engine: "knitr"
+          },
+          schema: {
+            enum: [
+              true,
+              false,
+              "NA"
+            ]
+          },
+          default: true,
+          description: {
+            short: "Include warning in rendered output.",
+            long: "Include warnings in rendered output. Possible values are `true`, `false`, or `NA`. \nIf `true`, messages are included in the output. If `false`, messages are not included. \nIf `NA`, messages are not included in output but shown in the knitr log to console.\n"
+          }
+        },
+        {
           name: "message",
           tags: {
             engine: "knitr"
@@ -21651,7 +21669,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "Short/abbreviated form of container-title;",
         "A minor contributor to the item; typically cited using \u201Cwith\u201D before\nthe name when listed in a bibliography.",
         "Curator of an exhibit or collection (e.g.&nbsp;in a museum).",
-        "Physical (e.g.&nbsp;size) or temporal (e.g.\uFFFD\uFFFDrunning time) dimensions of\nthe item.",
+        "Physical (e.g.&nbsp;size) or temporal (e.g.&nbsp;running time) dimensions of\nthe item.",
         "Director (e.g.&nbsp;of a film).",
         "Minor subdivision of a court with a <code>jurisdiction</code> for a\nlegal item",
         "(Container) edition holding the item (e.g.&nbsp;\u201C3\u201D when citing a chapter\nin the third edition of a book).",
@@ -24196,12 +24214,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 194269,
+        _internalId: 194272,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 194261,
+            _internalId: 194264,
             type: "enum",
             enum: [
               "png",
@@ -24217,7 +24235,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 194268,
+            _internalId: 194271,
             type: "anyOf",
             anyOf: [
               {
@@ -24817,8 +24835,8 @@ function mappedIndexToLineCol(eitherText) {
   };
 }
 function mappedLines(str2, keepNewLines = false) {
-  const lines3 = rangedLines(str2.value, keepNewLines);
-  return lines3.map((v) => mappedString(str2, [v.range]));
+  const lines2 = rangedLines(str2.value, keepNewLines);
+  return lines2.map((v) => mappedString(str2, [v.range]));
 }
 
 // parsing.ts
@@ -30795,6 +30813,27 @@ function createLocalizedError(obj) {
   };
 }
 
+// ../is-circular.ts
+var isCircular = (obj) => {
+  const objectSet = /* @__PURE__ */ new WeakSet();
+  const detect = (obj2) => {
+    if (obj2 && typeof obj2 === "object") {
+      if (objectSet.has(obj2)) {
+        return true;
+      }
+      objectSet.add(obj2);
+      for (const key in obj2) {
+        if (Object.hasOwn(obj2, key) && detect(obj2[key])) {
+          return true;
+        }
+      }
+      objectSet.delete(obj2);
+    }
+    return false;
+  };
+  return detect(obj);
+};
+
 // annotated-yaml.ts
 function postProcessAnnotation(parse) {
   if (parse.components.length === 1 && parse.start === parse.components[0].start && parse.end === parse.components[0].end) {
@@ -30945,16 +30984,10 @@ function buildJsYamlAnnotation(mappedYaml) {
       `Expected a single result, got ${results.length} instead`
     );
   }
-  try {
-    JSON.stringify(results[0]);
-  } catch (e) {
-    if (e.message.match("invalid string length")) {
-    } else if (e.message.match(/circular structure/)) {
-      throw new InternalError(
-        `Circular structure detected in parsed yaml: ${e.message}`
-      );
-    } else {
-    }
+  if (isCircular(results[0])) {
+    throw new InternalError(
+      `Circular structure detected in yaml`
+    );
   }
   return postProcessAnnotation(results[0]);
 }

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -8217,6 +8217,24 @@ try {
             }
           },
           {
+            name: "warning",
+            tags: {
+              engine: "knitr"
+            },
+            schema: {
+              enum: [
+                true,
+                false,
+                "NA"
+              ]
+            },
+            default: true,
+            description: {
+              short: "Include warning in rendered output.",
+              long: "Include warnings in rendered output. Possible values are `true`, `false`, or `NA`. \nIf `true`, messages are included in the output. If `false`, messages are not included. \nIf `NA`, messages are not included in output but shown in the knitr log to console.\n"
+            }
+          },
+          {
             name: "message",
             tags: {
               engine: "knitr"
@@ -21652,7 +21670,7 @@ try {
           "Short/abbreviated form of container-title;",
           "A minor contributor to the item; typically cited using \u201Cwith\u201D before\nthe name when listed in a bibliography.",
           "Curator of an exhibit or collection (e.g.&nbsp;in a museum).",
-          "Physical (e.g.&nbsp;size) or temporal (e.g.\uFFFD\uFFFDrunning time) dimensions of\nthe item.",
+          "Physical (e.g.&nbsp;size) or temporal (e.g.&nbsp;running time) dimensions of\nthe item.",
           "Director (e.g.&nbsp;of a film).",
           "Minor subdivision of a court with a <code>jurisdiction</code> for a\nlegal item",
           "(Container) edition holding the item (e.g.&nbsp;\u201C3\u201D when citing a chapter\nin the third edition of a book).",
@@ -24197,12 +24215,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 194269,
+          _internalId: 194272,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 194261,
+              _internalId: 194264,
               type: "enum",
               enum: [
                 "png",
@@ -24218,7 +24236,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 194268,
+              _internalId: 194271,
               type: "anyOf",
               anyOf: [
                 {
@@ -24831,8 +24849,8 @@ ${heading}`;
     };
   }
   function mappedLines(str2, keepNewLines = false) {
-    const lines3 = rangedLines(str2.value, keepNewLines);
-    return lines3.map((v) => mappedString(str2, [v.range]));
+    const lines2 = rangedLines(str2.value, keepNewLines);
+    return lines2.map((v) => mappedString(str2, [v.range]));
   }
 
   // parsing.ts
@@ -30809,6 +30827,27 @@ ${reindented}
     };
   }
 
+  // ../is-circular.ts
+  var isCircular = (obj) => {
+    const objectSet = /* @__PURE__ */ new WeakSet();
+    const detect = (obj2) => {
+      if (obj2 && typeof obj2 === "object") {
+        if (objectSet.has(obj2)) {
+          return true;
+        }
+        objectSet.add(obj2);
+        for (const key in obj2) {
+          if (Object.hasOwn(obj2, key) && detect(obj2[key])) {
+            return true;
+          }
+        }
+        objectSet.delete(obj2);
+      }
+      return false;
+    };
+    return detect(obj);
+  };
+
   // annotated-yaml.ts
   function postProcessAnnotation(parse) {
     if (parse.components.length === 1 && parse.start === parse.components[0].start && parse.end === parse.components[0].end) {
@@ -30959,16 +30998,10 @@ ${tidyverseInfo(
         `Expected a single result, got ${results.length} instead`
       );
     }
-    try {
-      JSON.stringify(results[0]);
-    } catch (e) {
-      if (e.message.match("invalid string length")) {
-      } else if (e.message.match(/circular structure/)) {
-        throw new InternalError(
-          `Circular structure detected in parsed yaml: ${e.message}`
-        );
-      } else {
-      }
+    if (isCircular(results[0])) {
+      throw new InternalError(
+        `Circular structure detected in yaml`
+      );
     }
     return postProcessAnnotation(results[0]);
   }

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -1188,6 +1188,24 @@
       }
     },
     {
+      "name": "warning",
+      "tags": {
+        "engine": "knitr"
+      },
+      "schema": {
+        "enum": [
+          true,
+          false,
+          "NA"
+        ]
+      },
+      "default": true,
+      "description": {
+        "short": "Include warning in rendered output.",
+        "long": "Include warnings in rendered output. Possible values are `true`, `false`, or `NA`. \nIf `true`, messages are included in the output. If `false`, messages are not included. \nIf `NA`, messages are not included in output but shown in the knitr log to console.\n"
+      }
+    },
+    {
       "name": "message",
       "tags": {
         "engine": "knitr"
@@ -14623,7 +14641,7 @@
     "Short/abbreviated form of container-title;",
     "A minor contributor to the item; typically cited using “with” before\nthe name when listed in a bibliography.",
     "Curator of an exhibit or collection (e.g.&nbsp;in a museum).",
-    "Physical (e.g.&nbsp;size) or temporal (e.g.��running time) dimensions of\nthe item.",
+    "Physical (e.g.&nbsp;size) or temporal (e.g.&nbsp;running time) dimensions of\nthe item.",
     "Director (e.g.&nbsp;of a film).",
     "Minor subdivision of a court with a <code>jurisdiction</code> for a\nlegal item",
     "(Container) edition holding the item (e.g.&nbsp;“3” when citing a chapter\nin the third edition of a book).",
@@ -17168,12 +17186,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 194269,
+    "_internalId": 194272,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 194261,
+        "_internalId": 194264,
         "type": "enum",
         "enum": [
           "png",
@@ -17189,7 +17207,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 194268,
+        "_internalId": 194271,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/formats/html/esbuild-analysis-cache.json
+++ b/src/resources/formats/html/esbuild-analysis-cache.json
@@ -2,7 +2,7 @@
   "quarto.js": {
     "inputs": {
       "quarto.js": {
-        "bytes": 26327,
+        "bytes": 26396,
         "imports": [],
         "format": "esm"
       }
@@ -20,10 +20,10 @@
         "entryPoint": "quarto.js",
         "inputs": {
           "quarto.js": {
-            "bytesInOutput": 21890
+            "bytesInOutput": 21946
           }
         },
-        "bytes": 21890
+        "bytes": 21946
       }
     }
   }

--- a/src/resources/schema/cell-textoutput.yml
+++ b/src/resources/schema/cell-textoutput.yml
@@ -69,6 +69,19 @@
 
       Note that this option is supported only for the `revealjs` format.
 
+- name: warning
+  tags:
+    engine: knitr
+  schema:
+    enum: [true, false, NA]
+  default: true
+  description:
+    short: Include warning in rendered output.
+    long: |
+      Include warnings in rendered output. Possible values are `true`, `false`, or `NA`. 
+      If `true`, messages are included in the output. If `false`, messages are not included. 
+      If `NA`, messages are not included in output but shown in the knitr log to console.
+
 - name: message
   tags:
     engine: knitr


### PR DESCRIPTION
In knitr, `warning: 'NA'` is supported. How to allow that for auto completion ? 

````markdown
---
title: "test"
format: html
---

```{r}
#| warning: NA
warning("Test")
```
````