### PR TITLE
fix asciidoc code annotations following pandoc update

### DIFF
--- a/src/resources/filters/quarto-pre/code-annotation.lua
+++ b/src/resources/filters/quarto-pre/code-annotation.lua
@@ -529,10 +529,10 @@ function code_annotations()
             local dl
             if _quarto.format.isAsciiDocOutput() then
               local formatted = pandoc.List()
-              for _i,v in ipairs(items) do
+              for _,v in ipairs(items) do
                 local annotationMarker = v[1] .. ' '
                 local definition = v[2]
-                tprepend(definition.content, {annotationMarker})
+                tprepend(definition.content, {pandoc.RawInline('asciidoc', annotationMarker)})
                 formatted:insert(definition)
               end
               dl = pandoc.Div(formatted)

--- a/tests/docs/smoke-all/2023/01/26/asciidoc-annotated-code.qmd
+++ b/tests/docs/smoke-all/2023/01/26/asciidoc-annotated-code.qmd
@@ -4,8 +4,13 @@ format:
   asciidoc: default
 _quarto:
   tests:
-    asciidoc: default
+    asciidoc: 
+      ensureFileRegexMatches:
+        - ['\<1\> First set', 'plt\.show\(\) \<3\>']
+        - ['\+\+\<\+\+1\+\+\>\+\+']
 ---
+
+This also covers https://github.com/quarto-dev/quarto-cli/issues/12441
 
 ## Annotated Code
 


### PR DESCRIPTION
 - Fix the test 
 - Use `rawInline` now that pandoc 3.6.2 escape `<` with `++<`

fix #12441 - see more details there. 


No changelog added because this was only introduced following Pandoc update for 1.7? 