### PR TITLE
feature: dynamic prefers color scheme

### DIFF
--- a/src/resources/formats/html/templates/quarto-html-after-body.ejs
+++ b/src/resources/formats/html/templates/quarto-html-after-body.ejs
@@ -22,7 +22,8 @@
   
       window.document.body.appendChild(a);
     }
-    
+    window.setColorSchemeToggle(window.hasAlternateSentinel())
+
     <% } %>
   
     <% if (tabby) {  %>

--- a/src/resources/formats/html/templates/quarto-html-after-body.ejs
+++ b/src/resources/formats/html/templates/quarto-html-after-body.ejs
@@ -22,41 +22,7 @@
   
       window.document.body.appendChild(a);
     }
-  
-    const toggleGiscusIfUsed = (isAlternate, darkModeDefault) => {
-      const baseTheme = document.querySelector('#giscus-base-theme')?.value ?? 'light';
-      const alternateTheme = document.querySelector('#giscus-alt-theme')?.value ?? 'dark';
-  
-      let newTheme = '';
-  
-      if(darkModeDefault) {
-        newTheme = isAlternate ? baseTheme : alternateTheme;
-      } else {
-        newTheme = isAlternate ? alternateTheme : baseTheme;
-      }
-  
-      const changeGiscusTheme = () => {
-  
-        // From: https://github.com/giscus/giscus/issues/336
-        const sendMessage = (message) => {
-          const iframe = document.querySelector('iframe.giscus-frame');
-          if (!iframe) return;
-          iframe.contentWindow.postMessage({ giscus: message }, 'https://giscus.app');
-        }
-  
-        sendMessage({
-          setConfig: {
-            theme: newTheme
-          }
-        });
-      }
-  
-      const isGiscussLoaded = window.document.querySelector('iframe.giscus-frame') !== null;
-      if (isGiscussLoaded) {
-        changeGiscusTheme();
-      }
-    }
-  
+    
     <% } %>
   
     <% if (tabby) {  %>

--- a/src/resources/formats/html/templates/quarto-html-before-body.ejs
+++ b/src/resources/formats/html/templates/quarto-html-before-body.ejs
@@ -184,8 +184,11 @@
 
     <% if (respectUserColorScheme) { %>
     queryPrefersDark.addEventListener("change", e => {
+      if(window.localStorage.getItem("quarto-color-scheme") !== null)
+        return;
       const alternate = e.matches
       toggleColorMode(alternate);
+      localAlternateSentinel = e.matches ? 'alternate' : 'default'; // this is used alongside local storage!
       toggleGiscusIfUsed(alternate, darkModeDefault);
     });
     <% } %>

--- a/src/resources/formats/html/templates/quarto-html-before-body.ejs
+++ b/src/resources/formats/html/templates/quarto-html-before-body.ejs
@@ -128,10 +128,46 @@
         return localAlternateSentinel;
       }
     }
+    
+    const toggleGiscusIfUsed = (isAlternate, darkModeDefault) => {
+      const baseTheme = document.querySelector('#giscus-base-theme')?.value ?? 'light';
+      const alternateTheme = document.querySelector('#giscus-alt-theme')?.value ?? 'dark';
+  
+      let newTheme = '';
+  
+      if(darkModeDefault) {
+        newTheme = isAlternate ? baseTheme : alternateTheme;
+      } else {
+        newTheme = isAlternate ? alternateTheme : baseTheme;
+      }
+  
+      const changeGiscusTheme = () => {
+  
+        // From: https://github.com/giscus/giscus/issues/336
+        const sendMessage = (message) => {
+          const iframe = document.querySelector('iframe.giscus-frame');
+          if (!iframe) return;
+          iframe.contentWindow.postMessage({ giscus: message }, 'https://giscus.app');
+        }
+  
+        sendMessage({
+          setConfig: {
+            theme: newTheme
+          }
+        });
+      }
+  
+      const isGiscussLoaded = window.document.querySelector('iframe.giscus-frame') !== null;
+      if (isGiscussLoaded) {
+        changeGiscusTheme();
+      }
+    };
+
     <% if (respectUserColorScheme) { %>
-      const darkModeDefault = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const queryPrefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+    const darkModeDefault = queryPrefersDark.matches;
     <% } else { %>
-      const darkModeDefault = <%= darkModeDefault %>;
+    const darkModeDefault = <%= darkModeDefault %>;
     <% } %>
       
     let localAlternateSentinel = darkModeDefault ? 'alternate' : 'default';
@@ -144,6 +180,14 @@
       setStyleSentinel(toAlternate);
       toggleGiscusIfUsed(toAlternate, darkModeDefault);
     };
+
+    <% if (respectUserColorScheme) { %>
+    queryPrefersDark.addEventListener("change", e => {
+      const alternate = e.matches
+      toggleColorMode(alternate);
+      toggleGiscusIfUsed(alternate, darkModeDefault);
+    });
+    <% } %>
 
     // Switch to dark mode if need be
     if (hasAlternateSentinel()) {

--- a/src/resources/formats/html/templates/quarto-html-before-body.ejs
+++ b/src/resources/formats/html/templates/quarto-html-before-body.ejs
@@ -21,6 +21,20 @@
       }
     }
 
+    window.setColorSchemeToggle = (alternate) => {
+      const toggles = window.document.querySelectorAll('.quarto-color-scheme-toggle');
+      for (let i=0; i < toggles.length; i++) {
+        const toggle = toggles[i];
+        if (toggle) {
+          if (alternate) {
+            toggle.classList.add("alternate");
+          } else {
+            toggle.classList.remove("alternate");
+          }
+        }
+      }
+    };
+
     const toggleColorMode = (alternate) => {
       // Switch the stylesheets
       const primaryStylesheets = window.document.querySelectorAll('link.quarto-color-scheme:not(.quarto-color-alternate)');
@@ -42,17 +56,7 @@
       manageTransitions('#quarto-margin-sidebar .nav-link', true);
 
       // Switch the toggles
-      const toggles = window.document.querySelectorAll('.quarto-color-scheme-toggle');
-      for (let i=0; i < toggles.length; i++) {
-        const toggle = toggles[i];
-        if (toggle) {
-          if (alternate) {
-            toggle.classList.add("alternate");
-          } else {
-            toggle.classList.remove("alternate");
-          }
-        }
-      }
+      window.setColorSchemeToggle(alternate)
 
       // Hack to workaround the fact that safari doesn't
       // properly recolor the scrollbar when toggling (#1455)
@@ -99,7 +103,7 @@
       return window.location.protocol === 'file:';
     }
 
-    const hasAlternateSentinel = () => {
+    window.hasAlternateSentinel = () => {
       let styleSentinel = getColorSchemeSentinel();
       if (styleSentinel !== null) {
         return styleSentinel === "alternate";
@@ -172,7 +176,7 @@
     // Dark / light mode switch
     window.quartoToggleColorScheme = () => {
       // Read the current dark / light value
-      let toAlternate = !hasAlternateSentinel();
+      let toAlternate = !window.hasAlternateSentinel();
       toggleColorMode(toAlternate);
       setStyleSentinel(toAlternate);
       toggleGiscusIfUsed(toAlternate, darkModeDefault);
@@ -187,7 +191,7 @@
     <% } %>
 
     // Switch to dark mode if need be
-    if (hasAlternateSentinel()) {
+    if (window.hasAlternateSentinel()) {
       toggleColorMode(true);
     } else {
       toggleColorMode(false);

--- a/src/resources/formats/html/templates/quarto-html-before-body.ejs
+++ b/src/resources/formats/html/templates/quarto-html-before-body.ejs
@@ -21,9 +21,6 @@
       }
     }
 
-    toggleBodyColorPrimary();
-
-
     const toggleColorMode = (alternate) => {
       // Switch the stylesheets
       const primaryStylesheets = window.document.querySelectorAll('link.quarto-color-scheme:not(.quarto-color-alternate)');

--- a/tests/integration/playwright/tests/html-dark-mode-defaultdark.spec.ts
+++ b/tests/integration/playwright/tests/html-dark-mode-defaultdark.spec.ts
@@ -87,3 +87,21 @@ test('Project specifies dark and light brands, dynamic respect-user-color-scheme
   await expect(locatr).toHaveCSS('background-color', blue);
   await check_toggle(page, false);
 });
+
+
+test('Project specifies dark and light brands, do not respect-user-color-scheme after toggling', async ({ page }) => {
+  await page.goto('./html/dark-brand/project-dark/simple-respect-color-scheme.html');
+  const locatr = await page.locator('body').first();
+  await expect(locatr).toHaveClass(`fullcontent quarto-dark`);
+  await expect(locatr).toHaveCSS('background-color', red);
+  await check_toggle(page, true);
+
+  await check_backgrounds(page, 'quarto-dark', red, blue);
+  await check_backgrounds(page, 'quarto-light', blue, red);
+  await check_toggle(page, true);
+
+  await page.emulateMedia({ colorScheme: 'light' });
+  await expect(locatr).toHaveClass(`fullcontent quarto-dark`);
+  await expect(locatr).toHaveCSS('background-color', red);
+  await check_toggle(page, true);
+});

--- a/tests/integration/playwright/tests/html-dark-mode-defaultdark.spec.ts
+++ b/tests/integration/playwright/tests/html-dark-mode-defaultdark.spec.ts
@@ -15,6 +15,11 @@ async function check_backgrounds(page, class_, primary, secondary) {
   await expect(locatr2).toHaveCSS('background-color', secondary);
 }
 
+async function check_toggle(page, alternate) {
+  const locatr = await page.locator("a.quarto-color-scheme-toggle");
+  await expect(locatr).toHaveClass(`top-right quarto-color-scheme-toggle${alternate?" alternate":""}`)
+}
+
 test.use({
   colorScheme: 'dark'
 });
@@ -27,26 +32,34 @@ const red = 'rgb(66, 7, 11)';
 test('Dark and light brand after user themes', async ({ page }) => {
   // brand overrides theme background color
   await page.goto('./html/dark-brand/brand-after-theme.html');
+  await check_toggle(page, true);
   await check_backgrounds(page, 'quarto-dark', red, blue);
+  await check_toggle(page, false);
 });
 
 // project tests
 
 test('Project specifies light and dark brands', async ({ page }) => {
   await page.goto('./html/dark-brand/project-light/simple.html');
+  await check_toggle(page, false);
   await check_backgrounds(page, 'quarto-light', blue, red);
+  await check_toggle(page, true);
 });
 
 
 test('Project specifies dark and light brands', async ({ page }) => {
   await page.goto('./html/dark-brand/project-dark/simple.html');
+  await check_toggle(page, true);
   await check_backgrounds(page, 'quarto-dark', red, blue);
+  await check_toggle(page, false);
 });
 
 
 test('Project specifies light and dark brands and respect-user-color-scheme', async ({ page }) => {
   await page.goto('./html/dark-brand/project-light/simple-respect-color-scheme.html');
+  await check_toggle(page, true);
   await check_backgrounds(page, 'quarto-dark', red, blue);
+  await check_toggle(page, false);
 });
 
 test('Project specifies light and dark brands, dynamic respect-user-color-scheme', async ({ page }) => {
@@ -54,10 +67,12 @@ test('Project specifies light and dark brands, dynamic respect-user-color-scheme
   const locatr = await page.locator('body').first();
   await expect(locatr).toHaveClass(`fullcontent quarto-dark`);
   await expect(locatr).toHaveCSS('background-color', red);
+  await check_toggle(page, true);
 
   await page.emulateMedia({ colorScheme: 'light' });
   await expect(locatr).toHaveClass(`fullcontent quarto-light`);
   await expect(locatr).toHaveCSS('background-color', blue);
+  await check_toggle(page, false);
 });
 
 test('Project specifies dark and light brands, dynamic respect-user-color-scheme', async ({ page }) => {
@@ -65,8 +80,10 @@ test('Project specifies dark and light brands, dynamic respect-user-color-scheme
   const locatr = await page.locator('body').first();
   await expect(locatr).toHaveClass(`fullcontent quarto-dark`);
   await expect(locatr).toHaveCSS('background-color', red);
+  await check_toggle(page, true);
 
   await page.emulateMedia({ colorScheme: 'light' });
   await expect(locatr).toHaveClass(`fullcontent quarto-light`);
   await expect(locatr).toHaveCSS('background-color', blue);
+  await check_toggle(page, false);
 });

--- a/tests/integration/playwright/tests/html-dark-mode-defaultdark.spec.ts
+++ b/tests/integration/playwright/tests/html-dark-mode-defaultdark.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect } from '@playwright/test';
 
+async function check_background(page, class_, bkcolor) {
+  const locatr = await page.locator('body').first();
+  await expect(locatr).toHaveClass(`fullcontent ${class_}`);
+  await expect(locatr).toHaveCSS('background-color', bkcolor);
+}
+
 async function check_backgrounds(page, class_, primary, secondary) {
   const locatr = await page.locator('body').first();
   await expect(locatr).toHaveClass(`fullcontent ${class_}`);
@@ -15,7 +21,6 @@ test.use({
 
 const blue = 'rgb(204, 221, 255)';
 const red = 'rgb(66, 7, 11)';
-
 
 // brands used in these documents have background colors
 
@@ -44,8 +49,24 @@ test('Project specifies light and dark brands and respect-user-color-scheme', as
   await check_backgrounds(page, 'quarto-dark', red, blue);
 });
 
+test('Project specifies light and dark brands, dynamic respect-user-color-scheme', async ({ page }) => {
+  await page.goto('./html/dark-brand/project-light/simple-respect-color-scheme.html');
+  const locatr = await page.locator('body').first();
+  await expect(locatr).toHaveClass(`fullcontent quarto-dark`);
+  await expect(locatr).toHaveCSS('background-color', red);
 
-test('Project specifies dark and light brands and respect-user-color-scheme', async ({ page }) => {
+  await page.emulateMedia({ colorScheme: 'light' });
+  await expect(locatr).toHaveClass(`fullcontent quarto-light`);
+  await expect(locatr).toHaveCSS('background-color', blue);
+});
+
+test('Project specifies dark and light brands, dynamic respect-user-color-scheme', async ({ page }) => {
   await page.goto('./html/dark-brand/project-dark/simple-respect-color-scheme.html');
-  await check_backgrounds(page, 'quarto-dark', red, blue);
+  const locatr = await page.locator('body').first();
+  await expect(locatr).toHaveClass(`fullcontent quarto-dark`);
+  await expect(locatr).toHaveCSS('background-color', red);
+
+  await page.emulateMedia({ colorScheme: 'light' });
+  await expect(locatr).toHaveClass(`fullcontent quarto-light`);
+  await expect(locatr).toHaveCSS('background-color', blue);
 });

--- a/tests/integration/playwright/tests/html-dark-mode-defaultlight.spec.ts
+++ b/tests/integration/playwright/tests/html-dark-mode-defaultlight.spec.ts
@@ -9,6 +9,12 @@ async function check_backgrounds(page, class_, primary, secondary) {
   await expect(locatr2).toHaveCSS('background-color', secondary);
 }
 
+
+async function check_toggle(page, alternate) {
+  const locatr = await page.locator("a.quarto-color-scheme-toggle");
+  await expect(locatr).toHaveClass(`top-right quarto-color-scheme-toggle${alternate?" alternate":""}`)
+}
+
 test.use({
   colorScheme: 'light'
 });
@@ -21,31 +27,41 @@ const red = 'rgb(66, 7, 11)';
 test('Dark and light brand after user themes', async ({ page }) => {
   // brand overrides theme background color
   await page.goto('./html/dark-brand/brand-after-theme.html');
+  await check_toggle(page, true);
   await check_backgrounds(page, 'quarto-dark', red, blue);
+  await check_toggle(page, false);
 });
 
 // project tests
 
 test('Project specifies light and dark brands', async ({ page }) => {
   await page.goto('./html/dark-brand/project-light/simple.html');
+  await check_toggle(page, false);
   await check_backgrounds(page, 'quarto-light', blue, red);
+  await check_toggle(page, true);
 });
 
 
 test('Project specifies dark and light brands', async ({ page }) => {
   await page.goto('./html/dark-brand/project-dark/simple.html');
+  await check_toggle(page, true);
   await check_backgrounds(page, 'quarto-dark', red, blue);
+  await check_toggle(page, false);
 });
 
 
 test('Project specifies light and dark brands and respect-user-color-scheme', async ({ page }) => {
   await page.goto('./html/dark-brand/project-light/simple-respect-color-scheme.html');
+  await check_toggle(page, false);
   await check_backgrounds(page, 'quarto-light', blue, red);
+  await check_toggle(page, true);
 });
 
 test('Project specifies dark and light brands and respect-user-color-scheme', async ({ page }) => {
   await page.goto('./html/dark-brand/project-dark/simple-respect-color-scheme.html');
+  await check_toggle(page, false);
   await check_backgrounds(page, 'quarto-light', blue, red);
+  await check_toggle(page, true);
 });
 
 
@@ -54,10 +70,12 @@ test('Project specifies light and dark brands, dynamic respect-user-color-scheme
   const locatr = await page.locator('body').first();
   await expect(locatr).toHaveClass(`fullcontent quarto-light`);
   await expect(locatr).toHaveCSS('background-color', blue);
+  await check_toggle(page, false);
 
   await page.emulateMedia({ colorScheme: 'dark' });
   await expect(locatr).toHaveClass(`fullcontent quarto-dark`);
   await expect(locatr).toHaveCSS('background-color', red);
+  await check_toggle(page, true);
 });
 
 test('Project specifies dark and light brands, dynamic respect-user-color-scheme', async ({ page }) => {
@@ -65,8 +83,10 @@ test('Project specifies dark and light brands, dynamic respect-user-color-scheme
   const locatr = await page.locator('body').first();
   await expect(locatr).toHaveClass(`fullcontent quarto-light`);
   await expect(locatr).toHaveCSS('background-color', blue);
+  await check_toggle(page, false);
 
   await page.emulateMedia({ colorScheme: 'dark' });
   await expect(locatr).toHaveClass(`fullcontent quarto-dark`);
   await expect(locatr).toHaveCSS('background-color', red);
+  await check_toggle(page, true);
 });

--- a/tests/integration/playwright/tests/html-dark-mode-defaultlight.spec.ts
+++ b/tests/integration/playwright/tests/html-dark-mode-defaultlight.spec.ts
@@ -47,3 +47,26 @@ test('Project specifies dark and light brands and respect-user-color-scheme', as
   await page.goto('./html/dark-brand/project-dark/simple-respect-color-scheme.html');
   await check_backgrounds(page, 'quarto-light', blue, red);
 });
+
+
+test('Project specifies light and dark brands, dynamic respect-user-color-scheme', async ({ page }) => {
+  await page.goto('./html/dark-brand/project-light/simple-respect-color-scheme.html');
+  const locatr = await page.locator('body').first();
+  await expect(locatr).toHaveClass(`fullcontent quarto-light`);
+  await expect(locatr).toHaveCSS('background-color', blue);
+
+  await page.emulateMedia({ colorScheme: 'dark' });
+  await expect(locatr).toHaveClass(`fullcontent quarto-dark`);
+  await expect(locatr).toHaveCSS('background-color', red);
+});
+
+test('Project specifies dark and light brands, dynamic respect-user-color-scheme', async ({ page }) => {
+  await page.goto('./html/dark-brand/project-dark/simple-respect-color-scheme.html');
+  const locatr = await page.locator('body').first();
+  await expect(locatr).toHaveClass(`fullcontent quarto-light`);
+  await expect(locatr).toHaveCSS('background-color', blue);
+
+  await page.emulateMedia({ colorScheme: 'dark' });
+  await expect(locatr).toHaveClass(`fullcontent quarto-dark`);
+  await expect(locatr).toHaveCSS('background-color', red);
+});


### PR DESCRIPTION
This is a case of "it was easier to fix this than to document it the way it is".

We can watch the media query `prefers-color-scheme` in exactly the same way we watch the visual toggle.

<strike>This does not introduce any new FOUC. However we still have a FOUC on some browsers when toggling dark mode dynamically #12309.</strike> This turns out to be a `quarto preview` issue.

I am hesitant to merge this, but it would make documenting `respect-user-color-scheme` ***much*** easier if we don't have to say it's only on page load and not dynamic.

First let's see if tests pass. I have added a bunch of them in this PR.