### PR TITLE
Fix grammar and abbreviation in CONTRIBUTING md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 You can contribute to Quarto in many ways:
 
 - By opening issues to provide feedback and share ideas.
-- By submitting Pull Request (PR) to fix opened issues
+- By submitting Pull Request (PR) to fix open issues
 - By submitting Pull Request (PR) to suggest new features (it is considered good practice to open an issue for discussion before working on a pull request for a new feature).
 
 Please be mindful of our [code of conduct](https://github.com/quarto-dev/quarto-cli/blob/main/.github/CODE_OF_CONDUCT.md) as you interact with other community members.
@@ -26,8 +26,8 @@ Pull requests are very welcome! Here's how to contribute via PR:
     $ git checkout -b feature/newthing
     ```
 
-2.  For significant changes (e.g more than small bug fixes), ensure that you have signed the [individual](https://posit.co/wp-content/uploads/2023/04/2023-03-13_TC_Indiv_contrib_agreement.pdf) or [corporate](https://posit.co/wp-content/uploads/2023/04/2023-03-13_TC_Corp_contrib_agreement.pdf) contributor agreement as appropriate. You can send the signed copy to [jj\@rstudio.com](mailto:jj@rstudio.com){.email}.
+2.  For significant changes (e.g., more than small bug fixes), ensure that you have signed the [individual](https://posit.co/wp-content/uploads/2023/04/2023-03-13_TC_Indiv_contrib_agreement.pdf) or [corporate](https://posit.co/wp-content/uploads/2023/04/2023-03-13_TC_Corp_contrib_agreement.pdf) contributor agreement as appropriate. You can send the signed copy to [jj\@rstudio.com](mailto:jj@rstudio.com){.email}.
 
-3.  Submit the [pull request](https://help.github.com/articles/using-pull-requests). It is ok to submit as draft in your are still working on it but would like some feedback from us. It always good to share in the open that you are working on it.
+3.  Submit the [pull request](https://help.github.com/articles/using-pull-requests). It is ok to submit as draft if your are still working on it but would like some feedback from us. It is always good to share in the open that you are working on it.
 
 We'll try to be as responsive as possible in reviewing and accepting pull requests.


### PR DESCRIPTION

Welcome to the quarto GitHub repo!

We are always happy to hear feedback from our users.

To file a _pull request_, please follow these instructions carefully: <https://yihui.org/issue/#bug-reports>

If you're a collaborator from outside `quarto-dev` making changes larger than a typo, please make sure you have filed an [individual](https://posit.co/wp-content/uploads/2023/04/2023-03-13_TC_Indiv_contrib_agreement.pdf) or [corporate](https://posit.co/wp-content/uploads/2023/04/2023-03-13_TC_Corp_contrib_agreement.pdf) contributor agreement. You can send the signed copy to <jj@rstudio.com>.

Also, please complete and keep the checklist below.

## Description

- fix **open**~ed~ issues
- e.**g.,** more than ...
- It **is** always ...

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog in the PR
- [x] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
