### PR TITLE
Support more alias format in `quarto.doc.is_format()` and so in `when-format`

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -154,8 +154,13 @@ All changes included in 1.7:
 - ([#12365](https://github.com/quarto-dev/quarto-cli/pull/12365)): `brand color` shortcode takes an optional `brandMode` second parameter, default `light`.
 - ([#12453](https://github.com/quarto-dev/quarto-cli/issues/12453)): Expose `_quarto.modules.brand` as `quarto.brand` and add `has_mode()` function.
 
-## Lua API
+### Conditional Content
 
+- ([#4411](https://github.com/quarto-dev/quarto-cli/issues/12462)): Added support for new format and aliases in `when-format` and `unless-format`: `confluence`, `docusaurus` (and `docusaurus-md`), `email`, `dashboard`, `gfm`, `hugo` (and `hugo-md`).
+
+### Quarto Lua API
+
+- ([#4411](https://github.com/quarto-dev/quarto-cli/issues/12462)): `quarto.format.is_format` is now working as expected with support of more aliases: `confluence`, `docusaurus` (and `docusaurus-md`), `email`, `dashboard`, `gfm`, `hugo` (and `hugo-md`)
 - ([#12299](https://github.com/quarto-dev/quarto-cli/issues/12299)): `quarto.doc.pdf_engine()` now correctly returns the PDF engine used for the document. `quarto.doc.cite_method()` now returns `nil` if no citation method will be used (i.e. no references is the document set).
 
 ## Languages

--- a/src/resources/filters/customnodes/content-hidden.lua
+++ b/src/resources/filters/customnodes/content-hidden.lua
@@ -183,8 +183,8 @@ function propertiesMatch(properties, profiles)
   local tests = {
     { constants.kWhenMeta, check_meta, false },
     { constants.kUnlessMeta, check_meta, true },
-    { constants.kWhenFormat, _quarto.format.isFormat, false },
-    { constants.kUnlessFormat, _quarto.format.isFormat, true },
+    { constants.kWhenFormat, quarto.format.is_format, false },
+    { constants.kUnlessFormat, quarto.format.is_format, true },
     { constants.kWhenProfile, check_profile, false },
     { constants.kUnlessProfile, check_profile, true }
   }

--- a/src/resources/pandoc/datadir/_format.lua
+++ b/src/resources/pandoc/datadir/_format.lua
@@ -265,6 +265,22 @@ local function _main()
         return isMarkdownOutput()
       elseif to == "asciidoc" or to == "asciidoctor" then
         return isAsciiDocOutput()
+      elseif to == "confluence" then
+        return isConfluenceOutput()
+      elseif to == "docusaurus" or to == "docusaurus-md" then
+        return isDocusaurusOutput()  
+      elseif to == "email" then
+        return isEmailOutput()
+      elseif to == "dashboard" then
+        return isDashboardOutput()
+      elseif to == "gfm" then
+        return isGithubMarkdownOutput()
+      elseif to == "hugo-md" or to == 'hugo' then
+        return isHugoMarkdownOutput()
+      --[[ Not working yet
+      elseif to == "ipynb" then
+        return isIpynbOutput()
+      ]]--
       else
         return false
       end 
@@ -279,7 +295,7 @@ local function _main()
     isRawLatex = isRawLatex,
     is_raw_latex = isRawLatex,
     isFormat = isFormat,
-    is_format = is_format,
+    is_format = isFormat,
     isLatexOutput = isLatexOutput,
     is_latex_output = isLatexOutput,
     isBeamerOutput = isBeamerOutput,

--- a/tests/docs/smoke-all/2023/09/22/beamer-numsec.qmd
+++ b/tests/docs/smoke-all/2023/09/22/beamer-numsec.qmd
@@ -3,11 +3,11 @@ title: Number Sections
 format: 
   beamer:
     number-sections: true
-    output-ext: tex
+keep-tex: true
 _quarto:
   tests:
     beamer:
-      ensureFileRegexMatches:
+      ensureLatexFileRegexMatches:
         - ['\{1 Section\}', '\{1[.]1 Subsection\}']
         - []
 ---

--- a/tests/docs/smoke-all/conditional-content/when-format.qmd
+++ b/tests/docs/smoke-all/conditional-content/when-format.qmd
@@ -74,7 +74,7 @@ _quarto:
         - ['Only visible in IPYNB']
         - ['Only visible in (?!IPYNB)']
     beamer:
-      ensureFileRegexMatches:
+      ensureLatexFileRegexMatches:
         - ['Only visible in BEAMER', 'Only visible in LATEX', 'Only visible in PDF']
         - ['Only visible in (?!BEAMER|LATEX|PDF)']
 ---

--- a/tests/docs/smoke-all/conditional-content/when-format.qmd
+++ b/tests/docs/smoke-all/conditional-content/when-format.qmd
@@ -1,0 +1,171 @@
+---
+title: Testing when-format
+keep-tex: true
+keep-typ: true
+_quarto:
+  tests:
+    latex:
+      ensureFileRegexMatches:
+        - ['Only visible in LATEX']
+        - ['Only visible in (?!LATEX|PDF)']
+    pdf:
+      ensureLatexFileRegexMatches:
+        - ['Only visible in LATEX', 'Only visible in PDF']
+        - ['Only visible in (?!LATEX|PDF)']
+    html:
+      ensureFileRegexMatches:
+        - ['Only visible in HTML', 'Only visible in HTMLJS']
+        - ['Only visible in (?!HTML)']
+    revealjs:
+      ensureFileRegexMatches:
+        - ['Only visible in HTML', 'Only visible in HTMLJS', 'Only visible in REVEALJS']
+        - ['Only visible in (?!HTML|REVEALJS)']
+
+    typst:
+      ensureTypstFileRegexMatches:
+        - ['Only visible in TYPST']
+        - ['Only visible in (?!TYPST)']
+    docx:
+      ensureDocxRegexMatches:
+        - ['Only visible in DOCX']
+        - ['Only visible in (?!DOCX)']
+    pptx:
+      ensurePptxRegexMatches:
+        - ['Only visible in PPTX']
+        - 2
+    docusaurus-md:
+      ensureFileRegexMatches:
+        - ['Only visible in DOCUSAURUS', 'Only visible in DOCUSAURUSMD', 'Only visible in MARKDOWN']
+        - ['Only visible in (?!DOCUSAURUS|MARKDOWN)']
+    hugo-md:
+      ensureFileRegexMatches:
+        - ['Only visible in HUGO', 'Only visible in MARKDOWN', 'Only visible in HUGOMD']
+        - ['Only visible in (?!HUGO|MARKDOWN)']
+    gfm:
+      ensureFileRegexMatches:
+        - ['Only visible in GFM', 'Only visible in MARKDOWN', 'Only visible in COMMONMARK']
+        - ['Only visible in (?!GFM|MARKDOWN|COMMONMARK)']
+    commonmark:
+      ensureFileRegexMatches:
+        - ['Only visible in COMMONMARK', 'Only visible in MARKDOWN']
+        - ['Only visible in (?!GFM|MARKDOWN|COMMONMARK)'] 
+    markdown:
+      ensureFileRegexMatches:
+        - ['Only visible in MARKDOWN']
+        - ['Only visible in (?!MARKDOWN)'] 
+    confluence-publish:
+      ensureFileRegexMatches:
+        - ['Only visible in CONFLUENCE']
+        - ['Only visible in (?!CONFLUENCE)'] 
+    asciidoc:
+      ensureFileRegexMatches:
+        - ['Only visible in ASCIIDOC']
+        - ['Only visible in (?!ASCIIDOC)'] 
+    dashboard:
+      ensureFileRegexMatches:
+        - ['Only visible in DASHBOARD', 'Only visible in HTML', 'Only visible in HTMLJS']
+        - ['Only visible in (?!HTML|DASHBOARD)']
+    email:
+      ensureFileRegexMatches:
+        - ['Only visible in EMAIL', 'Only visible in HTML', 'Only visible in HTMLJS']
+        - ['Only visible in (?!HTML|EMAIL)']
+    ipynb:
+      ensureFileRegexMatches:
+        - ['Only visible in IPYNB']
+        - ['Only visible in (?!IPYNB)']
+    beamer:
+      ensureFileRegexMatches:
+        - ['Only visible in BEAMER', 'Only visible in LATEX', 'Only visible in PDF']
+        - ['Only visible in (?!BEAMER|LATEX|PDF)']
+---
+
+::: {.content-visible when-format="html"}
+Only visible in HTML
+:::
+
+::: {.content-visible when-format="revealjs"}
+Only visible in REVEALJS
+:::
+
+::: {.content-visible when-format="html:js"}
+Only visible in HTMLJS
+:::
+
+::: {.content-visible when-format="latex"}
+Only visible in LATEX
+:::
+
+::: {.content-visible when-format="pdf"}
+Only visible in PDF
+:::
+
+::: {.content-visible when-format="typst"}
+Only visible in TYPST
+:::
+
+::: {.content-visible when-format="docx"}
+Only visible in DOCX
+:::
+
+::: {.content-visible when-format="pptx"}
+Only visible in PPTX
+:::
+
+::: {.content-visible when-format="epub"}
+Only visible in EPUB
+:::
+
+::: {.content-visible when-format="markdown"}
+Only visible in MARKDOWN
+:::
+
+::: {.content-visible when-format="gfm"}
+Only visible in GFM
+:::
+
+::: {.content-visible when-format="commonmark"}
+Only visible in COMMONMARK
+:::
+
+::: {.content-visible when-format="asciidoc"}
+Only visible in ASCIIDOC
+:::
+
+::: {.content-visible when-format="docusaurus"}
+Only visible in DOCUSAURUS
+:::
+
+::: {.content-visible when-format="docusaurus-md"}
+Only visible in DOCUSAURUSMD
+:::
+
+::: {.content-visible when-format="hugo"}
+Only visible in HUGO
+:::
+
+::: {.content-visible when-format="hugo-md"}
+Only visible in HUGOMD
+:::
+
+::: {.content-visible when-format="confluence"}
+Only visible in CONFLUENCE
+:::
+
+::: {.content-visible when-format="dashboard"}
+Only visible in DASHBOARD
+:::
+
+::: {.content-visible when-format="email"}
+Only visible in EMAIL
+:::
+
+::: {.content-visible when-format="ipynb"}
+Only visible in IPYNB
+:::
+
+::: {.content-visible when-format="beamer"}
+Only visible in BEAMER
+:::
+
+
+

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -109,8 +109,11 @@ export function outputForInput(
     outputExt = ext 
   } else {
     outputExt = baseFormat || "html";
-    if (baseFormat === "latex" || baseFormat == "context" || baseFormat == "beamer") {
+    if (baseFormat === "latex" || baseFormat == "context") {
       outputExt = "tex";
+    }
+    if (baseFormat === "beamer") {
+      outputExt = "pdf";
     }
     if (baseFormat === "revealjs") {
       outputExt = "html";

--- a/tests/verify.ts
+++ b/tests/verify.ts
@@ -17,7 +17,7 @@ import { readYamlFromString } from "../src/core/yaml.ts";
 import { ExecuteOutput, Verify } from "./test.ts";
 import { outputForInput } from "./utils.ts";
 import { unzip } from "../src/core/zip.ts";
-import { dirAndStem, which } from "../src/core/path.ts";
+import { dirAndStem, safeRemoveSync, which } from "../src/core/path.ts";
 import { isWindows } from "../src/deno_ral/platform.ts";
 import { execProcess } from "../src/core/process.ts";
 import { canonicalizeSnapshot, checkSnapshot } from "./verify-snapshot.ts";
@@ -488,7 +488,7 @@ export const verifyKeepFileRegexMatches = (
       try {
         await regexChecker(file, matches, noMatches);
       } finally {
-        await Deno.remove(file);
+        await safeRemoveSync(file);
       }
     }
     return verifyFileRegexMatches(keptFileChecker, `Inspecting intermediate ${keptFile} for Regex matches`)(keptFile, matchesUntyped, noMatchesUntyped);


### PR DESCRIPTION
partly close #4411

I am putting this here for later, considering full discussion in #4411 

Though I wanted to add this because I looked into it after the office hour. 

Basically this PR adds more alias based on our `is*Output()` Lua function. 

The problem still remains of having an exact match with the format in YAML for example. 

Also, jats is not working with conditional it seems 🤷‍♂️ 

