### PR TITLE
[perf] lua - wrap scope resolution in flag

### DIFF
--- a/src/resources/filters/main.lua
+++ b/src/resources/filters/main.lua
@@ -295,7 +295,8 @@ local quarto_pre_filters = {
   },
 
   { name = "pre-scope-resolution",
-    filter = resolve_scoped_elements()
+    filter = resolve_scoped_elements(),
+    flags = { "has_tables" }
   },
 
   { name = "pre-combined-figures-theorems-etc", filter = combineFilters({


### PR DESCRIPTION
In this episode of performance whack-a-mole, we improve Quarto's overall speed on `quarto-web` by 1%.