### PR TITLE
knitr, markdown - Add new lines before creating cell output div

### DIFF
--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -409,7 +409,8 @@ knitr_hooks <- function(format, resourceDir, handledLanguages) {
     } else {
       # Newline first and after to ensure Pandoc Fenced Div is correctly parsed
       paste0(
-        options[["indent"]], "\n::: {", 
+        "\n",
+        options[["indent"]], "::: {", 
         labelId(label), paste(classes, collapse = " ") ,forwardAttr, "}\n", x, "\n", cell.cap ,
         options[["indent"]], ":::\n"
       )

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -407,10 +407,11 @@ knitr_hooks <- function(format, resourceDir, handledLanguages) {
     if (identical(options[["results"]], "asis") && !needCell) {
       x
     } else {
+      # Newline first and after to ensure Pandoc Fenced Div is correctly parsed
       paste0(
-        options[["indent"]], "::: {", 
+        options[["indent"]], "\n::: {", 
         labelId(label), paste(classes, collapse = " ") ,forwardAttr, "}\n", x, "\n", cell.cap ,
-        options[["indent"]], ":::"
+        options[["indent"]], ":::\n"
       )
     }
   })

--- a/tests/docs/julia/intermediate-markdown-output/output-cell-div.markdown.md.snapshot
+++ b/tests/docs/julia/intermediate-markdown-output/output-cell-div.markdown.md.snapshot
@@ -1,0 +1,24 @@
+---
+title: "Untitled"
+format: markdown
+keep-md: true
+engine: julia
+---
+
+This does it:
+
+::: {.cell execution_count=1}
+``` {.julia .cell-code}
+1 + 1
+```
+
+::: {.cell-output .cell-output-display execution_count=1}
+```
+2
+```
+:::
+:::
+
+
+Other content
+

--- a/tests/docs/julia/intermediate-markdown-output/output-cell-div.qmd
+++ b/tests/docs/julia/intermediate-markdown-output/output-cell-div.qmd
@@ -1,0 +1,12 @@
+---
+title: "Untitled"
+format: markdown
+keep-md: true
+engine: julia
+---
+
+This does it:
+```{julia}
+1 + 1
+```
+Other content

--- a/tests/docs/jupyter/intermediate-markdown-output/output-cell-div.markdown.md.snapshot
+++ b/tests/docs/jupyter/intermediate-markdown-output/output-cell-div.markdown.md.snapshot
@@ -1,0 +1,23 @@
+---
+title: "Untitled"
+format: markdown
+keep-md: true
+---
+
+This does it:
+
+::: {.cell execution_count=1}
+``` {.python .cell-code}
+1 + 1
+```
+
+::: {.cell-output .cell-output-display execution_count=1}
+```
+2
+```
+:::
+:::
+
+
+Other content
+

--- a/tests/docs/jupyter/intermediate-markdown-output/output-cell-div.qmd
+++ b/tests/docs/jupyter/intermediate-markdown-output/output-cell-div.qmd
@@ -1,0 +1,11 @@
+---
+title: "Untitled"
+format: markdown
+keep-md: true
+---
+
+This does it:
+```{python}
+1 + 1
+```
+Other content

--- a/tests/docs/knitr/intermediate-markdown-output/output-cell-div.markdown.md.snapshot
+++ b/tests/docs/knitr/intermediate-markdown-output/output-cell-div.markdown.md.snapshot
@@ -1,0 +1,25 @@
+---
+title: "Untitled"
+format: markdown
+keep-md: true
+---
+
+This does it:
+
+::: {.cell}
+
+```{.r .cell-code}
+1 + 1
+```
+
+::: {.cell-output .cell-output-stdout}
+
+```
+[1] 2
+```
+
+
+:::
+:::
+
+Other content

--- a/tests/docs/knitr/intermediate-markdown-output/output-cell-div.qmd
+++ b/tests/docs/knitr/intermediate-markdown-output/output-cell-div.qmd
@@ -1,0 +1,11 @@
+---
+title: "Untitled"
+format: markdown
+keep-md: true
+---
+
+This does it:
+```{r}
+1 + 1
+```
+Other content

--- a/tests/smoke/engine/intermediate-output-markdown.test.ts
+++ b/tests/smoke/engine/intermediate-output-markdown.test.ts
@@ -1,0 +1,29 @@
+import { dirname, join } from "path";
+import { ensureSnapshotMatches, noErrors, printsMessage } from "../../verify.ts";
+import { fileLoader } from "../../utils.ts";
+import { safeRemoveIfExists } from "../../../src/core/path.ts";
+import { testRender } from "../render/render.ts";
+
+// Define engines to test
+const engines = [
+  { name: "knitr" },
+  { name: "jupyter" },
+  { name: "julia" }
+];
+
+// Run tests for each engine
+engines.forEach(engine => {
+  // Test for engine
+  const inputQmd = fileLoader(engine.name, "intermediate-markdown-output")("output-cell-div.qmd", "markdown");
+  const md = join(dirname(inputQmd.input), "output-cell-div.markdown.md");
+  testRender(inputQmd.input, "markdown", true, [
+    noErrors,
+    // Lua Warning are in INFO
+    printsMessage({ level: "INFO", regex: /WARNING \(.*\)\s+The following string was found in the document: :::/, negate: true}),
+    ensureSnapshotMatches(md)
+  ], { 
+    teardown: async () => { 
+      safeRemoveIfExists(md); 
+    } });
+});
+


### PR DESCRIPTION
Otherwise this is not compatible with Pandoc's Markdown expecting empty new lines before a div

This contributes to fix warning seen in 
- https://github.com/quarto-dev/quarto-cli/issues/12361

And it makes **knitr** intermediate output more similar to Jupyter and Julia engine

Let's see if it breaks some test... 🤔 
