### PR TITLE
[feat] typescript - projects have a persistent disk cache

### DIFF
--- a/src/command/preview/cmd.ts
+++ b/src/command/preview/cmd.ts
@@ -278,7 +278,7 @@ export const previewCommand = new Command()
       // get project and preview format
       const nbContext = notebookContext();
       const project = (await projectContext(dirname(file), nbContext)) ||
-        singleFileProjectContext(file, nbContext);
+        (await singleFileProjectContext(file, nbContext));
       const formats = await (async () => {
         const services = renderServices(nbContext);
         try {

--- a/src/command/preview/preview.ts
+++ b/src/command/preview/preview.ts
@@ -373,7 +373,7 @@ export async function previewFormat(
     return format;
   }
   const nbContext = notebookContext();
-  project = project || singleFileProjectContext(file, nbContext);
+  project = project || (await singleFileProjectContext(file, nbContext));
   formats = formats ||
     await withRenderServices(
       nbContext,
@@ -484,6 +484,8 @@ export async function renderForPreview(
     },
     [],
   ));
+
+  renderResult.context.cleanup();
 
   return {
     file,

--- a/src/command/publish/cmd.ts
+++ b/src/command/publish/cmd.ts
@@ -339,7 +339,7 @@ async function createPublishOptions(
 
   // check for directory (either website or single-file project)
   const project = (await projectContext(path, nbContext)) ||
-    singleFileProjectContext(path, nbContext);
+    (await singleFileProjectContext(path, nbContext));
   if (Deno.statSync(path).isDirectory) {
     if (projectIsWebsite(project)) {
       input = project;

--- a/src/command/render/cmd.ts
+++ b/src/command/render/cmd.ts
@@ -245,6 +245,9 @@ export const renderCommand = new Command()
         const services = renderServices(notebookContext());
         try {
           renderResultInput = relative(Deno.cwd(), walk.path) || ".";
+          if (renderResult) {
+            renderResult.context.cleanup();
+          }
           renderResult = await render(renderResultInput, {
             services,
             flags,
@@ -255,6 +258,7 @@ export const renderCommand = new Command()
 
           // check for error
           if (renderResult.error) {
+            renderResult.context.cleanup();
             throw renderResult.error;
           }
         } finally {
@@ -274,6 +278,10 @@ export const renderCommand = new Command()
 
         if (finalOutput) {
           info("Output created: " + finalOutput + "\n");
+        }
+
+        if (renderResult) {
+          renderResult.context.cleanup();
         }
       }
     } else {

--- a/src/command/render/pandoc-html.ts
+++ b/src/command/render/pandoc-html.ts
@@ -53,7 +53,6 @@ export async function resolveSassBundles(
   inputDir: string,
   extras: FormatExtras,
   format: Format,
-  temp: TempContext,
   project: ProjectContext,
 ) {
   extras = cloneDeep(extras);
@@ -159,11 +158,11 @@ export async function resolveSassBundles(
 
     for (const target of targets) {
       let cssPath: string | undefined;
-      cssPath = await compileSass(target.bundles, temp);
+      cssPath = await compileSass(target.bundles, project);
       // First, Clean CSS
       cleanSourceMappingUrl(cssPath);
       // look for a sentinel 'dark' value, extract variables
-      const cssResult = await processCssIntoExtras(cssPath, extras, temp);
+      const cssResult = await processCssIntoExtras(cssPath, extras, project);
       cssPath = cssResult.path;
 
       // it can happen that processing generate an empty css file (e.g quarto-html deps with Quarto CSS variables)
@@ -261,7 +260,7 @@ export async function resolveSassBundles(
     inputDir,
     extras,
     format,
-    temp,
+    project,
     hasDarkStyles ? "light" : "default",
     defaultStyle,
   );
@@ -272,7 +271,7 @@ export async function resolveSassBundles(
       inputDir,
       extras,
       format,
-      temp,
+      project,
       "dark",
       defaultStyle,
     );
@@ -291,7 +290,7 @@ async function resolveQuartoSyntaxHighlighting(
   inputDir: string,
   extras: FormatExtras,
   format: Format,
-  temp: TempContext,
+  project: ProjectContext,
   style: "dark" | "light" | "default",
   defaultStyle?: "dark" | "light",
 ) {
@@ -381,7 +380,7 @@ async function resolveQuartoSyntaxHighlighting(
             rules: rules.join("\n"),
           },
         }],
-        temp,
+        project,
         false,
       );
 
@@ -500,8 +499,9 @@ interface CSSResult {
 async function processCssIntoExtras(
   cssPath: string,
   extras: FormatExtras,
-  temp: TempContext,
+  project: ProjectContext,
 ): Promise<CSSResult> {
+  const { temp } = project;
   extras.html = extras.html || {};
 
   const css = Deno.readTextFileSync(cssPath);

--- a/src/command/render/pandoc.ts
+++ b/src/command/render/pandoc.ts
@@ -536,7 +536,6 @@ export async function runPandoc(
       options.format,
       cwd,
       options.libDir,
-      options.services.temp,
       dependenciesFile,
       options.project,
     );
@@ -962,9 +961,6 @@ export async function runPandoc(
 
   // filter results json file
   const filterResultsFile = options.services.temp.createFile();
-
-  // timing results json file
-  const timingResultsFile = options.services.temp.createFile();
 
   const writerKeys: ("to" | "writer")[] = ["to", "writer"];
   for (const key of writerKeys) {
@@ -1397,7 +1393,6 @@ async function resolveExtras(
   format: Format,
   inputDir: string,
   libDir: string,
-  temp: TempContext,
   dependenciesFile: string,
   project: ProjectContext,
 ) {
@@ -1415,7 +1410,6 @@ async function resolveExtras(
       inputDir,
       extras,
       format,
-      temp,
       project,
     );
 

--- a/src/command/render/render-contexts.ts
+++ b/src/command/render/render-contexts.ts
@@ -89,6 +89,21 @@ import {
 import { ExtensionContext } from "../../extension/types.ts";
 import { NotebookContext } from "../../render/notebook/notebook-types.ts";
 
+// we can't naively ld.cloneDeep everything
+// because that destroys class instances
+// with private members
+//
+// Currently, that's ProjectContext.
+//
+// TODO: Ideally, we shouldn't be copying the RenderContext at all.
+export function copyRenderContext(
+  context: RenderContext,
+): RenderContext {
+  return {
+    ...ld.cloneDeep(context),
+    project: context.project,
+  };
+}
 export async function resolveFormatsFromMetadata(
   metadata: Metadata,
   input: string,
@@ -741,9 +756,6 @@ export async function projectMetadataForInputFile(
   input: string,
   project: ProjectContext,
 ): Promise<Metadata> {
-  // don't mutate caller
-  project = ld.cloneDeep(project) as ProjectContext;
-
   if (project.dir && project.config) {
     // If there is directory and configuration information
     // process paths
@@ -751,10 +763,10 @@ export async function projectMetadataForInputFile(
       projectType(project.config?.project?.[kProjectType]),
       project.dir,
       dirname(input),
-      project.config,
+      ld.cloneDeep(project.config),
     ) as Metadata;
   } else {
     // Just return the config or empty metadata
-    return project.config || {};
+    return ld.cloneDeep(project.config) || {};
   }
 }

--- a/src/command/render/render-files.ts
+++ b/src/command/render/render-files.ts
@@ -48,7 +48,7 @@ import { outputRecipe } from "./output.ts";
 
 import { renderPandoc } from "./render.ts";
 import { PandocRenderCompletion, RenderServices } from "./types.ts";
-import { renderContexts } from "./render-contexts.ts";
+import { copyRenderContext, renderContexts } from "./render-contexts.ts";
 import { renderProgress } from "./render-info.ts";
 import {
   ExecutedFile,
@@ -503,7 +503,7 @@ async function renderFileInternal(
 
   for (const format of Object.keys(contexts)) {
     pushTiming("render-context");
-    const context = ld.cloneDeep(contexts[format]) as RenderContext; // since we're going to mutate it...
+    const context = copyRenderContext(contexts[format]); // since we're going to mutate it...
 
     // disquality some documents from server: shiny
     if (isServerShiny(context.format) && context.project) {

--- a/src/command/render/render-shared.ts
+++ b/src/command/render/render-shared.ts
@@ -33,6 +33,7 @@ import { kTextPlain } from "../../core/mime.ts";
 import { normalizePath } from "../../core/path.ts";
 import { notebookContext } from "../../render/notebook/notebook-context.ts";
 import { singleFileProjectContext } from "../../project/types/single-file/single-file.ts";
+import { assert } from "testing/asserts";
 
 export async function render(
   path: string,
@@ -95,8 +96,9 @@ export async function render(
   // validate that we didn't get any project-only options
   validateDocumentRenderFlags(options.flags);
 
+  assert(!context, "Expected no context here");
   // NB: singleFileProjectContext is currently not fully-featured
-  context = singleFileProjectContext(path, nbContext, options.flags);
+  context = await singleFileProjectContext(path, nbContext, options.flags);
 
   // otherwise it's just a file render
   const result = await renderFiles(

--- a/src/command/render/types.ts
+++ b/src/command/render/types.ts
@@ -102,7 +102,7 @@ export interface RenderResourceFiles {
 }
 
 export interface RenderResult {
-  context?: ProjectContext;
+  context: ProjectContext;
   baseDir?: string;
   outputDir?: string;
   files: RenderResultFile[];

--- a/src/command/serve/cmd.ts
+++ b/src/command/serve/cmd.ts
@@ -69,7 +69,7 @@ export const serveCommand = new Command()
 
     const nbContext = notebookContext();
     const context = (await projectContext(input, nbContext)) ||
-      singleFileProjectContext(input, nbContext);
+      (await singleFileProjectContext(input, nbContext));
     const formats = await withRenderServices(
       nbContext,
       (services: RenderServices) =>

--- a/src/command/serve/serve.ts
+++ b/src/command/serve/serve.ts
@@ -48,7 +48,7 @@ export async function serve(options: RunOptions): Promise<ProcessResult> {
   const { host, port } = await resolveHostAndPort(options);
   const nbContext = notebookContext();
   const project = (await projectContext(options.input, nbContext)) ||
-    singleFileProjectContext(options.input, nbContext);
+    (await singleFileProjectContext(options.input, nbContext));
 
   const engine = await fileExecutionEngine(options.input, undefined, project);
   if (engine?.run) {

--- a/src/core/cache/cache-types.ts
+++ b/src/core/cache/cache-types.ts
@@ -1,0 +1,43 @@
+/*
+ * types.ts
+ *
+ * Types for ./cache.ts
+ *
+ * Copyright (C) 2025 Posit Software, PBC
+ */
+
+export type ProjectCacheKey = string[];
+
+export type DiskCacheEntry = {
+  hash: string;
+  type: "buffer" | "string";
+};
+export type ImmediateStringCacheEntry = {
+  value: string;
+  type: "string-immediate";
+};
+export type ImmediateBufferCacheEntry = {
+  value: Uint8Array;
+  type: "buffer-immediate";
+};
+export type CacheIndexEntry =
+  | DiskCacheEntry
+  | ImmediateStringCacheEntry
+  | ImmediateBufferCacheEntry;
+
+export type ProjectCache = {
+  addSmallString(key: ProjectCacheKey, value: string): Promise<void>;
+  addSmallBuffer(key: ProjectCacheKey, value: Uint8Array): Promise<void>;
+  addBuffer: (key: ProjectCacheKey, value: Uint8Array) => Promise<void>;
+  addString: (key: ProjectCacheKey, value: string) => Promise<void>;
+
+  getSmallBuffer: (key: ProjectCacheKey) => Promise<Uint8Array | null>;
+  getSmallString: (key: ProjectCacheKey) => Promise<string | null>;
+  getBuffer: (key: ProjectCacheKey) => Promise<Uint8Array | null>;
+  getString: (key: ProjectCacheKey) => Promise<string | null>;
+
+  get: (key: ProjectCacheKey) => Promise<CacheIndexEntry | null>;
+
+  close: () => void;
+  clear: () => Promise<void>;
+};

--- a/src/core/cache/cache.ts
+++ b/src/core/cache/cache.ts
@@ -1,0 +1,237 @@
+/*
+ * cache.ts
+ *
+ * A persistent cache for projects
+ *
+ * Copyright (C) 2025 Posit Software, PBC
+ */
+
+import { assert } from "testing/asserts";
+import { ensureDirSync } from "../../deno_ral/fs.ts";
+import { join } from "../../deno_ral/path.ts";
+import { md5HashBytes } from "../hash.ts";
+import { satisfies } from "semver/mod.ts";
+import { quartoConfig } from "../quarto.ts";
+import { CacheIndexEntry, ProjectCache } from "./cache-types.ts";
+import { ProjectContext } from "../../project/types.ts";
+import {
+  type DiskCacheEntry,
+  type ImmediateBufferCacheEntry,
+  type ImmediateStringCacheEntry,
+} from "./cache-types.ts";
+export { type ProjectCache } from "./cache-types.ts";
+
+const currentCacheVersion = "1";
+const requiredQuartoVersions: Record<string, string> = {
+  "1": ">1.7.0",
+};
+
+class ProjectCacheImpl {
+  projectScratchDir: string;
+  index: Deno.Kv | null;
+
+  constructor(_projectScratchDir: string) {
+    this.projectScratchDir = _projectScratchDir;
+    this.index = null;
+  }
+
+  close() {
+    if (this.index) {
+      this.index.close();
+      this.index = null;
+    }
+  }
+
+  async clear(): Promise<void> {
+    assert(this.index);
+    const entries = this.index.list({ prefix: [] });
+    for await (const entry of entries) {
+      const diskValue = entry.value;
+      if (entry.key[0] !== "version") {
+        Deno.removeSync(
+          join(this.projectScratchDir, "project-cache", diskValue as string),
+        );
+      }
+      await this.index.delete(entry.key);
+    }
+  }
+
+  async createOnDisk(): Promise<void> {
+    assert(this.index);
+    this.index.set(["version"], currentCacheVersion);
+  }
+
+  async init(): Promise<void> {
+    const indexPath = join(this.projectScratchDir, "project-cache");
+    ensureDirSync(indexPath);
+    this.index = await Deno.openKv(join(indexPath, "deno-kv-file"));
+    let version = await this.index.get(["version"]);
+    if (version.value === null) {
+      await this.createOnDisk();
+      version = await this.index.get(["version"]);
+    }
+    assert(typeof version.value === "string");
+    const requiredVersion = requiredQuartoVersions[version.value];
+    if (
+      !requiredVersion || !satisfies(quartoConfig.version(), requiredVersion)
+    ) {
+      console.warn("Unknown project cache version.");
+      console.warn(
+        "Project cache was likely created by a newer version of Quarto.",
+      );
+      console.warn("Quarto will clear the project cache.");
+      await this.clear();
+      await this.createOnDisk();
+    }
+  }
+
+  async addBuffer(key: string[], value: Uint8Array): Promise<void> {
+    assert(this.index);
+    const hash = await md5HashBytes(value);
+    Deno.writeFileSync(
+      join(this.projectScratchDir, "project-cache", hash),
+      value,
+    );
+    const result = await this.index.set(key, {
+      hash,
+      type: "buffer",
+    });
+    assert(result.ok);
+  }
+
+  async addString(key: string[], value: string): Promise<void> {
+    assert(this.index);
+    const buffer = new TextEncoder().encode(value);
+    const hash = await md5HashBytes(buffer);
+    Deno.writeTextFileSync(
+      join(this.projectScratchDir, "project-cache", hash),
+      value,
+    );
+    const result = await this.index.set(key, {
+      hash,
+      type: "string",
+    });
+    assert(result.ok);
+  }
+
+  async addSmallBuffer(key: string[], value: Uint8Array): Promise<void> {
+    assert(this.index);
+    const result = await this.index.set(key, {
+      value,
+      type: "buffer-immediate",
+    });
+    assert(result.ok);
+  }
+
+  async addSmallString(key: string[], value: string): Promise<void> {
+    assert(this.index);
+    const result = await this.index.set(key, {
+      value,
+      type: "string-immediate",
+    });
+    assert(result.ok);
+  }
+
+  async get(key: string[]): Promise<CacheIndexEntry | null> {
+    assert(this.index);
+    const kvResult = await this.index.get(key);
+    if (kvResult.value === null) {
+      return null;
+    }
+    return kvResult.value as CacheIndexEntry;
+  }
+
+  async _getAs<T>(
+    key: string[],
+    getter: (hash: CacheIndexEntry) => T,
+  ): Promise<T | null> {
+    assert(this.index);
+    const result = await this.get(key);
+    if (result === null) {
+      return null;
+    }
+    try {
+      return getter(result);
+    } catch (e) {
+      if (!(e instanceof Deno.errors.NotFound)) {
+        throw e;
+      }
+      console.warn(
+        `Entry ${result} not found -- clearing entry in index`,
+      );
+      await this.index.delete(key);
+      return null;
+    }
+  }
+
+  async getSmallString(key: string[]): Promise<string | null> {
+    return this._getAs(key, (result) => {
+      assert(result.type === "string-immediate", "Expected string");
+      return (result as ImmediateStringCacheEntry).value;
+    });
+  }
+
+  async getSmallBuffer(key: string[]): Promise<Uint8Array | null> {
+    return this._getAs(key, (result) => {
+      assert(result.type === "buffer-immediate", "Expected buffer");
+      return (result as ImmediateBufferCacheEntry).value;
+    });
+  }
+
+  async getBuffer(key: string[]): Promise<Uint8Array | null> {
+    return this._getAs(key, (result) => {
+      assert(result.type === "buffer", "Expected buffer");
+      const { hash } = result as DiskCacheEntry;
+      return Deno.readFileSync(
+        join(this.projectScratchDir, "project-cache", hash),
+      );
+    });
+  }
+
+  async getString(key: string[]): Promise<string | null> {
+    return this._getAs(key, (result) => {
+      assert(result.type === "string", "Expected string");
+      const { hash } = result as DiskCacheEntry;
+      return Deno.readTextFileSync(
+        join(this.projectScratchDir, "project-cache", hash),
+      );
+    });
+  }
+
+  memoizeStringFunction(
+    key: string[],
+    fn: (param: string) => Promise<string>,
+  ): (param: string) => Promise<string> {
+    return async (param: string) => {
+      const paramHash = await md5HashBytes(new TextEncoder().encode(param));
+      const memoizationKey = [...key, paramHash];
+      const cached = await this.getString(memoizationKey);
+      if (cached !== null) {
+        return cached;
+      }
+      const result = await fn(param);
+      await this.addString(memoizationKey, result);
+      return result;
+    };
+  }
+}
+
+export const createProjectCache = async (
+  projectScratchDir: string,
+): Promise<ProjectCache> => {
+  const result = new ProjectCacheImpl(projectScratchDir);
+  await result.init();
+  return result as ProjectCache;
+};
+
+export const memoizeStringFunction = (
+  key: string[],
+  fn: (param: string) => Promise<string>,
+): (project: ProjectContext, param: string) => Promise<string> => {
+  return async (project: ProjectContext, param: string) => {
+    return (project.diskCache as ProjectCacheImpl).memoizeStringFunction(
+      key,
+      fn,
+    )(param);
+  };
+};

--- a/src/format/reveal/format-reveal-theme.ts
+++ b/src/format/reveal/format-reveal-theme.ts
@@ -68,7 +68,6 @@ export async function revealTheme(
   format: Format,
   input: string,
   libDir: string,
-  temp: TempContext,
   project: ProjectContext,
 ) {
   // metadata override to return
@@ -196,7 +195,7 @@ export async function revealTheme(
   };
 
   // compile sass
-  const css = await compileSass([bundleLayers], temp);
+  const css = await compileSass([bundleLayers], project);
   // Remove sourcemap information
   cleanSourceMappingUrl(css);
   // convert from string to bytes

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -212,7 +212,6 @@ export function revealjsFormat() {
           format,
           input,
           libDir,
-          services.temp,
           project,
         );
 

--- a/src/project/serve/serve.ts
+++ b/src/project/serve/serve.ts
@@ -824,6 +824,7 @@ function previewControlChannelRequestHandler(
             })
           ).then((result) => {
             if (result.error) {
+              result.context.cleanup();
               renderManager.onRenderError(result.error);
             } else {
               // print output created
@@ -844,6 +845,7 @@ function previewControlChannelRequestHandler(
                 resourceFiles,
                 watcher.project(),
               );
+              result.context.cleanup();
 
               info("Output created: " + finalOutput + "\n");
 

--- a/src/project/types.ts
+++ b/src/project/types.ts
@@ -21,6 +21,9 @@ import {
   ProjectConfig as ProjectConfig_Project,
 } from "../resources/types/schema-types.ts";
 import { ProjectEnvironment } from "./project-environment-types.ts";
+import { ProjectCache } from "../core/cache/cache-types.ts";
+import { TempContext } from "../core/temp-types.ts";
+
 export {
   type NavigationItem as NavItem,
   type NavigationItemObject,
@@ -110,6 +113,11 @@ export interface ProjectContext {
   environment: () => Promise<ProjectEnvironment>;
 
   isSingleFile: boolean;
+
+  diskCache: ProjectCache;
+  temp: TempContext;
+
+  cleanup: () => void;
 }
 
 export interface ProjectFiles {

--- a/src/publish/publish.ts
+++ b/src/publish/publish.ts
@@ -88,6 +88,7 @@ export async function publishSite(
           {},
         );
 
+        result.context.cleanup();
         if (result.error) {
           throw result.error;
         }
@@ -169,6 +170,7 @@ export async function publishDocument(
           flags,
         });
         if (result.error) {
+          result.context.cleanup();
           throw result.error;
         }
 
@@ -258,6 +260,7 @@ export async function publishDocument(
             relBasePath,
           );
         }
+        result.context.cleanup();
 
         return normalizePublishFiles({
           baseDir: finalBaseDir,

--- a/src/quarto-core/inspect.ts
+++ b/src/quarto-core/inspect.ts
@@ -126,15 +126,16 @@ export async function inspectConfig(path?: string): Promise<InspectedConfig> {
     }
   } else {
     const project = await projectContext(path, nbContext) ||
-      singleFileProjectContext(path, nbContext);
+      (await singleFileProjectContext(path, nbContext));
     const engine = await fileExecutionEngine(path, undefined, project);
     if (engine) {
       // partition markdown
       const partitioned = await engine.partitionedMarkdown(path);
 
+      // FIXME Why are we doing this twice? See "const project..." above
       // get formats
       const context = (await projectContext(path, nbContext)) ||
-        singleFileProjectContext(path, nbContext);
+        (await singleFileProjectContext(path, nbContext));
       const src = await context.resolveFullMarkdownForFile(engine, path);
       if (engine) {
         const errors = await validateDocumentFromSource(


### PR DESCRIPTION
This adds a ProjectCache class and a `diskCache` field to project contexts. I will be using it for our perf work, but I think there's room to make this more broadly used in Quarto itself.