### PR TITLE
don't loose DOCTYPE header in embed resource processing

### DIFF
--- a/src/core/pandoc/self-contained.ts
+++ b/src/core/pandoc/self-contained.ts
@@ -48,6 +48,7 @@ export const pandocIngestSelfContainedContent = async (
 
   // The raw html contents
   const contents = Deno.readTextFileSync(file);
+  const doctypeMatch = contents.match(/^<!DOCTYPE.*?>/);
   const dom = await parseHtml(contents);
   await bundleModules(dom, workingDir);
 
@@ -63,6 +64,9 @@ export const pandocIngestSelfContainedContent = async (
   cmd.push("--template", template);
   cmd.push("--output", filename);
   cmd.push("--metadata", "title=placeholder");
+  if (doctypeMatch) {
+    cmd.push("--variable", `doctype=${doctypeMatch[0]}`);
+  }
   cmd.push("--embed-resources");
   if (resourcePath && resourcePath.length) {
     cmd.push("--resource-path", resourcePath.join(":"));

--- a/src/core/pandoc/self-contained.ts
+++ b/src/core/pandoc/self-contained.ts
@@ -54,6 +54,9 @@ export const pandocIngestSelfContainedContent = async (
 
   const input: string[] = [];
   input.push("````````{=html}");
+  if (doctypeMatch) {
+    input.push(doctypeMatch[0]);
+  }
   input.push(dom.documentElement!.outerHTML);
   input.push("````````");
 
@@ -64,9 +67,6 @@ export const pandocIngestSelfContainedContent = async (
   cmd.push("--template", template);
   cmd.push("--output", filename);
   cmd.push("--metadata", "title=placeholder");
-  if (doctypeMatch) {
-    cmd.push("--variable", `doctype=${doctypeMatch[0]}`);
-  }
   cmd.push("--embed-resources");
   if (resourcePath && resourcePath.length) {
     cmd.push("--resource-path", resourcePath.join(":"));

--- a/src/resources/formats/html/pandoc-selfcontained/selfcontained.html
+++ b/src/resources/formats/html/pandoc-selfcontained/selfcontained.html
@@ -1,1 +1,2 @@
+$if(doctype)$$doctype$$endif$
 $body$

--- a/src/resources/formats/html/pandoc-selfcontained/selfcontained.html
+++ b/src/resources/formats/html/pandoc-selfcontained/selfcontained.html
@@ -1,2 +1,1 @@
-$if(doctype)$$doctype$$endif$
 $body$

--- a/tests/docs/smoke-all/2025/04/04/12295.qmd
+++ b/tests/docs/smoke-all/2025/04/04/12295.qmd
@@ -1,0 +1,28 @@
+---
+title: DOCTYPE is not lost when using embed-resources
+embed-resources: true
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - []
+        - []
+      ensureFileRegexMatches:
+        - ['\<\!DOCTYPE html\>'] 
+        - []
+    revealjs:
+      ensureHtmlElements:
+        - []
+        - []
+      ensureFileRegexMatches:
+        - ['\<\!DOCTYPE html\>'] 
+        - []
+---
+
+Example from https://github.com/quarto-dev/quarto-cli/issues/12295: Not having DOCTYPE lead to browser using a Quirk mode for CSS, and not applying the standard HTML5. 
+
+## Header
+
+```bash
+quarto render --help
+```


### PR DESCRIPTION
fix #12295


If a HTML file does not have DOCTYPE, then the browser are using Quirks mode and not applying standard HTML5 CSS. Hence the problem seen in #12295 

- https://developer.mozilla.org/en-US/docs/Glossary/Doctype
- https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode