### PR TITLE
Use latex table patterns including optional argument

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -37,6 +37,7 @@ All changes included in 1.7:
 
 - ([#11835](https://github.com/quarto-dev/quarto-cli/issues/11835)): Take markdown structure into account when detecting minimum heading level.
 - ([#11903](https://github.com/quarto-dev/quarto-cli/issues/11903)): `crossref` configuration like `fig-title` or `tbl-title` now correctly supports multi word values, e.g. `fig-title: 'Supplementary Figure'`.
+- ([#11878](https://github.com/quarto-dev/quarto-cli/issues/11878)): Correctly fixup raw LaTeX table having an unexpected table env with options (e.g `\begin{table}[c]`) to be handled as crossref table.
 
 ## `typst` format
 

--- a/src/resources/filters/common/tables.lua
+++ b/src/resources/filters/common/tables.lua
@@ -130,15 +130,12 @@ end
 
 function hasRawLatexTable(raw)
   if _quarto.format.isRawLatex(raw) and _quarto.format.isLatexOutput() then
-    for i,pattern in ipairs(_quarto.patterns.latexTablePatterns) do
-      if _quarto.modules.patterns.match_all_in_table(pattern)(raw.text) then
-        return true
-      end
+    local matched, _ = _quarto.modules.patterns.match_in_list_of_patterns(raw.text, _quarto.patterns.latexAllTableEnvPatterns)
+    if matched then
+      return true
     end
-    return false
-  else
-    return false
   end
+  return false
 end
 
 local tableCheckers = {

--- a/src/resources/filters/modules/patterns.lua
+++ b/src/resources/filters/modules/patterns.lua
@@ -65,12 +65,12 @@ local function match_all_in_table(pattern_table)
   return inner
 end
 
--- return the matched content for the first pattern in the list that matches
+-- return the pattern, and matched content for the first pattern in the list that matches
 local function match_in_list_of_patterns(raw_tex, list_of_patterns)
   for _,pattern in ipairs(list_of_patterns) do
     local matched =  { match_all_in_table(pattern)(raw_tex) }
     if matched and #matched > 0 then
-      return table.unpack(matched)
+      return matched, pattern
     end
   end
   return nil

--- a/src/resources/filters/modules/patterns.lua
+++ b/src/resources/filters/modules/patterns.lua
@@ -65,6 +65,17 @@ local function match_all_in_table(pattern_table)
   return inner
 end
 
+-- return the matched content for the first pattern in the list that matches
+local function match_in_list_of_patterns(raw_tex, list_of_patterns)
+  for _,pattern in ipairs(list_of_patterns) do
+    local matched =  { match_all_in_table(pattern)(raw_tex) }
+    if matched then
+      return table.unpack(matched)
+    end
+  end
+  return nil
+end
+
 return {
   attr_identifier = attr_identifier,
   engine_escape = engine_escape,
@@ -93,5 +104,6 @@ return {
   latex_table_star = latex_table_star,
 
   match_all_in_table = match_all_in_table,
+  match_in_list_of_patterns = match_in_list_of_patterns,
   combine_patterns = combine_patterns
 }

--- a/src/resources/filters/modules/patterns.lua
+++ b/src/resources/filters/modules/patterns.lua
@@ -67,7 +67,7 @@ end
 
 -- return the pattern, and matched content for the first pattern in the list that matches
 local function match_in_list_of_patterns(raw_tex, list_of_patterns)
-  for _,pattern in ipairs(list_of_patterns) do
+  for _, pattern in ipairs(list_of_patterns) do
     local matched =  { match_all_in_table(pattern)(raw_tex) }
     if matched and #matched > 0 then
       return matched, pattern

--- a/src/resources/filters/modules/patterns.lua
+++ b/src/resources/filters/modules/patterns.lua
@@ -69,7 +69,7 @@ end
 local function match_in_list_of_patterns(raw_tex, list_of_patterns)
   for _,pattern in ipairs(list_of_patterns) do
     local matched =  { match_all_in_table(pattern)(raw_tex) }
-    if matched then
+    if matched and #matched > 0 then
       return table.unpack(matched)
     end
   end

--- a/src/resources/filters/normalize/flags.lua
+++ b/src/resources/filters/normalize/flags.lua
@@ -57,10 +57,9 @@ function compute_flags()
       end
 
       if _quarto.format.isRawLatex(el) then
-        local long_table_match = _quarto.modules.patterns.match_all_in_table(_quarto.patterns.latexLongtablePattern)
+        local long_table_match, _ = _quarto.modules.patterns.match_in_list_of_patterns(el.text, _quarto.patterns.latexLongtableEnvPatterns)
         local caption_match = _quarto.modules.patterns.match_all_in_table(_quarto.patterns.latexCaptionPattern)
-        if (long_table_match(el.text) and
-            not caption_match(el.text)) then
+        if (long_table_match and not caption_match(el.text)) then
             flags.has_longtable_no_caption_fixup = true
         end
       end

--- a/src/resources/filters/normalize/flags.lua
+++ b/src/resources/filters/normalize/flags.lua
@@ -58,9 +58,11 @@ function compute_flags()
 
       if _quarto.format.isRawLatex(el) then
         local long_table_match, _ = _quarto.modules.patterns.match_in_list_of_patterns(el.text, _quarto.patterns.latexLongtableEnvPatterns)
-        local caption_match = _quarto.modules.patterns.match_all_in_table(_quarto.patterns.latexCaptionPattern)
-        if (long_table_match and not caption_match(el.text)) then
-            flags.has_longtable_no_caption_fixup = true
+        if long_table_match then
+            local caption_match, _= _quarto.modules.patterns.match_in_list_of_patterns(el.text, _quarto.patterns.latexCaptionPatterns)
+            if not caption_match then
+              flags.has_longtable_no_caption_fixup = true
+            end
         end
       end
 

--- a/src/resources/filters/quarto-post/latex.lua
+++ b/src/resources/filters/quarto-post/latex.lua
@@ -573,11 +573,11 @@ function render_latex_fixups()
   return {{
     RawBlock = function(raw)
       if _quarto.format.isRawLatex(raw) then
-        local long_table_match = _quarto.modules.patterns.match_all_in_table(_quarto.patterns.latexLongtablePattern)
+        local longtable_match, longtable_pattern = _quarto.modules.patterns.match_in_list_of_patterns(raw.text, _quarto.patterns.latexLongtableEnvPatterns)
         local caption_match = _quarto.modules.patterns.match_all_in_table(_quarto.patterns.latexCaptionPattern)
-        if long_table_match(raw.text) and not caption_match(raw.text) then
+        if longtable_match and not caption_match(raw.text) then
           raw.text = raw.text:gsub(
-            _quarto.modules.patterns.combine_patterns(_quarto.patterns.latexLongtablePattern), "\\begin{longtable*}%2\\end{longtable*}", 1)
+            _quarto.modules.patterns.combine_patterns(longtable_pattern), "\\begin{longtable*}%2\\end{longtable*}", 1)
           return raw
         end
       end

--- a/src/resources/filters/quarto-post/latex.lua
+++ b/src/resources/filters/quarto-post/latex.lua
@@ -573,11 +573,13 @@ function render_latex_fixups()
   return {{
     RawBlock = function(raw)
       if _quarto.format.isRawLatex(raw) then
-        local longtable_match, longtable_pattern = _quarto.modules.patterns.match_in_list_of_patterns(raw.text, _quarto.patterns.latexLongtableEnvPatterns)
+        local longtable_match, _ = _quarto.modules.patterns.match_in_list_of_patterns(raw.text, _quarto.patterns.latexLongtableEnvPatterns)
         if longtable_match then
           local caption_match = _quarto.modules.patterns.match_in_list_of_patterns(raw.text, _quarto.patterns.latexCaptionPatterns)
           if not caption_match then
-            -- FIXME: this star addition to the longtable env does not support keeping any possible option or alignement (i.e `\begin{longtable}[c*]{ll}`)
+            -- We need to use the most generic pattern (last of the list) as we want to replace the environment and keep any options 
+            -- (e.g. `\begin{longtable}[c]{ll}` -> \begin{longtable*}[c]{ll} in flextable)
+            local longtable_pattern = _quarto.patterns.latexLongtableEnvPatterns[#_quarto.patterns.latexLongtableEnvPatterns]
             raw.text = raw.text:gsub(_quarto.modules.patterns.combine_patterns(longtable_pattern), "\\begin{longtable*}%2\\end{longtable*}", 1)
             return raw
           end

--- a/src/resources/filters/quarto-post/latex.lua
+++ b/src/resources/filters/quarto-post/latex.lua
@@ -574,11 +574,13 @@ function render_latex_fixups()
     RawBlock = function(raw)
       if _quarto.format.isRawLatex(raw) then
         local longtable_match, longtable_pattern = _quarto.modules.patterns.match_in_list_of_patterns(raw.text, _quarto.patterns.latexLongtableEnvPatterns)
-        local caption_match = _quarto.modules.patterns.match_all_in_table(_quarto.patterns.latexCaptionPattern)
-        if longtable_match and not caption_match(raw.text) then
-          raw.text = raw.text:gsub(
-            _quarto.modules.patterns.combine_patterns(longtable_pattern), "\\begin{longtable*}%2\\end{longtable*}", 1)
-          return raw
+        if longtable_match then
+          local caption_match = _quarto.modules.patterns.match_in_list_of_patterns(raw.text, _quarto.patterns.latexCaptionPatterns)
+          if not caption_match then
+            -- FIXME: this star addition to the longtable env does not support keeping any possible option or alignement (i.e `\begin{longtable}[c*]{ll}`)
+            raw.text = raw.text:gsub(_quarto.modules.patterns.combine_patterns(longtable_pattern), "\\begin{longtable*}%2\\end{longtable*}", 1)
+            return raw
+          end
         end
       end
     end,

--- a/src/resources/filters/quarto-pre/parsefiguredivs.lua
+++ b/src/resources/filters/quarto-pre/parsefiguredivs.lua
@@ -742,10 +742,11 @@ function parse_floatreftargets()
       end
 
       -- finally, if the user passed a \\begin{table} float environment
-      -- we just remove it because we'll re-emit later ourselves
-      local begin_table, table_body, _ = _quarto.modules.patterns.match_in_list_of_patterns(raw.text, _quarto.patterns.latexTableEnvPatterns)
-      if begin_table ~= nil then
-        raw.text = table_body
+      -- we just remove it because we'll re-emit later ourselves  
+      local matched, _ = _quarto.modules.patterns.match_in_list_of_patterns(raw.text, _quarto.patterns.latexTableEnvPatterns)
+      if matched then
+        -- table_body is second matched element.
+        raw.text = matched[2]
       end
 
       return quarto.FloatRefTarget({

--- a/src/resources/filters/quarto-pre/parsefiguredivs.lua
+++ b/src/resources/filters/quarto-pre/parsefiguredivs.lua
@@ -743,9 +743,8 @@ function parse_floatreftargets()
 
       -- finally, if the user passed a \\begin{table} float environment
       -- we just remove it because we'll re-emit later ourselves
-
-      local b, e, begin_table, table_body, end_table = raw.text:find(patterns.latex_table)
-      if b ~= nil then
+      local begin_table, table_body, _ = _quarto.modules.patterns.match_in_list_of_patterns(raw.text, _quarto.patterns.latexTableEnvPatterns)
+      if begin_table ~= nil then
         raw.text = table_body
       end
 

--- a/src/resources/filters/quarto-pre/table-captions.lua
+++ b/src/resources/filters/quarto-pre/table-captions.lua
@@ -171,13 +171,10 @@ function applyTableCaptions(el, tblCaptions, tblLabels)
           raw.text = raw.text:gsub(captionPattern, "%1" .. captionText:gsub("%%", "%%%%") .. "%3", 1)
           idx = idx + 1
         elseif hasRawLatexTable(raw) then
-          for i,pattern in ipairs(_quarto.patterns.latexTablePatterns) do
-            local match_fun = _quarto.modules.patterns.match_all_in_table(pattern)
-            if match_fun(raw.text) then
-              local combined_pattern = _quarto.modules.patterns.combine_patterns(pattern)
+          local matched_env, pattern_env = _quarto.modules.patterns.match_in_list_of_patterns(raw.text, _quarto.patterns.latexAllTableEnvPatterns)
+          if matched_env then
+              local combined_pattern = _quarto.modules.patterns.combine_patterns(pattern_env)
               raw.text = applyLatexTableCaption(raw.text, tblCaptions[idx], tblLabels[idx], combined_pattern)
-              break
-            end
           end
           idx = idx + 1
         elseif hasPagedHtmlTable(raw) then

--- a/src/resources/filters/quarto-pre/table-captions.lua
+++ b/src/resources/filters/quarto-pre/table-captions.lua
@@ -29,14 +29,16 @@ function table_captions()
           el = _quarto.ast.walk(el, {
             RawBlock = function(raw)
               if _quarto.format.isRawLatex(raw) then
-                local tabular_match = _quarto.modules.patterns.match_all_in_table(_quarto.patterns.latexTabularPattern)
-                local table_match = _quarto.modules.patterns.match_all_in_table(_quarto.patterns.latexTablePattern)
-                if tabular_match(raw.text) and not table_match(raw.text) then
-                  raw.text = raw.text:gsub(
-                    _quarto.modules.patterns.combine_patterns(_quarto.patterns.latexTabularPattern),
-                    "\\begin{table}\n\\centering\n%1%2%3\n\\end{table}\n",
-                    1)
-                  return raw
+                local tabular_match, tabular_pattern = _quarto.modules.patterns.match_in_list_of_patterns(raw.text, _quarto.patterns.latexTabularEnvPatterns)
+                if tabular_match then 
+                  local table_match, _ = _quarto.modules.patterns.match_in_list_of_patterns(raw.text, _quarto.patterns.latexTableEnvPatterns)
+                  if not table_match then
+                    raw.text = raw.text:gsub(
+                      _quarto.modules.patterns.combine_patterns(tabular_pattern),
+                      "\\begin{table}\n\\centering\n%1%2%3\n\\end{table}\n",
+                      1)
+                    return raw
+                  end
                 end
               end
             end

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -1876,6 +1876,10 @@ _quarto = {
    processDependencies = processDependencies,
    format = format,
    patterns = {
+      latexTableEnvPatterns = pandoc.List({
+         latexTablePatternWithPos_table, 
+         latexTablePattern_table
+      }),
       latexTabularPattern = latexTabularPattern_table,
       latexTablePattern = latexTablePattern_table,
       latexLongtablePattern = latexLongtablePattern_table,

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -1880,7 +1880,9 @@ _quarto = {
          latexTablePatternWithPos_table, 
          latexTablePattern_table
       }),
-      latexTabularPattern = latexTabularPattern_table,
+      latexTabularEnvPatterns = pandoc.List({
+         latexTabularPattern_table
+      }),
       latexTablePattern = latexTablePattern_table,
       latexLongtablePattern = latexLongtablePattern_table,
       latexTablePatterns = latexTablePatterns,

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -1707,17 +1707,29 @@ local function resolveServiceWorkers(serviceworkers)
    end
 end
 
+-- Lua Patterns for LaTeX Table Environment
 
+--    1. \begin{table}[h] ... \end{table}
 local latexTablePatternWithPos_table = { "\\begin{table}%[[^%]]+%]", ".*", "\\end{table}" }
 local latexTablePattern_table = { "\\begin{table}", ".*", "\\end{table}" }
+
+--    2. \begin{longtable}[c*]{l|r|r} 
+--       FIXME: These two patterns with longtable align options do no account for newlines in options,
+--       however pandoc will break align options over lines. This leads to specific treatment needed
+--       as latexLongtablePattern_table will be the pattern, matching options in content.
+--       see split_longtable_start() usage in src\resources\filters\customnodes\floatreftarget.lua
 local latexLongtablePatternWithPosAndAlign_table = { "\\begin{longtable}%[[^%]]+%]{[^\n]*}", ".*", "\\end{longtable}" }
-local latexLongtablePatternWithPos_table = { "\\begin{longtable}%[[^%]]+%]", ".*", "\\end{longtable}" }
 local latexLongtablePatternWithAlign_table = { "\\begin{longtable}{[^\n]*}", ".*", "\\end{longtable}" }
+local latexLongtablePatternWithPos_table = { "\\begin{longtable}%[[^%]]+%]", ".*", "\\end{longtable}" }
 local latexLongtablePattern_table = { "\\begin{longtable}", ".*", "\\end{longtable}" }
+
+--    3. \begin{tabular}[c]{l|r|r}
 local latexTabularPatternWithPosAndAlign_table = { "\\begin{tabular}%[[^%]]+%]{[^\n]*}", ".*", "\\end{tabular}" }
 local latexTabularPatternWithPos_table = { "\\begin{tabular}%[[^%]]+%]", ".*", "\\end{tabular}" }
 local latexTabularPatternWithAlign_table = { "\\begin{tabular}{[^\n]*}", ".*", "\\end{tabular}" }
 local latexTabularPattern_table = { "\\begin{tabular}", ".*", "\\end{tabular}" }
+
+-- Lua Pattern for Caption environment
 local latexCaptionPattern_table = { "\\caption{", ".-", "}[^\n]*\n" }
 
 -- global quarto params
@@ -1874,6 +1886,9 @@ _quarto = {
          latexTabularPattern_table
       }),
       latexLongtableEnvPatterns = pandoc.List({
+         latexLongtablePatternWithPosAndAlign_table,
+         latexLongtablePatternWithPos_table,
+         latexLongtablePatternWithAlign_table,
          latexLongtablePattern_table
       }),
       -- This is all table env patterns

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -1874,6 +1874,9 @@ local function file_exists(name)
 _quarto = {   
    processDependencies = processDependencies,
    format = format,
+   -- Each list in patterns below contains Lua pattern as table,
+   -- where elements are ordered from more specific match to more generic one.
+   -- They are meant to be used with _quarto.modules.patterns.match_in_list_of_patterns()
    patterns = {
       latexTableEnvPatterns = pandoc.List({
          latexTablePatternWithPos_table, 

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -1708,7 +1708,7 @@ local function resolveServiceWorkers(serviceworkers)
 end
 
 
-local latexTableWithOptionsPattern_table = { "\\begin{table}%[[^%]]+%]", ".*", "\\end{table}" }
+local latexTablePatternWithPos_table = { "\\begin{table}%[[^%]]+%]", ".*", "\\end{table}" }
 local latexTablePattern_table = { "\\begin{table}", ".*", "\\end{table}" }
 local latexLongtablePatternWithPosAndAlign_table = { "\\begin{longtable}%[[^%]]+%]{[^\n]*}", ".*", "\\end{longtable}" }
 local latexLongtablePatternWithPos_table = { "\\begin{longtable}%[[^%]]+%]", ".*", "\\end{longtable}" }
@@ -1721,16 +1721,16 @@ local latexTabularPattern_table = { "\\begin{tabular}", ".*", "\\end{tabular}" }
 local latexCaptionPattern_table = { "\\caption{", ".-", "}[^\n]*\n" }
 
 local latexTablePatterns = pandoc.List({
-  latexTableWithOptionsPattern_table,
-  latexTablePattern_table,
-  latexLongtablePatternWithPosAndAlign_table,
-  latexLongtablePatternWithPos_table,
-  latexLongtablePatternWithAlign_table,
-  latexLongtablePattern_table,
-  latexTabularPatternWithPosAndAlign_table,
-  latexTabularPatternWithPos_table,
-  latexTabularPatternWithAlign_table,
-  latexTabularPattern_table,
+   latexTablePatternWithPos_table,
+   latexTablePattern_table,
+   latexLongtablePatternWithPosAndAlign_table,
+   latexLongtablePatternWithPos_table,
+   latexLongtablePatternWithAlign_table,
+   latexLongtablePattern_table,
+   latexTabularPatternWithPosAndAlign_table,
+   latexTabularPatternWithPos_table,
+   latexTabularPatternWithAlign_table,
+   latexTabularPattern_table,
 })
 
 -- global quarto params

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -1868,6 +1868,9 @@ _quarto = {
          latexTablePattern_table
       }),
       latexTabularEnvPatterns = pandoc.List({
+         latexTabularPatternWithPosAndAlign_table,
+         latexTabularPatternWithPos_table,
+         latexTabularPatternWithAlign_table,
          latexTabularPattern_table
       }),
       latexLongtableEnvPatterns = pandoc.List({

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -1883,7 +1883,9 @@ _quarto = {
       latexTabularEnvPatterns = pandoc.List({
          latexTabularPattern_table
       }),
-      latexLongtablePattern = latexLongtablePattern_table,
+      latexLongtableEnvPatterns = pandoc.List({
+         latexLongtablePattern_table
+      }),
       latexTablePatterns = latexTablePatterns,
       latexCaptionPattern = latexCaptionPattern_table
    },

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -1886,7 +1886,9 @@ _quarto = {
          latexTabularPatternWithAlign_table,
          latexTabularPattern_table,
       }),
-      latexCaptionPattern = latexCaptionPattern_table
+      latexCaptionPatterns = pandoc.List({
+         latexCaptionPattern_table
+      })
    },
    traverser = utils.walk,
    utils = utils,

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -1883,7 +1883,6 @@ _quarto = {
       latexTabularEnvPatterns = pandoc.List({
          latexTabularPattern_table
       }),
-      latexTablePattern = latexTablePattern_table,
       latexLongtablePattern = latexLongtablePattern_table,
       latexTablePatterns = latexTablePatterns,
       latexCaptionPattern = latexCaptionPattern_table

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -1720,19 +1720,6 @@ local latexTabularPatternWithAlign_table = { "\\begin{tabular}{[^\n]*}", ".*", "
 local latexTabularPattern_table = { "\\begin{tabular}", ".*", "\\end{tabular}" }
 local latexCaptionPattern_table = { "\\caption{", ".-", "}[^\n]*\n" }
 
-local latexTablePatterns = pandoc.List({
-   latexTablePatternWithPos_table,
-   latexTablePattern_table,
-   latexLongtablePatternWithPosAndAlign_table,
-   latexLongtablePatternWithPos_table,
-   latexLongtablePatternWithAlign_table,
-   latexLongtablePattern_table,
-   latexTabularPatternWithPosAndAlign_table,
-   latexTabularPatternWithPos_table,
-   latexTabularPatternWithAlign_table,
-   latexTabularPattern_table,
-})
-
 -- global quarto params
 local paramsJson = base64.decode(os.getenv("QUARTO_FILTER_PARAMS"))
 local quartoParams = json.decode(paramsJson)
@@ -1886,7 +1873,19 @@ _quarto = {
       latexLongtableEnvPatterns = pandoc.List({
          latexLongtablePattern_table
       }),
-      latexTablePatterns = latexTablePatterns,
+      -- This is all table env patterns
+      latexAllTableEnvPatterns = pandoc.List({
+         latexTablePatternWithPos_table,
+         latexTablePattern_table,
+         latexLongtablePatternWithPosAndAlign_table,
+         latexLongtablePatternWithPos_table,
+         latexLongtablePatternWithAlign_table,
+         latexLongtablePattern_table,
+         latexTabularPatternWithPosAndAlign_table,
+         latexTabularPatternWithPos_table,
+         latexTabularPatternWithAlign_table,
+         latexTabularPattern_table,
+      }),
       latexCaptionPattern = latexCaptionPattern_table
    },
    traverser = utils.walk,

--- a/tests/docs/smoke-all/crossrefs/float/latex/latex-raw-table-env-1.qmd
+++ b/tests/docs/smoke-all/crossrefs/float/latex/latex-raw-table-env-1.qmd
@@ -1,10 +1,11 @@
 ---
 title: Crossref Raw LaTeX table including table env
-format: latex
+format: pdf
+keep-tex: true
 _quarto:
   tests:
-    latex:
-      ensureFileRegexMatches:
+    pdf:
+      ensureLatexFileRegexMatches:
         - ['\n\\begin\{table\}\n', 'See Table~\\ref\{tbl-mod\}']
         - []
 ---

--- a/tests/docs/smoke-all/crossrefs/float/latex/latex-raw-table-env-1.qmd
+++ b/tests/docs/smoke-all/crossrefs/float/latex/latex-raw-table-env-1.qmd
@@ -1,0 +1,40 @@
+---
+title: Crossref Raw LaTeX table including table env
+format: latex
+_quarto:
+  tests:
+    latex:
+      ensureFileRegexMatches:
+        - ['\n\\begin\{table\}\n', 'See Table~\\ref\{tbl-mod\}']
+        - []
+---
+
+`\begin{table}` should be catched and remove as Quarto does add its own
+
+```{=latex}
+\begin{table}
+   \caption{\label{tbl-mod} no title}
+   \centering
+   \begin{tabular}{lc}
+      \tabularnewline \midrule \midrule
+      Dependent Variable: & disp\\  
+      Model:              & (1)\\  
+      \midrule
+      \emph{Variables}\\
+      Constant            & 580.9$^{***}$\\   
+                          & (41.74)\\   
+      mpg                 & -17.43$^{***}$\\   
+                          & (1.993)\\   
+      \midrule
+      \emph{Fit statistics}\\
+      Observations        & 32\\  
+      R$^2$               & 0.71834\\  
+      Adjusted R$^2$      & 0.70895\\  
+      \midrule \midrule
+      \multicolumn{2}{l}{\emph{IID standard-errors in parentheses}}\\
+      \multicolumn{2}{l}{\emph{Signif. Codes: ***: 0.01, **: 0.05, *: 0.1}}\\
+   \end{tabular}
+\end{table}
+```
+
+See @tbl-mod

--- a/tests/docs/smoke-all/crossrefs/float/latex/latex-raw-table-env-2.qmd
+++ b/tests/docs/smoke-all/crossrefs/float/latex/latex-raw-table-env-2.qmd
@@ -1,0 +1,40 @@
+---
+title: Crossref Raw LaTeX table including table env with position
+format: latex
+_quarto:
+  tests:
+    latex:
+      ensureFileRegexMatches:
+        - ['\n\\begin\{table\}\n', 'See Table~\\ref\{tbl-mod\}']
+        - ['\[htbp\]']
+---
+
+`\begin{table}` should be catched and remove as Quarto does add its own, including when option position are used.
+
+```{=latex}
+\begin{table}[htbp]
+   \caption{\label{tbl-mod} no title}
+   \centering
+   \begin{tabular}{lc}
+      \tabularnewline \midrule \midrule
+      Dependent Variable: & disp\\  
+      Model:              & (1)\\  
+      \midrule
+      \emph{Variables}\\
+      Constant            & 580.9$^{***}$\\   
+                          & (41.74)\\   
+      mpg                 & -17.43$^{***}$\\   
+                          & (1.993)\\   
+      \midrule
+      \emph{Fit statistics}\\
+      Observations        & 32\\  
+      R$^2$               & 0.71834\\  
+      Adjusted R$^2$      & 0.70895\\  
+      \midrule \midrule
+      \multicolumn{2}{l}{\emph{IID standard-errors in parentheses}}\\
+      \multicolumn{2}{l}{\emph{Signif. Codes: ***: 0.01, **: 0.05, *: 0.1}}\\
+   \end{tabular}
+\end{table}
+```
+
+See @tbl-mod

--- a/tests/docs/smoke-all/crossrefs/float/latex/latex-raw-table-env-2.qmd
+++ b/tests/docs/smoke-all/crossrefs/float/latex/latex-raw-table-env-2.qmd
@@ -1,10 +1,11 @@
 ---
 title: Crossref Raw LaTeX table including table env with position
-format: latex
+format: pdf
+keep-tex: true
 _quarto:
   tests:
-    latex:
-      ensureFileRegexMatches:
+    pdf:
+      ensureLatexFileRegexMatches:
         - ['\n\\begin\{table\}\n', 'See Table~\\ref\{tbl-mod\}']
         - ['\[htbp\]']
 ---


### PR DESCRIPTION
This PR adapt the way we use patterns to find table environment. We need to consider possible optional arguments on environment when detecting them. 

We have some patterns for that
https://github.com/quarto-dev/quarto-cli/blob/9792cd1b402579901ef2e9b2486d5d4cbe3ef328/src/resources/pandoc/datadir/init.lua#L1711-L1721

They are multiple because Lua pattern does not have support for `(...)?` optional match grouped.

They are not used everywhere, and there are other patterns definition not considering possible optional. 

This PR fixes #11878 showing what I think we could do. If this is ok, I can do the change to clarify our code as we have `_quarto.patterns.(...)`, `_quarto.modules.patterns.(...)` and all local variables `latex(...)Pattern(...)_table` 

This is up for discussion, but I think this change should help and fix #11878



