### PR TITLE
Warn when `quarto render file.ipynb` (with no --execute) finds empty ipynb output cells.

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -140,6 +140,7 @@ All changes included in 1.7:
 
 ### `jupyter`
 
+- ([#10575](https://github.com/quarto-dev/quarto-cli/issues/10575)): Warn when rendering .ipynb files with `execute: false` and code cells without output.
 - ([#12114](https://github.com/quarto-dev/quarto-cli/issues/12114)): `JUPYTERCACHE` environment variable from [Jupyter cache CLI](https://jupyter-cache.readthedocs.io/en/latest/using/cli.html) is now respected by Quarto when `cache: true` is used. This environment variable allows to change the path of the cache directory.
 - ([#12374](https://github.com/quarto-dev/quarto-cli/issues/12374)): Detect language properly in Jupyter notebooks that lack the `language` field in their `kernelspec`s.
 - ([#12228](https://github.com/quarto-dev/quarto-cli/issues/12228)): `quarto render` will now fails if errors are detected at IPython display level. Setting `error: true` globally or at cell level will keep the error to show in output and not stop the rendering.

--- a/src/execute/jupyter/jupyter.ts
+++ b/src/execute/jupyter/jupyter.ts
@@ -111,6 +111,7 @@ import { runExternalPreviewServer } from "../../preview/preview-server.ts";
 import { onCleanup } from "../../core/cleanup.ts";
 import { projectOutputDir } from "../../project/project-shared.ts";
 import { assert } from "testing/asserts";
+import { warn } from "log";
 
 export const jupyterEngine: ExecutionEngine = {
   name: kJupyterEngine,
@@ -379,6 +380,12 @@ export const jupyterEngine: ExecutionEngine = {
 
     const nb = jupyterFromJSON(nbContents);
 
+    if (!execute && nb.cells.some((cell) => cell.execution_count === null)) {
+      // warn users that the notebook was not executed
+      warn(
+        `${options.target.input} contains unexecuted code cells. Use 'execute: true' to execute the notebook.`,
+      );
+    }
     // cells tagged 'shinylive' should be emmited as markdown
     fixupShinyliveCodeCells(nb);
 

--- a/tests/docs/jupyter/issue-10575.ipynb
+++ b/tests/docs/jupyter/issue-10575.ipynb
@@ -1,0 +1,32 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "format: html\n",
+        "---"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "print(\"Hello, world\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "name": "python3",
+      "language": "python",
+      "display_name": "Python 3 (ipykernel)",
+      "path": "/Users/cscheid/virtualenvs/homebrew-python3/share/jupyter/kernels/python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 4
+}

--- a/tests/smoke/jupyter/issue-10575.test.ts
+++ b/tests/smoke/jupyter/issue-10575.test.ts
@@ -1,0 +1,29 @@
+/*
+ * issue-10575.test.ts
+ * 
+ * https://github.com/quarto-dev/quarto-cli/issues/10575
+ *
+ * Copyright (C) 2023 Posit Software, PBC
+ */
+
+import { existsSync } from "../../../src/deno_ral/fs.ts";
+import { quarto } from "../../../src/quarto.ts";
+import { testQuartoCmd } from "../../test.ts";
+import { printsMessage } from "../../verify.ts";
+
+testQuartoCmd("render",
+  ["docs/jupyter/issue-10575.ipynb"],
+  [
+    printsMessage({level: "WARN", regex: /contains unexecuted code cells/}),
+  ],
+    {
+      teardown: async () => {
+        if (existsSync("docs/jupyter/issue-10575_files")) {
+          await Deno.remove("docs/jupyter/issue-10575_files", { recursive: true });
+        }
+        if (existsSync("docs/jupyter/issue-10575.html")) {
+          await Deno.remove("docs/jupyter/issue-10575.html");
+        }
+      },
+    },
+  );


### PR DESCRIPTION
Closes #10575.