### PR TITLE
Feature/pdfcodeblock

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,6 @@ Pull requests are very welcome! Here's how to contribute via PR:
 
 2.  For significant changes (e.g more than small bug fixes), ensure that you have signed the [individual](https://posit.co/wp-content/uploads/2023/04/2023-03-13_TC_Indiv_contrib_agreement.pdf) or [corporate](https://posit.co/wp-content/uploads/2023/04/2023-03-13_TC_Corp_contrib_agreement.pdf) contributor agreement as appropriate. You can send the signed copy to [jj\@rstudio.com](mailto:jj@rstudio.com){.email}.
 
-3.  Submit the [pull request](https://help.github.com/articles/using-pull-requests). It is ok to submit as draft in your are still working on it but would like some feedback from us. It always good to share in the open that you are working on it.
+3.  Submit the [pull request](https://help.github.com/articles/using-pull-requests). It is ok to submit as draft if your are still working on it but would like some feedback from us. It is always good to share in the open that you are working on it.
 
 We'll try to be as responsive as possible in reviewing and accepting pull requests.

--- a/src/resources/filters/layout/meta.lua
+++ b/src/resources/filters/layout/meta.lua
@@ -31,6 +31,7 @@ function layout_meta_inject_latex_packages()
       -- Both options could be undefined, true / false or set to a color value
       local useCodeBlockBorder = (adaptiveTextHighlighting and meta[kCodeBlockBorderLeft] == nil and meta[kCodeBlockBackground] == nil) or (meta[kCodeBlockBorderLeft] ~= nil and meta[kCodeBlockBorderLeft] ~= false)
       local useCodeBlockBg = meta[kCodeBlockBackground] ~= nil and meta[kCodeBlockBackground] ~= false
+      local deactivateCodeBlockBg = meta[kCodeBlockBackground] ~= nil and meta[kCodeBlockBackground] == false
 
       -- if we're going to display a border or background
       -- we need to inject color handling as well as the 
@@ -100,6 +101,16 @@ function layout_meta_inject_latex_packages()
         end)
       end
 
+
+      -- if we're NOT going to display a border or background we need to inject
+      -- code to modify the pandoc behavior for fenced code blocks boxes.
+      -- This can be used to especially allow code blocks in other boxes like
+      -- callback
+      if (not useCodeBlockBorder and deactivateCodeBlockBg) then
+        metaInjectLatex(meta, function(inject)
+          inject("\\ifdefined\\Shaded\\renewenvironment{Shaded}{}\\fi")
+        end)
+      end
 
 
       -- enable column layout (packages and adjust geometry)

--- a/src/resources/schema/document-code.yml
+++ b/src/resources/schema/document-code.yml
@@ -93,6 +93,10 @@
     long: |
       Specifies to apply a background color on code blocks. Provide a hex color to specify that the background color is
       enabled as well as the color of the background.
+
+      For PDF output, if you specify `false`  and `code-block-border-left` is `false` or not set, the code block is not
+      enclosed in a floating LaTeX environment. This is especially useful for long code blocks nested inside a callout block,
+      as it allows correct page breaks to occur. Line numbering and annotations are not affected.
 - name: highlight-style
   tags:
     formats: [$html-all, docx, ms, $pdf-all]

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,7 +6,7 @@ We run several type of tests
 
 - Unit tests, located in `unit/` folder
 - Integration tests, located in `integration/` folder
-- smoke tests localed in `smoke` folder
+- smoke tests located in `smoke` folder
 
 Tests are run in our CI workflow on GHA at each commit, and for each PR.
 

--- a/tests/docs/smoke-all/2025/01/21/issue-11698.qmd
+++ b/tests/docs/smoke-all/2025/01/21/issue-11698.qmd
@@ -1,0 +1,66 @@
+--- 
+title: "foo"
+code-block-bg: false
+format: pdf
+---
+:::: {.callout-caution icon=false}
+## Self implementation 
+
+Implement the code yourself by filling out the missing sections:
+
+```{python}
+#| code-fold: true
+#| eval: false
+#| code-summary: "Code fragment for implementation."
+#| fig-cap: "Test"
+import numpy as np
+import matplotlib.pyplot as plt
+%config InlineBackend.figure_formats = ["svg"]
+
+frequ = 2 * np.pi * 50
+f = lambda t: 0.8 * np.sin(t * frequ)
+diod = lambda t: (np.exp(1.2 + t) - 1)
+
+t = np.linspace(0, 2 * np.pi / frequ, 1024, endpoint=False)
+x = np.linspace(np.min(f(t)) * 1.3, np.max(f(t)) * 1.1, 1024)
+
+ic = lambda t: diod(f(t))
+
+k = np.arange(0, 16) * 1 / 16
+
+# The provided figures where used to create the illustation
+if True:
+    plt.figure()
+    plt.plot(f(t), t)
+    plt.plot([np.min(t),np.max(t)], [0,0], "gray")
+    plt.axis("off")
+    #plt.savefig("sin.svg", transparent=True)
+    plt.figure()
+    plt.plot(x, diod(x))
+    z = np.array([0, np.min(f(t)), np.max(f(t))])
+    plt.plot(z, diod(z), "bx")
+    plt.axis("off")
+    plt.xlim([-2,5])
+    plt.gcf().patch.set_visible(False)
+    #plt.savefig("diode.svg", transparent=True)
+
+    plt.figure()
+    plt.plot(t, ic(t))
+    plt.plot(2*np.pi*k/frequ, ic(2*np.pi*k/frequ), "ro")
+    plt.axis("off")
+    #plt.savefig("ic.svg", transparent=True, bbox_inches ="tight")
+
+y = ic(k)
+yhat = (np.fft.fft(y))
+#Necessary correction factor for the FFT
+factor = 1 / 16
+yy = factor * yhat
+
+ic_mean = np.mean(ic(np.linspace(0, 1/50, 2**20)))
+c0 = yy[0].real
+effective_value = np.linalg.norm(yy[1:])
+harmonic_distortion = np.linalg.norm(yy[3:-2])/np.linalg.norm(yy[1:])
+```
+::::
+
+Some text that will not be displayed in the correct color.


### PR DESCRIPTION
## Description

As discussed in #11698, for PDF output, nested fenced code blocks no longer allow for page break and you can create color leakage. As this is an inherent problem with the LaTeX treatment of floating environments and the `tcolorbox` package (currently) used to create the background color for fenced code blocks in PDF documents a workaround is included.

The variable `code-block-bg` can be set to a HTML color tag or to a boolean. The boolean `false` has no particular effect as this will create no background color. Therefore, I selected this variable to explicitly deactivate the `tcolorbox` when set to false. The potential conflict with `code-block-border-left` is avoided by only applying the behavior if `code-block-border-left` is `false` or not set. Line numbers an annotations can be combined without any problems. 

I included the example from the #11698 as a test as well but from my point of view this is not extremely helpful. I would need to test the resulting `tex` file for certain content and I could not find out how this is done. If you can hint me in the right direction I'm happy to extend this. 

## Note on implementation

This could also be implemented as a `elseif` but from my point of view it is cleaner this way, happy to change if you think differently. 

I tried to argue why I _reused_ a variable instead of creating a new variable but if this _multi use_  is not wanted I can change it to a specific variable. 

## Miscellaneous 

I also found two typos on the way. If I should create a separate PR from them please let me know. 

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes -> #11698 
- [x] updated the appropriate changelog in the PR
- [x] ensured the present test suite passes
- [x] added new tests -> see comment above for suitability
- [x] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR -> [PR](https://github.com/quarto-dev/quarto-web/pull/1550)
