### PR TITLE
perf - improve coalesce_raw

### DIFF
--- a/src/resources/filters/quarto-finalize/coalesceraw.lua
+++ b/src/resources/filters/quarto-finalize/coalesceraw.lua
@@ -32,40 +32,52 @@ function coalesce_raw()
   
   table.insert(filters, {
     Inlines = function(inlines)
-      local list_of_lists = collate(inlines, function(block, prev_block)
-        return block.t == "RawInline" and 
-              prev_block.t == "RawInline" and prev_block.format == block.format
-      end)
-      local result = pandoc.Inlines({})
-      for _, lst in ipairs(list_of_lists) do
-        local first_el = lst[1]
-        if first_el.t == "RawInline" then
-          local text = table.concat(lst:map(function(block) return block.text end), "")
-          local new_block = pandoc.RawInline(first_el.format, text)
-          result:insert(new_block)
+      local current_node = nil
+      for i = 1, #inlines do
+        if inlines[i].t ~= "RawInline" then
+          current_node = nil
         else
-          result:insert(first_el)
+          if current_node and inlines[i].format == current_node.format then
+            current_node.text = current_node.text .. inlines[i].text
+            inlines[i].text = ""
+          else
+            current_node = inlines[i]
+          end
         end
       end
-      return result
+      return inlines
     end,
     Blocks = function(blocks)
-      local list_of_lists = collate(blocks, function(block, prev_block)
-        return block.t == "RawBlock" and block.format:match(".*-merge$") and 
-              prev_block.t == "RawBlock" and prev_block.format == block.format
-      end)
-      local result = pandoc.Blocks({})
-      for _, lst in ipairs(list_of_lists) do
-        local first_el = lst[1]
-        if first_el.t == "RawBlock" and first_el.format:match(".*-merge") then
-          local text = table.concat(lst:map(function(block) return block.text end), "%\n")
-          local new_block = pandoc.RawBlock(first_el.format:gsub("-merge$", ""), text)
-          result:insert(new_block)
+      local current_node = nil
+      for i = 1, #blocks do
+        if blocks[i].t ~= "RawBlock" or not blocks[i].format:match(".*-merge") then
+          current_node = nil
         else
-          result:insert(first_el)
+          if current_node and blocks[i].format == current_node.format then
+            current_node.text = current_node.text .. blocks[i].text
+            blocks[i].text = ""
+          else
+            current_node = blocks[i]
+          end
         end
       end
-      return result
+      return blocks
+      -- local list_of_lists = collate(blocks, function(block, prev_block)
+      --   return block.t == "RawBlock" and block.format:match(".*-merge$") and 
+      --         prev_block.t == "RawBlock" and prev_block.format == block.format
+      -- end)
+      -- local result = pandoc.Blocks({})
+      -- for _, lst in ipairs(list_of_lists) do
+      --   local first_el = lst[1]
+      --   if first_el.t == "RawBlock" and first_el.format:match(".*-merge") then
+      --     local text = table.concat(lst:map(function(block) return block.text end), "%\n")
+      --     local new_block = pandoc.RawBlock(first_el.format:gsub("-merge$", ""), text)
+      --     result:insert(new_block)
+      --   else
+      --     result:insert(first_el)
+      --   end
+      -- end
+      -- return result
     end
   })
   return filters

--- a/src/resources/filters/quarto-finalize/coalesceraw.lua
+++ b/src/resources/filters/quarto-finalize/coalesceraw.lua
@@ -62,22 +62,6 @@ function coalesce_raw()
         end
       end
       return blocks
-      -- local list_of_lists = collate(blocks, function(block, prev_block)
-      --   return block.t == "RawBlock" and block.format:match(".*-merge$") and 
-      --         prev_block.t == "RawBlock" and prev_block.format == block.format
-      -- end)
-      -- local result = pandoc.Blocks({})
-      -- for _, lst in ipairs(list_of_lists) do
-      --   local first_el = lst[1]
-      --   if first_el.t == "RawBlock" and first_el.format:match(".*-merge") then
-      --     local text = table.concat(lst:map(function(block) return block.text end), "%\n")
-      --     local new_block = pandoc.RawBlock(first_el.format:gsub("-merge$", ""), text)
-      --     result:insert(new_block)
-      --   else
-      --     result:insert(first_el)
-      --   end
-      -- end
-      -- return result
     end
   })
   return filters


### PR DESCRIPTION
With some A/B testing, we find evidence that the code in the PR is faster than that of main (I can share the script later)

```
$ N_TRIALS=3000 QUARTO_NO_TYPECHECK=1 ./run_experiment_2.py coalesce-raw.csv main tmp-2025-01-21-coalesce-raw quarto render --quiet docs/references/formats/presentations/revealjs.qmd
┏━━━━━━━━━┳━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━┓
┃ Variant ┃ Count ┃ Mean    ┃ Std Dev   ┃
┡━━━━━━━━━╇━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━┩
│ A       │ 10    │ 2.51012 │ 0.0106346 │
│ B       │ 10    │ 2.49222 │ 0.0101653 │
└─────────┴───────┴─────────┴───────────┘
{'outcome': 'significant', 'winner': 'B', 'p_value': np.float64(0.0018407964064409569), 'total_samples': 20, 'alpha_spent': 0.05, 'statistics': {'counts': {'A': 10, 'B': 10}, 'means': {'A': 2.510115218162537, 'B': 2.4922211170196533}, 'variances': {'A': 0.00011309452203267512, 'B': 0.00010333396089645674}}}
Statistical Summary:
===================
Variant     Count         Mean      Std Dev
-------- -------- ------------ ------------
A              10     2.510115     0.010635
B              10     2.492221     0.010165
```

I used `docs/references/formats/presentations/revealjs.qmd` from `quarto-web` because I measured that file to be the one to take the longest time in a site render.