### PR TITLE
print error in tests when reading project fails

### DIFF
--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -52,6 +52,7 @@ export function findProjectOutputDir(projectdir: string | undefined) {
     // deno-lint-ignore no-explicit-any
     type = ((yaml as any).project as any).type;
   } catch (error) {
+    console.error(error);
     throw new Error("Failed to read quarto project YAML", error);
   }
   if (type === "book") {


### PR DESCRIPTION
cc @cderv 

When the project is invalid in a playwright test, the actual error is not printed. It just prints

```
Playwright tests are passing ... FAILED (1m56s)

 ERRORS 

Playwright tests are passing => ./integration/playwright-tests.test.ts:60:6
error: Error: Failed to read quarto project YAML
    throw new Error("Failed to read quarto project YAML", error);
          ^
    at findProjectOutputDir (file:///home/runner/work/quarto-cli/quarto-cli/tests/utils.ts:55:11)
    at outputForInput (file:///home/runner/work/quarto-cli/quarto-cli/tests/utils.ts:81:36)
    at cleanoutput (file:///home/runner/work/quarto-cli/quarto-cli/tests/smoke/render/render.ts:93:15)
    at fn (file:///home/runner/work/quarto-cli/quarto-cli/tests/integration/playwright-tests.test.ts:81:9)
```

It doesn't seem that the actual error makes it into the playwright report either.

I'm not sure if the second parameter to `new Error()` is valid; [according to MDN it should be `{cause: error}`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error#options).

I tried this but still I could not find the actual error, so I suggest printing it instead.

What do you think?

(Background: I am new to Quarto projects, and `quarto render` will succeed if the project does not have `project.type`, but tests will fail. I think it would be good if the error messages indicate the actual problem.)