### PR TITLE
Remove multine error message from stack correctly

### DIFF
--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -344,8 +344,14 @@ Please consider reporting it at https://github.com/quarto-dev/quarto-cli. Thank 
     if (!message) {
       message = err.stack;
     } else {
-      message = message + "\n\nStack trace:\n" +
-        err.stack.split("\n").slice(1).join("\n");
+      const stackLines = err.stack.split("\n");
+      const firstAtLineIndex = stackLines.findIndex((line) =>
+        /^\s*at /.test(line)
+      );
+      if (firstAtLineIndex !== -1) {
+        const stackTrace = stackLines.slice(firstAtLineIndex).join("\n");
+        message = message + "\n\nStack trace:\n" + stackTrace;
+      }
     }
   }
 


### PR DESCRIPTION
````sh
❯ quarto convert "line 1

line 2

line 3

line 4"
ERROR: File not found: 'line 1

line 2

line 3

line 4'

Stack trace:
    at Command.actionHandler (file:///home/cderv/project/quarto-cli/src/command/convert/cmd.ts:54:13)
    at async Command.execute (https://deno.land/x/cliffy@v1.0.0-rc.3/command/command.ts:1948:7)
    at async Command.parseCommand (https://deno.land/x/cliffy@v1.0.0-rc.3/command/command.ts:1780:14)
    at async quarto (file:///home/cderv/project/quarto-cli/src/quarto.ts:190:5)
    at async file:///home/cderv/project/quarto-cli/src/quarto.ts:219:5
    at async file:///home/cderv/project/quarto-cli/src/core/main.ts:41:14
    at async mainRunner (file:///home/cderv/project/quarto-cli/src/core/main.ts:43:5)
    at async file:///home/cderv/project/quarto-cli/src/quarto.ts:209:3
````

I get this now on Linux

Previously it was 

`````sh
❯ quarto convert "line 1

line 2

line 3

line 4"
ERROR: File not found: 'line 1

line 2

line 3

line 4'

Stack trace:

line 2

line 3

line 4'
    at Command.actionHandler (file:///home/cderv/.local/share/qvm/versions/v1.6.42/bin/quarto.js:108237:15)
    at async Command.execute (file:///home/cderv/.local/share/qvm/versions/v1.6.42/bin/quarto.js:8111:13)
    at async Command.parseCommand (file:///home/cderv/.local/share/qvm/versions/v1.6.42/bin/quarto.js:8001:20)
    at async quarto (file:///home/cderv/.local/share/qvm/versions/v1.6.42/bin/quarto.js:126627:9)
    at async file:///home/cderv/.local/share/qvm/versions/v1.6.42/bin/quarto.js:126654:9
    at async mainRunner (file:///home/cderv/.local/share/qvm/versions/v1.6.42/bin/quarto.js:126519:9)
    at async file:///home/cderv/.local/share/qvm/versions/v1.6.42/bin/quarto.js:126645:5
````

(on Windows multiline input is not easy to add so I don't get the same error)

@cscheid do you think this is valid to remove anything in stack before first `  at` line ? 

