### PR TITLE
do not emit dark stylesheets when there is no dark brand

### DIFF
--- a/src/command/render/pandoc-html.ts
+++ b/src/command/render/pandoc-html.ts
@@ -123,12 +123,12 @@ export async function resolveSassBundles(
       }
       return bundle as SassBundle;
     });
-    if (!foundBrand.light || !foundBrand.dark) {
+    if (maybeBrandBundle && (!foundBrand.light || !foundBrand.dark)) {
       bundles.unshift({
         dependency,
         key: "brand",
-        user: !foundBrand.light && maybeBrandBundle?.user as SassLayer[] || [],
-        dark: !foundBrand.dark && maybeBrandBundle?.dark?.user && {
+        user: !foundBrand.light && maybeBrandBundle.user as SassLayer[] || [],
+        dark: !foundBrand.dark && maybeBrandBundle.dark?.user && {
               user: maybeBrandBundle.dark.user as SassLayer[],
               default: maybeBrandBundle.dark.default,
             } || undefined,

--- a/src/core/sass/brand.ts
+++ b/src/core/sass/brand.ts
@@ -582,14 +582,16 @@ export async function brandSassLayers(
     dark: []
   };
 
-  for (const layer of [sassLayers.light, sassLayers.dark]) {
-    layer.push({
-      defaults: '$theme: "brand" !default;',
-      uses: "",
-      functions: "",
-      mixins: "",
-      rules: "",
-    });
+  for (const mode of ["light", "dark"] as Array<"dark" | "light">) {
+    if (brand && brand[mode]) {
+      sassLayers[mode].push({
+        defaults: '$theme: "brand" !default;',
+        uses: "",
+        functions: "",
+        mixins: "",
+        rules: "",
+      });
+    }
   }
   if (brand?.light?.data.color) {
     sassLayers.light.push(brandColorLayer(brand?.light, nameMap));
@@ -658,10 +660,10 @@ export async function brandSassFormatExtras(
           key: "brand",
           dependency: "bootstrap",
           user: htmlSassBundleLayers.light,
-          dark: {
+          dark: htmlSassBundleLayers.dark.length ? {
             user: htmlSassBundleLayers.dark,
             default: darkModeDefault(format.metadata)
-          }
+          } : undefined
         },
       ],
     },

--- a/src/project/project-shared.ts
+++ b/src/project/project-shared.ts
@@ -602,18 +602,18 @@ export async function projectResolveBrand(
         let light, dark;
         if (typeof brand.light === "string") {
           light = await loadRelativeBrand(brand.light);
-        } else {
+        } else if (brand.light) {
           light = new Brand(
-            brand.light!,
+            brand.light,
             dirname(fileName),
             project.dir,
           );
         }
         if (typeof brand.dark === "string") {
           dark = await loadRelativeBrand(brand.dark);
-        } else {
+        } else if(brand.dark) {
           dark = new Brand(
-            brand.dark!,
+            brand.dark,
             dirname(fileName),
             project.dir,
           );

--- a/tests/docs/smoke-all/dark-mode/light-brand.qmd
+++ b/tests/docs/smoke-all/dark-mode/light-brand.qmd
@@ -1,0 +1,17 @@
+---
+format: html
+brand:
+  light: united-brand.yml
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - []
+        - ["link[href*=\"-dark-\"]"]
+---
+
+## Hello
+
+```markdown
+![asdf](asd.png)
+```

--- a/tests/docs/smoke-all/dark-mode/light-theme.qmd
+++ b/tests/docs/smoke-all/dark-mode/light-theme.qmd
@@ -1,0 +1,17 @@
+---
+format: html
+theme:
+  light: united
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - []
+        - ["link[href*=\"-dark-\"]"]
+---
+
+## Hello
+
+```markdown
+![asdf](asd.png)
+```

--- a/tests/docs/smoke-all/dark-mode/no-brand.qmd
+++ b/tests/docs/smoke-all/dark-mode/no-brand.qmd
@@ -1,0 +1,15 @@
+---
+format: html
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - []
+        - ["link[href*=\"-dark-\"]"]
+---
+
+## Hello
+
+```markdown
+![asdf](asd.png)
+```


### PR DESCRIPTION
Properly handle absent light or dark brand; do not emit empty light/dark brand bundles.

This fixes the syntax highlighting issue we were seeing. (But note the issue can still be seen with arrow syntax highlighting when JavaScript is disabled; see #12399.)