### PR TITLE
check - compare binary dependency versions strictly by default (#10047)

### DIFF
--- a/configuration
+++ b/configuration
@@ -7,6 +7,9 @@
 # but it also used when packaging (e.g. run configure.sh, then prepare-dist.sh, then package.sh)
 # deno_dom should match release at https://github.com/b-fuze/deno-dom/releases
 
+# NB: When these are updated, you must also update the versions
+# in src/command/check/check.ts
+
 # Binary dependencies
 export DENO=v1.46.3
 # TODO figure out where 0.1.41 apple silicon libs are available

--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -35,6 +35,7 @@ All changes included in 1.7:
 
 ## `quarto check`
 
+- ([#10047](https://github.com/quarto-dev/quarto-cli/issues/10047)): `quarto check` will now check binary dependency versions strictly by default. Use `quarto check --no-strict` to revert to old behavior.
 - ([#11608](https://github.com/quarto-dev/quarto-cli/pull/11608)): Do not issue error message when calling `quarto check info`.
 
 ## `quarto convert`

--- a/src/command/check/cmd.ts
+++ b/src/command/check/cmd.ts
@@ -9,6 +9,10 @@ import { check, enforceTargetType } from "./check.ts";
 
 export const checkCommand = new Command()
   .name("check")
+  .option(
+    "--no-strict",
+    "When set, will not fail if dependency versions don't match precisely",
+  )
   .arguments("[target:string]")
   .description(
     "Verify correct functioning of Quarto installation.\n\n" +
@@ -18,7 +22,8 @@ export const checkCommand = new Command()
   .example("Check Jupyter engine", "quarto check jupyter")
   .example("Check Knitr engine", "quarto check knitr")
   .example("Check installation and all engines", "quarto check all")
-  .action(async (_options: unknown, targetStr?: string) => {
+  // deno-lint-ignore no-explicit-any
+  .action(async (options: any, targetStr?: string) => {
     targetStr = targetStr || "all";
-    await check(enforceTargetType(targetStr));
+    await check(enforceTargetType(targetStr), options.strict);
   });


### PR DESCRIPTION
Adds `--no-strict` to `quarto check`, now uses strict version checking by default.

Closes #10047.