### PR TITLE
ask knitr to hold/coalesce echos when renderings is set

### DIFF
--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -124,6 +124,12 @@ knitr_hooks <- function(format, resourceDir, handledLanguages) {
     options
   }
 
+  # coalesce echos so that all code is displayed for renderings: [light, dark]
+  opts_hooks[["renderings"]] <- function(options){
+    options$fig.show = 'hold'
+    options
+  }
+
   opts_hooks[["collapse"]] <- function(options) {
     if (isTRUE(options[["collapse"]])) {
       comment <- options[["comment"]]

--- a/tests/docs/smoke-all/dark-mode/ggplot-brandless.qmd
+++ b/tests/docs/smoke-all/dark-mode/ggplot-brandless.qmd
@@ -63,7 +63,7 @@ ggplot(mtcars, aes(mpg, wt)) +
 
 ### with crossref but no caption
 
-::: {#fig-thematic-ggplot}
+::: {#fig-ggplot}
 ```{r}
 #| echo: true
 #| renderings:
@@ -89,15 +89,13 @@ ggplot(mtcars, aes(mpg, disp)) +
   geom_point(aes(colour = factor(cyl))) + colour_scale
 ```
 
-thematic - base r graphics
+ggplot - dark only
 
 </div>
 
-## patchwork
-
 ### with crossref and caption
 
-::: {#fig-thematic-patchwork}
+::: {#fig-ggplot-mpg-hp}
 ```{r}
 #| renderings: [light, dark]
 theme_set(united_theme)

--- a/tests/docs/smoke-all/dark-mode/ggplot-duobrand-echo.qmd
+++ b/tests/docs/smoke-all/dark-mode/ggplot-duobrand-echo.qmd
@@ -1,0 +1,74 @@
+---
+title: "knitr dark mode - ggplot"
+brand:
+  light: united-brand.yml
+  dark: slate-brand.yml
+execute:
+  echo: false
+  warning: false
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        -
+          - 'body.quarto-light'
+          - 'div.cell div.light-content'
+          - 'div.cell div.dark-content'
+          - 'div.cell div.cell-code pre.code-with-copy'
+        - []
+      ensureFileRegexMatches:
+        -
+          - 'united_theme <span class="sc">\+</span> colour_scale'
+          - 'slate_theme <span class="sc">\+</span> colour_scale'
+        - []
+---
+
+```{r}
+#| echo: false
+#| warning: false
+library(ggplot2)
+
+ggplot_theme <- function(bgcolor, fgcolor) {
+  theme_minimal(base_size = 11) %+%
+  theme(
+    panel.border = element_blank(),
+    panel.grid.major.y = element_blank(),
+    panel.grid.minor.y = element_blank(),
+    panel.grid.major.x = element_blank(),
+    panel.grid.minor.x = element_blank(),
+    text = element_text(colour = fgcolor),
+    axis.text = element_text(colour = fgcolor),
+    rect = element_rect(colour = bgcolor, fill = bgcolor),
+    plot.background = element_rect(fill = bgcolor, colour = NA),
+    axis.line = element_line(colour = fgcolor),
+    axis.ticks = element_line(colour = fgcolor)
+  )
+}
+
+brand_ggplot <- function(brand_yml) {
+  brand <- yaml::yaml.load_file(brand_yml)
+  ggplot_theme(brand$color$background, brand$color$foreground)
+}
+
+united_theme <- brand_ggplot("united-brand.yml")
+slate_theme <- brand_ggplot("slate-brand.yml")
+
+colour_scale <- scale_colour_manual(values = c("darkorange", "purple", "cyan4"))
+```
+
+### with crossref but no caption
+
+and `echo: true`
+
+::: {#fig-ggplot}
+
+```{r}
+#| echo: true
+#| renderings: [light, dark]
+ggplot(mtcars, aes(mpg, disp)) +
+  geom_point(aes(colour = factor(cyl))) + united_theme + colour_scale
+ggplot(mtcars, aes(mpg, disp)) +
+  geom_point(aes(colour = factor(cyl))) + slate_theme + colour_scale
+```
+
+:::

--- a/tests/docs/smoke-all/dark-mode/ggplot-duobrand.qmd
+++ b/tests/docs/smoke-all/dark-mode/ggplot-duobrand.qmd
@@ -65,7 +65,7 @@ ggplot(mtcars, aes(mpg, wt)) +
 
 and `echo: true`
 
-::: {#fig-thematic-ggplot}
+::: {#fig-ggplot}
 
 ```{r}
 #| echo: true
@@ -83,8 +83,6 @@ ggplot(mtcars, aes(mpg, disp)) +
 
 ### with caption but no crossref
 
-dark rendering only
-
 <div>
 
 ```{r}
@@ -93,15 +91,14 @@ ggplot(mtcars, aes(mpg, disp)) +
   geom_point(aes(colour = factor(cyl))) + slate_theme + colour_scale
 ```
 
-thematic - base r graphics
+ggplot - dark only
 
 </div>
 
-## patchwork
 
 ### with crossref and caption
 
-::: {#fig-thematic-patchwork}
+::: {#fig-ggplot-mpg-hp}
 ```{r}
 #| renderings: [light, dark]
 ggplot(mtcars, aes(mpg, hp)) +


### PR DESCRIPTION
fixes #12362

As suggested by @cderv, add a hook to knitr to hold/coalesce echos when `renderings` is set, so that echos are not interspersed with plot outputs. 

This makes knitr consistent with other engines, and allows all the code to be displayed with `renderings: [light, dark]`.