### PR TITLE
[perf] lua - combine finalize filters

### DIFF
--- a/src/resources/filters/main.lua
+++ b/src/resources/filters/main.lua
@@ -92,8 +92,9 @@ import("./quarto-finalize/dependencies.lua")
 import("./quarto-finalize/book-cleanup.lua")
 import("./quarto-finalize/mediabag.lua")
 import("./quarto-finalize/meta-cleanup.lua")
-import("./quarto-finalize/coalesceraw.lua")
-import("./quarto-finalize/descaffold.lua")
+-- import("./quarto-finalize/coalesceraw.lua")
+-- import("./quarto-finalize/descaffold.lua")
+import("./quarto-finalize/finalize-combined-1.lua")
 import("./quarto-finalize/typst.lua")
 
 import("./normalize/flags.lua")
@@ -550,22 +551,26 @@ local quarto_finalize_filters = {
     filter = dependencies(),
     traverser = 'jog',
   },
-  { name = "finalize-coalesce-raw",
-    filters = coalesce_raw(),
+  { name = "finalize-combined-1",
+    filter = finalize_combined_1(),
     traverser = 'jog',
   },
-  { name = "finalize-descaffold",
-    filter = descaffold(),
-    traverser = 'jog',
-  },
+  -- { name = "finalize-coalesce-raw",
+  --   filters = coalesce_raw(),
+  --   traverser = 'jog',
+  -- },
+  -- { name = "finalize-descaffold",
+  --   filter = descaffold(),
+  --   traverser = 'jog',
+  -- },
   { name = "finalize-wrapped-writer",
     filter = wrapped_writer(),
     traverser = 'jog',
   },
-  { name = "finalize-typst-state",
-    filter = setup_typst_state(),
-    traverser = 'jog',
-  },
+  -- { name = "finalize-typst-state",
+  --   filter = setup_typst_state(),
+  --   traverser = 'jog',
+  -- },
 }
 
 local quarto_layout_filters = {
@@ -665,7 +670,11 @@ tappend(quarto_filter_list, quarto_post_filters)
 table.insert(quarto_filter_list, { name = "post-render", filter = {} }) -- entry point for user filters
 table.insert(quarto_filter_list, { name = "pre-finalize", filter = {} }) -- entry point for user filters
 tappend(quarto_filter_list, quarto_finalize_filters)
-table.insert(quarto_filter_list, { name = "post-finalize", filter = {} }) -- entry point for user filters
+table.insert(quarto_filter_list, { name = "post-finalize", filter = {
+  -- Pandoc = function(doc)
+  --   quarto_prof.stop()
+  -- end
+} }) -- entry point for user filters
 
 -- now inject user-defined filters on appropriate positions
 inject_user_filters_at_entry_points(quarto_filter_list)

--- a/src/resources/filters/quarto-finalize/finalize-combined-1.lua
+++ b/src/resources/filters/quarto-finalize/finalize-combined-1.lua
@@ -1,0 +1,76 @@
+-- finalize_combined_1.lua
+--
+-- An optimized implementation of the following filters in a single pass:
+--   - coalesce_raw
+--   - descaffold
+--
+-- Copyright (C) 2025 Posit Software, PBC
+--
+-- Raw blocks are selectively coalesced if they're written
+-- to:
+--    - the same format
+--    - with a suffix of -merge
+--
+-- This specifically matters in the case of some latex rawblocks which
+-- cannot be separated by a newline (like minipages in a figure)
+--
+-- note that in LaTeX output, we need to strip Div nodes, since they
+-- can "delimit" two raw blocks and prevent them from being coalesced.
+
+function finalize_combined_1()
+  local changed = false
+
+  return {
+    Plain = function(plain) -- descaffold
+      if #plain.content == 0 then
+        return {}
+      end
+    end,
+    Span = function(el) -- descaffold
+      if el.classes:includes("quarto-scaffold") then
+        return el.content
+      end
+    end,
+    Div = function(el) 
+      if (quarto.doc.isFormat("latex") and #el.classes == 0 and #el.attributes == 0 and el.identifier == "") or -- coalesce_raw
+        el.classes:includes("quarto-scaffold") then -- descaffold
+        return el.content
+      end
+    end,
+    Inlines = function(inlines) -- coalesce_raw
+      local current_node = nil
+      for i = 1, #inlines do
+        if inlines[i].t ~= "RawInline" then
+          current_node = nil
+        else
+          if current_node and inlines[i].format == current_node.format then
+            changed = true
+            current_node.text = current_node.text .. inlines[i].text
+            inlines[i].text = ""
+          else
+            current_node = inlines[i]
+          end
+        end
+      end
+      return inlines
+    end,
+    Blocks = function(blocks) -- coalesce_raw
+      local current_node = nil
+      for i = 1, #blocks do
+        if blocks[i].t ~= "RawBlock" or not blocks[i].format:match(".*-merge$") then
+          current_node = nil
+        else
+          blocks[i].format = blocks[i].format:gsub("-merge$", "")
+          if current_node and blocks[i].format == current_node.format then
+            changed = true
+            current_node.text = current_node.text .. blocks[i].text
+            blocks[i].text = ""
+          else
+            current_node = blocks[i]
+          end
+        end
+      end
+      return blocks
+    end
+  }
+end

--- a/src/resources/filters/quarto-finalize/finalize-combined-1.lua
+++ b/src/resources/filters/quarto-finalize/finalize-combined-1.lua
@@ -74,3 +74,7 @@ function finalize_combined_1()
     end
   }
 end
+
+function make_scaffold(ctor, node)
+  return ctor(node or {}, pandoc.Attr("", {"quarto-scaffold", "hidden"}, {}))
+end


### PR DESCRIPTION
It seems hard to avoid the overhead of coalesce_raw, but we can write by hand a filter that combines its behavior with one of its neighbors on the list. This appears to work well on A/B testing.

```
$ run_experiment.py main 2025-01-23-finalize-combined deno run --allow-all ~/repos/github/quarto-dev/quarto-cli/tools/run-pandoc-capture.ts render-command.json
┏━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Variant ┃ Count ┃ Mean     ┃ Std Dev    ┃
┡━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━┩
│ A       │ 10    │ 0.591234 │ 0.00634839 │
│ B       │ 9     │ 0.534588 │ 0.00587546 │
└─────────┴───────┴──────────┴────────────┘
{'outcome': 'significant', 'winner': 'B', 'p_value': np.float64(5.109983792608639e-13), 'total_samples': 20, 'alpha_spent': 0.05, 'statistics': {'counts': {'A': 10, 'B': 10}, 'means': {'A': 0.5912335634231567, 'B': 0.5357627630233764}, 'variances': {'A': 4.030205561839084e-05, 'B': 4.3499259748558394e-05}}}
Statistical Summary:
===================
Variant     Count         Mean      Std Dev
-------- -------- ------------ ------------
A              10     0.591234     0.006348
B              10     0.535763     0.006595
```