### PR TITLE
Update `QuartoNotebookRunner.jl` to `0.12.3`

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -65,7 +65,7 @@ All changes included in 1.7:
 ### `julia`
 
 - ([#11659](https://github.com/quarto-dev/quarto-cli/pull/11659)): Fix escaping bug where paths containing spaces or backslashes break server startup on Windows.
-- ([#12020](https://github.com/quarto-dev/quarto-cli/pull/12020)): Update QuartoNotebookRunner to 0.12.1.
+- ([#12092](https://github.com/quarto-dev/quarto-cli/pull/12092)): Update QuartoNotebookRunner to 0.12.3.
 
 ## Other Fixes and Improvements
 

--- a/src/resources/julia/Project.toml
+++ b/src/resources/julia/Project.toml
@@ -2,4 +2,4 @@
 QuartoNotebookRunner = "4c0109c6-14e9-4c88-93f0-2b974d3468f4"
 
 [compat]
-QuartoNotebookRunner = "=0.12.1"
+QuartoNotebookRunner = "=0.12.3"


### PR DESCRIPTION
A couple of bug fixes are included in this upgrade:

- Fix printing of colour in console output from cells
- Correct PNG image size metadata
- Fix rendering of `PrettyTables.jl` tables