### PR TITLE
Feature: `brand-mode` to choose light or dark brand in Typst

### DIFF
--- a/src/command/render/filters.ts
+++ b/src/command/render/filters.ts
@@ -9,6 +9,7 @@ import { existsSync } from "../../deno_ral/fs.ts";
 import {
   kBibliography,
   kBrand,
+  kBrandMode,
   kCitationLocation,
   kCiteMethod,
   kClearCellOptions,
@@ -909,6 +910,7 @@ const extractTypstFilterParams = (format: Format) => {
     [kTocIndent]: format.metadata[kTocIndent],
     [kLogo]: format.metadata[kLogo],
     [kCssPropertyProcessing]: format.metadata[kCssPropertyProcessing],
+    [kBrandMode]: format.metadata[kBrandMode],
     [kHtmlPreTagProcessing]: format.metadata[kHtmlPreTagProcessing],
   };
 };

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -141,6 +141,7 @@ export const kFontPaths = "font-paths";
 export const kHtmlTableProcessing = "html-table-processing";
 export const kHtmlPreTagProcessing = "html-pre-tag-processing";
 export const kCssPropertyProcessing = "css-property-processing";
+export const kBrandMode = "brand-mode";
 export const kUseRsvgConvert = "use-rsvg-convert";
 export const kValidateYaml = "validate-yaml";
 

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -15623,6 +15623,22 @@ try {
             description: "The paper size for the document.\n"
           },
           {
+            name: "brand-mode",
+            schema: {
+              enum: [
+                "light",
+                "dark"
+              ]
+            },
+            default: "light",
+            tags: {
+              formats: [
+                "typst"
+              ]
+            },
+            description: "The brand mode to use for rendering the Typst document, `light` or `dark`.\n"
+          },
+          {
             name: "layout",
             schema: {
               maybeArrayOf: "string"
@@ -20936,6 +20952,7 @@ try {
           "Number of matches to display (defaults to 20)",
           "Matches after which to collapse additional results",
           "Provide button for copying search link",
+          "When false, do not merge navbar crumbs into the crumbs in\n<code>search.json</code>.",
           "One or more keys that will act as a shortcut to launch search (single\ncharacters)",
           "One or more keys that will act as a shortcut to launch search (single\ncharacters)",
           "Whether to include search result parents when displaying items in\nsearch results (when possible).",
@@ -21096,6 +21113,7 @@ try {
           "Number of matches to display (defaults to 20)",
           "Matches after which to collapse additional results",
           "Provide button for copying search link",
+          "When false, do not merge navbar crumbs into the crumbs in\n<code>search.json</code>.",
           "One or more keys that will act as a shortcut to launch search (single\ncharacters)",
           "One or more keys that will act as a shortcut to launch search (single\ncharacters)",
           "Whether to include search result parents when displaying items in\nsearch results (when possible).",
@@ -23420,6 +23438,7 @@ try {
           "Number of matches to display (defaults to 20)",
           "Matches after which to collapse additional results",
           "Provide button for copying search link",
+          "When false, do not merge navbar crumbs into the crumbs in\n<code>search.json</code>.",
           "One or more keys that will act as a shortcut to launch search (single\ncharacters)",
           "One or more keys that will act as a shortcut to launch search (single\ncharacters)",
           "Whether to include search result parents when displaying items in\nsearch results (when possible).",
@@ -23773,6 +23792,7 @@ try {
           "Number of matches to display (defaults to 20)",
           "Matches after which to collapse additional results",
           "Provide button for copying search link",
+          "When false, do not merge navbar crumbs into the crumbs in\n<code>search.json</code>.",
           "One or more keys that will act as a shortcut to launch search (single\ncharacters)",
           "One or more keys that will act as a shortcut to launch search (single\ncharacters)",
           "Whether to include search result parents when displaying items in\nsearch results (when possible).",
@@ -24023,7 +24043,8 @@ try {
           "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
           "Manuscript configuration",
           "internal-schema-hack",
-          "List execution engines you want to give priority when determining\nwhich engine should render a notebook. If two engines have support for a\nnotebook, the one listed earlier will be chosen. Quarto\u2019s default order\nis \u2018knitr\u2019, \u2018jupyter\u2019, \u2018markdown\u2019, \u2018julia\u2019."
+          "List execution engines you want to give priority when determining\nwhich engine should render a notebook. If two engines have support for a\nnotebook, the one listed earlier will be chosen. Quarto\u2019s default order\nis \u2018knitr\u2019, \u2018jupyter\u2019, \u2018markdown\u2019, \u2018julia\u2019.",
+          "The brand mode to use for rendering the Typst document,\n<code>light</code> or <code>dark</code>."
         ],
         "schema/external-schemas.yml": [
           {
@@ -24252,12 +24273,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 194252,
+          _internalId: 194259,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 194244,
+              _internalId: 194251,
               type: "enum",
               enum: [
                 "png",
@@ -24273,7 +24294,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 194251,
+              _internalId: 194258,
               type: "anyOf",
               anyOf: [
                 {
@@ -31416,6 +31437,51 @@ ${tidyverseInfo(
   }
 
   // ../yaml-validation/validator.ts
+  function createNiceError(obj) {
+    const {
+      violatingObject,
+      source,
+      message
+    } = obj;
+    const locF = mappedIndexToLineCol(source);
+    let location;
+    try {
+      location = {
+        start: locF(violatingObject.start),
+        end: locF(violatingObject.end)
+      };
+    } catch (_e) {
+      location = {
+        start: { line: 0, column: 0 },
+        end: { line: 0, column: 0 }
+      };
+    }
+    const mapResult = source.map(violatingObject.start);
+    const fileName = mapResult ? mapResult.originalString.fileName : void 0;
+    return {
+      heading: message,
+      error: [],
+      info: {},
+      fileName,
+      location,
+      sourceContext: createSourceContext(violatingObject.source, {
+        start: violatingObject.start,
+        end: violatingObject.end
+      })
+    };
+  }
+  var NoExprTag = class extends Error {
+    constructor(violatingObject, source) {
+      super(`Unexpected !expr tag`);
+      this.name = "NoExprTag";
+      this.niceError = createNiceError({
+        violatingObject,
+        source,
+        message: "!expr tags are not allowed in Quarto outside of knitr code cells."
+      });
+    }
+    niceError;
+  };
   var ValidationContext = class {
     instancePath;
     root;
@@ -31806,6 +31872,9 @@ ${tidyverseInfo(
             return value.components[i];
           }
         }
+      }
+      if (value.result && typeof value.result === "object" && !Array.isArray(value.result) && value.result.tag === "!expr") {
+        throw new NoExprTag(value, value.source);
       }
       throw new InternalError(`Couldn't locate key ${key}`);
     };

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -8594,6 +8594,22 @@
       "description": "The paper size for the document.\n"
     },
     {
+      "name": "brand-mode",
+      "schema": {
+        "enum": [
+          "light",
+          "dark"
+        ]
+      },
+      "default": "light",
+      "tags": {
+        "formats": [
+          "typst"
+        ]
+      },
+      "description": "The brand mode to use for rendering the Typst document, `light` or `dark`.\n"
+    },
+    {
       "name": "layout",
       "schema": {
         "maybeArrayOf": "string"
@@ -13907,6 +13923,7 @@
     "Number of matches to display (defaults to 20)",
     "Matches after which to collapse additional results",
     "Provide button for copying search link",
+    "When false, do not merge navbar crumbs into the crumbs in\n<code>search.json</code>.",
     "One or more keys that will act as a shortcut to launch search (single\ncharacters)",
     "One or more keys that will act as a shortcut to launch search (single\ncharacters)",
     "Whether to include search result parents when displaying items in\nsearch results (when possible).",
@@ -14067,6 +14084,7 @@
     "Number of matches to display (defaults to 20)",
     "Matches after which to collapse additional results",
     "Provide button for copying search link",
+    "When false, do not merge navbar crumbs into the crumbs in\n<code>search.json</code>.",
     "One or more keys that will act as a shortcut to launch search (single\ncharacters)",
     "One or more keys that will act as a shortcut to launch search (single\ncharacters)",
     "Whether to include search result parents when displaying items in\nsearch results (when possible).",
@@ -16391,6 +16409,7 @@
     "Number of matches to display (defaults to 20)",
     "Matches after which to collapse additional results",
     "Provide button for copying search link",
+    "When false, do not merge navbar crumbs into the crumbs in\n<code>search.json</code>.",
     "One or more keys that will act as a shortcut to launch search (single\ncharacters)",
     "One or more keys that will act as a shortcut to launch search (single\ncharacters)",
     "Whether to include search result parents when displaying items in\nsearch results (when possible).",
@@ -16744,6 +16763,7 @@
     "Number of matches to display (defaults to 20)",
     "Matches after which to collapse additional results",
     "Provide button for copying search link",
+    "When false, do not merge navbar crumbs into the crumbs in\n<code>search.json</code>.",
     "One or more keys that will act as a shortcut to launch search (single\ncharacters)",
     "One or more keys that will act as a shortcut to launch search (single\ncharacters)",
     "Whether to include search result parents when displaying items in\nsearch results (when possible).",
@@ -16994,7 +17014,8 @@
     "Disambiguating year suffix in author-date styles (e.g.&nbsp;“a” in “Doe,\n1999a”).",
     "Manuscript configuration",
     "internal-schema-hack",
-    "List execution engines you want to give priority when determining\nwhich engine should render a notebook. If two engines have support for a\nnotebook, the one listed earlier will be chosen. Quarto’s default order\nis ‘knitr’, ‘jupyter’, ‘markdown’, ‘julia’."
+    "List execution engines you want to give priority when determining\nwhich engine should render a notebook. If two engines have support for a\nnotebook, the one listed earlier will be chosen. Quarto’s default order\nis ‘knitr’, ‘jupyter’, ‘markdown’, ‘julia’.",
+    "The brand mode to use for rendering the Typst document,\n<code>light</code> or <code>dark</code>."
   ],
   "schema/external-schemas.yml": [
     {
@@ -17223,12 +17244,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 194252,
+    "_internalId": 194259,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 194244,
+        "_internalId": 194251,
         "type": "enum",
         "enum": [
           "png",
@@ -17244,7 +17265,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 194251,
+        "_internalId": 194258,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/filters/modules/typst_css.lua
+++ b/src/resources/filters/modules/typst_css.lua
@@ -176,7 +176,7 @@ local typst_named_colors = {
   lime = '#01ff70',
 }
 
-local brandMode = 'light' --- ugh
+local brandMode = param('brand-mode') or 'light'
 
 -- css can have fraction or percent
 -- typst can have int or percent
@@ -748,6 +748,7 @@ local function expand_side_shorthand(items, context, warnings)
 end
 
 return {
+  set_brand_mode = set_brand_mode,
   parse_color = parse_color,
   parse_opacity = parse_opacity,
   output_color = output_color,

--- a/src/resources/filters/quarto-post/cell-renderings.lua
+++ b/src/resources/filters/quarto-post/cell-renderings.lua
@@ -47,6 +47,13 @@ function choose_cell_renderings()
       if quarto.format.isHtmlOutput() and lightDiv and darkDiv then
         blocks:insert(pandoc.Div(lightDiv.content, pandoc.Attr("", {'light-content'}, {})))
         blocks:insert(pandoc.Div(darkDiv.content, pandoc.Attr("", {'dark-content'}, {})))
+      elseif quarto.format.isTypstOutput() and lightDiv and darkDiv then
+        local brandMode = param('brand-mode') or 'light'
+        if brandMode == 'light' then
+          blocks:insert(lightDiv)
+        elseif brandMode == 'dark' then
+          blocks:insert(darkDiv)
+        end
       else
         blocks:insert(lightDiv or darkDiv)
       end

--- a/src/resources/filters/quarto-post/typst-brand-yaml.lua
+++ b/src/resources/filters/quarto-post/typst-brand-yaml.lua
@@ -59,7 +59,7 @@ function render_typst_brand_yaml()
   return {
     Pandoc = function(pandoc0)
       local brand = param('brand')
-      local brandMode = 'light'
+      local brandMode = param('brand-mode') or 'light'
       brand = brand and brand[brandMode]
       if brand and brand.processedData then
         -- color
@@ -300,7 +300,7 @@ function render_typst_brand_yaml()
       end
     end,
     Meta = function(meta)
-      local brandMode = 'light'
+      local brandMode = param('brand-mode') or 'light'
       -- it can contain the path but we want to store an object here
       if not meta.brand or pandoc.utils.type(meta.brand) == 'Inlines' then
         meta.brand = {}

--- a/src/resources/schema/document-layout.yml
+++ b/src/resources/schema/document-layout.yml
@@ -48,6 +48,15 @@
   description: |
     The paper size for the document.
 
+- name: brand-mode
+  schema:
+    enum: [light, dark]
+  default: light
+  tags:
+    formats: [typst]
+  description: |
+    The brand mode to use for rendering the Typst document, `light` or `dark`.
+
 - name: layout
   schema:
     maybeArrayOf: string

--- a/tests/docs/smoke-all/typst/brand-yaml/color/typst-css-duobrand-named-color-dark.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/color/typst-css-duobrand-named-color-dark.qmd
@@ -1,0 +1,39 @@
+---
+title: Translate brand named color references from CSS to Typst
+format:
+  typst:
+    keep-typ: true
+    brand-mode: dark
+brand:
+  light:
+    color:
+      palette:
+        dark-grey: "#444"
+        blue: "#82aeef"
+  dark:
+    color:
+      palette:
+        dark-grey: "#222"
+        blue: "#415777"
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - '#block\(fill: brand-color\.dark-grey\)\[\s*#set text\(fill: brand-color\.blue\);'
+          - 'blue: rgb\("#415777"\)'
+          - 'dark-grey: rgb\("#222"\)'
+        - []
+---
+
+
+```{=typst}
+// stopgap to make this look ok
+#set block(inset: 6pt)
+```
+
+:::{style="background-color: var(--brand-dark-grey); color: var(--brand-blue)"}
+This div is blue on dark grey.
+:::
+
+{{< lipsum 2 >}}

--- a/tests/docs/smoke-all/typst/brand-yaml/color/typst-css-duobrand-named-color.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/color/typst-css-duobrand-named-color.qmd
@@ -1,0 +1,38 @@
+---
+title: Translate brand named color references from CSS to Typst
+format:
+  typst:
+    keep-typ: true
+brand:
+  light:
+    color:
+      palette:
+        dark-grey: "#444"
+        blue: "#82aeef"
+  dark:
+    color:
+      palette:
+        dark-grey: "#222"
+        blue: "#415777"
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - '#block\(fill: brand-color\.dark-grey\)\[\s*#set text\(fill: brand-color\.blue\);'
+          - 'blue: rgb\("#82aeef"\)'
+          - 'dark-grey: rgb\("#444"\)'
+        - []
+---
+
+
+```{=typst}
+// stopgap to make this look ok
+#set block(inset: 6pt)
+```
+
+:::{style="background-color: var(--brand-dark-grey); color: var(--brand-blue)"}
+This div is blue on dark grey.
+:::
+
+{{< lipsum 2 >}}

--- a/tests/docs/smoke-all/typst/brand-yaml/color/typst-css-duobrand-wrong-named-color-dark.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/color/typst-css-duobrand-wrong-named-color-dark.qmd
@@ -1,0 +1,42 @@
+---
+title: Translate brand named color references from CSS to Typst
+format:
+  typst:
+    keep-typ: true
+    brand-mode: dark
+brand:
+  light:
+    color:
+      palette:
+        light-grey: "#444"
+        blue: "#82aeef"
+  dark:
+    color:
+      palette:
+        dark-grey: "#222"
+        blue: "#415777"
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'blue: rgb\("#415777"\)'
+          - 'dark-grey: rgb\("#222"\)'
+          - '#set text\(fill: brand-color\.blue\);'
+        -
+      printsMessage:
+        level: INFO
+        regex: 'unknown brand color light-grey'
+---
+
+
+```{=typst}
+// stopgap to make this look ok
+#set block(inset: 6pt)
+```
+
+:::{style="background-color: var(--brand-light-grey); color: var(--brand-blue)"}
+This div is blue on dark grey.
+:::
+
+{{< lipsum 2 >}}

--- a/tests/docs/smoke-all/typst/brand-yaml/color/typst-css-duobrand-wrong-named-color-light.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/color/typst-css-duobrand-wrong-named-color-light.qmd
@@ -1,0 +1,42 @@
+---
+title: Translate brand named color references from CSS to Typst
+format:
+  typst:
+    keep-typ: true
+    brand-mode: light
+brand:
+  light:
+    color:
+      palette:
+        light-grey: "#444"
+        blue: "#82aeef"
+  dark:
+    color:
+      palette:
+        dark-grey: "#222"
+        blue: "#415777"
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'blue: rgb\("#82aeef"\)'
+          - 'light-grey: rgb\("#444"\)'
+          - '#set text\(fill: brand-color\.blue\);'
+        -
+      printsMessage:
+        level: INFO
+        regex: 'unknown brand color dark-grey'
+---
+
+
+```{=typst}
+// stopgap to make this look ok
+#set block(inset: 6pt)
+```
+
+:::{style="background-color: var(--brand-dark-grey); color: var(--brand-blue)"}
+This div is blue on dark grey.
+:::
+
+{{< lipsum 2 >}}


### PR DESCRIPTION
As promised, this turned out to be quite simple once everything else was in place.

Filing as draft because
- [x] <strike>this needs a better name than `choose-brand`</strike>
- [x] some lingering cases in `typst_css.lua` where it needs access to `choose-brand` instead of hard-coded `brandMode = 'light'`
- [x] needs tests

Cases like 

https://github.com/quarto-dev/quarto-cli/blob/5df4e19e9edb5b1c7c894b033e37151c4fd8898b/tests/docs/smoke-all/typst/brand-yaml/color/typst-css-named-brand-color.qmd#L26-L28


