### PR TITLE
crossref, latex - correctly table env for raw table produced by computations

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -38,7 +38,7 @@ All changes included in 1.7:
 
 - ([#11835](https://github.com/quarto-dev/quarto-cli/issues/11835)): Take markdown structure into account when detecting minimum heading level.
 - ([#11903](https://github.com/quarto-dev/quarto-cli/issues/11903)): `crossref` configuration like `fig-title` or `tbl-title` now correctly supports multi word values, e.g. `fig-title: 'Supplementary Figure'`.
-- ([#11878](https://github.com/quarto-dev/quarto-cli/issues/11878)): Correctly fixup raw LaTeX table having an unexpected table env with options (e.g `\begin{table}[c]`) to be handled as crossref table.
+- ([#11878](https://github.com/quarto-dev/quarto-cli/issues/11878), [#12085](https://github.com/quarto-dev/quarto-cli/issues/12085)): Correctly fixup raw LaTeX table having an unexpected table env with options (e.g `\begin{table}[!ht]`) to be handled as crossref table.
 
 ## `typst` format
 

--- a/src/resources/filters/quarto-pre/parsefiguredivs.lua
+++ b/src/resources/filters/quarto-pre/parsefiguredivs.lua
@@ -66,9 +66,10 @@ local function remove_latex_crossref_envs(content, name)
         if not _quarto.format.isRawLatex(raw) then
           return nil
         end
-        local b, e, begin_table, table_body, end_table = raw.text:find(patterns.latex_table)
-        if b ~= nil then
-          raw.text = table_body
+        local matched, _ = _quarto.modules.patterns.match_in_list_of_patterns(raw.text, _quarto.patterns.latexTableEnvPatterns)
+        if matched then
+          -- table_body is second matched element.
+          raw.text = matched[2]
           return raw
         else
           return nil
@@ -548,6 +549,8 @@ function parse_floatreftargets()
         })
         return parse_float_div(div)
       elseif isTableDiv(div) then
+        -- FIXUP: We don't go here for a `#tbl-` id as it is matched as a FigureDiv above
+        -- TO REMOVE ? 
         return parse_float_div(div)
       end
 

--- a/tests/docs/smoke-all/crossrefs/float/latex/latex-raw-table-env-3.qmd
+++ b/tests/docs/smoke-all/crossrefs/float/latex/latex-raw-table-env-3.qmd
@@ -1,0 +1,68 @@
+---
+title: Crossref Raw LaTeX table with table env and position when produced by cell computation
+format: pdf
+keep-tex: true
+_quarto:
+  tests:
+    pdf:
+      ensureLatexFileRegexMatches:
+        - ['\n\\begin\{table\}\n', 'See Table~\\ref\{tbl-test\}']
+        - []
+---
+
+`\begin{table}` should be catched and remove as Quarto does add its own, when this produced from a cell
+
+## Example with Julia Cell
+
+Derived https://github.com/quarto-dev/quarto-cli/issues/12085
+
+::: {#tbl-test .cell execution_count=1}
+```` { .cell-code}
+```{{julia}}
+#| label: tbl-test
+#| output: asis
+struct Latex
+    s::String
+end
+
+Base.show(io::IO, m::MIME"text/latex", l::Latex) = print(io, l.s)
+
+Latex(raw"""
+\begin{table}
+\setlength\tabcolsep{0pt}
+\centering
+\begin{tabular}{@{\extracolsep{2ex}}*{5}{ccccc}}
+\toprule
+$\theta 1$ & $\theta 1$ & $\theta 1$ & $\theta 1$ & $\theta 1$ \\
+\midrule
+$\theta 2$ & $\theta 2$ & $\theta 2$ & $\theta 2$ & $\theta 2$ \\
+$\theta 3$ & $\theta 3$ & $\theta 3$ & $\theta 3$ & $\theta 3$ \\
+$\theta 4$ & $\theta 4$ & $\theta 4$ & $\theta 4$ & $\theta 4$ \\
+$\theta 5$ & $\theta 5$ & $\theta 5$ & $\theta 5$ & $\theta 5$ \\
+\bottomrule
+\end{tabular}
+\end{table}
+""")
+```
+
+````
+```{=tex}
+\begin{table}
+\setlength\tabcolsep{0pt}
+\centering
+\begin{tabular}{@{\extracolsep{2ex}}*{5}{ccccc}}
+\toprule
+$\theta 1$ & $\theta 1$ & $\theta 1$ & $\theta 1$ & $\theta 1$ \\
+\midrule
+$\theta 2$ & $\theta 2$ & $\theta 2$ & $\theta 2$ & $\theta 2$ \\
+$\theta 3$ & $\theta 3$ & $\theta 3$ & $\theta 3$ & $\theta 3$ \\
+$\theta 4$ & $\theta 4$ & $\theta 4$ & $\theta 4$ & $\theta 4$ \\
+$\theta 5$ & $\theta 5$ & $\theta 5$ & $\theta 5$ & $\theta 5$ \\
+\bottomrule
+\end{tabular}
+\end{table}
+```
+:::
+
+
+See @tbl-test

--- a/tests/docs/smoke-all/crossrefs/float/latex/latex-raw-table-env-4.qmd
+++ b/tests/docs/smoke-all/crossrefs/float/latex/latex-raw-table-env-4.qmd
@@ -1,0 +1,68 @@
+---
+title: Crossref Raw LaTeX table with table env and position when produced by cell computation
+format: pdf
+keep-tex: true
+_quarto:
+  tests:
+    pdf:
+      ensureLatexFileRegexMatches:
+        - ['\n\\begin\{table\}\n', 'See Table~\\ref\{tbl-test\}']
+        - ['\\begin\{table\}[\!ht]']
+---
+
+`\begin{table}` should be catched and remove as Quarto does add its own, including when option position are used and when this produced from a cell
+
+## Example with Julia Cell
+
+From https://github.com/quarto-dev/quarto-cli/issues/12085
+
+::: {#tbl-test .cell execution_count=1}
+```` { .cell-code}
+```{{julia}}
+#| label: tbl-test
+#| output: asis
+struct Latex
+    s::String
+end
+
+Base.show(io::IO, m::MIME"text/latex", l::Latex) = print(io, l.s)
+
+Latex(raw"""
+\begin{table}[!ht]
+\setlength\tabcolsep{0pt}
+\centering
+\begin{tabular}{@{\extracolsep{2ex}}*{5}{ccccc}}
+\toprule
+$\theta 1$ & $\theta 1$ & $\theta 1$ & $\theta 1$ & $\theta 1$ \\
+\midrule
+$\theta 2$ & $\theta 2$ & $\theta 2$ & $\theta 2$ & $\theta 2$ \\
+$\theta 3$ & $\theta 3$ & $\theta 3$ & $\theta 3$ & $\theta 3$ \\
+$\theta 4$ & $\theta 4$ & $\theta 4$ & $\theta 4$ & $\theta 4$ \\
+$\theta 5$ & $\theta 5$ & $\theta 5$ & $\theta 5$ & $\theta 5$ \\
+\bottomrule
+\end{tabular}
+\end{table}
+""")
+```
+
+````
+```{=tex}
+\begin{table}[!ht]
+\setlength\tabcolsep{0pt}
+\centering
+\begin{tabular}{@{\extracolsep{2ex}}*{5}{ccccc}}
+\toprule
+$\theta 1$ & $\theta 1$ & $\theta 1$ & $\theta 1$ & $\theta 1$ \\
+\midrule
+$\theta 2$ & $\theta 2$ & $\theta 2$ & $\theta 2$ & $\theta 2$ \\
+$\theta 3$ & $\theta 3$ & $\theta 3$ & $\theta 3$ & $\theta 3$ \\
+$\theta 4$ & $\theta 4$ & $\theta 4$ & $\theta 4$ & $\theta 4$ \\
+$\theta 5$ & $\theta 5$ & $\theta 5$ & $\theta 5$ & $\theta 5$ \\
+\bottomrule
+\end{tabular}
+\end{table}
+```
+:::
+
+
+See @tbl-test


### PR DESCRIPTION
This is a follow up of previous adaptation to take into account table options in environment done in #11921

So this is the same fix using new patterns matching, but in different places - when RawBlock are produced within a output .cell Div. 

closes #12085