### PR TITLE
[perf] lua,ast_pipeline - combine a filter to reduce number of passes

### DIFF
--- a/src/resources/filters/normalize/astpipeline.lua
+++ b/src/resources/filters/normalize/astpipeline.lua
@@ -46,10 +46,5 @@ function quarto_ast_pipeline()
           parse_blockreftargets()
       }),
     },
-    {
-      name = "normalize-3",
-      filter = handle_subfloatreftargets(),
-      traverser = 'jog',
-    }
   }
 end


### PR DESCRIPTION
`normalize-3` was [among our slowest filters](https://posit-carlos.quarto.pub/quarto-17-performance-notes/posts/2025-01-24/#fig-after) on `main`. This PR rewrites the post-processing of FloatRefTargets so that the work done in that filter happens inside `normalize-2`. Our A/B tester shows statistically significant improvement:

```
{'outcome': 'significant', 'winner': 'B', 'p_value': np.float64(5.343099192664396e-05), 'total_samples': 20, 'alpha_spent': 0.05, 'statistics': {'counts': {'A': 10, 'B': 10}, 'means': {'A': 0.7966938972473144, 'B': 0.7741650581359864}, 'variances': {'A': 7.135757199649984e-05, 'B': 9.23875652483197e-05}}}
Statistical Summary:
===================
Variant     Count         Mean      Std Dev
-------- -------- ------------ ------------
A              10     0.796694     0.008447
B              10     0.774165     0.009612
```

