### PR TITLE
Bump QuartoNotebookRunner to 0.12.0

### DIFF
--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Setup Julia
         uses: julia-actions/setup-julia@v2
         with:
-          version: "1.11"
+          version: "1.11.3"
 
       - name: Cache Julia Packages
         uses: julia-actions/cache@v2

--- a/src/resources/julia/Project.toml
+++ b/src/resources/julia/Project.toml
@@ -2,4 +2,4 @@
 QuartoNotebookRunner = "4c0109c6-14e9-4c88-93f0-2b974d3468f4"
 
 [compat]
-QuartoNotebookRunner = "=0.11.6"
+QuartoNotebookRunner = "=0.12.0"

--- a/tests/Manifest.toml
+++ b/tests/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.2"
+julia_version = "1.11.3"
 manifest_format = "2.0"
 project_hash = "0af1d64f93f9c216a25d220e89fda045c4edc0aa"
 


### PR DESCRIPTION
Upgrades to the latest QNR.jl version. This version now supports running different versions of Julia in individual notebooks. Previously we required all the Julia versions to match the version used by the Julia server process.