### PR TITLE
Backport/revealjs/heading color (#12182)

### DIFF
--- a/news/changelog-1.6.md
+++ b/news/changelog-1.6.md
@@ -2,6 +2,8 @@
 
 ## In this release
 
+- ([#12147](https://github.com/quarto-dev/quarto-cli/issues/12147)): `serif` and `simple` themes defaults back to have their heading color (`$presentation-heading-color`) to be the same as the body color (`$body-color`) as in Quarto 1.5.
+
 ## In previous releases
 
 - ([#12148](https://github.com/quarto-dev/quarto-cli/issues/12148)): Don't import libraries outside of `core/lib` into `core/lib`, to avoid pulling in Deno-specific requirements into browser environments.

--- a/package/src/common/patches/revealjs-theme-0001-simple.patch
+++ b/package/src/common/patches/revealjs-theme-0001-simple.patch
@@ -28,7 +28,7 @@ index f0472d7b9..3b1e3cbdc 100644
 +$font-family-sans-serif: "Lato", sans-serif !default;
 +$body-color: #000 !default;
 +$presentation-heading-font: "News Cycle", sans-serif !default;
-+$presentation-heading-color: #000 !default;
++$presentation-heading-color: $body-color !default;
 +$presentation-heading-text-shadow: none !default;
 +$presentation-heading-text-transform: none !default;
 +$body-bg: #fff !default;

--- a/package/src/common/patches/revealjs-theme-0001-sky.patch
+++ b/package/src/common/patches/revealjs-theme-0001-sky.patch
@@ -28,7 +28,7 @@ index 62a52b782..2debff7bc 100644
 +$font-family-sans-serif: "Open Sans", sans-serif !default;
 +$body-color: #333 !default;
 +$presentation-heading-font: "Quicksand", sans-serif !default;
-+$presentation-heading-color: #333 !default;
++$presentation-heading-color: $body-color !default;
 +$presentation-heading-letter-spacing: -0.08em !default;
 +$presentation-heading-text-shadow: none !default;
 +$body-bg: #f7fbfc !default;

--- a/src/resources/formats/revealjs/themes/simple.scss
+++ b/src/resources/formats/revealjs/themes/simple.scss
@@ -19,7 +19,7 @@
 $font-family-sans-serif: "Lato", sans-serif !default;
 $body-color: #000 !default;
 $presentation-heading-font: "News Cycle", sans-serif !default;
-$presentation-heading-color: #000 !default;
+$presentation-heading-color: $body-color !default;
 $presentation-heading-text-shadow: none !default;
 $presentation-heading-text-transform: none !default;
 $body-bg: #fff !default;

--- a/src/resources/formats/revealjs/themes/sky.scss
+++ b/src/resources/formats/revealjs/themes/sky.scss
@@ -17,7 +17,7 @@
 $font-family-sans-serif: "Open Sans", sans-serif !default;
 $body-color: #333 !default;
 $presentation-heading-font: "Quicksand", sans-serif !default;
-$presentation-heading-color: #333 !default;
+$presentation-heading-color: $body-color !default;
 $presentation-heading-letter-spacing: -0.08em !default;
 $presentation-heading-text-shadow: none !default;
 $body-bg: #f7fbfc !default;


### PR DESCRIPTION
> [!WARNING]
> This PR is a backport PR against v1.6 release


This port #12182 closing #12147 as this is fixing regression in patches for new revealjs update

We can merge if we do another patch release before next 1.7

- [ ] If we do this then don't forget to move the changelog 1.7 note in regression

https://github.com/quarto-dev/quarto-cli/blob/7f8cfd083113b96268df9de008cbbb15521c263b/news/changelog-1.7.md#L54-L56