### PR TITLE
[perf] astpipeline - switch to jog in ::: detection

### DIFF
--- a/src/resources/filters/normalize/astpipeline.lua
+++ b/src/resources/filters/normalize/astpipeline.lua
@@ -3,22 +3,15 @@
 
 function quarto_ast_pipeline()
   local function warn_on_stray_triple_colons()
-    local function block_handler(block)
-      _quarto.ast.walk(block, {
-        Str = function(el)
+    return {
+      Str = function(el)
           if string.match(el.text, ":::(:*)") then 
             local error_message = 
               "\nThe following string was found in the document: " .. el.text .. 
-              "\nThis string was found in a block element with the following content:\n\n" .. pandoc.utils.stringify(block) .. 
               "\n\nThis usually indicates a problem with a fenced div in the document. Please check the document for errors."
             warn(error_message)
           end
-        end
-      })
-  end
-    return {
-      Para = block_handler,
-      Plain = block_handler,
+      end
     }
   end
   return {


### PR DESCRIPTION
Small perf win with using `jog` to do our triple-colon detection of bad div parses. In a single file, this decreases the runtime from 3.171s to 3.139s (averaged over 100 runs, and tested to be statistically significant). It's "only" 1%, but these add up.