### PR TITLE
[perf] lua - use jog for scope resolution

### DIFF
--- a/src/resources/filters/quarto-pre/resolvescopedelements.lua
+++ b/src/resources/filters/quarto-pre/resolvescopedelements.lua
@@ -5,13 +5,15 @@ function resolve_scoped_elements()
   local resolve_table_colwidths_scoped = require("modules/tablecolwidths").resolve_table_colwidths_scoped
 
   local scoped_filter = {
+    context = true,
     Table = resolve_table_colwidths_scoped
   }
-  return {
-    -- because our emulated filter has a special case for Pandoc documents
-    -- which doesn't create copies, we don't need to return doc here
-    Pandoc = function(doc)
-      _quarto.ast.scoped_walk(doc.blocks, scoped_filter)
-    end
-  }
+  return scoped_filter
+  -- return {
+  --   -- because our emulated filter has a special case for Pandoc documents
+  --   -- which doesn't create copies, we don't need to return doc here
+  --   Pandoc = function(doc)
+  --     _quarto.traverser(doc.blocks, scoped_filter)
+  --   end
+  -- }
 end


### PR DESCRIPTION
Another clear perf win, with 10% off the total Pandoc runtime by using jog for our slowest filter:

```
$ run_experiment.py main perf/2025-01-24-scope-resolution deno run --allow-all ~/repos/github/quarto-dev/quarto-cli/tools/run-pandoc-capture.ts render-command.json
┏━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Variant ┃ Count ┃ Mean     ┃ Std Dev    ┃
┡━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━┩
│ A       │ 10    │ 0.399428 │ 0.00842317 │
│ B       │ 3     │ 0.357802 │ 0.00330199 │
└─────────┴───────┴──────────┴────────────┘
{'outcome': 'significant', 'winner': 'B', 'p_value': np.float64(3.288711787529413e-08), 'total_samples': 20, 'alpha_spent': 0.05, 'statistics': {'counts': {'A': 10, 'B': 10}, 'means': {'A': 0.39942762851715086, 'B': 0.36351425647735597}, 'variances': {'A': 7.094985341440929e-05, 'B': 6.671159754942368e-05}}}
Statistical Summary:
===================
Variant     Count         Mean      Std Dev
-------- -------- ------------ ------------
A              10     0.399428     0.008423
B              10     0.363514     0.008168
```

Incidentally, we're getting much better timing stdevs by skipping `quarto render`.