### PR TITLE
typst - forward class and attributes on codeblock in listing

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -51,6 +51,7 @@ All changes included in 1.7:
 - ([#11860](https://github.com/quarto-dev/quarto-cli/issues/11860)): ES6 modules that import other local JS modules in documents with `embed-resources: true` are now correctly embedded.
 - ([#1325](https://github.com/quarto-dev/quarto-cli/issues/1325)): Dark Mode pages should not flash light on reload. (Nor should Light Mode pages flash dark.)
 - ([#12307](https://github.com/quarto-dev/quarto-cli/issues/12307)): Tabsets using `tabby.js` in non-boostrap html (`theme: pandoc`, `theme: none` or `minimal: true`) now correctly render reactive content when `server: shiny` is used.
+- ([#12356](https://github.com/quarto-dev/quarto-cli/issues/12356)): Remove duplicate id in HTML document when using `#lst-` prefix label for using Quarto crossref.
 
 ## `pdf` format
 

--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -72,6 +72,7 @@ All changes included in 1.7:
 - ([#11676](https://github.com/quarto-dev/quarto-cli/pull/11676)): Convert unitless image widths from pixels to inches for column layouts.
 - ([#11835](https://github.com/quarto-dev/quarto-cli/issues/11835)): Take markdown structure into account when detecting minimum heading level.
 - ([#11964](https://github.com/quarto-dev/quarto-cli/issues/11964)): Using panel layout without a crossref label now correctly do not add an empty `#block[]` that was leading to an unnecessary space in output.
+- ([#12354](https://github.com/quarto-dev/quarto-cli/issues/12354)): CodeBlock in Listing with `#lst-` prefix are now correctly highlighted.
 
 ## Interactive Shiny Document
 

--- a/src/resources/filters/customnodes/floatreftarget.lua
+++ b/src/resources/filters/customnodes/floatreftarget.lua
@@ -1017,6 +1017,13 @@ end, function(float)
     -- Listings shouldn't emit centered blocks. 
     -- We don't know how to disable that right now using #show rules for #figures in template.
     content:insert(1, pandoc.RawBlock("typst", "#set align(left)"))
+
+    -- Classes and attributes for the CodeBlocks needs to be set from the parsed floats to the CodeBlock
+    local found_listing = get_node_from_float_and_type(float, "CodeBlock")
+    if found_listing then
+      found_listing.attr = merge_attrs(found_listing.attr, pandoc.Attr("", float.classes or {}, float.attributes or {}))
+    end
+
   end
 
   if float.has_subfloats then

--- a/src/resources/filters/customnodes/floatreftarget.lua
+++ b/src/resources/filters/customnodes/floatreftarget.lua
@@ -335,18 +335,6 @@ end, function(float)
     float.content.caption.long = float.caption_long
     float.content.attr = pandoc.Attr(float.identifier, float.classes or {}, float.attributes or {})
     return float.content
-  elseif float_type == "lst" then
-    local handle_code_block = function(codeblock)
-      codeblock.attr = merge_attrs(codeblock.attr, pandoc.Attr("", float.classes or {}, float.attributes or {}))
-      return codeblock
-    end
-    if float.content.t == "CodeBlock" then
-      float.content = handle_code_block(float.content)
-    else
-      float.content = _quarto.ast.walk(float.content, {
-        CodeBlock = handle_code_block
-      })
-    end
   end
 
   local fig_scap = attribute(float, kFigScap, nil)
@@ -630,19 +618,6 @@ _quarto.ast.add_renderer("FloatRefTarget", function(_)
   return _quarto.format.isHtmlOutput()
 end, function(float)
   decorate_caption_with_crossref(float)
-
-  ------------------------------------------------------------------------------------
-  -- Special handling for listings
-  local found_listing = get_node_from_float_and_type(float, "CodeBlock")
-  if found_listing then
-    found_listing.attr = merge_attrs(found_listing.attr, pandoc.Attr("", float.classes or {}, float.attributes or {}))
-    -- FIXME this seems to be necessary for our postprocessor to kick in
-    -- check this out later
-    found_listing.identifier = float.identifier
-  end
-
-  ------------------------------------------------------------------------------------
-  
   return float_reftarget_render_html_figure(float)
 end)
 
@@ -1017,13 +992,6 @@ end, function(float)
     -- Listings shouldn't emit centered blocks. 
     -- We don't know how to disable that right now using #show rules for #figures in template.
     content:insert(1, pandoc.RawBlock("typst", "#set align(left)"))
-
-    -- Classes and attributes for the CodeBlocks needs to be set from the parsed floats to the CodeBlock
-    local found_listing = get_node_from_float_and_type(float, "CodeBlock")
-    if found_listing then
-      found_listing.attr = merge_attrs(found_listing.attr, pandoc.Attr("", float.classes or {}, float.attributes or {}))
-    end
-
   end
 
   if float.has_subfloats then

--- a/src/resources/filters/quarto-pre/parsefiguredivs.lua
+++ b/src/resources/filters/quarto-pre/parsefiguredivs.lua
@@ -656,8 +656,8 @@ function parse_floatreftargets()
       end
       code.attr.attributes['lst-cap'] = nil
       
-      local attr = code.attr
-      -- code.attr = pandoc.Attr("", {}, {})
+      local attr = pandoc.Attr(code.identifier, code.attr.classes, code.attr.attributes)
+      code.attr = pandoc.Attr("", code.classes, code.attr.attributes)
       return construct({
         attr = attr,
         type = "Listing",
@@ -686,7 +686,7 @@ function parse_floatreftargets()
       end
       
       local attr = code.attr
-      code.attr = pandoc.Attr("", {}, {})
+      code.attr = pandoc.Attr("", code.classes, code.attr.attributes)
       return construct({
         attr = attr,
         type = "Listing",

--- a/tests/docs/smoke-all/2025/03/25/issue-12354.qmd
+++ b/tests/docs/smoke-all/2025/03/25/issue-12354.qmd
@@ -1,0 +1,20 @@
+---
+format: 
+  typst: default
+  html: default
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ['div#lst-1.listing', 'div#lst-2.listing']
+        - ['div#lst-1.sourceCode', 'div#lst-2.sourceCode']
+---
+
+```{#lst-1 .r filename="asdfoasdf.R" lst-cap="A listing." my-key="value"}
+print("Hello, world!")
+```
+
+
+```{#lst-2 .r lst-cap="A listing." my-key="value"}
+print("Hello, world!")
+```

--- a/tests/docs/smoke-all/crossrefs/float/latex/latex-listings-1.qmd
+++ b/tests/docs/smoke-all/crossrefs/float/latex/latex-listings-1.qmd
@@ -5,7 +5,7 @@ _quarto:
   tests:
     latex:
       ensureFileRegexMatches:
-        - []
+        - [Shaded]
         - []
 ---
 

--- a/tests/docs/smoke-all/crossrefs/float/typst/typst-listings-2.qmd
+++ b/tests/docs/smoke-all/crossrefs/float/typst/typst-listings-2.qmd
@@ -14,8 +14,13 @@ _quarto:
         - []
 ---
 
-```{#lst-customers .sql lst-cap="Customers Query"}
+::: {#lst-customers}
+
+```{.sql}
 SELECT * FROM Customers
 ```
+Customers Query
+
+:::
 
 Then we query the customers database (@lst-customers).


### PR DESCRIPTION
This ensure to have proper syntax highlighting.Welcome to the quarto GitHub repo!

this fixes #12354 