### PR TITLE
project config can specify light and dark brand files

### DIFF
--- a/src/command/render/pandoc-html.ts
+++ b/src/command/render/pandoc-html.ts
@@ -101,7 +101,6 @@ export async function resolveSassBundles(
       const userBrand = bundle.user?.findIndex((layer) => layer === "brand");
       let cloned = false;
       if (userBrand && userBrand !== -1) {
-        // console.log('light brand order specified', userBrand, cloned);
         bundle = cloneDeep(bundle);
         cloned = true;
         bundle.user!.splice(userBrand, 1, ...(maybeBrandBundle?.user || []));
@@ -109,7 +108,6 @@ export async function resolveSassBundles(
       }
       const darkBrand = bundle.dark?.user?.findIndex((layer) => layer === "brand");
       if (darkBrand && darkBrand !== -1) {
-        // console.log('dark brand order specified', darkBrand, cloned);
         if (!cloned) {
           bundle = cloneDeep(bundle);
         }

--- a/tests/docs/playwright/html/dark-brand/project-light-dark/_quarto.yml
+++ b/tests/docs/playwright/html/dark-brand/project-light-dark/_quarto.yml
@@ -1,0 +1,5 @@
+project:
+  type: default
+brand:
+  dark: red-background.yml
+  light: blue-background.yml

--- a/tests/docs/playwright/html/dark-brand/project-light-dark/blue-background.yml
+++ b/tests/docs/playwright/html/dark-brand/project-light-dark/blue-background.yml
@@ -1,0 +1,3 @@
+color:
+  background: "#ccddff"
+  foreground: "#336644"

--- a/tests/docs/playwright/html/dark-brand/project-light-dark/brand-false.qmd
+++ b/tests/docs/playwright/html/dark-brand/project-light-dark/brand-false.qmd
@@ -1,0 +1,49 @@
+---
+title: "dark brand - ggplot"
+brand: false
+execute:
+  echo: false
+  warning: false
+---
+
+```{r}
+#| echo: false
+#| warning: false
+library(ggplot2)
+
+ggplot_theme <- function(bgcolor, fgcolor) {
+  theme_minimal(base_size = 11) %+%
+  theme(
+    panel.border = element_blank(),
+    panel.grid.major.y = element_blank(),
+    panel.grid.minor.y = element_blank(),
+    panel.grid.major.x = element_blank(),
+    panel.grid.minor.x = element_blank(),
+    text = element_text(colour = fgcolor),
+    axis.text = element_text(colour = fgcolor),
+    rect = element_rect(colour = bgcolor, fill = bgcolor),
+    plot.background = element_rect(fill = bgcolor, colour = NA),
+    axis.line = element_line(colour = fgcolor),
+    axis.ticks = element_line(colour = fgcolor)
+  )
+}
+
+brand_ggplot <- function(brand_yml) {
+  brand <- yaml::yaml.load_file(brand_yml)
+  ggplot_theme(brand$color$background, brand$color$foreground)
+}
+
+blue_theme <- brand_ggplot("blue-background.yml")
+red_theme <- brand_ggplot("red-background.yml")
+
+colour_scale <- scale_colour_manual(values = c("darkorange", "purple", "cyan4"))
+```
+
+
+```{r}
+#| renderings: [light, dark]
+ggplot(mtcars, aes(mpg, wt)) +
+  geom_point(aes(colour = factor(cyl))) + blue_theme + colour_scale
+ggplot(mtcars, aes(mpg, wt)) +
+  geom_point(aes(colour = factor(cyl))) + red_theme + colour_scale
+```

--- a/tests/docs/playwright/html/dark-brand/project-light-dark/brand-under-theme.qmd
+++ b/tests/docs/playwright/html/dark-brand/project-light-dark/brand-under-theme.qmd
@@ -1,0 +1,51 @@
+---
+title: "dark brand - ggplot"
+theme:
+  light: simplex
+  dark: cyborg # same effect as [brand, cyborg]
+execute:
+  echo: false
+  warning: false
+---
+
+```{r}
+#| echo: false
+#| warning: false
+library(ggplot2)
+
+ggplot_theme <- function(bgcolor, fgcolor) {
+  theme_minimal(base_size = 11) %+%
+  theme(
+    panel.border = element_blank(),
+    panel.grid.major.y = element_blank(),
+    panel.grid.minor.y = element_blank(),
+    panel.grid.major.x = element_blank(),
+    panel.grid.minor.x = element_blank(),
+    text = element_text(colour = fgcolor),
+    axis.text = element_text(colour = fgcolor),
+    rect = element_rect(colour = bgcolor, fill = bgcolor),
+    plot.background = element_rect(fill = bgcolor, colour = NA),
+    axis.line = element_line(colour = fgcolor),
+    axis.ticks = element_line(colour = fgcolor)
+  )
+}
+
+brand_ggplot <- function(brand_yml) {
+  brand <- yaml::yaml.load_file(brand_yml)
+  ggplot_theme(brand$color$background, brand$color$foreground)
+}
+
+blue_theme <- brand_ggplot("blue-background.yml")
+red_theme <- brand_ggplot("red-background.yml")
+
+colour_scale <- scale_colour_manual(values = c("darkorange", "purple", "cyan4"))
+```
+
+
+```{r}
+#| renderings: [light, dark]
+ggplot(mtcars, aes(mpg, wt)) +
+  geom_point(aes(colour = factor(cyl))) + blue_theme + colour_scale
+ggplot(mtcars, aes(mpg, wt)) +
+  geom_point(aes(colour = factor(cyl))) + red_theme + colour_scale
+```

--- a/tests/docs/playwright/html/dark-brand/project-light-dark/red-background.yml
+++ b/tests/docs/playwright/html/dark-brand/project-light-dark/red-background.yml
@@ -1,0 +1,3 @@
+color:
+  background: "#42070b"
+  foreground: "#cceedd"

--- a/tests/docs/playwright/html/dark-brand/project-light-dark/simple.qmd
+++ b/tests/docs/playwright/html/dark-brand/project-light-dark/simple.qmd
@@ -1,0 +1,48 @@
+---
+title: "dark brand - ggplot"
+execute:
+  echo: false
+  warning: false
+---
+
+```{r}
+#| echo: false
+#| warning: false
+library(ggplot2)
+
+ggplot_theme <- function(bgcolor, fgcolor) {
+  theme_minimal(base_size = 11) %+%
+  theme(
+    panel.border = element_blank(),
+    panel.grid.major.y = element_blank(),
+    panel.grid.minor.y = element_blank(),
+    panel.grid.major.x = element_blank(),
+    panel.grid.minor.x = element_blank(),
+    text = element_text(colour = fgcolor),
+    axis.text = element_text(colour = fgcolor),
+    rect = element_rect(colour = bgcolor, fill = bgcolor),
+    plot.background = element_rect(fill = bgcolor, colour = NA),
+    axis.line = element_line(colour = fgcolor),
+    axis.ticks = element_line(colour = fgcolor)
+  )
+}
+
+brand_ggplot <- function(brand_yml) {
+  brand <- yaml::yaml.load_file(brand_yml)
+  ggplot_theme(brand$color$background, brand$color$foreground)
+}
+
+blue_theme <- brand_ggplot("blue-background.yml")
+red_theme <- brand_ggplot("red-background.yml")
+
+colour_scale <- scale_colour_manual(values = c("darkorange", "purple", "cyan4"))
+```
+
+
+```{r}
+#| renderings: [light, dark]
+ggplot(mtcars, aes(mpg, wt)) +
+  geom_point(aes(colour = factor(cyl))) + blue_theme + colour_scale
+ggplot(mtcars, aes(mpg, wt)) +
+  geom_point(aes(colour = factor(cyl))) + red_theme + colour_scale
+```

--- a/tests/integration/playwright/tests/html-dark-mode-nojs.spec.ts
+++ b/tests/integration/playwright/tests/html-dark-mode-nojs.spec.ts
@@ -20,3 +20,14 @@ test('Light brand default, no JS', async ({ page }) => {
   await expect(locatr).toHaveClass('fullcontent quarto-light');
   await expect(locatr).toHaveCSS('background-color', 'rgb(252, 252, 252)');
 });
+
+
+test('Project dark brand default, no JS', async ({ page }) => {
+  // This document use a custom theme file that change the background color of the title banner
+  // Same user defined color should be used in both dark and light theme
+  await page.goto('./html/dark-brand/project-light-dark/simple.html');
+  const locatr = await page.locator('body').first();
+  await expect(locatr).toHaveClass('fullcontent quarto-dark');
+  await expect(locatr).toHaveCSS('background-color', 'rgb(66, 7, 11)');
+});
+

--- a/tests/integration/playwright/tests/html-dark-mode.spec.ts
+++ b/tests/integration/playwright/tests/html-dark-mode.spec.ts
@@ -1,26 +1,55 @@
 import { test, expect } from '@playwright/test';
 
-test('Dark and light brand after user themes', async ({ page }) => {
-  // This document use a custom theme file that change the background color of the title banner
-  // Same user defined color should be used in both dark and light theme
-  await page.goto('./html/dark-brand/brand-after-theme.html');
+async function check_red_blue(page) {
   const locatr = await page.locator('body').first();
   await expect(locatr).toHaveClass('fullcontent quarto-dark');
   await expect(locatr).toHaveCSS('background-color', 'rgb(66, 7, 11)');
   await page.locator("a.quarto-color-scheme-toggle").click();
   const locatr2 = await page.locator('body').first();
   await expect(locatr2).toHaveCSS('background-color', 'rgb(204, 221, 255)');
-});
+}
 
-
-test('Dark and light brand before user themes', async ({ page }) => {
-  // This document use a custom theme file that change the background color of the title banner
-  // Same user defined color should be used in both dark and light theme
-  await page.goto('./html/dark-brand/brand-before-theme.html');
+async function check_theme_overrides(page) {
   const locatr = await page.locator('body').first();
   await expect(locatr).toHaveClass('fullcontent quarto-light');
   await expect(locatr).toHaveCSS('background-color', 'rgb(252, 252, 252)');
   await page.locator("a.quarto-color-scheme-toggle").click();
   const locatr2 = await page.locator('body').first();
   await expect(locatr2).toHaveCSS('background-color', 'rgb(6, 6, 6)');
+}
+// themes used in these documents have background colors
+
+test('Dark and light brand after user themes', async ({ page }) => {
+  // brand overrides theme background color
+  await page.goto('./html/dark-brand/brand-after-theme.html');
+  await check_red_blue(page);
+});
+
+test('Dark and light brand before user themes', async ({ page }) => {
+  // theme will override brand
+  await page.goto('./html/dark-brand/brand-before-theme.html');
+  await check_theme_overrides(page);
+});
+
+// project tests
+
+test('Project specifies dark and light brands', async ({ page }) => {
+  await page.goto('./html/dark-brand/project-light-dark/simple.html');
+  await check_red_blue(page);
+});
+
+test('Project brand before user themes', async ({ page }) => {
+  // theme will override brand
+  await page.goto('./html/dark-brand/project-light-dark/brand-under-theme.html');
+  await check_theme_overrides(page);
+});
+
+test('Brand false remove project brand', async ({ page }) => {
+  // theme will override brand
+  await page.goto('./html/dark-brand/project-light-dark/brand-false.html');
+  const locatr = await page.locator('body').first();
+  await expect(locatr).toHaveClass('fullcontent quarto-light');
+  await expect(locatr).toHaveCSS('background-color', 'rgb(255, 255, 255)');
+  // no toggle
+  expect(await page.locator('a.quarto-color-scheme-toggle').count()).toEqual(0);
 });


### PR DESCRIPTION
Enables

```yaml
brand:
  light: light-brand.yml
  dark: dark-brand.yml
```

in project configuration (`_quarto.yml`)