### PR TITLE
Update `QuartoNotebookRunner.jl` to `0.13.1`

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -69,7 +69,7 @@ All changes included in 1.7:
 ### `julia`
 
 - ([#11659](https://github.com/quarto-dev/quarto-cli/pull/11659)): Fix escaping bug where paths containing spaces or backslashes break server startup on Windows.
-- ([#12092](https://github.com/quarto-dev/quarto-cli/pull/12092)): Update QuartoNotebookRunner to 0.12.3.
+- ([#12121](https://github.com/quarto-dev/quarto-cli/pull/12121)): Update QuartoNotebookRunner to 0.13.1. Support for evaluating Python cells via [PythonCall.jl](https://github.com/JuliaPy/PythonCall.jl) added.
 
 ## Other Fixes and Improvements
 

--- a/src/resources/julia/Project.toml
+++ b/src/resources/julia/Project.toml
@@ -2,4 +2,4 @@
 QuartoNotebookRunner = "4c0109c6-14e9-4c88-93f0-2b974d3468f4"
 
 [compat]
-QuartoNotebookRunner = "=0.12.3"
+QuartoNotebookRunner = "=0.13.1"


### PR DESCRIPTION
Updates the backend to the latest minor release.

This includes support for running `{python}` code cells (in addition to the already supported `{julia}` and `{r}`). It uses https://github.com/JuliaPy/PythonCall.jl to manage the `python` process for this, and allows passing values via `$` interpolation between all three languages.

The announcement post can be found at https://discourse.julialang.org/t/ann-native-julia-engine-for-quarto-using-quartonotebookrunner-jl/112753/56, and includes an example of using this new feature.