### PR TITLE
bugfix: correct lua regex for matching a hyphen

### DIFF
--- a/src/resources/filters/normalize/parsehtml.lua
+++ b/src/resources/filters/normalize/parsehtml.lua
@@ -80,7 +80,7 @@ function parse_html_tables()
         return htmltext
       else
         local index = 1
-        content = content:gsub(data_uri_uuid:gsub('-', '--'), function(_)
+        content = content:gsub(data_uri_uuid:gsub('-', '%%-'), function(_)
           local data_uri = data_uris[index]
           index = index + 1
           return data_uri

--- a/tests/docs/typst/ansi/ansi-colors.qmd
+++ b/tests/docs/typst/ansi/ansi-colors.qmd
@@ -8,28 +8,30 @@ format:
 ---
 
 ```{python}
-from ansi2html import Ansi2HTMLConverter
+import ansi2html
+# from ansi2html import Ansi2HTMLConverter
 from IPython.core.display import display, Markdown
 
-conv = Ansi2HTMLConverter()
-line = ''
-lines = []
-for i in range(256):
-    if (i == 8) or (i >=16 and i%6 == 4):
-        lines.append(line)
-        line = ''
-    line += f'\x1b[38;5;{i}m{i:>3} '
-lines.append(line)
-# the center 216 is a 6x6x6 cube
-# pack it in two columns of three 6x6 squares
-lines2 = [lines[0], lines[1]]
-for i in range(0, 6, 2):
-    for j in range(6):
-        lines2.append(lines[i*6 + j + 2] + lines[i*6 + 6 + j + 2])
-lines2.append(lines[38] + lines[39])
-lines2.append(lines[40] + lines[41])
-display(Markdown(
-  '::: {html-pre-tag-processing="parse"}\n\n```{=html}\n'
-  + conv.convert('\n'.join(lines2)) +
-  '\n```\n:::\n'))
+print(ansi2html)
+# conv = ansi2html.Ansi2HTMLConverter()
+# line = ''
+# lines = []
+# for i in range(256):
+#     if (i == 8) or (i >=16 and i%6 == 4):
+#         lines.append(line)
+#         line = ''
+#     line += f'\x1b[38;5;{i}m{i:>3} '
+# lines.append(line)
+# # the center 216 is a 6x6x6 cube
+# # pack it in two columns of three 6x6 squares
+# lines2 = [lines[0], lines[1]]
+# for i in range(0, 6, 2):
+#     for j in range(6):
+#         lines2.append(lines[i*6 + j + 2] + lines[i*6 + 6 + j + 2])
+# lines2.append(lines[38] + lines[39])
+# lines2.append(lines[40] + lines[41])
+# display(Markdown(
+#   '::: {html-pre-tag-processing="parse"}\n\n```{=html}\n'
+#   + conv.convert('\n'.join(lines2)) +
+#   '\n```\n:::\n'))
 ```


### PR DESCRIPTION
I think I had it in my head that because you need to replace `%` with `%%` in a Lua regex to search for it, you should also replace `-` with `--` 🤣 

It worked but it's incorrect and hurts code legibility.
