### PR TITLE
reflect dark brand in lua metadata

### DIFF
--- a/src/command/render/render-contexts.ts
+++ b/src/command/render/render-contexts.ts
@@ -614,7 +614,7 @@ async function resolveFormats(
 
     // resolve brand in project and forward it to format
     const brand = await project.resolveBrand(target.source);
-    mergedFormats[format].render.brand = brand?.light;
+    mergedFormats[format].render.brand = brand;
 
     // apply defaults from brand yaml under the metadata of the current format
     const brandFormatDefaults: Metadata =

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -110,6 +110,8 @@ export const kSelfContainedMath = "self-contained-math";
 export const kBiblioConfig = "biblio-config";
 export const kBodyClasses = "body-classes";
 export const kBrand = "brand";
+export const kLight = "light";
+export const kDark = "dark";
 
 export const kLatexAutoMk = "latex-auto-mk";
 export const kLatexAutoInstall = "latex-auto-install";

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -58,6 +58,7 @@ import {
   kCrossrefThmTitle,
   kCss,
   kCssPropertyProcessing,
+  kDark,
   kDfPrint,
   kDisplayName,
   kDownloadUrl,
@@ -123,6 +124,7 @@ import {
   kLatexTlmgrOpts,
   kLaunchBinderTitle,
   kLaunchDevContainerTitle,
+  kLight,
   kLinkExternalFilter,
   kLinkExternalIcon,
   kLinkExternalNewwindow,
@@ -453,6 +455,11 @@ export interface Format {
   extensions?: Record<string, unknown>;
 }
 
+export interface LightDarkBrand {
+  [kLight]?: Brand;
+  [kDark]?: Brand
+}
+
 export interface FormatRender {
   [kKeepTex]?: boolean;
   [kKeepTyp]?: boolean;
@@ -514,7 +521,7 @@ export interface FormatRender {
   [kValidateYaml]?: boolean;
   [kCanonicalUrl]?: boolean | string;
   [kBodyClasses]?: string;
-  [kBrand]?: Brand;
+  [kBrand]?: LightDarkBrand;
 }
 
 export interface FormatExecute {

--- a/src/format/reveal/format-reveal.ts
+++ b/src/format/reveal/format-reveal.ts
@@ -375,7 +375,7 @@ export function revealjsFormat() {
 }
 
 const determineRevealLogo = (format: Format): string | undefined => {
-  const brandData = format.render.brand?.processedData;
+  const brandData = format.render.brand?.light?.processedData;
   if (brandData?.logo) {
     const keys: ("medium" | "small" | "large")[] = ["medium", "small", "large"];
     // add slide logo if we have one
@@ -404,7 +404,7 @@ function revealMarkdownAfterBody(format: Format) {
       revealLogo = revealLogo.path;
     }
     if (["small", "medium", "large"].includes(revealLogo)) {
-      const brandData = format.render.brand?.processedData;
+      const brandData = format.render.brand?.light?.processedData;
       const logoInfo = brandData?.logo
         ?.[revealLogo as ("medium" | "small" | "large")];
       if (typeof logoInfo === "string") {

--- a/src/resources/filters/customnodes/callout.lua
+++ b/src/resources/filters/customnodes/callout.lua
@@ -252,6 +252,8 @@ function _callout_main()
       icon = attrs.fa_icon_typst
     end
     local brand = param("brand")
+    local brandMode = 'light'
+    brand = brand and brand[brandMode]
     if brand then
       local color = brand.processedData and brand.processedData.color
       if color and callout_theme_color_map[callout.type] and

--- a/src/resources/filters/modules/brand/brand.lua
+++ b/src/resources/filters/modules/brand/brand.lua
@@ -1,16 +1,18 @@
 -- brand.lua
 -- Copyright (C) 2020-2024 Posit Software, PBC
 
-local function get_color_css(name)
+local function get_color_css(brandMode, name)
+  assert(brandMode == 'light' or brandMode == 'dark')
   local brand = param("brand")
-  brand = brand and brand.processedData -- from src/core/brand/brand.ts
+  brand = brand and brand[brandMode] and brand[brandMode].processedData
   if not brand then return nil end
   local cssColor = brand.color[name]
   return cssColor
 end
 
-local function get_color(name)
-  local cssColor = get_color_css(name)
+local function get_color(brandMode, name)
+  assert(brandMode == 'light' or brandMode == 'dark')
+  local cssColor = get_color_css(brandMode, name)
   if not cssColor then return nil end
   if _quarto.format.isTypstOutput() then
     return _quarto.format.typst.css.output_color(_quarto.format.typst.css.parse_color(cssColor))
@@ -18,22 +20,10 @@ local function get_color(name)
   return cssColor
 end
 
-local function get_background_color(name, opacity)
+local function get_typography(brandMode, fontName)
+  assert(brandMode == 'light' or brandMode == 'dark')
   local brand = param("brand")
-  brand = brand and brand.processedData -- from src/core/brand/brand.ts
-  if not brand then return nil end
-  local cssColor = brand.color[name]
-  if not cssColor then return nil end
-  if _quarto.format.isTypstOutput() then
-    return _quarto.format.typst.css.output_color(_quarto.modules.typst.css.parse_color(cssColor), {unit = 'fraction', value = opacity})
-  end
-  -- todo: implement for html if useful
-  return cssColor
-end
-
-local function get_typography(fontName)
-  local brand = param("brand")
-  brand = brand and brand.processedData -- from src/core/brand/brand.ts
+  brand = brand and brand[brandMode] and brand[brandMode].processedData
   if not brand then return nil end
   local typography = brand.typography and brand.typography[fontName]
   if not typography then return nil end
@@ -41,7 +31,7 @@ local function get_typography(fontName)
   if type(typography) == 'string' then typography = {family = typography} end
   for k, v in pairs(typography) do
     if k == 'color' or k == 'background-color' then
-      typsted[k] = get_color(v) or _quarto.format.typst.css.output_color(_quarto.format.typst.css.parse_color(v))
+      typsted[k] = get_color(brandMode, v) or _quarto.format.typst.css.output_color(_quarto.format.typst.css.parse_color(v))
     elseif k == 'size' then
       local length = _quarto.format.typst.css.parse_length(v)
       if length and fontName == 'base' and length.unit == 'rem' then
@@ -58,9 +48,10 @@ local function get_typography(fontName)
   return typsted 
 end
 
-local function get_logo(name)
+local function get_logo(brandMode, name)
+  assert(brandMode == 'light' or brandMode == 'dark')
   local brand = param("brand")
-  brand = brand and brand.processedData -- from src/core/brand/brand.ts
+  brand = brand and brand[brandMode] and brand[brandMode].processedData
   if not brand then return nil end
   return brand.logo and (brand.logo[name] or brand.logo.images[name])
 end
@@ -68,7 +59,6 @@ end
 return {
   get_color_css = get_color_css,
   get_color = get_color,
-  get_background_color = get_background_color,
   get_typography = get_typography,
   get_logo = get_logo,
 }

--- a/src/resources/filters/modules/typst_css.lua
+++ b/src/resources/filters/modules/typst_css.lua
@@ -176,6 +176,8 @@ local typst_named_colors = {
   lime = '#01ff70',
 }
 
+local brandMode = 'light' --- ugh
+
 -- css can have fraction or percent
 -- typst can have int or percent
 -- what goes for opacity also goes for alpha
@@ -346,7 +348,7 @@ local function output_color(color, opacity, warnings)
       end
       color = parse_color(typst_named_colors[color.value] or css_named_colors[color.value])
     elseif color.type == 'brand' then
-      local cssColor = _quarto.modules.brand.get_color_css(color.value)
+      local cssColor = _quarto.modules.brand.get_color_css(brandMode, color.value)
       if not cssColor then
         output_warning(warnings, 'unknown brand color ' .. color.value)
         return nil
@@ -384,7 +386,7 @@ local function output_color(color, opacity, warnings)
         return nil
       end
     elseif color.type == 'brand' then
-      local cssColor = _quarto.modules.brand.get_color_css(color.value)
+      local cssColor = _quarto.modules.brand.get_color_css(brandMode, color.value)
       if not cssColor then
         output_warning(warnings, 'unknown brand color ' .. color.value)
         return nil
@@ -488,7 +490,7 @@ local css_lengths = {
   mm = passthrough,
   em = passthrough,
   rem = function(val, _, _, warnings)
-    local base = _quarto.modules.brand.get_typography('base')
+    local base = _quarto.modules.brand.get_typography(brandMode, 'base')
     if base and base.size then
       local base_size = parse_length(base.size)
       if not base_size then

--- a/src/resources/filters/quarto-post/dashboard.lua
+++ b/src/resources/filters/quarto-post/dashboard.lua
@@ -746,10 +746,10 @@ function render_dashboard()
           local which
           if pandoc.utils.type(logo) == 'Inlines' then 
             which = logo[1].text
-            local brandLogo = _quarto.modules.brand.get_logo(logo[1].text)
+            local brandLogo = _quarto.modules.brand.get_logo('light', logo[1].text)
             resolved = brandLogo and brandLogo.light
           elseif type(logo) == 'table' then
-            local brandLogo = _quarto.modules.brand.get_logo(logo.path[1].text)
+            local brandLogo = _quarto.modules.brand.get_logo('light', logo.path[1].text)
             if brandLogo then
               resolved = brandLogo.light
               if logo.alt then
@@ -763,9 +763,9 @@ function render_dashboard()
             end
           end
         else
-          logo = _quarto.modules.brand.get_logo('small')
-            or _quarto.modules.brand.get_logo('medium')
-            or _quarto.modules.brand.get_logo('large')
+          logo = _quarto.modules.brand.get_logo('light', 'small')
+            or _quarto.modules.brand.get_logo('light', 'medium')
+            or _quarto.modules.brand.get_logo('light', 'large')
           resolved = logo and logo.light
         end
         if resolved then

--- a/src/resources/filters/quarto-post/typst-brand-yaml.lua
+++ b/src/resources/filters/quarto-post/typst-brand-yaml.lua
@@ -59,14 +59,15 @@ function render_typst_brand_yaml()
   return {
     Pandoc = function(pandoc0)
       local brand = param('brand')
-      local raw_block_shown = false
+      local brandMode = 'light'
+      brand = brand and brand[brandMode]
       if brand and brand.processedData then
         -- color
         if brand.processedData.color and next(brand.processedData.color) then
           local brandColor = brand.processedData.color
           local colors = {}
           for name, _ in pairs(brandColor) do
-            colors[name] = _quarto.modules.brand.get_color(name)
+            colors[name] = _quarto.modules.brand.get_color(brandMode, name)
           end
           local decl = '#let brand-color = ' .. to_typst_dict_indent(colors)
           quarto.doc.include_text('in-header', decl)
@@ -93,7 +94,7 @@ function render_typst_brand_yaml()
           return key .. ': ' .. value .. ', '
         end
         -- typography
-        local base = _quarto.modules.brand.get_typography('base')
+        local base = _quarto.modules.brand.get_typography(brandMode, 'base')
         if base and next(base) then
             quarto.doc.include_text('in-header', table.concat({
               '#set text(',
@@ -112,7 +113,7 @@ function render_typst_brand_yaml()
           end
         end
 
-        local headings = _quarto.modules.brand.get_typography('headings')
+        local headings = _quarto.modules.brand.get_typography(brandMode, 'headings')
         if headings and next(headings) then
             quarto.doc.include_text('in-header', table.concat({
               '#show heading: set text(',
@@ -133,7 +134,7 @@ function render_typst_brand_yaml()
           end
         end
 
-        local monospaceInline = _quarto.modules.brand.get_typography('monospace-inline')
+        local monospaceInline = _quarto.modules.brand.get_typography(brandMode, 'monospace-inline')
         if monospaceInline and next(monospaceInline) then
             quarto.doc.include_text('in-header', table.concat({
               '#show raw.where(block: false): set text(',
@@ -152,7 +153,7 @@ function render_typst_brand_yaml()
           }))
         end
     
-        local monospaceBlock = _quarto.modules.brand.get_typography('monospace-block')
+        local monospaceBlock = _quarto.modules.brand.get_typography(brandMode, 'monospace-block')
         if monospaceBlock and next(monospaceBlock) then
           quarto.doc.include_text('in-header', table.concat({
             '#show raw.where(block: true): set text(',
@@ -181,8 +182,8 @@ function render_typst_brand_yaml()
           end
         end
 
-        local link = _quarto.modules.brand.get_typography('link')
-        local primaryColor = _quarto.modules.brand.get_color('primary')
+        local link = _quarto.modules.brand.get_typography(brandMode, 'link')
+        local primaryColor = _quarto.modules.brand.get_color(brandMode, 'primary')
         if link and next(link) or primaryColor then
           link = link or {}
           quarto.doc.include_text('in-header', table.concat({
@@ -209,21 +210,21 @@ function render_typst_brand_yaml()
         local foundLogo = null
          if logo then
           if type(logo) == 'string' then
-            foundLogo = _quarto.modules.brand.get_logo(logo) or {light={path=logo}}
+            foundLogo = _quarto.modules.brand.get_logo(brandMode, logo) or {light={path=logo}}
           elseif type(logo) == 'table' then
             for k, v in pairs(logo) do
               logoOptions[k] = v
             end
             if logo.path then
-              foundLogo =  _quarto.modules.brand.get_logo(logo.path) or {light={path=logo}}
+              foundLogo =  _quarto.modules.brand.get_logo(brandMode, logo.path) or {light={path=logo}}
             end
           end
         end
         if not foundLogo and brand.processedData.logo then
           local tries = {'large', 'small', 'medium'} -- low to high priority
-          foundLogo = _quarto.modules.brand.get_logo('medium')
-            or _quarto.modules.brand.get_logo('small')
-            or _quarto.modules.brand.get_logo('large')
+          foundLogo = _quarto.modules.brand.get_logo(brandMode, 'medium')
+            or _quarto.modules.brand.get_logo(brandMode, 'small')
+            or _quarto.modules.brand.get_logo(brandMode, 'large')
         end
         if foundLogo then
           if foundLogo.light then
@@ -299,12 +300,13 @@ function render_typst_brand_yaml()
       end
     end,
     Meta = function(meta)
+      local brandMode = 'light'
       -- it can contain the path but we want to store an object here
       if not meta.brand or pandoc.utils.type(meta.brand) == 'Inlines' then
         meta.brand = {}
       end
       meta.brand.typography = meta.brand.typography or {}
-      local base = _quarto.modules.brand.get_typography('base')
+      local base = _quarto.modules.brand.get_typography(brandMode, 'base')
       if base and next(base) then
         meta.brand.typography.base = {
           family = base.family,
@@ -312,8 +314,8 @@ function render_typst_brand_yaml()
         }
       end
 
-      local headings = _quarto.modules.brand.get_typography('headings')
-      local foregroundColor = _quarto.modules.brand.get_color('foreground')
+      local headings = _quarto.modules.brand.get_typography(brandMode, 'headings')
+      local foregroundColor = _quarto.modules.brand.get_color(brandMode, 'foreground')
       if headings and next(headings) or base and next(base) or foregroundColor then
         base = base or {}
         headings = headings or {}

--- a/src/resources/filters/quarto-pre/shortcodes-handlers.lua
+++ b/src/resources/filters/quarto-pre/shortcodes-handlers.lua
@@ -134,8 +134,12 @@ function initShortcodeHandlers()
     end
 
     if brandCommand == "color" then 
+      local brandMode = 'light'
+      if #args > 2 then
+        brandMode = read_arg(args, 3) or brandMode
+      end
       local color_name = read_arg(args, 2)
-      local color_value = brand.get_color(color_name)
+      local color_value = brand.get_color(brandMode, color_name)
       if color_value == nil then
         return warn_bad_brand_command()
       else

--- a/tests/docs/smoke-all/brand/test-01/test_brand.lua
+++ b/tests/docs/smoke-all/brand/test-01/test_brand.lua
@@ -1,6 +1,6 @@
 local brand = require("modules/brand/brand")
 
 function Pandoc(doc)
-  assert(brand.get_color("primary") == "#ff0000")
+  assert(brand.get_color("light", "primary") == "#ff0000")
   return doc
 end

--- a/tests/docs/smoke-all/dark-mode/ggplot-duobrand.qmd
+++ b/tests/docs/smoke-all/dark-mode/ggplot-duobrand.qmd
@@ -63,7 +63,10 @@ ggplot(mtcars, aes(mpg, wt)) +
 
 ### with crossref but no caption
 
+and `echo: true`
+
 ::: {#fig-thematic-ggplot}
+
 ```{r}
 #| echo: true
 #| renderings:
@@ -74,7 +77,9 @@ ggplot(mtcars, aes(mpg, disp)) +
 ggplot(mtcars, aes(mpg, disp)) +
   geom_point(aes(colour = factor(cyl))) + united_theme + colour_scale
 ```
+
 :::
+
 
 ### with caption but no crossref
 


### PR DESCRIPTION
`light` and/or `dark` brands provided to Lua filters via `param("brand")`.

Lua `_quarto.modules.brand` functions now take `'light'` or `'dark'` as first parameter.

This is a "pure" refactor, no new features.