### PR TITLE
Support several words for cross ref option in LaTeX 

### DIFF
--- a/src/resources/filters/crossref/meta.lua
+++ b/src/resources/filters/crossref/meta.lua
@@ -10,7 +10,7 @@ function crossrefMetaInject()
         if isInlineEl(inlines) then
           toConvert = pandoc.Plain(inlines)
         end
-        return trim(pandoc.write(pandoc.Pandoc(toConvert)))
+        return trim(pandoc.write(pandoc.Pandoc(toConvert), "latex"))
       end
       metaInjectLatex(meta, function(inject)
         

--- a/src/resources/filters/crossref/meta.lua
+++ b/src/resources/filters/crossref/meta.lua
@@ -6,7 +6,11 @@ function crossrefMetaInject()
   return {
     Meta = function(meta)
       local function as_latex(inlines)
-        return trim(pandoc.write(pandoc.Pandoc(inlines), "latex"))
+        local toConvert = inlines
+        if isInlineEl(inlines) then
+          toConvert = pandoc.Plain(inlines)
+        end
+        return trim(pandoc.write(pandoc.Pandoc(toConvert)))
       end
       metaInjectLatex(meta, function(inject)
         

--- a/src/resources/filters/crossref/meta.lua
+++ b/src/resources/filters/crossref/meta.lua
@@ -6,11 +6,7 @@ function crossrefMetaInject()
   return {
     Meta = function(meta)
       local function as_latex(inlines)
-        local toConvert = inlines
-        if isInlineEl(inlines) then
-          toConvert = pandoc.Plain(inlines)
-        end
-        return trim(pandoc.write(pandoc.Pandoc(toConvert), "latex"))
+        return trim(pandoc.write(pandoc.Pandoc(quarto.utils.as_blocks(inlines)), "latex"))
       end
       metaInjectLatex(meta, function(inject)
         

--- a/tests/docs/smoke-all/crossrefs/float/latex/latex-fig-title.qmd
+++ b/tests/docs/smoke-all/crossrefs/float/latex/latex-fig-title.qmd
@@ -1,0 +1,18 @@
+---
+title: Multi word fig title should be one line
+format: latex
+crossref: 
+  fig-title: 'Supplementary Figure'
+_quarto:
+  tests:
+    latex:
+      ensureFileRegexMatches:
+        - ['\\figurename\{Supplementary Figure\}']
+        - []
+---
+
+## Unresolved Crossref Figure
+
+![Elephant](img/surus.jpg){#fig-elephant}
+
+See @fig-elephant for examples. 


### PR DESCRIPTION
fix #11903 

As explained in #11903, inlines needs to be wrapped in Plain before being converted to latex as otherwise `pandoc.Pandoc({inlines})` will automatically do it on each element. This leads to multiline output which is incorrect. 

My understanding is that `as_latex()` would work only with Inlines, but for safety measure, I added a `isInlineEl()` check to wrap only in this case. 

We can remove if not necessary. Assigning @cscheid as crossref related, and @tarleb as this is Lua PR. 