### PR TITLE
Update `QuartoNotebookRunner.jl` to 0.14.0

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -81,7 +81,7 @@ All changes included in 1.7:
 ### `julia`
 
 - ([#11659](https://github.com/quarto-dev/quarto-cli/pull/11659)): Fix escaping bug where paths containing spaces or backslashes break server startup on Windows.
-- ([#12121](https://github.com/quarto-dev/quarto-cli/pull/12121)): Update QuartoNotebookRunner to 0.13.1. Support for evaluating Python cells via [PythonCall.jl](https://github.com/JuliaPy/PythonCall.jl) added.
+- ([#12121](https://github.com/quarto-dev/quarto-cli/pull/12121)): Update QuartoNotebookRunner to 0.14.0. Support for evaluating Python cells via [PythonCall.jl](https://github.com/JuliaPy/PythonCall.jl) added. Support for notebook caching via `execute.cache` added.
 - ([#12151](https://github.com/quarto-dev/quarto-cli/pull/12151)): Basic YAML validation is now active for document using Julia engine.
 
 ### `jupyter`

--- a/src/resources/julia/Project.toml
+++ b/src/resources/julia/Project.toml
@@ -2,4 +2,4 @@
 QuartoNotebookRunner = "4c0109c6-14e9-4c88-93f0-2b974d3468f4"
 
 [compat]
-QuartoNotebookRunner = "=0.13.1"
+QuartoNotebookRunner = "=0.14.0"


### PR DESCRIPTION
Changelog updated as well. Main addition to this version is support for caching via

```yml
execute:
  cache: true
```