### PR TITLE
lua, PanelLayout - don't create a div if preamble is empty

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -44,6 +44,7 @@ All changes included in 1.7:
 - ([#11578](https://github.com/quarto-dev/quarto-cli/issues/11578)): Typst column layout widths use fractional `fr` units instead of percent `%` units for unitless and default widths in order to fill the enclosing block and not spill outside it.
 - ([#11676](https://github.com/quarto-dev/quarto-cli/pull/11676)): Convert unitless image widths from pixels to inches for column layouts.
 - ([#11835](https://github.com/quarto-dev/quarto-cli/issues/11835)): Take markdown structure into account when detecting minimum heading level.
+- ([#11964](https://github.com/quarto-dev/quarto-cli/issues/11964)): Using panel layout without a crossref label now correctly do not add an empty `#block[]` that was leading to an unnecessary space in output.
 
 ## Lua Filters and extensions
 

--- a/src/resources/filters/customnodes/panellayout.lua
+++ b/src/resources/filters/customnodes/panellayout.lua
@@ -76,7 +76,7 @@ _quarto.ast.add_handler({
         tbl.attributes = as_plain_table(tbl.attr.attributes)
         tbl.attr = nil
       end
-      tbl.preamble = pandoc.Div(tbl.preamble)
+      tbl.preamble = not _quarto.utils.is_empty_node(tbl.preamble) and pandoc.Div(tbl.preamble) or nil
     end
     -- compute vertical alignment and remove attribute
     if tbl.attributes == nil then

--- a/tests/docs/smoke-all/2025/01/31/11964.qmd
+++ b/tests/docs/smoke-all/2025/01/31/11964.qmd
@@ -1,0 +1,25 @@
+---
+title: No empty preamble in layout panel
+format: 
+  html: default
+  typst:
+    keep-typ: true
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - [] 
+        - ['<div>\s*</div>\s*<div class="quarto-layout-panel"']
+    typst:
+      ensureTypstFileRegexMatches:
+        - []
+        - ['#block\[\s*\]']
+---
+
+:::{layout-ncol=2}
+
+Test 1
+
+Test 2
+
+:::


### PR DESCRIPTION
closes #11964 

Default preamble is empty list and we need to make sure to not create a `Div` when empty preamble is found. 

In typst or HTML this would create an empty block - for LaTeX we do have a finalizer to descaffold a Div with no attributes at all. 
