### PR TITLE
Feature: cell renderings, light and dark

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -43,6 +43,7 @@ All changes included in 1.7:
 
 ## `html` format
 
+- ([#12277](https://github.com/quarto-dev/quarto-cli/pull/12277)): Provide light and dark plot and table renderings with `renderings: [light,dark]`
 - ([#11860](https://github.com/quarto-dev/quarto-cli/issues/11860)): ES6 modules that import other local JS modules in documents with `embed-resources: true` are now correctly embedded.
 
 ## `pdf` format

--- a/src/format/html/format-html-bootstrap.ts
+++ b/src/format/html/format-html-bootstrap.ts
@@ -1060,6 +1060,18 @@ function bootstrapHtmlFinalizer(format: Format, flags: PandocFlags) {
       }
     }
 
+    // start body with light or dark class for proper display when JS is disabled
+    let initialLightDarkClass = "quarto-light";
+    // some logic duplicated from resolveThemeLayer
+    const theme = format.metadata.theme;
+    if (theme && !Array.isArray(theme) && typeof theme === "object") {
+      const keys = Object.keys(theme);
+      if(keys.length > 1 && keys[0] === "dark") {
+        initialLightDarkClass = "quarto-dark";
+      }
+    }
+    doc.body.classList.add(initialLightDarkClass);
+
     // If there is no margin content and no toc in the right margin
     // then lower the z-order so everything else can get on top
     // of the sidebar

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -7042,6 +7042,13 @@ var require_yaml_intelligence_resources = __commonJS({
           description: "Classes to apply to cell container"
         },
         {
+          name: "renderings",
+          schema: {
+            arrayOf: "string"
+          },
+          description: "Array of rendering names"
+        },
+        {
           name: "tags",
           tags: {
             engine: "jupyter"
@@ -19887,6 +19894,13 @@ var require_yaml_intelligence_resources = __commonJS({
           },
           errorMessage: "type key not supported at project type-level. Use `project: type: ...` instead.",
           description: "internal-schema-hack"
+        },
+        {
+          name: "engines",
+          schema: {
+            arrayOf: "string"
+          },
+          description: "List execution engines you want to give priority when determining which engine should render a notebook. If two engines have support for a notebook, the one listed earlier will be chosen. Quarto's default order is 'knitr', 'jupyter', 'markdown', 'julia'."
         }
       ],
       "schema/schema.yml": [
@@ -23967,7 +23981,9 @@ var require_yaml_intelligence_resources = __commonJS({
         },
         "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
         "Manuscript configuration",
-        "internal-schema-hack"
+        "internal-schema-hack",
+        "Array of rendering names",
+        "List execution engines you want to give priority when determining\nwhich engine should render a notebook. If two engines have support for a\nnotebook, the one listed earlier will be chosen. Quarto\u2019s default order\nis \u2018knitr\u2019, \u2018jupyter\u2019, \u2018markdown\u2019, \u2018julia\u2019."
       ],
       "schema/external-schemas.yml": [
         {
@@ -24196,12 +24212,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 194269,
+        _internalId: 194327,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 194261,
+            _internalId: 194319,
             type: "enum",
             enum: [
               "png",
@@ -24217,7 +24233,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 194268,
+            _internalId: 194326,
             type: "anyOf",
             anyOf: [
               {
@@ -33253,11 +33269,22 @@ var jupyterEngineSchema = defineCached(
   },
   "engine-jupyter"
 );
+var juliaEnginesSchema = defineCached(
+  // deno-lint-ignore require-await
+  async () => {
+    return {
+      schema: makeEngineSchema("julia"),
+      errorHandlers: []
+    };
+  },
+  "engine-julia"
+);
 async function getEngineOptionsSchema() {
   const obj = {
     markdown: await markdownEngineSchema(),
     knitr: await knitrEngineSchema(),
-    jupyter: await jupyterEngineSchema()
+    jupyter: await jupyterEngineSchema(),
+    julia: await juliaEnginesSchema()
   };
   return obj;
 }

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -7043,6 +7043,13 @@ try {
             description: "Classes to apply to cell container"
           },
           {
+            name: "renderings",
+            schema: {
+              arrayOf: "string"
+            },
+            description: "Array of rendering names"
+          },
+          {
             name: "tags",
             tags: {
               engine: "jupyter"
@@ -19888,6 +19895,13 @@ try {
             },
             errorMessage: "type key not supported at project type-level. Use `project: type: ...` instead.",
             description: "internal-schema-hack"
+          },
+          {
+            name: "engines",
+            schema: {
+              arrayOf: "string"
+            },
+            description: "List execution engines you want to give priority when determining which engine should render a notebook. If two engines have support for a notebook, the one listed earlier will be chosen. Quarto's default order is 'knitr', 'jupyter', 'markdown', 'julia'."
           }
         ],
         "schema/schema.yml": [
@@ -23968,7 +23982,9 @@ try {
           },
           "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
           "Manuscript configuration",
-          "internal-schema-hack"
+          "internal-schema-hack",
+          "Array of rendering names",
+          "List execution engines you want to give priority when determining\nwhich engine should render a notebook. If two engines have support for a\nnotebook, the one listed earlier will be chosen. Quarto\u2019s default order\nis \u2018knitr\u2019, \u2018jupyter\u2019, \u2018markdown\u2019, \u2018julia\u2019."
         ],
         "schema/external-schemas.yml": [
           {
@@ -24197,12 +24213,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 194269,
+          _internalId: 194327,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 194261,
+              _internalId: 194319,
               type: "enum",
               enum: [
                 "png",
@@ -24218,7 +24234,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 194268,
+              _internalId: 194326,
               type: "anyOf",
               anyOf: [
                 {
@@ -33267,11 +33283,22 @@ ${tidyverseInfo(
     },
     "engine-jupyter"
   );
+  var juliaEnginesSchema = defineCached(
+    // deno-lint-ignore require-await
+    async () => {
+      return {
+        schema: makeEngineSchema("julia"),
+        errorHandlers: []
+      };
+    },
+    "engine-julia"
+  );
   async function getEngineOptionsSchema() {
     const obj = {
       markdown: await markdownEngineSchema(),
       knitr: await knitrEngineSchema(),
-      jupyter: await jupyterEngineSchema()
+      jupyter: await jupyterEngineSchema(),
+      julia: await juliaEnginesSchema()
     };
     return obj;
   }

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -14,6 +14,13 @@
       "description": "Classes to apply to cell container"
     },
     {
+      "name": "renderings",
+      "schema": {
+        "arrayOf": "string"
+      },
+      "description": "Array of rendering names"
+    },
+    {
       "name": "tags",
       "tags": {
         "engine": "jupyter"
@@ -12859,6 +12866,13 @@
       },
       "errorMessage": "type key not supported at project type-level. Use `project: type: ...` instead.",
       "description": "internal-schema-hack"
+    },
+    {
+      "name": "engines",
+      "schema": {
+        "arrayOf": "string"
+      },
+      "description": "List execution engines you want to give priority when determining which engine should render a notebook. If two engines have support for a notebook, the one listed earlier will be chosen. Quarto's default order is 'knitr', 'jupyter', 'markdown', 'julia'."
     }
   ],
   "schema/schema.yml": [
@@ -16939,7 +16953,9 @@
     },
     "Disambiguating year suffix in author-date styles (e.g.&nbsp;“a” in “Doe,\n1999a”).",
     "Manuscript configuration",
-    "internal-schema-hack"
+    "internal-schema-hack",
+    "Array of rendering names",
+    "List execution engines you want to give priority when determining\nwhich engine should render a notebook. If two engines have support for a\nnotebook, the one listed earlier will be chosen. Quarto’s default order\nis ‘knitr’, ‘jupyter’, ‘markdown’, ‘julia’."
   ],
   "schema/external-schemas.yml": [
     {
@@ -17168,12 +17184,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 194269,
+    "_internalId": 194327,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 194261,
+        "_internalId": 194319,
         "type": "enum",
         "enum": [
           "png",
@@ -17189,7 +17205,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 194268,
+        "_internalId": 194326,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/filters/main.lua
+++ b/src/resources/filters/main.lua
@@ -61,6 +61,7 @@ import("./quarto-init/knitr-fixup.lua")
 import("./quarto-post/render-asciidoc.lua")
 import("./quarto-post/book.lua")
 import("./quarto-post/cites.lua")
+import("./quarto-post/cell-renderings.lua")
 import("./quarto-post/delink.lua")
 import("./quarto-post/docx.lua")
 import("./quarto-post/fig-cleanup.lua")
@@ -392,6 +393,10 @@ local quarto_post_filters = {
       bibliography()
     },
     traverser = 'jog',
+  },
+  { name = "post-choose-cell_renderings",
+    filter = choose_cell_renderings(),
+    flags = { "has_renderings" },
   },
   { name = "post-landscape-div",
     filter = landscape_div(),

--- a/src/resources/filters/normalize/flags.lua
+++ b/src/resources/filters/normalize/flags.lua
@@ -109,6 +109,11 @@ function compute_flags()
             flags.needs_output_unrolling = true
           end
         end
+
+        -- cell-renderings.lua
+        if node.attributes["renderings"] then
+          flags.has_renderings = true
+        end
       end
     end,
     CodeBlock = function(node)

--- a/src/resources/filters/quarto-post/cell-renderings.lua
+++ b/src/resources/filters/quarto-post/cell-renderings.lua
@@ -1,0 +1,57 @@
+function choose_cell_renderings()
+  function jsonDecodeArray(json)
+    if json:sub(1, 1) == '[' then
+      return quarto.json.decode(json)
+    elseif json:sub(1, 1) == '{' then
+      quarto.log.warning('expected array or scalar', json)
+    else
+      return {json}
+    end
+  end
+  
+  return {
+    Div = function(div)
+      -- Only process cell div with renderings attr
+      if not div.classes:includes("cell") or not div.attributes["renderings"] then
+        return nil
+      end
+      local renderingsJson = div.attributes['renderings']
+      local renderings = jsonDecodeArray(renderingsJson)
+      if not type(renderings) == "table" or #renderings == 0 then
+        quarto.log.warning("renderings expected array of rendering names, got", renderings)
+        return nil
+      end
+      local cods = {}
+      local firstCODIndex = nil
+      for i, cellOutput in ipairs(div.content) do
+        if cellOutput.classes:includes("cell-output-display") then
+          if not firstCODIndex then
+            firstCODIndex = i
+          end
+          table.insert(cods, cellOutput)
+        end
+      end
+    
+      if #cods ~= #renderings then
+        quarto.log.warning("need", #renderings, "cell-output-display for renderings", table.concat(renderings, ",") .. ";", "got", #cods)
+        return nil
+      end
+    
+      local outputs = {}
+      for i, r in ipairs(renderings) do
+        outputs[r] = cods[i]
+      end
+      local lightDiv = outputs['light']
+      local darkDiv = outputs['dark']
+      local blocks = pandoc.Blocks({table.unpack(div.content, 1, firstCODIndex - 1)})
+      if quarto.format.isHtmlOutput() and lightDiv and darkDiv then
+        blocks:insert(pandoc.Div(lightDiv.content, pandoc.Attr("", {'light-content'}, {})))
+        blocks:insert(pandoc.Div(darkDiv.content, pandoc.Attr("", {'dark-content'}, {})))
+      else
+        blocks:insert(lightDiv or darkDiv)
+      end
+      div.content = blocks
+      return div
+    end
+  }
+end

--- a/src/resources/formats/html/bootstrap/dist/scss/_light-dark.scss
+++ b/src/resources/formats/html/bootstrap/dist/scss/_light-dark.scss
@@ -1,0 +1,7 @@
+body.quarto-light .dark-content {
+  display: none;
+}
+
+body.quarto-dark .light-content {
+  display: none;
+}

--- a/src/resources/formats/html/bootstrap/dist/scss/bootstrap.scss
+++ b/src/resources/formats/html/bootstrap/dist/scss/bootstrap.scss
@@ -1,7 +1,6 @@
 @import "mixins/banner";
 @include bsBanner("");
 
-
 // scss-docs-start import-stack
 // Configuration
 @import "variables-dark";
@@ -14,6 +13,7 @@
 @import "type";
 @import "images";
 @import "containers";
+@import "light-dark";
 @import "grid";
 @import "tables";
 @import "forms";

--- a/src/resources/schema/cell-attributes.yml
+++ b/src/resources/schema/cell-attributes.yml
@@ -10,6 +10,11 @@
   schema: string
   description: "Classes to apply to cell container"
 
+- name: renderings
+  schema:
+    arrayOf: string
+  description: "Array of rendering names"
+
 - name: tags
   tags:
     engine: jupyter

--- a/tests/docs/smoke-all/dark-mode/ggplot-brandless.qmd
+++ b/tests/docs/smoke-all/dark-mode/ggplot-brandless.qmd
@@ -1,0 +1,116 @@
+---
+title: "knitr dark mode - thematic"
+format:
+  html:
+    theme:
+      light: united
+      dark: slate
+    keep-md: true
+execute:
+  echo: false
+  warning: false
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        -
+          - 'body.quarto-light'
+          - 'div.cell div.light-content'
+          - 'div.cell div.dark-content'
+          - 'div.cell div.cell-code pre.code-with-copy'
+        - []
+---
+
+```{r}
+#| echo: false
+#| warning: false
+library(ggplot2)
+
+ggplot_theme <- function(bgcolor, fgcolor) {
+  theme_minimal(base_size = 11) %+%
+  theme(
+    panel.border = element_blank(),
+    panel.grid.major.y = element_blank(),
+    panel.grid.minor.y = element_blank(),
+    panel.grid.major.x = element_blank(),
+    panel.grid.minor.x = element_blank(),
+    text = element_text(colour = fgcolor),
+    axis.text = element_text(colour = fgcolor),
+    rect = element_rect(colour = bgcolor, fill = bgcolor),
+    plot.background = element_rect(fill = bgcolor, colour = NA),
+    axis.line = element_line(colour = fgcolor),
+    axis.ticks = element_line(colour = fgcolor)
+  )
+}
+
+united_theme <- ggplot_theme("#ffffff", "#333333")
+slate_theme <- ggplot_theme("#282B30", "#aaaaaa")
+
+colour_scale <- scale_colour_manual(values = c("darkorange", "purple", "cyan4"))
+```
+
+### no crossref, no caption
+
+```{r}
+#| renderings: [light, dark]
+theme_set(united_theme)
+ggplot(mtcars, aes(mpg, wt)) +
+  geom_point(aes(colour = factor(cyl))) + colour_scale
+theme_set(slate_theme)
+ggplot(mtcars, aes(mpg, wt)) +
+  geom_point(aes(colour = factor(cyl))) + colour_scale
+```
+
+### with crossref but no caption
+
+::: {#fig-thematic-ggplot}
+```{r}
+#| echo: true
+#| renderings:
+#|   - dark
+#|   - light
+theme_set(slate_theme)
+ggplot(mtcars, aes(mpg, disp)) +
+  geom_point(aes(colour = factor(cyl))) + colour_scale
+theme_set(united_theme)
+ggplot(mtcars, aes(mpg, disp)) +
+  geom_point(aes(colour = factor(cyl))) + colour_scale
+```
+:::
+
+### with caption but no crossref
+
+<div>
+
+```{r}
+#| renderings: [dark]
+theme_set(slate_theme)
+ggplot(mtcars, aes(mpg, disp)) +
+  geom_point(aes(colour = factor(cyl))) + colour_scale
+```
+
+thematic - base r graphics
+
+</div>
+
+## patchwork
+
+### with crossref and caption
+
+::: {#fig-thematic-patchwork}
+```{r}
+#| renderings: [light, dark]
+theme_set(united_theme)
+ggplot(mtcars, aes(mpg, hp)) +
+  geom_point(aes(colour = factor(cyl))) + colour_scale
+theme_set(slate_theme)
+ggplot(mtcars, aes(mpg, hp)) +
+  geom_point(aes(colour = factor(cyl))) + colour_scale
+```
+
+mtcars - mpg vs hp
+:::
+
+Here's a [link](https://example.com).
+
+{{< lipsum 3 >}}

--- a/tests/docs/smoke-all/dark-mode/matplotlib-brandless-defaultdark.qmd
+++ b/tests/docs/smoke-all/dark-mode/matplotlib-brandless-defaultdark.qmd
@@ -1,0 +1,196 @@
+---
+title: "jupyter dark mode - matplotlib"
+engine: jupyter
+format:
+  html:
+    theme:
+      dark: slate
+      light: united
+keep-md: true
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        -
+          - 'body.quarto-dark'
+          - 'div.cell div.light-content'
+          - 'div.cell div.dark-content'
+        - []
+---
+
+```{python}
+#| echo: false
+import yaml
+import tempfile
+import os
+
+def apply_mpl_colors(bgcolor, fgcolor, primarycolor):
+    fd, name = tempfile.mkstemp("mplstyle")
+    os.close(fd)
+    with open(name, "w") as out:
+        out.write("axes.facecolor: \"%s\"\n" % bgcolor)
+        out.write("axes.edgecolor: \"%s\"\n" % fgcolor)
+        out.write("axes.labelcolor: \"%s\"\n" % fgcolor)
+        out.write("axes.titlecolor: \"%s\"\n" % fgcolor)
+        out.write("figure.facecolor: \"%s\"\n" % bgcolor)
+        out.write("figure.edgecolor: \"%s\"\n" % fgcolor)
+        out.write("text.color: \"%s\"\n" % fgcolor)
+        out.write("xtick.color: \"%s\"\n" % fgcolor)
+        out.write("ytick.color: \"%s\"\n" % fgcolor)
+        # seems to require named color, is there a better way?
+        out.write("axes.prop_cycle: cycler('color', ['%s'])" % primarycolor)
+    plt.style.use(name)
+    os.unlink(name)
+
+def united_colors():
+    apply_mpl_colors("#ffffff", "#333333", "red")
+
+def slate_colors():
+    apply_mpl_colors("#282B30", "#aaaaaa", "white")
+```
+
+### No crossref or caption
+```{python}
+#| echo: false
+#| renderings: [light, dark]
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Parameters for the normal distribution
+mean = 0
+std_dev = 1
+
+# Generate data
+x = np.linspace(mean - 4*std_dev, mean + 4*std_dev, 1000)
+y = (1/(std_dev * np.sqrt(2 * np.pi))) * np.exp(-0.5 * ((x - mean) / std_dev)**2)
+
+# Plotting
+united_colors()
+plt.figure(figsize=(8, 5))
+plt.plot(x, y, label='Normal Distribution')
+plt.title('Normal Distribution Curve')
+plt.xlabel('X-axis')
+plt.ylabel('Probability Density')
+plt.legend()
+plt.grid(True)
+plt.show()
+
+slate_colors()
+plt.figure(figsize=(8, 5))
+plt.plot(x, y, label='Normal Distribution')
+plt.title('Normal Distribution Curve')
+plt.xlabel('X-axis')
+plt.ylabel('Probability Density')
+plt.legend()
+plt.grid(True)
+plt.show()
+```
+
+### With crossref but no caption
+
+::: {#fig-matplotlib-line}
+```{python}
+#| echo: false
+#| renderings: [light, dark]
+import matplotlib.pyplot as plt
+
+united_colors()
+plt.title("Hello")
+plt.plot([1,2,3])
+plt.grid(True)
+plt.show(block=False)
+
+slate_colors()
+plt.figure()
+plt.title("Hello")
+plt.plot([1,2,3])
+plt.grid(True)
+plt.show(block=False)
+```
+:::
+
+### With caption but no crossref
+
+::: {}
+```{python}
+#| echo: false
+#| renderings: [light, dark]
+
+# author: "anthropic claude-3-5-sonnet-20240620"
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Generate data points
+x = np.linspace(0, 2 * np.pi, 100)
+y = np.sin(x)
+
+united_colors()
+plt.figure(figsize=(10, 6))
+plt.plot(x, y)
+plt.title('Sine Wave')
+plt.xlabel('x')
+plt.ylabel('sin(x)')
+plt.grid(True)
+plt.axhline(y=0, color='k', linestyle='--')
+plt.axvline(x=0, color='k', linestyle='--')
+plt.show()
+
+slate_colors()
+plt.figure(figsize=(10, 6))
+plt.plot(x, y)
+plt.title('Sine Wave')
+plt.xlabel('x')
+plt.ylabel('sin(x)')
+plt.grid(True)
+plt.axhline(y=0, color='k', linestyle='--')
+plt.axvline(x=0, color='k', linestyle='--')
+plt.show()
+```
+matplotlib sine wave
+
+:::
+
+### With crossref and caption
+
+::: {#fig-matplotlib-cosine}
+```{python}
+#| echo: false
+#| renderings: [dark, light]
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Generate data points
+x = np.linspace(0, 2 * np.pi, 100)
+y = np.cos(x)
+
+# Create the plot
+slate_colors()
+plt.figure(figsize=(10, 6))
+plt.plot(x, y)
+plt.title('Cosine Wave')
+plt.xlabel('x')
+plt.ylabel('cos(x)')
+plt.grid(True)
+plt.axhline(y=0, color='k', linestyle='--')
+plt.axvline(x=0, color='k', linestyle='--')
+plt.show()
+
+united_colors()
+plt.figure(figsize=(10, 6))
+plt.plot(x, y)
+plt.title('Cosine Wave')
+plt.xlabel('x')
+plt.ylabel('cos(x)')
+plt.grid(True)
+plt.axhline(y=0, color='k', linestyle='--')
+plt.axvline(x=0, color='k', linestyle='--')
+plt.show()
+```
+
+matplotlib cosine wave
+:::
+
+Here's a [link](https://example.com).
+
+
+{{< lipsum 3 >}}

--- a/tests/docs/smoke-all/dark-mode/matplotlib-brandless.qmd
+++ b/tests/docs/smoke-all/dark-mode/matplotlib-brandless.qmd
@@ -1,0 +1,199 @@
+---
+title: "jupyter dark mode - matplotlib"
+engine: jupyter
+format:
+  html:
+    theme:
+      light: united
+      dark: slate
+keep-md: true
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        -
+          - 'body.quarto-light'
+          - 'div.cell div.light-content'
+          - 'div.cell div.dark-content'
+          - 'div.cell div.cell-code pre.code-with-copy'
+        - []
+---
+
+```{python}
+#| echo: false
+import yaml
+import tempfile
+import os
+
+def apply_mpl_colors(bgcolor, fgcolor, primarycolor):
+    fd, name = tempfile.mkstemp("mplstyle")
+    os.close(fd)
+    with open(name, "w") as out:
+        out.write("axes.facecolor: \"%s\"\n" % bgcolor)
+        out.write("axes.edgecolor: \"%s\"\n" % fgcolor)
+        out.write("axes.labelcolor: \"%s\"\n" % fgcolor)
+        out.write("axes.titlecolor: \"%s\"\n" % fgcolor)
+        out.write("figure.facecolor: \"%s\"\n" % bgcolor)
+        out.write("figure.edgecolor: \"%s\"\n" % fgcolor)
+        out.write("text.color: \"%s\"\n" % fgcolor)
+        out.write("xtick.color: \"%s\"\n" % fgcolor)
+        out.write("ytick.color: \"%s\"\n" % fgcolor)
+        # seems to require named color, is there a better way?
+        out.write("axes.prop_cycle: cycler('color', ['%s'])" % primarycolor)
+    plt.style.use(name)
+    os.unlink(name)
+
+def united_colors():
+    apply_mpl_colors("#ffffff", "#333333", "red")
+
+def slate_colors():
+    apply_mpl_colors("#282B30", "#aaaaaa", "white")
+```
+
+### No crossref or caption
+```{python}
+#| echo: false
+#| renderings: [light, dark]
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Parameters for the normal distribution
+mean = 0
+std_dev = 1
+
+# Generate data
+x = np.linspace(mean - 4*std_dev, mean + 4*std_dev, 1000)
+y = (1/(std_dev * np.sqrt(2 * np.pi))) * np.exp(-0.5 * ((x - mean) / std_dev)**2)
+
+# Plotting
+united_colors()
+plt.figure(figsize=(8, 5))
+plt.plot(x, y, label='Normal Distribution')
+plt.title('Normal Distribution Curve')
+plt.xlabel('X-axis')
+plt.ylabel('Probability Density')
+plt.legend()
+plt.grid(True)
+plt.show()
+
+slate_colors()
+plt.figure(figsize=(8, 5))
+plt.plot(x, y, label='Normal Distribution')
+plt.title('Normal Distribution Curve')
+plt.xlabel('X-axis')
+plt.ylabel('Probability Density')
+plt.legend()
+plt.grid(True)
+plt.show()
+```
+
+### With crossref but no caption
+
+And `echo: true`
+
+::: {#fig-matplotlib-line}
+```{python}
+#| echo: true
+#| renderings: [light, dark]
+import matplotlib.pyplot as plt
+
+united_colors()
+plt.title("Hello")
+plt.plot([1,2,3])
+plt.grid(True)
+plt.show(block=False)
+
+slate_colors()
+plt.figure()
+plt.title("Hello")
+plt.plot([1,2,3])
+plt.grid(True)
+plt.show(block=False)
+```
+:::
+
+### With caption but no crossref
+
+::: {}
+```{python}
+#| echo: false
+#| renderings: [light, dark]
+
+# author: "anthropic claude-3-5-sonnet-20240620"
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Generate data points
+x = np.linspace(0, 2 * np.pi, 100)
+y = np.sin(x)
+
+united_colors()
+plt.figure(figsize=(10, 6))
+plt.plot(x, y)
+plt.title('Sine Wave')
+plt.xlabel('x')
+plt.ylabel('sin(x)')
+plt.grid(True)
+plt.axhline(y=0, color='k', linestyle='--')
+plt.axvline(x=0, color='k', linestyle='--')
+plt.show()
+
+slate_colors()
+plt.figure(figsize=(10, 6))
+plt.plot(x, y)
+plt.title('Sine Wave')
+plt.xlabel('x')
+plt.ylabel('sin(x)')
+plt.grid(True)
+plt.axhline(y=0, color='k', linestyle='--')
+plt.axvline(x=0, color='k', linestyle='--')
+plt.show()
+```
+matplotlib sine wave
+
+:::
+
+### With crossref and caption
+
+::: {#fig-matplotlib-cosine}
+```{python}
+#| echo: false
+#| renderings: [dark, light]
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Generate data points
+x = np.linspace(0, 2 * np.pi, 100)
+y = np.cos(x)
+
+# Create the plot
+slate_colors()
+plt.figure(figsize=(10, 6))
+plt.plot(x, y)
+plt.title('Cosine Wave')
+plt.xlabel('x')
+plt.ylabel('cos(x)')
+plt.grid(True)
+plt.axhline(y=0, color='k', linestyle='--')
+plt.axvline(x=0, color='k', linestyle='--')
+plt.show()
+
+united_colors()
+plt.figure(figsize=(10, 6))
+plt.plot(x, y)
+plt.title('Cosine Wave')
+plt.xlabel('x')
+plt.ylabel('cos(x)')
+plt.grid(True)
+plt.axhline(y=0, color='k', linestyle='--')
+plt.axvline(x=0, color='k', linestyle='--')
+plt.show()
+```
+
+matplotlib cosine wave
+:::
+
+Here's a [link](https://example.com).
+
+
+{{< lipsum 3 >}}


### PR DESCRIPTION
Enables the cell attribute

```
#| renderings: [light, dark]
```

If the cell contains two `div.cell-output-display`, the content will be put in a `div.light-content` and a `div.dark-content` instead.

Then `.dark-content` is hidden when `body` has `.quarto-light`, and vice-versa.

To do:
 - [ ] <strike>Warn if caption or label on the same cell, as they won't work right</strike>
 - [x] Add `has_renderings` flag in `flags.lua` and check in `main.lua`
 - [x] Use `.quarto-dark` instead of `.quarto-light` if dark theme is default
