### PR TITLE
perf - move stripNotes to after we know if it's needed

### DIFF
--- a/src/resources/filters/main.lua
+++ b/src/resources/filters/main.lua
@@ -296,6 +296,12 @@ local quarto_pre_filters = {
     traverser = 'jog',
   },
 
+  { name = "strip-notes-from-hidden",
+    filter = strip_notes_from_hidden(),
+    flags = { "has_notes" },
+    traverser = 'jog',
+  },
+
   { name = "pre-combined-hidden",
     filter = combineFilters({
       hidden(),

--- a/src/resources/filters/normalize/flags.lua
+++ b/src/resources/filters/normalize/flags.lua
@@ -178,7 +178,10 @@ function compute_flags()
     end,
     Figure = function(node)
       flags.has_pandoc3_figure = true
-    end
+    end,
+    Note = function(node)
+      flags.has_notes = true
+    end,
   }, {
     Meta = function(el)
       local lightbox_auto = lightbox_module.automatic(el)

--- a/src/resources/filters/normalize/normalize.lua
+++ b/src/resources/filters/normalize/normalize.lua
@@ -20,15 +20,6 @@ local authors = require 'modules/authors'
 local license = require 'modules/license'
 local shortcode_ast = require 'modules/astshortcode'
 
-local function stripNotes(el) 
-  local result = _quarto.ast.walk(el, {
-    Note = function(_el)
-      return pandoc.Null()
-    end
-  })
-  return result
-end
-
 function normalize_filter() 
   return {
     Meta = function(meta)
@@ -59,22 +50,6 @@ function normalize_filter()
       normalized = shortcode_ast.parse(normalized)
 
       return normalized
-    end,
-    Div = function(div)
-      -- Don't allow footnotes in the hidden element (markdown pipeline)
-      -- since that will result in duplicate footnotes
-      -- in the rendered output
-      if div.classes:includes('hidden') then
-        return stripNotes(div)
-      end
-    end,
-    Span = function(span)
-      -- Don't allow footnotes in the hidden element (markdown pipeline)
-      -- since that will result in duplicate footnotes
-      -- in the rendered output      
-      if span.classes:includes('hidden') then
-        return stripNotes(span)
-      end
     end
   }
 end

--- a/src/resources/filters/quarto-pre/hidden.lua
+++ b/src/resources/filters/quarto-pre/hidden.lua
@@ -81,8 +81,32 @@ function hidden()
   end
 end
 
-
-
-
-
-
+function strip_notes_from_hidden()
+  local function stripNotes(el) 
+    local result = _quarto.ast.walk(el, {
+      Note = function(_el)
+        return pandoc.Null()
+      end
+    })
+    return result
+  end
+  
+  return {
+    Div = function(div)
+      -- Don't allow footnotes in the hidden element (markdown pipeline)
+      -- since that will result in duplicate footnotes
+      -- in the rendered output
+      if div.classes:includes('hidden') then
+        return stripNotes(div)
+      end
+    end,
+    Span = function(span)
+      -- Don't allow footnotes in the hidden element (markdown pipeline)
+      -- since that will result in duplicate footnotes
+      -- in the rendered output      
+      if span.classes:includes('hidden') then
+        return stripNotes(span)
+      end
+    end
+  }
+end


### PR DESCRIPTION
This is a bigger one that I found - we're running a fairly expensive check inside every div and span for `Note` nodes. This PR moves the check so it happens after `flags`, and then we know whether the document contains footnotes at all.

```
{'outcome': 'significant', 'winner': 'B', 'p_value': np.float64(1.3498071778535291e-06), 'total_samples': 20, 'alpha_spent': 0.05, 'statistics': {'counts': {'A': 10, 'B': 10}, 'means': {'A': 0.776877474784851, 'B': 0.7512164831161499}, 'variances': {'A': 7.183128859722387e-05, 'B': 2.541789535892569e-05}}}
Statistical Summary:
===================
Variant     Count         Mean      Std Dev
-------- -------- ------------ ------------
A              10     0.776877     0.008475
B              10     0.751216     0.005042
```