### PR TITLE
py-shiny - Use explicit = syntax for option

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -47,6 +47,10 @@ All changes included in 1.7:
 - ([#11835](https://github.com/quarto-dev/quarto-cli/issues/11835)): Take markdown structure into account when detecting minimum heading level.
 - ([#11964](https://github.com/quarto-dev/quarto-cli/issues/11964)): Using panel layout without a crossref label now correctly do not add an empty `#block[]` that was leading to an unnecessary space in output.
 
+## Interactive Shiny Document
+
+- ([#12059](https://github.com/quarto-dev/quarto-cli/issues/12059)): `quarto preview` now correctly run on Windows an interactive Quarto doc with Jupyter engine and py-shiny, when using a `*.py` file as resource.
+
 ## Lua Filters and extensions
 
 - ([#11526](https://github.com/quarto-dev/quarto-cli/pull/11526)):

--- a/src/execute/jupyter/jupyter.ts
+++ b/src/execute/jupyter/jupyter.ts
@@ -515,8 +515,7 @@ export const jupyterEngine: ExecutionEngine = {
     ];
     if (options.reload) {
       cmd.push("--reload");
-      cmd.push(`--reload-includes`);
-      cmd.push(`*.py`);
+      cmd.push(`--reload-includes=*.py`);
     }
 
     // start server


### PR DESCRIPTION
Otherwise, `quarto preview` does not work on Windows as quoting is not enough to avoid shell expension https://github.com/pallets/click/issues/2359

Could be revisited if shiny for python opt-out shell expansion

closes #12059 

Not sure if we can add test. 
