### PR TITLE
Use correct comment language syntax for the cell options in knitr engine file

### DIFF
--- a/tests/docs/smoke-all/2023/10/29/6985-b.qmd
+++ b/tests/docs/smoke-all/2023/10/29/6985-b.qmd
@@ -8,5 +8,5 @@ code-fold: true
 ```
 
 ```{js}
-#| file: script.js
+//| file: script.js
 ```

--- a/tests/docs/smoke-all/knitr/eng-sql.qmd
+++ b/tests/docs/smoke-all/knitr/eng-sql.qmd
@@ -2,6 +2,7 @@
 title: cell output display wrapping for sql engine
 engine: knitr
 format: html
+keep-md: true
 filters:
   - at: pre-quarto
     path: check-output-display.lua
@@ -15,8 +16,8 @@ dbWriteTable(con, "mtcars", mtcars)
 ```
 
 ```{sql}
-#| column: margin
-#| connection: con
+--| column: margin
+--| connection: con
 
 select cyl from mtcars limit 5
 ```

--- a/tests/docs/test-knitr-sql.qmd
+++ b/tests/docs/test-knitr-sql.qmd
@@ -28,7 +28,7 @@ ORDER BY manufacturer, displ DESC
 New way to write this option
 
 ```{sql}
-#| connection: con
+--| connection: con
 SELECT manufacturer, displ, cty
 FROM mpg
 ORDER BY manufacturer, displ DESC


### PR DESCRIPTION
This fixes the CI error we get since update to 0.52. 

This is related to change in 
- https://github.com/yihui/knitr/pull/2225

I'll follow up to see if we need to be less strict in **knitr** context 🤔 