### PR TITLE
Add error handling for IPython display errors in notebook cell execution

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -140,6 +140,7 @@ All changes included in 1.7:
 
 - ([#12114](https://github.com/quarto-dev/quarto-cli/issues/12114)): `JUPYTERCACHE` environment variable from [Jupyter cache CLI](https://jupyter-cache.readthedocs.io/en/latest/using/cli.html) is now respected by Quarto when `cache: true` is used. This environment variable allows to change the path of the cache directory.
 - ([#12374](https://github.com/quarto-dev/quarto-cli/issues/12374)): Detect language properly in Jupyter notebooks that lack the `language` field in their `kernelspec`s.
+- ([#12228](https://github.com/quarto-dev/quarto-cli/issues/12228)): `quarto render` will now fails if errors are detected at IPython display level. Setting `error: true` globally or at cell level will keep the error to show in output and not stop the rendering.
 
 ## Other Fixes and Improvements
 

--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -161,6 +161,7 @@ All changes included in 1.7:
 - ([#11803](https://github.com/quarto-dev/quarto-cli/pull/11803)): Added a new CLI command `quarto call`. First users of this interface are the new `quarto call engine julia ...` subcommands.
 - ([#12338](https://github.com/quarto-dev/quarto-cli/issues/12338)): Add an additional workaround for the SCSS parser used in color variable extraction.
 - ([#12369](https://github.com/quarto-dev/quarto-cli/pull/12369)): `quarto preview` correctly throws a YAML validation error when a `format` key does not conform.
+- ([#12238](https://gijit.com/quarto-dev/quarto-cli/issues/12238)): Very long error (e.g. in Jupyter Notenook with backtrace) are now no more truncated in the console.
 
 ## Languages
 

--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -37,6 +37,7 @@ export interface LogMessageOptions {
   indent?: number;
   format?: (line: string) => string;
   colorize?: boolean;
+  stripAnsiCode?: boolean;
 }
 
 // deno-lint-ignore no-explicit-any
@@ -229,6 +230,7 @@ export class LogFileHandler extends FileHandler {
         ...logRecord.args[0] as LogMessageOptions,
         bold: false,
         dim: false,
+        stripAnsiCode: true,
         format: undefined,
       };
       let msg = applyMsgOptions(logRecord.msg, options);
@@ -417,7 +419,9 @@ function applyMsgOptions(msg: string, options: LogMessageOptions) {
   if (options.format) {
     msg = options.format(msg);
   }
-
+  if (options.stripAnsiCode) {
+    msg = colors.stripAnsiCode(msg);
+  }
   return msg;
 }
 

--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -156,9 +156,23 @@ export class StdErrOutputHandler extends BaseHandler {
     return msg;
   }
   log(msg: string): void {
-    Deno.stderr.writeSync(
-      new TextEncoder().encode(msg),
-    );
+    const encoder = new TextEncoder();
+    const data = encoder.encode(msg);
+
+    let bytesWritten = 0;
+    while (bytesWritten < data.length) {
+      // Write the remaining portion of the buffer
+      const remaining = data.subarray(bytesWritten);
+      const written = Deno.stderr.writeSync(remaining);
+
+      // If we wrote 0 bytes, something is wrong - avoid infinite loop
+      if (written === 0) {
+        // Could add fallback handling here if needed
+        break;
+      }
+
+      bytesWritten += written;
+    }
   }
 }
 

--- a/src/execute/jupyter/jupyter-kernel.ts
+++ b/src/execute/jupyter/jupyter-kernel.ts
@@ -64,6 +64,11 @@ export async function executeKernelOneshot(
   );
 
   if (!result.success) {
+    trace(options, "Error executing notebook with oneshot kernel");
+    if (result.stderr) {
+      error(result.stderr, { colorize: false });
+    }
+    printExecDiagnostics(options.kernelspec, result.stderr);
     return Promise.reject();
   }
 }
@@ -209,6 +214,7 @@ async function execJupyter(
           "PYDEVD_DISABLE_FILE_VALIDATION": "1",
         },
         stdout: "piped",
+        stderr: "piped",
       },
       kernelCommand(command, "", options),
     );
@@ -443,6 +449,9 @@ async function connectToKernel(
     debug,
   }, options.kernelspec);
   if (!result.success) {
+    if (result.stderr) {
+      error(result.stderr, { colorize: false });
+    }
     return Promise.reject();
   }
 

--- a/src/execute/jupyter/jupyter-kernel.ts
+++ b/src/execute/jupyter/jupyter-kernel.ts
@@ -64,11 +64,6 @@ export async function executeKernelOneshot(
   );
 
   if (!result.success) {
-    trace(options, "Error executing notebook with oneshot kernel");
-    if (result.stderr) {
-      error(result.stderr, { colorize: false });
-    }
-    printExecDiagnostics(options.kernelspec, result.stderr);
     return Promise.reject();
   }
 }
@@ -214,7 +209,6 @@ async function execJupyter(
           "PYDEVD_DISABLE_FILE_VALIDATION": "1",
         },
         stdout: "piped",
-        stderr: "piped",
       },
       kernelCommand(command, "", options),
     );
@@ -449,9 +443,6 @@ async function connectToKernel(
     debug,
   }, options.kernelspec);
   if (!result.success) {
-    if (result.stderr) {
-      error(result.stderr, { colorize: false });
-    }
     return Promise.reject();
   }
 

--- a/src/resources/jupyter/jupyter.py
+++ b/src/resources/jupyter/jupyter.py
@@ -226,19 +226,21 @@ def run_server_subprocess(options, status):
 # run a notebook directly (not a server)
 def run_notebook(options, status):
 
-   # run notebook w/ some special exception handling. note that we don't 
+   # run notebook w/ some special exception handling. note that we don't
    # log exceptions here b/c they are considered normal course of execution
    # for errors that occur in notebook cells
-   try:   
+   try:
+      trace('Running notebook_execute')
       notebook_execute(options, status)
    except Exception as e:
+      trace(f'run_notebook caught exception: {type(e).__name__}')
       # CellExecutionError for execution at the terminal includes a bunch
       # of extra stack frames internal to this script. remove them
       msg = str(e)
       kCellExecutionError = "nbclient.exceptions.CellExecutionError: "
       loc = msg.find(kCellExecutionError)
       if loc != -1:
-         msg = msg[loc + len(kCellExecutionError)]
+         msg = msg[loc + len(kCellExecutionError):]
       sys.stderr.write("\n\n" + msg + "\n")
       sys.stderr.flush()
       sys.exit(1)

--- a/src/resources/jupyter/jupyter.py
+++ b/src/resources/jupyter/jupyter.py
@@ -19,6 +19,7 @@ except:
 
 from log import log_init, log, log_error, trace
 from notebook import notebook_execute, RestartKernel
+from nbclient.exceptions import CellExecutionError
 
 import asyncio
 if sys.platform == 'win32':
@@ -241,8 +242,7 @@ def run_notebook(options, status):
       loc = msg.find(kCellExecutionError)
       if loc != -1:
          msg = msg[loc + len(kCellExecutionError):]
-      sys.stderr.write("\n\n" + msg + "\n")
-      sys.stderr.flush()
+      status("\n\n" + msg + "\n")
       sys.exit(1)
 
 

--- a/src/resources/jupyter/log.py
+++ b/src/resources/jupyter/log.py
@@ -37,8 +37,10 @@ else:
    def log(level, msg):
       logging.getLogger().log(level, msg)
 
-def log_error(msg, exc_info = False):
-   logging.getLogger().log(logging.ERROR, msg, exc_info = exc_info, stack_info = not exc_info)
+def log_error(msg, exc_info = False, stack_info = None):
+   if stack_info is None:
+      stack_info = not exc_info
+   logging.getLogger().log(logging.ERROR, msg, exc_info = exc_info, stack_info = stack_info)
 
 def trace(msg):
    prev_frame = inspect.stack()[1]

--- a/src/resources/jupyter/notebook.py
+++ b/src/resources/jupyter/notebook.py
@@ -563,14 +563,14 @@ def cell_execute(client, cell, index, execution_count, eval_default, store_histo
             if output.get('output_type') == 'error':
                trace("   Uncaught error found in output")
                from nbclient.exceptions import CellExecutionError
-               error_name = output.get('ename', 'Error')
+               error_name = output.get('ename', 'UnnamedError')
                error_value = output.get('evalue', '')
                traceback = output.get('traceback', [])
                # Use same error raising mechanism as nbclient
                raise CellExecutionError.from_cell_and_msg(
                   cell,
                   {
-                     'ename': error_name,
+                     'ename': 'UncaughtCellError:' + error_name,
                      'evalue': error_value,
                      'traceback': traceback
                   }

--- a/src/resources/jupyter/notebook.py
+++ b/src/resources/jupyter/notebook.py
@@ -517,7 +517,7 @@ def cell_execute(client, cell, index, execution_count, eval_default, store_histo
 
    # check options for eval and error
    eval = cell_options.get('eval', eval_default)
-   allow_errors = cell_options.get('error', False)
+   allow_errors = cell_options.get('error')
      
    trace(f"cell_execute with eval={eval}")
 
@@ -554,7 +554,7 @@ def cell_execute(client, cell, index, execution_count, eval_default, store_histo
             del cell["metadata"]["tags"]
 
       # Check for display errors in output (respecting both global and cell settings)
-      cell_allows_errors = client.allow_errors or allow_errors
+      cell_allows_errors = allow_errors if allow_errors is not None else client.allow_errors
       if not cell_allows_errors:
          for output in cell.outputs:
             if output.get('output_type') == 'error':

--- a/src/resources/jupyter/notebook.py
+++ b/src/resources/jupyter/notebook.py
@@ -520,6 +520,8 @@ def cell_execute(client, cell, index, execution_count, eval_default, store_histo
    allow_errors = cell_options.get('error')
      
    trace(f"cell_execute with eval={eval}")
+   if (allow_errors == True):
+      trace(f"cell_execute with allow_errors={allow_errors}")
 
    # execute if eval is active
    if eval == True:
@@ -556,9 +558,10 @@ def cell_execute(client, cell, index, execution_count, eval_default, store_histo
       # Check for display errors in output (respecting both global and cell settings)
       cell_allows_errors = allow_errors if allow_errors is not None else client.allow_errors
       if not cell_allows_errors:
+         trace("Cell does not allow errors: checking for uncaught errors")
          for output in cell.outputs:
             if output.get('output_type') == 'error':
-               trace("Uncaught error found in output")
+               trace("   Uncaught error found in output")
                from nbclient.exceptions import CellExecutionError
                error_name = output.get('ename', 'Error')
                error_value = output.get('evalue', '')

--- a/tests/docs/smoke-all/jupyter/error/.gitignore
+++ b/tests/docs/smoke-all/jupyter/error/.gitignore
@@ -1,0 +1,1 @@
+*.quarto_ipynb

--- a/tests/docs/smoke-all/jupyter/error/display-error-false.qmd
+++ b/tests/docs/smoke-all/jupyter/error/display-error-false.qmd
@@ -9,12 +9,12 @@ _quarto:
         - '${input_stem}.quarto_ipynb'
 ---
 
-With default setting, this document should error at rendering because of Exception at IPython.display level. 
+With default setting, this document should error at rendering because of an exception at IPython.display level. 
 
 By default `nbconvert` does not throw exception for error thrown by IPython display, on purpose as document output is still valid as there are other representation. 
 
 ```{python}
-# First cell - create an object with a buggy _repr_html_ method
+# First cell - create an object with a buggy _repr_markdown_ method
 class BuggyDisplay:
     def __init__(self):
         self.data = "This works fine"
@@ -37,12 +37,9 @@ buggy = BuggyDisplay()
 ```
 
 ```{python}
-# Second cell - display the object (triggers error in _repr_html_)
-# This will show an error in the output but won't stop execution
 buggy
 ```
 
 ```{python}
-# Third cell - proves execution continues
 print("Execution continued despite display error")
 ```

--- a/tests/docs/smoke-all/jupyter/error/display-error-false.qmd
+++ b/tests/docs/smoke-all/jupyter/error/display-error-false.qmd
@@ -1,0 +1,47 @@
+---
+title: test
+format: html
+_quarto:
+  tests:
+    html:
+      shouldError: default
+---
+
+With default setting, this document should error at rendering because of Exception at IPython.display level. 
+
+By default `nbconvert` does not throw exception for error thrown by IPython display, on purpose as document output is still valid as there are other representation. 
+
+```{python}
+# First cell - create an object with a buggy _repr_html_ method
+class BuggyDisplay:
+    def __init__(self):
+        self.data = "This works fine"
+    
+    def _repr_html_(self):
+        # This error happens during display, not execution
+        # raise ValueError("Display phase error!")
+        return "<b>HTML fallback:</b> " + self.data
+
+    def _repr_markdown_(self):
+        # Markdown representation as fallback when HTML fails
+        # return "**Markdown fallback:** " + self.data
+        raise ValueError("Display phase error!")
+    
+    def __repr__(self):
+        # This ensures the object has a string representation
+        return self.data
+
+# Create the object
+buggy = BuggyDisplay()
+```
+
+```{python}
+# Second cell - display the object (triggers error in _repr_html_)
+# This will show an error in the output but won't stop execution
+buggy
+```
+
+```{python}
+# Third cell - proves execution continues
+print("Execution continued despite display error")
+```

--- a/tests/docs/smoke-all/jupyter/error/display-error-false.qmd
+++ b/tests/docs/smoke-all/jupyter/error/display-error-false.qmd
@@ -5,6 +5,8 @@ _quarto:
   tests:
     html:
       shouldError: default
+      postRenderCleanup:
+        - '${input_stem}.quarto_ipynb'
 ---
 
 With default setting, this document should error at rendering because of Exception at IPython.display level. 

--- a/tests/docs/smoke-all/jupyter/error/display-error-false.qmd
+++ b/tests/docs/smoke-all/jupyter/error/display-error-false.qmd
@@ -20,13 +20,12 @@ class BuggyDisplay:
         self.data = "This works fine"
     
     def _repr_html_(self):
-        # This error happens during display, not execution
-        # raise ValueError("Display phase error!")
+        # HTML representation used for `format: html`
         return "<b>HTML fallback:</b> " + self.data
 
     def _repr_markdown_(self):
-        # Markdown representation as fallback when HTML fails
-        # return "**Markdown fallback:** " + self.data
+        # This error happens during display, not execution
+        # even if the markdown reprensentation is not used
         raise ValueError("Display phase error!")
     
     def __repr__(self):

--- a/tests/docs/smoke-all/jupyter/error/display-error-true-cell.qmd
+++ b/tests/docs/smoke-all/jupyter/error/display-error-true-cell.qmd
@@ -38,12 +38,9 @@ buggy = BuggyDisplay()
 
 ```{python}
 #| error: true
-# Second cell - display the object (triggers error in _repr_html_)
-# This will show an error in the output but won't stop execution
 buggy
 ```
 
 ```{python}
-# Third cell - proves execution continues
 print("Execution continued despite display error")
 ```

--- a/tests/docs/smoke-all/jupyter/error/display-error-true-cell.qmd
+++ b/tests/docs/smoke-all/jupyter/error/display-error-true-cell.qmd
@@ -1,0 +1,49 @@
+---
+title: test
+format: html
+_quarto:
+  tests:
+    html:
+      ensureHtmlElementContents: 
+        selectors: ['div.cell-output-error']
+        matches: ['ValueError\: Display phase error for HTML']
+        noMatches: []
+---
+
+With `error: true` in cell, this document should not error at rendering and Exception at IPython.display level should be shown in output. 
+
+By default `nbconvert` does not throw exception for error thrown by IPython display, on purpose as document output is still valid as there are other representation. 
+
+```{python}
+# First cell - create an object with a buggy _repr_html_ method
+class BuggyDisplay:
+    def __init__(self):
+        self.data = "This works fine"
+    
+    def _repr_html_(self):
+        # This error happens during display, not execution
+        raise ValueError("Display phase error for HTML!")
+
+    def _repr_markdown_(self):
+        # Markdown representation as fallback when HTML fails
+        return "**Markdown fallback:** " + self.data
+
+    def __repr__(self):
+        # This ensures the object has a string representation
+        return self.data
+
+# Create the object
+buggy = BuggyDisplay()
+```
+
+```{python}
+#| error: true
+# Second cell - display the object (triggers error in _repr_html_)
+# This will show an error in the output but won't stop execution
+buggy
+```
+
+```{python}
+# Third cell - proves execution continues
+print("Execution continued despite display error")
+```

--- a/tests/docs/smoke-all/jupyter/error/display-error-true-global-cell-false.qmd
+++ b/tests/docs/smoke-all/jupyter/error/display-error-true-global-cell-false.qmd
@@ -1,0 +1,47 @@
+---
+title: test
+format: html
+execute:
+  error: true
+_quarto:
+  tests:
+    html:
+      shouldError: default
+      postRenderCleanup:
+        - '${input_stem}.quarto_ipynb'
+---
+
+With `error: true`, and `error: false` at cell level, this document should error at rendering.
+
+By default `nbconvert` does not throw exception for error thrown by IPython display, on purpose as document output is still valid as there are other representation. 
+
+```{python}
+class BuggyDisplay:
+    def __init__(self):
+        self.data = "This works fine"
+    
+    def _repr_html_(self):
+        # HTML representation used for `format: html`
+        return "<b>HTML fallback:</b> " + self.data
+
+    def _repr_markdown_(self):
+        # This error happens during display, not execution
+        # even if the markdown reprensentation is not used
+        raise ValueError("Display phase error for Markdown!")
+    
+    def __repr__(self):
+        # This ensures the object has a string representation
+        return self.data
+
+# Create the object
+buggy = BuggyDisplay()
+```
+
+```{python}
+#| error: false
+buggy
+```
+
+```{python}
+print("Execution continued despite display error")
+```

--- a/tests/docs/smoke-all/jupyter/error/display-error-true-global.qmd
+++ b/tests/docs/smoke-all/jupyter/error/display-error-true-global.qmd
@@ -1,0 +1,49 @@
+---
+title: test
+format: html
+execute:
+  error: true
+_quarto:
+  tests:
+    html:
+      ensureHtmlElementContents: 
+        selectors: ['div.cell-output-error']
+        matches: ['ValueError\: Display phase error for Markdown']
+---
+
+With `error: true` this document should not error at rendering and Exception at IPython.display level should be shown in output. 
+
+By default `nbconvert` does not throw exception for error thrown by IPython display, on purpose as document output is still valid as there are other representation. 
+
+```{python}
+# First cell - create an object with a buggy _repr_html_ method
+class BuggyDisplay:
+    def __init__(self):
+        self.data = "This works fine"
+    
+    def _repr_html_(self):
+        # This error happens during display, not execution
+        return "<b>HTML fallback:</b> " + self.data
+
+    def _repr_markdown_(self):
+        # Markdown representation as fallback when HTML fails
+        raise ValueError("Display phase error for Markdown!")
+    
+    def __repr__(self):
+        # This ensures the object has a string representation
+        return self.data
+
+# Create the object
+buggy = BuggyDisplay()
+```
+
+```{python}
+# Second cell - display the object (triggers error in _repr_html_)
+# This will show an error in the output but won't stop execution
+buggy
+```
+
+```{python}
+# Third cell - proves execution continues
+print("Execution continued despite display error")
+```

--- a/tests/docs/smoke-all/jupyter/error/display-error-true-global.qmd
+++ b/tests/docs/smoke-all/jupyter/error/display-error-true-global.qmd
@@ -22,11 +22,12 @@ class BuggyDisplay:
         self.data = "This works fine"
     
     def _repr_html_(self):
-        # This error happens during display, not execution
+        # HTML representation used for `format: html`
         return "<b>HTML fallback:</b> " + self.data
 
     def _repr_markdown_(self):
-        # Markdown representation as fallback when HTML fails
+        # This error happens during display, not execution
+        # even if the markdown reprensentation is not used
         raise ValueError("Display phase error for Markdown!")
     
     def __repr__(self):

--- a/tests/docs/smoke-all/jupyter/error/display-error-true-global.qmd
+++ b/tests/docs/smoke-all/jupyter/error/display-error-true-global.qmd
@@ -16,7 +16,7 @@ With `error: true` this document should not error at rendering and Exception at 
 By default `nbconvert` does not throw exception for error thrown by IPython display, on purpose as document output is still valid as there are other representation. 
 
 ```{python}
-# First cell - create an object with a buggy _repr_html_ method
+# First cell - create an object with a buggy _repr_markdown_ method
 class BuggyDisplay:
     def __init__(self):
         self.data = "This works fine"
@@ -39,12 +39,9 @@ buggy = BuggyDisplay()
 ```
 
 ```{python}
-# Second cell - display the object (triggers error in _repr_html_)
-# This will show an error in the output but won't stop execution
 buggy
 ```
 
 ```{python}
-# Third cell - proves execution continues
 print("Execution continued despite display error")
 ```

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -34,6 +34,7 @@ import {
   ensurePptxMaxSlides,
   ensureLatexFileRegexMatches,
   printsMessage,
+  shouldError
 } from "../verify.ts";
 import { readYamlFromMarkdown } from "../../src/core/yaml.ts";
 import { findProjectDir, findProjectOutputDir, outputForInput } from "../utils.ts";
@@ -134,7 +135,10 @@ function resolveTestSpecs(
         // deno-lint-ignore no-explicit-any
         const [key, value] of Object.entries(testObj as Record<string, any>)
       ) {
-        if (key === "noErrors") {
+        if (key == "shouldError") {
+          checkWarnings = false;
+          verifyFns.push(shouldError);
+        } else if (key === "noErrors") {
           checkWarnings = false;
           verifyFns.push(noErrors);
         } else {

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -211,7 +211,9 @@ function resolveTestSpecs(
                 throw new Error(`Using ensureLatexFileRegexMatches requires setting 'keep-tex: true' in file ${input}`);
               }
             }
-            if (typeof value === "object") {
+            
+            if (typeof value === "object" && Array.isArray(value)) {
+              // Only use spread operator for arrays
               verifyFns.push(verifyMap[key](outputFile.outputPath, ...value));
             } else {
               verifyFns.push(verifyMap[key](outputFile.outputPath, value));

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -34,7 +34,8 @@ import {
   ensurePptxMaxSlides,
   ensureLatexFileRegexMatches,
   printsMessage,
-  shouldError
+  shouldError,
+  ensureHtmlElementContents
 } from "../verify.ts";
 import { readYamlFromMarkdown } from "../../src/core/yaml.ts";
 import { findProjectDir, findProjectOutputDir, outputForInput } from "../utils.ts";
@@ -125,6 +126,7 @@ function resolveTestSpecs(
   // deno-lint-ignore no-explicit-any
   const verifyMap: Record<string, any> = {
     ensureHtmlElements,
+    ensureHtmlElementContents,
     ensureFileRegexMatches,
     ensureLatexFileRegexMatches,
     ensureTypstFileRegexMatches,

--- a/tests/smoke/website/draft-utils.ts
+++ b/tests/smoke/website/draft-utils.ts
@@ -26,11 +26,11 @@ export const hasContentLinksToDrafts = (siteDir: string) => {
 }
 
 export const hasEnvelopeLinksToDrafts = (siteDir: string) => {
-  return ensureHtmlElementContents(join(siteDir, "index.html"), ["#quarto-sidebar", "#quarto-header", ".quarto-listing-default"], ["Draft!!"], []);
+  return ensureHtmlElementContents(join(siteDir, "index.html"), { selectors: ["#quarto-sidebar", "#quarto-header", ".quarto-listing-default"], matches: ["Draft!!"], noMatches: [] });
 }
 
 export const doesntHaveEnvelopeLinksToDrafts = (siteDir: string) => {
-  return ensureHtmlElementContents(join(siteDir, "index.html"), ["#quarto-sidebar", "#quarto-header", ".quarto-listing-default"], [], ["Draft!!"]);
+  return ensureHtmlElementContents(join(siteDir, "index.html"), { selectors: ["#quarto-sidebar", "#quarto-header", ".quarto-listing-default"], matches: [], noMatches: ["Draft!!"] });
 }
 
 export const siteMapHasDraft = (siteDir: string) => {

--- a/tests/verify.ts
+++ b/tests/verify.ts
@@ -83,25 +83,45 @@ export const withPptxContent = async <T>(
   }
 };
 
+const checkErrors = (outputs: ExecuteOutput[]): { errors: boolean, messages: string | undefined } => {
+  const isError = (output: ExecuteOutput) => {
+    return output.levelName.toLowerCase() === "error";
+  };
+  const errors = outputs.some(isError);
+
+  const messages = errors ? outputs.filter(isError).map((outputs) => outputs.msg).join("\n") : undefined
+
+  return({
+    errors,
+    messages
+  })
+}
+
 export const noErrors: Verify = {
   name: "No Errors",
   verify: (outputs: ExecuteOutput[]) => {
-    const isError = (output: ExecuteOutput) => {
-      return output.levelName.toLowerCase() === "error";
-    };
+    
+    const { errors, messages } = checkErrors(outputs);
 
-    const errors = outputs.some(isError);
+    assert(
+      !errors,
+      `Errors During Execution\n|${messages}|`,
+    );
 
-    // Output an error or warning if it exists
-    if (errors) {
-      const messages = outputs.filter(isError).map((outputs) => outputs.msg)
-        .join("\n");
+    return Promise.resolve();
+  },
+};
 
-      assert(
-        !errors,
-        `Errors During Execution\n|${messages}|`,
-      );
-    }
+export const shouldError: Verify = {
+  name: "Should Error",
+  verify: (outputs: ExecuteOutput[]) => {
+
+    const { errors } = checkErrors(outputs);
+
+    assert(
+      errors,
+      `No errors during execution while rendering was expected to fail.`,
+    );
 
     return Promise.resolve();
   },

--- a/tests/verify.ts
+++ b/tests/verify.ts
@@ -345,31 +345,33 @@ export const ensureHtmlElements = (
 };
 
 export const ensureHtmlElementContents = (
-  file: string,
-  selectors: string[],
-  matches: (string | RegExp)[],
-  noMatches: (string | RegExp)[]
+  file: string, 
+  options : {
+    selectors: string[],
+    matches: (string | RegExp)[],
+    noMatches?: (string | RegExp)[]
+  }
 ) => {
   return {
     name: "Inspecting HTML for Selector Contents",
     verify: async (_output: ExecuteOutput[]) => {
       const htmlInput = await Deno.readTextFile(file);
       const doc = new DOMParser().parseFromString(htmlInput, "text/html")!;
-      selectors.forEach((sel) => {
+      options.selectors.forEach((sel) => {
         const el = doc.querySelector(sel);
         if (el !== null) {
           const contents = el.innerText;
-          matches.forEach((regex) => {
+          options.matches.forEach((regex) => {
             assert(
               asRegexp(regex).test(contents),
-              `Required match ${String(regex)} is missing from selector ${sel}.`,
+              `Required match ${String(regex)} is missing from selector ${sel} content: ${contents}.`,
             );
           });
 
-          noMatches.forEach((regex) => {
+          options.noMatches?.forEach((regex) => {
             assert(
               !asRegexp(regex).test(contents),
-              `Unexpected match ${String(regex)} is present from selector ${sel}.`,
+              `Unexpected match ${String(regex)} is present from selector ${sel} content: ${contents}.`,
             );
           });
   


### PR DESCRIPTION
> [!NOTE]
> This is only a proposal and this needs to be discussed. 

Closes #12228

With this change, `quarto render` would fail for any error not caught by `nbclient` as cell execution error. 

`nbclient` does not error out when a cell has an error due to a display error. This PR adds error handling for display errors in notebook cells so that `quarto render` will error out. `error: true` controls the behavior to allow or not allow the error.

Tests are added to shown the new behavior. 

**We may not want that solution** but this is probably coherent with `error` config as true or false expectation. 

If we do not do this, I think it is still not good to output the display error as a cell error without a way to remove it. We could also tweak our processing so that we remove this output in some situations and show the display error as a warning.

----

*This PR comes with a few tweaks to `smoke-all` to be able to do more from in-document testing specification and also have a better configuration with a name (so YAML validation for tests will become a reality at some point. I am making the changes slowly across our tests)*