### PR TITLE
Backport/gha update to new V2 Github Action API 

### DIFF
--- a/.github/actions/cache-typst/action.yml
+++ b/.github/actions/cache-typst/action.yml
@@ -1,33 +1,49 @@
-name: "Cache Typst package"
+name: "Restore any Typst package cache"
 description: "Configures the caching for Typst packages"
+outputs:
+  cache-hit:
+    description: "Was a cache found with primary key ?"
+    value: ${{ steps.cache-typst-restore.outputs.cache-hit }}
+  cache-primary-key:
+    description: "Key of the cache to find and save"
+    value: ${{ steps.cache-typst-restore.outputs.cache-primary-key }}
+  cache-matched-key:
+    description: "Key of the cache found and used."
+    value: ${{ steps.cache-typst-restore.outputs.cache-matched-key }}
+  cache-path:
+    description: "where is the packages cache for typst ?"
+    value: ${{ steps.cache-typst-path.outputs.TYPST_CACHE }}
 
 runs:
   using: "composite"
   steps:
     - name: Typst Cache path
+      id: cache-typst-path
       run: |
         case $RUNNER_OS in
           "Linux")
-              echo "TYPST_CACHE=${XDG_CACHE_HOME:-~/.cache}/typst/packages/" >> $GITHUB_ENV
+              typst_cache="${XDG_CACHE_HOME:-~/.cache}/typst/packages/"
               ;;
           "macOS")
-              echo "TYPST_CACHE=~/Library/Caches/typst/packages/" >> $GITHUB_ENV
+              typst_cache="~/Library/Caches/typst/packages/"
               ;;
           "Windows")
-              echo "TYPST_CACHE=$LOCALAPPDATA/typst/packages/" >> $GITHUB_ENV
+              typst_cache="$LOCALAPPDATA/typst/packages/"
               ;;
             *)
               echo "$RUNNER_OS not supported"
               exit 1
               ;;
         esac
+        echo "TYPST_CACHE=${typst_cache}" >> $GITHUB_ENV
+        echo "TYPST_CACHE=${typst_cache}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Cache Typst package folder
-      uses: actions/cache@v4
+      id: cache-typst-restore
+      uses: actions/cache/restore@v4
       with:
         path: ${{ env.TYPST_CACHE }}
-        key: ${{ runner.os }}-typst-1-${{ github.run_id }}
+        key: ${{ runner.os }}-typst-1
         restore-keys: |
-          ${{ runner.os }}-typst-1-
-        save-always: true
+          ${{ runner.os }}-typst-

--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -105,14 +105,16 @@ jobs:
           cat("r-version=", R.Version()$version.string, "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
         shell: Rscript {0}
 
-      - name: Cache R packages
-        uses: actions/cache@v4
+      - name: Restore Renv package cache
+        id: cache-renv-packages-restore
+        uses: actions/cache/restore@v4
         with:
-          path: ${{ env.RENV_PATHS_ROOT }}
-          key: ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-renv-2-${{ hashFiles('tests/renv.lock') }}
+          path: |
+            ${{ env.RENV_PATHS_ROOT }}
+            renv/library
+          key: ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-renv-3-${{ hashFiles('tests/renv.lock') }}
           restore-keys: |
-            ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-renv-2-
-          save-always: ${{ inputs.extra-r-packages == '' }} # don't save cache if we have extra R packages
+            ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-renv-3-
 
       - name: Install missing system deps
         if: runner.os == 'Linux'
@@ -130,8 +132,8 @@ jobs:
           renv::restore()
           # Install dev versions for our testing
           # Use r-universe to avoid github api calls
-          try(install.packages('knitr', repos = 'https://yihui.r-universe.dev'))
-          try(install.packages('rmarkdown', repos = 'https://rstudio.r-universe.dev'))
+          try(install.packages('rmarkdown', repos = c('https://rstudio.r-universe.dev', getOption('repos'))))
+          try(install.packages('knitr', repos = c('https://yihui.r-universe.dev', getOption('repos'))))
           if ('${{ inputs.extra-r-packages }}' != '') {
             cat(sprintf("::notice::Running with the following extra R packages for pak: %s\n", "${{ inputs.extra-r-packages }}"))
             renv::install(strsplit("${{ inputs.extra-r-packages }}", split = ",")[[1]])
@@ -143,7 +145,7 @@ jobs:
       - name: Install uv for Python
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.30"
+          version: "0.5.9"
           enable-cache: true
           cache-dependency-glob: "tests/uv.lock"
 
@@ -161,6 +163,7 @@ jobs:
           quarto install tinytex
 
       - name: Cache Typst packages
+        id: cache-typst
         uses: ./.github/actions/cache-typst
 
       - name: Install Chrome
@@ -169,7 +172,7 @@ jobs:
       - name: Setup Julia
         uses: julia-actions/setup-julia@v2
         with:
-          version: "1.10"
+          version: "1.11.3"
 
       - name: Cache Julia Packages
         uses: julia-actions/cache@v2
@@ -183,7 +186,7 @@ jobs:
           export JUPYTER=$(find $(dirname $(uv run --frozen which jupyter))/ -type f -name "jupyter.exe" -o -name "jupyter")
           uv run --frozen julia --color=yes --project=. -e "import Pkg; Pkg.instantiate(); Pkg.build(\"IJulia\"); Pkg.precompile()"
           echo "Julia Jupyter:"
-          julia --project=. -e "import IJulia;println(IJulia.JUPYTER);println(IJulia.find_jupyter_subcommand(\"notebook\"))"
+          uv run julia --project=. -e "import IJulia;println(IJulia.JUPYTER);println(IJulia.find_jupyter_subcommand(\"notebook\"))"
 
       - name: Setup timing file for timed test
         if: ${{ matrix.time-test == true }}
@@ -289,9 +292,26 @@ jobs:
           name: timed test file
           path: tests/timing-for-ci.txt
 
+      - name: Save Typst cache
+        if: always() && steps.cache-typst.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          key: ${{ steps.cache-typst.outputs.cache-primary-key }}
+          path: ${{ steps.cache-typst.outputs.cache-path }}
+
+      - name: Save Renv package cache
+        # don't save cache if we have extra R packages
+        if: ${{ always() && steps.cache-renv-packages-restore.outputs.cache-hit != 'true' && inputs.extra-r-packages == '' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ env.RENV_PATHS_ROOT }}
+            renv/library
+          key: ${{ steps.cache-renv-packages-restore.outputs.cache-primary-key }}
+
       - uses: actions/upload-artifact@v4
-        # PLaywright test only runs on Linux for now
-        if: ${{ !cancelled() && runner.os != 'Windows' }}
+        # Upload pLaywright test report if they exists (playwright is only running on Linux for now)
+        if: ${{ !cancelled() && runner.os != 'Windows' && hashFiles('tests/integration/playwright/playwright-report/**/*') != '' }}
         with:
           name: playwright-report
           path: ./tests/integration/playwright/playwright-report/


### PR DESCRIPTION
This is required as we still run CI on v1.6 branch for each patch release we do. 

(cherry picked from commit 46d71b0fd440dbae2a0d044c95f52622724a3939)

from #12108 (quarto-dev/gha/cache-update)