### PR TITLE
Backport #11885 from quarto-dev/chrome-headless

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -4,6 +4,7 @@
 
 - ([#11561](https://github.com/quarto-dev/quarto-cli/issues/11561)): Fix a regression with `$border-color` that impacted, callouts borders, tabset borders, and table borders of the defaults themes. `$border-color` is now correctly a mixed of `$body-color` and `$body-bg` even for the default theme.
 - ([#11943](https://github.com/quarto-dev/quarto-cli/issues/11943)): Fix callout title color on dark theme in revealjs following Revealjs update in quarto 1.6.
+- ([#10532](https://github.com/quarto-dev/quarto-cli/issues/10532)): Quarto changed default of `--headless=old` to `--headless` as [Chrome 132 has removed old headless mode](https://developer.chrome.com/blog/removing-headless-old-from-chrome) and only support new mode. For using old mode, `QUARTO_CHROMIUM` could be set to a [new `chrome-headless-shell` binary](https://developer.chrome.com/blog/chrome-headless-shell) or too an older chrome version (between 128 and 132) and `QUARTO_CHROMIUM_HEADLESS_MODE` set to `old` for using old headless mode with that compatabitle version.
 
 ## In previous releases
 

--- a/src/core/cri/cri.ts
+++ b/src/core/cri/cri.ts
@@ -85,7 +85,7 @@ export async function criClient(appPath?: string, port?: number) {
   const app: string = appPath || await getBrowserExecutablePath();
 
   // Allow to adapt the headless mode depending on the Chrome version
-  const headlessMode = getenv("QUARTO_CHROMIUM_HEADLESS_MODE", "old");
+  const headlessMode = getenv("QUARTO_CHROMIUM_HEADLESS_MODE", "none");
 
   const cmd = [
     app,
@@ -97,6 +97,9 @@ export async function criClient(appPath?: string, port?: number) {
     // move to the new mode. We'll use `--headless=old` as the default for now
     // until the new mode is more stable, or until we really pin a version as default to be used.
     // This is also impacting in chromote and pagedown R packages and we could keep syncing with them.
+    // EDIT: 17/01/2025 - old mode is gone in Chrome 132. Let's default to new mode to unbreak things.
+    // Best course of action is to pin a version of Chrome and use the chrome-headless-shell more adapted to our need.
+    // ref: https://developer.chrome.com/blog/chrome-headless-shell
     `--headless${headlessMode == "none" ? "" : "=" + headlessMode}`,
     "--no-sandbox",
     "--disable-gpu",


### PR DESCRIPTION
> [!WARNING]
> This is a backport PR again v1.16 

chrome - change back to `--headless` as default.

This should prevent further problem with recent Chrome and current Quarto 1.6 release

Follow up PR to 
- #11885 
