### PR TITLE
Fix test environment configuration of Julia on Windows

### DIFF
--- a/tests/configure-test-env.ps1
+++ b/tests/configure-test-env.ps1
@@ -33,7 +33,7 @@ try {$null = gcm julia -ea stop; $julia=$true } catch {
 If ($julia) {
   # TODO: Check to do equivalent of virtualenv
   Write-Host "Setting up Julia environment"
-  uv run --frozen julia --color=yes --project=. -e 'import Pkg; Pkg.instantiate(); Pkg.build(\"IJulia\"); Pkg.precompile()'
+  uv run --frozen julia --color=yes --project=. -e "import Pkg; Pkg.instantiate(); Pkg.build("""IJulia"""); Pkg.precompile()"
 }
 
 # Check TinyTeX

--- a/tests/configure-test-env.ps1
+++ b/tests/configure-test-env.ps1
@@ -33,7 +33,7 @@ try {$null = gcm julia -ea stop; $julia=$true } catch {
 If ($julia) {
   # TODO: Check to do equivalent of virtualenv
   Write-Host "Setting up Julia environment"
-  uv run --frozen julia --color=yes --project=. -e "import Pkg; Pkg.instantiate(); Pkg.build(`"IJulia`"); Pkg.precompile()"
+  uv run --frozen julia --color=yes --project=. -e 'import Pkg; Pkg.instantiate(); Pkg.build(\"IJulia\"); Pkg.precompile()'
 }
 
 # Check TinyTeX

--- a/tests/configure-test-env.ps1
+++ b/tests/configure-test-env.ps1
@@ -33,7 +33,7 @@ try {$null = gcm julia -ea stop; $julia=$true } catch {
 If ($julia) {
   # TODO: Check to do equivalent of virtualenv
   Write-Host "Setting up Julia environment"
-  uv run --frozen julia --color=yes --project=. -e "import Pkg; Pkg.instantiate(); Pkg.build("""IJulia"""); Pkg.precompile()"
+  uv run --frozen julia --color=yes --project=. -e 'import Pkg; Pkg.instantiate(); Pkg.build("""IJulia"""); Pkg.precompile()'
 }
 
 # Check TinyTeX


### PR DESCRIPTION
> [!NOTE]
> I found that my Windows 11's built-in Windows PowerShell has the following issue while the one I downloaded from Microsoft Store does not. The version of the former is `5.1` and that of the latter is `7.5.0`. Still, I suggest a fix that works in both versions. 

## Description

On Linux, I verified that test environment configuration of Julia works with the following lines of code:

https://github.com/quarto-dev/quarto-cli/blob/1eb9e51faf9751145e0e7c02f0b4d706cd6621c6/tests/configure-test-env.sh#L39-L45

What if the double quotes in `"IJulia"` were omitted? Then it would not work as the following log shows:

```zsh
root@8aadfbdbf62f:~# julia -e 'println("IJulia")'
IJulia
root@8aadfbdbf62f:~# julia -e 'println(IJulia)'
ERROR: UndefVarError: `Hello` not defined in `Main`
Stacktrace:
 [1] top-level scope
   @ none:1
```

In fact, the very same error happens on Windows unlike on Linux with the following lines of code because of incomplete escape of double quotes with backticks(`` ` ``):

https://github.com/quarto-dev/quarto-cli/blob/1eb9e51faf9751145e0e7c02f0b4d706cd6621c6/tests/configure-test-env.ps1#L33-L37

```powershell
PS C:\> $PSVersionTable.PSVersion

Major  Minor  Build  Revision
-----  -----  -----  --------
5      1      26100  2161
PS C:\> julia -e "println(`"Hello`")"
ERROR: UndefVarError: `Hello` not defined in `Main`
Stacktrace:
 [1] top-level scope
   @ none:1
PS C:\> julia -e "println(Hello)"
ERROR: UndefVarError: `Hello` not defined in `Main`
Stacktrace:
 [1] top-level scope
   @ none:1
```

I selected the second option from the following four approaches because it works both on Windows 11's built-in Windows PowerShell (version `5.1`) and Microsoft Store's PowerShell (version `7.5.0`), and the single quotes are also used in the corresponding Linux command:

```powershell
PS C:\> $PSVersionTable.PSVersion

Major  Minor  Build  Revision
-----  -----  -----  --------
5      1      26100  2161
PS C:\> julia -e 'println(\"Hello\")'
Hello
PS C:\> julia -e 'println("""Hello""")'
Hello
PS C:\> julia -e "println(\`"Hello\`")"
Hello
PS C:\> julia -e "println(""""""Hello"""""")"
Hello
```

```powershell
PS C:\> $PSVersionTable.PSVersion

Major  Minor  Patch  PreReleaseLabel BuildLabel
-----  -----  -----  --------------- ----------
7      5      0

PS C:\> julia -e 'println(\"Hello\")'
ERROR: ParseError:
# Error @ none:1:9
println(\"Hello\")
#       ╙ ── not a unary operator
Stacktrace:
 [1] top-level scope
   @ none:1
PS C:\> julia -e 'println("""Hello""")'
Hello
PS C:\> julia -e "println(\`"Hello\`")"
ERROR: ParseError:
# Error @ none:1:9
println(\"Hello\")
#       ╙ ── not a unary operator
Stacktrace:
 [1] top-level scope
   @ none:1
PS C:\> julia -e "println(""""""Hello"""""")"
Hello
```

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] ensured the present test suite passes
