### PR TITLE
Fix YAML validation in cell metadata

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -13,6 +13,8 @@ All changes included in 1.7:
 ## YAML validation
 
 - ([#11654](https://github.com/quarto-dev/quarto-cli/issues/11654)): Allow `page-inset` as value in `column` key for code cells.
+- ([#12151](https://github.com/quarto-dev/quarto-cli/issues/12151)): Fix YAML validation in computations cell on Windows.
+- ([#12151](https://github.com/quarto-dev/quarto-cli/pull/12151)): Basic YAML validation is now active in cell for document using Julia engine.
 
 ## Website projects
 
@@ -72,6 +74,7 @@ All changes included in 1.7:
 
 - ([#11659](https://github.com/quarto-dev/quarto-cli/pull/11659)): Fix escaping bug where paths containing spaces or backslashes break server startup on Windows.
 - ([#12121](https://github.com/quarto-dev/quarto-cli/pull/12121)): Update QuartoNotebookRunner to 0.13.1. Support for evaluating Python cells via [PythonCall.jl](https://github.com/JuliaPy/PythonCall.jl) added.
+- ([#12151](https://github.com/quarto-dev/quarto-cli/pull/12151)): Basic YAML validation is now active for document using Julia engine.
 
 ## Other Fixes and Improvements
 

--- a/src/core/lib/yaml-schema/chunk-metadata.ts
+++ b/src/core/lib/yaml-schema/chunk-metadata.ts
@@ -132,6 +132,16 @@ const jupyterEngineSchema = defineCached(
   },
   "engine-jupyter",
 );
+const juliaEnginesSchema = defineCached(
+  // deno-lint-ignore require-await
+  async () => {
+    return {
+      schema: makeEngineSchema("julia"),
+      errorHandlers: [],
+    };
+  },
+  "engine-julia",
+);
 
 export async function getEngineOptionsSchema(): Promise<
   Record<string, ConcreteSchema>
@@ -140,6 +150,7 @@ export async function getEngineOptionsSchema(): Promise<
     markdown: await markdownEngineSchema(),
     knitr: await knitrEngineSchema(),
     jupyter: await jupyterEngineSchema(),
+    julia: await juliaEnginesSchema(),
   };
 
   return obj;

--- a/src/core/schema/validate-document.ts
+++ b/src/core/schema/validate-document.ts
@@ -9,7 +9,7 @@ import { breakQuartoMd } from "../lib/break-quarto-md.ts";
 import { mappedString } from "../mapped-text.ts";
 import { rangedLines } from "../ranged-text.ts";
 import { readAnnotatedYamlFromMappedString } from "./annotated-yaml.ts";
-import { error, info } from "../../deno_ral/log.ts";
+import { error } from "../../deno_ral/log.ts";
 import { partitionCellOptionsMapped } from "../lib/partition-cell-options.ts";
 import { withValidator } from "../lib/yaml-validation/validator-queue.ts";
 import { ValidationError } from "./validated-yaml.ts";

--- a/src/core/schema/validate-document.ts
+++ b/src/core/schema/validate-document.ts
@@ -97,11 +97,11 @@ export async function validateDocumentFromSource(
   } else {
     firstContentCellIndex = 0;
   }
-
   for (const cell of nb.cells.slice(firstContentCellIndex)) {
     if (
       cell.cell_type === "markdown" ||
-      cell.cell_type === "raw"
+      cell.cell_type === "raw" ||
+      cell.cell_type?.language === "_directive"
     ) {
       // not a language chunk
       continue;
@@ -110,16 +110,14 @@ export async function validateDocumentFromSource(
     const lang = cell.cell_type.language;
 
     try {
-      const fullCell = mappedString(cell.sourceVerbatim, [{
-        start: lang.length + 6,
-        end: cell.sourceVerbatim.value.length - 3,
-      }]);
-      await partitionCellOptionsMapped(
-        lang,
-        fullCell,
-        true,
-        engine,
-      );
+      if (cell.sourceWithYaml) {
+        await partitionCellOptionsMapped(
+          lang,
+          cell.sourceWithYaml,
+          true,
+          engine,
+        );
+      }
     } catch (e) {
       if (e instanceof ValidationError) {
         error("Validation of YAML cell metadata failed.");

--- a/src/core/schema/validate-document.ts
+++ b/src/core/schema/validate-document.ts
@@ -124,7 +124,7 @@ export async function validateDocumentFromSource(
       if (e instanceof ValidationError) {
         error("Validation of YAML cell metadata failed.");
         for (const err of e.validationErrors) {
-          info(tidyverseFormatError(err.niceError));
+          error(tidyverseFormatError(err.niceError), { colorize: false });
         }
         result.push(...e.validationErrors);
       } else {

--- a/src/core/schema/validate-document.ts
+++ b/src/core/schema/validate-document.ts
@@ -9,7 +9,7 @@ import { breakQuartoMd } from "../lib/break-quarto-md.ts";
 import { mappedString } from "../mapped-text.ts";
 import { rangedLines } from "../ranged-text.ts";
 import { readAnnotatedYamlFromMappedString } from "./annotated-yaml.ts";
-import { error } from "../../deno_ral/log.ts";
+import { error, info } from "../../deno_ral/log.ts";
 import { partitionCellOptionsMapped } from "../lib/partition-cell-options.ts";
 import { withValidator } from "../lib/yaml-validation/validator-queue.ts";
 import { ValidationError } from "./validated-yaml.ts";
@@ -124,7 +124,7 @@ export async function validateDocumentFromSource(
       if (e instanceof ValidationError) {
         error("Validation of YAML cell metadata failed.");
         for (const err of e.validationErrors) {
-          console.log(tidyverseFormatError(err.niceError));
+          info(tidyverseFormatError(err.niceError));
         }
         result.push(...e.validationErrors);
       } else {

--- a/tests/docs/yaml/fail-validation-julia-backticks.qmd
+++ b/tests/docs/yaml/fail-validation-julia-backticks.qmd
@@ -1,0 +1,11 @@
+---
+title: "YAML intelligence should fail with knitr engine"
+engine: julia
+---
+
+This code cell has more than default 3 backticks
+
+````{julia}
+#| echo: 123
+1 + 1
+````

--- a/tests/docs/yaml/fail-validation-julia.qmd
+++ b/tests/docs/yaml/fail-validation-julia.qmd
@@ -1,0 +1,9 @@
+---
+title: "YAML intelligence should fail with knitr engine"
+engine: julia
+---
+
+```{julia}
+#| echo: 123
+1 + 1
+```

--- a/tests/docs/yaml/fail-validation-jupyter-backticks.qmd
+++ b/tests/docs/yaml/fail-validation-jupyter-backticks.qmd
@@ -1,0 +1,10 @@
+---
+title: "YAML intelligence should fail with knitr engine"
+---
+
+This code cell has more than default 3 backticks
+
+````{python}
+#| echo: 123
+1 + 1
+````

--- a/tests/docs/yaml/fail-validation-jupyter.qmd
+++ b/tests/docs/yaml/fail-validation-jupyter.qmd
@@ -1,0 +1,8 @@
+---
+title: "YAML intelligence should fail with knitr engine"
+---
+
+```{python}
+#| echo: 123
+1 + 1
+```

--- a/tests/docs/yaml/fail-validation-knitr-backticks.qmd
+++ b/tests/docs/yaml/fail-validation-knitr-backticks.qmd
@@ -1,0 +1,10 @@
+---
+title: "YAML intelligence should fail with knitr engine"
+---
+
+This code cell has more than default 3 backticks
+
+````{r}
+#| echo: 123
+1 + 1
+````

--- a/tests/docs/yaml/fail-validation-knitr.qmd
+++ b/tests/docs/yaml/fail-validation-knitr.qmd
@@ -1,0 +1,8 @@
+---
+title: "YAML intelligence should fail with knitr engine"
+---
+
+```{r}
+#| echo: 123
+1 + 1
+```

--- a/tests/smoke/yaml-intelligence/yaml-intelligence-code-cell-options.test.ts
+++ b/tests/smoke/yaml-intelligence/yaml-intelligence-code-cell-options.test.ts
@@ -1,0 +1,25 @@
+import { testQuartoCmd } from "../../test.ts";
+import { fileLoader } from "../../utils.ts";
+import { printsMessage } from "../../verify.ts";
+
+const yamlDocs = fileLoader("yaml");
+
+const testYamlValidationFails = (file: string) => {
+  testQuartoCmd(
+    "render",
+    [yamlDocs(file, "html").input, "--to", "html", "--log-level", "error", "--quiet"],
+    [printsMessage("ERROR", /Validation of YAML cell metadata failed/)],
+  );
+};
+
+const files = [
+  "fail-validation-knitr.qmd",
+  "fail-validation-jupyter.qmd",
+  "fail-validation-julia.qmd",
+  "fail-validation-knitr-backticks.qmd",
+  "fail-validation-jupyter-backticks.qmd",
+  "fail-validation-julia-backticks.qmd",
+];
+
+files.forEach(testYamlValidationFails);
+

--- a/tests/smoke/yaml-intelligence/yaml-intelligence-code-cell-options.test.ts
+++ b/tests/smoke/yaml-intelligence/yaml-intelligence-code-cell-options.test.ts
@@ -17,9 +17,8 @@ const files = [
   "fail-validation-knitr-backticks.qmd",
   "fail-validation-jupyter.qmd",
   "fail-validation-jupyter-backticks.qmd",
-  // FIXME: Activate this when Quarto schema for Julia engine
-  //"fail-validation-julia.qmd",
-  //"fail-validation-julia-backticks.qmd",
+  "fail-validation-julia.qmd",
+  "fail-validation-julia-backticks.qmd",
 ];
 
 files.forEach(testYamlValidationFails);

--- a/tests/smoke/yaml-intelligence/yaml-intelligence-code-cell-options.test.ts
+++ b/tests/smoke/yaml-intelligence/yaml-intelligence-code-cell-options.test.ts
@@ -7,18 +7,19 @@ const yamlDocs = fileLoader("yaml");
 const testYamlValidationFails = (file: string) => {
   testQuartoCmd(
     "render",
-    [yamlDocs(file, "html").input, "--to", "html", "--log-level", "error", "--quiet"],
+    [yamlDocs(file, "html").input, "--to", "html", "--quiet"],
     [printsMessage("ERROR", /Validation of YAML cell metadata failed/)],
   );
 };
 
 const files = [
   "fail-validation-knitr.qmd",
-  "fail-validation-jupyter.qmd",
-  "fail-validation-julia.qmd",
   "fail-validation-knitr-backticks.qmd",
+  "fail-validation-jupyter.qmd",
   "fail-validation-jupyter-backticks.qmd",
-  "fail-validation-julia-backticks.qmd",
+  // FIXME: Activate this when Quarto schema for Julia engine
+  //"fail-validation-julia.qmd",
+  //"fail-validation-julia-backticks.qmd",
 ];
 
 files.forEach(testYamlValidationFails);


### PR DESCRIPTION
On windows, this does not fail and should

````markdown
---
title: "YAML intelligence should fail with knitr engine"
---

```{r}
#| echo: 123
1 + 1
```
````

And possibly using more backtick should fail always, and it is not
`````markdown
---
title: "YAML intelligence should fail with knitr engine"
engine: julia
---

This code cell has more than default 3 backticks

````{julia}
#| echo: 123
1 + 1
````
`````