### PR TITLE
create project temp in correct directory and clean it up.

### DIFF
--- a/src/core/temp.ts
+++ b/src/core/temp.ts
@@ -56,8 +56,8 @@ export function globalTempContext() {
 
 export function createTempContext(options?: Deno.MakeTempOptions): TempContext {
   let dir: string | undefined = Deno.makeTempDirSync({
-    ...options,
     dir: tempDir,
+    ...options,
   });
 
   const tempContextCleanupHandlers: VoidFunction[] = [];

--- a/src/core/temp.ts
+++ b/src/core/temp.ts
@@ -55,6 +55,9 @@ export function globalTempContext() {
 }
 
 export function createTempContext(options?: Deno.MakeTempOptions): TempContext {
+  if (options?.dir) {
+    ensureDirSync(options?.dir);
+  }
   let dir: string | undefined = Deno.makeTempDirSync({
     dir: tempDir,
     ...options,

--- a/src/project/project-context.ts
+++ b/src/project/project-context.ts
@@ -265,7 +265,8 @@ export async function projectContext(
         }
 
         const temp = createTempContext({
-          dir: join(dir, ".quarto", "temp"),
+          dir: join(dir, ".quarto"),
+          prefix: "quarto-session-temp",
         });
         const result: ProjectContext = {
           resolveBrand: async (fileName?: string) =>
@@ -313,6 +314,7 @@ export async function projectContext(
           temp,
           cleanup: () => {
             result.diskCache.close();
+            temp.cleanup();
           },
         };
 


### PR DESCRIPTION
(cc @cderv)

We weren't cleaning quarto's temporary directories for projects properly, nor were we creating them where we expected. This fixes both issues.