### PR TITLE
gha - adapt cache saving to new actions/cache@v4

### DIFF
--- a/.github/actions/cache-typst/action.yml
+++ b/.github/actions/cache-typst/action.yml
@@ -9,7 +9,7 @@ outputs:
     value: ${{ steps.cache-typst-restore.outputs.cache-primary-key }}
   cache-matched-key:
     description: "Key of the cache found and used."
-    value: ${{ steps.cache-typst-restore.outputs.cache-primary-key }}
+    value: ${{ steps.cache-typst-restore.outputs.cache-matched-key }}
   cache-path:
     description: "where is the packages cache for typst ?"
     value: ${{ steps.cache-typst-path.outputs.TYPST_CACHE }}
@@ -22,20 +22,21 @@ runs:
       run: |
         case $RUNNER_OS in
           "Linux")
-              echo "TYPST_CACHE=${XDG_CACHE_HOME:-~/.cache}/typst/packages/" >> $GITHUB_ENV
+              typst_cache="${XDG_CACHE_HOME:-~/.cache}/typst/packages/"
               ;;
           "macOS")
-              echo "TYPST_CACHE=~/Library/Caches/typst/packages/" >> $GITHUB_ENV
+              typst_cache="~/Library/Caches/typst/packages/"
               ;;
           "Windows")
-              echo "TYPST_CACHE=$LOCALAPPDATA/typst/packages/" >> $GITHUB_ENV
+              typst_cache="$LOCALAPPDATA/typst/packages/"
               ;;
             *)
               echo "$RUNNER_OS not supported"
               exit 1
               ;;
         esac
-        echo "TYPST_CACHE=${TYPST_CACHE}" >> $GITHUB_OUTPUT
+        echo "TYPST_CACHE=${typst_cache}" >> $GITHUB_ENV
+        echo "TYPST_CACHE=${typst_cache}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Cache Typst package folder

--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -105,14 +105,16 @@ jobs:
           cat("r-version=", R.Version()$version.string, "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
         shell: Rscript {0}
 
-      - name: Cache R packages
-        uses: actions/cache@v4
+      - name: Restore Renv package cache
+        id: cache-renv-packages-restore
+        uses: actions/cache/restore@v4
         with:
-          path: ${{ env.RENV_PATHS_ROOT }}
-          key: ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-renv-2-${{ hashFiles('tests/renv.lock') }}
+          path: |
+            ${{ env.RENV_PATHS_ROOT }}
+            renv/library
+          key: ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-renv-3-${{ hashFiles('tests/renv.lock') }}
           restore-keys: |
-            ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-renv-2-
-          save-always: ${{ inputs.extra-r-packages == '' }} # don't save cache if we have extra R packages
+            ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-renv-3-
 
       - name: Install missing system deps
         if: runner.os == 'Linux'
@@ -296,6 +298,16 @@ jobs:
         with:
           key: ${{ steps.cache-typst.outputs.cache-primary-key }}
           path: ${{ steps.cache-typst.outputs.cache-path }}
+
+      - name: Save Renv package cache
+        # don't save cache if we have extra R packages
+        if: ${{ always() && steps.cache-renv-packages-restore.outputs.cache-hit != 'true' && inputs.extra-r-packages == '' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ env.RENV_PATHS_ROOT }}
+            renv/library
+          key: ${{ steps.cache-renv-packages-restore.outputs.cache-primary-key }}
 
       - uses: actions/upload-artifact@v4
         # PLaywright test only runs on Linux for now

--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -175,8 +175,6 @@ jobs:
           version: "1.11.3"
 
       - name: Cache Julia Packages
-        # FIXME: deactivate julia cache for now
-        if: false
         uses: julia-actions/cache@v2
 
       - name: Restore Julia Packages

--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -312,8 +312,8 @@ jobs:
           key: ${{ steps.cache-renv-packages-restore.outputs.cache-primary-key }}
 
       - uses: actions/upload-artifact@v4
-        # PLaywright test only runs on Linux for now
-        if: ${{ !cancelled() && runner.os != 'Windows' }}
+        # Upload pLaywright test report if they exists (playwright is only running on Linux for now)
+        if: ${{ !cancelled() && runner.os != 'Windows' && hashFiles('tests/integration/playwright/playwright-report/**/*') != '' }}
         with:
           name: playwright-report
           path: ./tests/integration/playwright/playwright-report/

--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -293,7 +293,7 @@ jobs:
           path: tests/timing-for-ci.txt
 
       - name: Save Typst cache
-        if: always()
+        if: always() && steps.cache-typst.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           key: ${{ steps.cache-typst.outputs.cache-primary-key }}

--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -175,6 +175,8 @@ jobs:
           version: "1.11.3"
 
       - name: Cache Julia Packages
+        # FIXME: deactivate julia cache for now
+        if: false
         uses: julia-actions/cache@v2
 
       - name: Restore Julia Packages


### PR DESCRIPTION
`save-always` is deprecated, and now it needs to be a two step process: restore and save

based on adaptation at r-lib/actions/setup-renv in https://github.com/r-lib/actions/commit/108c7a6b3ecd9f71dbd0ce7d9e6ca9f57e2d244f


