### PR TITLE
revert snyk autoPR

### DIFF
--- a/src/webui/quarto-preview/deno.lock
+++ b/src/webui/quarto-preview/deno.lock
@@ -203,7 +203,7 @@
   "workspace": {
     "packageJson": {
       "dependencies": [
-        "npm:@fluentui/react-components@~9.60.0",
+        "npm:@fluentui/react-components@~9.48.0",
         "npm:@fluentui/react-icons@^2.0.201",
         "npm:@types/react-dom@^18.2.0",
         "npm:@types/react@^18.2.0",

--- a/src/webui/quarto-preview/package.json
+++ b/src/webui/quarto-preview/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@fluentui/react-icons": "^2.0.201",
-    "@fluentui/react-components": "~9.60.0",
+    "@fluentui/react-components": "~9.48.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "ansi-output": "^0.0.9"


### PR DESCRIPTION
We need to revert https://github.com/quarto-dev/quarto-cli/pull/12320. The selected version causes a windows miscompilation in TS.

Thanks @cderv for spotting this.