### PR TITLE
chore(bug_report.yml): add Positron link, better discussion board highlight

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -96,13 +96,13 @@ body:
 
   - type: textarea
     attributes:
-      label: Expected behavior
-      description: Tell us what should happen.
+      label: Actual behavior
+      description: Tell us what happens instead.
 
   - type: textarea
     attributes:
-      label: Actual behavior
-      description: Tell us what happens instead.
+      label: Expected behavior
+      description: Tell us what should happen.
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,21 +6,21 @@ body:
   - type: markdown
     attributes:
       value: |
-        Welcome to the quarto GitHub repository!
+        Welcome to the Quarto CLI GitHub repository!
         We are always happy to hear feedback from our users.
 
         This is the repository for the command-line program `quarto`:
 
         - If you're reporting an issue with the VS Code extension, please visit https://github.com/quarto-dev/quarto
         - If you're reporting an issue inside RStudio, please visit https://github.com/rstudio/rstudio
+        - If you're reporting an issue inside **Positron**, please visit https://github.com/posit-dev/positron
+        - If you want to ask for a feature, please use the [Feature Requests GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/feature-requests).
+        - If you want to ask for help, please use the [Q&A GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/q-a).
 
         Quarto is under active development!
         If convenient, we'd appreciate if you could check that the issue persists on the [latest pre-release](https://github.com/quarto-dev/quarto-cli/releases).
 
         Finally, so that we can get the most out of your bug report, consider reading our ["Bug Reports" guide](https://quarto.org/bug-reports.html).
-
-        If you want to ask for a feature, please use the [Feature Requests GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/feature-requests).
-        If you want to ask for help, please use the [Q&A GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/q-a).
 
         Thank you for using Quarto!
 


### PR DESCRIPTION
* Changed the welcome message to specify the "Quarto CLI GitHub repository" instead of just "quarto GitHub repository."
* Added a new line directing users to report issues inside **Positron** to the Positron GitHub repository.
* Moved the instructions for feature requests and help discussions to a more prominent position in the template.
* Swap labels for expected and actual behavior (This makes the flow more coherent, *i.e.*, describe what happens after the steps to reproduce, then what should happen)