### PR TITLE
Feature: document-level setting for `renderings`

### DIFF
--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -16792,6 +16792,13 @@ var require_yaml_intelligence_resources = __commonJS({
           description: "Theme name, theme scss file, or a mix of both."
         },
         {
+          name: "renderings",
+          schema: {
+            arrayOf: "string"
+          },
+          description: "Array of rendering names, e.g. `[light, dark]`"
+        },
+        {
           name: "body-classes",
           tags: {
             formats: [
@@ -23341,7 +23348,7 @@ var require_yaml_intelligence_resources = __commonJS({
         "Print a list of figures in the document.",
         "Print a list of tables in the document.",
         "Setting this to false prevents this document from being included in\nsearches.",
-        "Setting this to false prevents the <code>repo-actions</code> from\nappearing on this page.",
+        "Setting this to false prevents the <code>repo-actions</code> from\nappearing on this page. Other possible values are <code>none</code> or\none or more of <code>edit</code>, <code>source</code>, and\n<code>issue</code>, <em>e.g.</em>\n<code>[edit, source, issue]</code>.",
         {
           short: "Links to source repository actions",
           long: "Links to source repository actions (<code>none</code> or one or more\nof <code>edit</code>, <code>source</code>, <code>issue</code>)"
@@ -24061,7 +24068,8 @@ var require_yaml_intelligence_resources = __commonJS({
         "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
         "Manuscript configuration",
         "internal-schema-hack",
-        "List execution engines you want to give priority when determining\nwhich engine should render a notebook. If two engines have support for a\nnotebook, the one listed earlier will be chosen. Quarto\u2019s default order\nis \u2018knitr\u2019, \u2018jupyter\u2019, \u2018markdown\u2019, \u2018julia\u2019."
+        "List execution engines you want to give priority when determining\nwhich engine should render a notebook. If two engines have support for a\nnotebook, the one listed earlier will be chosen. Quarto\u2019s default order\nis \u2018knitr\u2019, \u2018jupyter\u2019, \u2018markdown\u2019, \u2018julia\u2019.",
+        "Array of rendering names, e.g.&nbsp;<code>[light, dark]</code>"
       ],
       "schema/external-schemas.yml": [
         {
@@ -24290,12 +24298,12 @@ var require_yaml_intelligence_resources = __commonJS({
         mermaid: "%%"
       },
       "handlers/mermaid/schema.yml": {
-        _internalId: 194627,
+        _internalId: 194632,
         type: "object",
         description: "be an object",
         properties: {
           "mermaid-format": {
-            _internalId: 194619,
+            _internalId: 194624,
             type: "enum",
             enum: [
               "png",
@@ -24311,7 +24319,7 @@ var require_yaml_intelligence_resources = __commonJS({
             exhaustiveCompletions: true
           },
           theme: {
-            _internalId: 194626,
+            _internalId: 194631,
             type: "anyOf",
             anyOf: [
               {

--- a/src/resources/editor/tools/yaml/web-worker.js
+++ b/src/resources/editor/tools/yaml/web-worker.js
@@ -16793,6 +16793,13 @@ try {
             description: "Theme name, theme scss file, or a mix of both."
           },
           {
+            name: "renderings",
+            schema: {
+              arrayOf: "string"
+            },
+            description: "Array of rendering names, e.g. `[light, dark]`"
+          },
+          {
             name: "body-classes",
             tags: {
               formats: [
@@ -23342,7 +23349,7 @@ try {
           "Print a list of figures in the document.",
           "Print a list of tables in the document.",
           "Setting this to false prevents this document from being included in\nsearches.",
-          "Setting this to false prevents the <code>repo-actions</code> from\nappearing on this page.",
+          "Setting this to false prevents the <code>repo-actions</code> from\nappearing on this page. Other possible values are <code>none</code> or\none or more of <code>edit</code>, <code>source</code>, and\n<code>issue</code>, <em>e.g.</em>\n<code>[edit, source, issue]</code>.",
           {
             short: "Links to source repository actions",
             long: "Links to source repository actions (<code>none</code> or one or more\nof <code>edit</code>, <code>source</code>, <code>issue</code>)"
@@ -24062,7 +24069,8 @@ try {
           "Disambiguating year suffix in author-date styles (e.g.&nbsp;\u201Ca\u201D in \u201CDoe,\n1999a\u201D).",
           "Manuscript configuration",
           "internal-schema-hack",
-          "List execution engines you want to give priority when determining\nwhich engine should render a notebook. If two engines have support for a\nnotebook, the one listed earlier will be chosen. Quarto\u2019s default order\nis \u2018knitr\u2019, \u2018jupyter\u2019, \u2018markdown\u2019, \u2018julia\u2019."
+          "List execution engines you want to give priority when determining\nwhich engine should render a notebook. If two engines have support for a\nnotebook, the one listed earlier will be chosen. Quarto\u2019s default order\nis \u2018knitr\u2019, \u2018jupyter\u2019, \u2018markdown\u2019, \u2018julia\u2019.",
+          "Array of rendering names, e.g.&nbsp;<code>[light, dark]</code>"
         ],
         "schema/external-schemas.yml": [
           {
@@ -24291,12 +24299,12 @@ try {
           mermaid: "%%"
         },
         "handlers/mermaid/schema.yml": {
-          _internalId: 194627,
+          _internalId: 194632,
           type: "object",
           description: "be an object",
           properties: {
             "mermaid-format": {
-              _internalId: 194619,
+              _internalId: 194624,
               type: "enum",
               enum: [
                 "png",
@@ -24312,7 +24320,7 @@ try {
               exhaustiveCompletions: true
             },
             theme: {
-              _internalId: 194626,
+              _internalId: 194631,
               type: "anyOf",
               anyOf: [
                 {

--- a/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
+++ b/src/resources/editor/tools/yaml/yaml-intelligence-resources.json
@@ -9764,6 +9764,13 @@
       "description": "Theme name, theme scss file, or a mix of both."
     },
     {
+      "name": "renderings",
+      "schema": {
+        "arrayOf": "string"
+      },
+      "description": "Array of rendering names, e.g. `[light, dark]`"
+    },
+    {
       "name": "body-classes",
       "tags": {
         "formats": [
@@ -16313,7 +16320,7 @@
     "Print a list of figures in the document.",
     "Print a list of tables in the document.",
     "Setting this to false prevents this document from being included in\nsearches.",
-    "Setting this to false prevents the <code>repo-actions</code> from\nappearing on this page.",
+    "Setting this to false prevents the <code>repo-actions</code> from\nappearing on this page. Other possible values are <code>none</code> or\none or more of <code>edit</code>, <code>source</code>, and\n<code>issue</code>, <em>e.g.</em>\n<code>[edit, source, issue]</code>.",
     {
       "short": "Links to source repository actions",
       "long": "Links to source repository actions (<code>none</code> or one or more\nof <code>edit</code>, <code>source</code>, <code>issue</code>)"
@@ -17033,7 +17040,8 @@
     "Disambiguating year suffix in author-date styles (e.g.&nbsp;“a” in “Doe,\n1999a”).",
     "Manuscript configuration",
     "internal-schema-hack",
-    "List execution engines you want to give priority when determining\nwhich engine should render a notebook. If two engines have support for a\nnotebook, the one listed earlier will be chosen. Quarto’s default order\nis ‘knitr’, ‘jupyter’, ‘markdown’, ‘julia’."
+    "List execution engines you want to give priority when determining\nwhich engine should render a notebook. If two engines have support for a\nnotebook, the one listed earlier will be chosen. Quarto’s default order\nis ‘knitr’, ‘jupyter’, ‘markdown’, ‘julia’.",
+    "Array of rendering names, e.g.&nbsp;<code>[light, dark]</code>"
   ],
   "schema/external-schemas.yml": [
     {
@@ -17262,12 +17270,12 @@
     "mermaid": "%%"
   },
   "handlers/mermaid/schema.yml": {
-    "_internalId": 194627,
+    "_internalId": 194632,
     "type": "object",
     "description": "be an object",
     "properties": {
       "mermaid-format": {
-        "_internalId": 194619,
+        "_internalId": 194624,
         "type": "enum",
         "enum": [
           "png",
@@ -17283,7 +17291,7 @@
         "exhaustiveCompletions": true
       },
       "theme": {
-        "_internalId": 194626,
+        "_internalId": 194631,
         "type": "anyOf",
         "anyOf": [
           {

--- a/src/resources/filters/normalize/flags.lua
+++ b/src/resources/filters/normalize/flags.lua
@@ -195,6 +195,9 @@ function compute_flags()
       elseif lightbox_auto == false then
         flags.has_lightbox = false
       end
+      if el.renderings then
+        flags.has_renderings = true
+      end
     end,
   }}
 end

--- a/src/resources/filters/quarto-post/cell-renderings.lua
+++ b/src/resources/filters/quarto-post/cell-renderings.lua
@@ -8,15 +8,31 @@ function choose_cell_renderings()
       return {json}
     end
   end
+
+  local documentRenderings
   
   return {
+    traverse = "topdown",
+    Meta = function(meta)
+      if meta.renderings then
+        documentRenderings = {}
+        for _, inlines in ipairs(meta.renderings) do
+          table.insert(documentRenderings, inlines[1].text)
+        end
+      end
+    end,
     Div = function(div)
       -- Only process cell div with renderings attr
-      if not div.classes:includes("cell") or not div.attributes["renderings"] then
+      if not div.classes:includes("cell") or (not documentRenderings and not div.attributes["renderings"]) then
         return nil
       end
-      local renderingsJson = div.attributes['renderings']
-      local renderings = jsonDecodeArray(renderingsJson)
+      local renderings
+      if div.attributes['renderings'] then
+        local renderingsJson = div.attributes['renderings']
+        renderings = jsonDecodeArray(renderingsJson)
+      else
+        renderings = documentRenderings
+      end
       if not type(renderings) == "table" or #renderings == 0 then
         quarto.log.warning("renderings expected array of rendering names, got", renderings)
         return nil

--- a/src/resources/schema/document-options.yml
+++ b/src/resources/schema/document-options.yml
@@ -34,6 +34,11 @@
                   description: The dark theme name, theme scss file, or a mix of both.
   description: Theme name, theme scss file, or a mix of both.
 
+- name: renderings
+  schema:
+    arrayOf: string
+  description: "Array of rendering names, e.g. `[light, dark]`"
+
 - name: body-classes
   tags:
     formats: [$html-doc]

--- a/tests/docs/smoke-all/dark-mode/dark-brand.qmd
+++ b/tests/docs/smoke-all/dark-mode/dark-brand.qmd
@@ -1,0 +1,17 @@
+---
+format: html
+brand:
+  dark: slate-brand.yml
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ["link[href*=\"-dark-\"]"]
+        - []
+---
+
+## Hello
+
+```markdown
+![asdf](asd.png)
+```

--- a/tests/docs/smoke-all/dark-mode/dark-theme.qmd
+++ b/tests/docs/smoke-all/dark-mode/dark-theme.qmd
@@ -1,0 +1,17 @@
+---
+format: revealjs
+theme:
+  dark: slate
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ["link[href*=\"-dark-\"]"]
+        - []
+---
+
+## Hello
+
+```markdown
+![asdf](asd.png)
+```

--- a/tests/docs/smoke-all/dark-mode/ggplot-duobrand-doc-renderings.qmd
+++ b/tests/docs/smoke-all/dark-mode/ggplot-duobrand-doc-renderings.qmd
@@ -1,0 +1,130 @@
+---
+title: "knitr dark mode - ggplot"
+brand:
+  light: united-brand.yml
+  dark: slate-brand.yml
+execute:
+  echo: false
+  warning: false
+renderings: [light, dark]
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        -
+          - 'body.quarto-light'
+          - 'div.cell div.light-content'
+          - 'div.cell div.dark-content'
+          - 'div.cell div.cell-code pre.code-with-copy'
+        - []
+---
+
+```{r}
+#| echo: false
+#| warning: false
+library(ggplot2)
+
+ggplot_theme <- function(bgcolor, fgcolor) {
+  theme_minimal(base_size = 11) %+%
+    theme(
+      panel.border = element_blank(),
+      panel.grid.major.y = element_blank(),
+      panel.grid.minor.y = element_blank(),
+      panel.grid.major.x = element_blank(),
+      panel.grid.minor.x = element_blank(),
+      text = element_text(colour = fgcolor),
+      axis.text = element_text(colour = fgcolor),
+      rect = element_rect(colour = bgcolor, fill = bgcolor),
+      plot.background = element_rect(fill = bgcolor, colour = NA),
+      axis.line = element_line(colour = fgcolor),
+      axis.ticks = element_line(colour = fgcolor)
+    )
+}
+
+brand_ggplot <- function(brand_yml) {
+  brand <- yaml::yaml.load_file(brand_yml)
+  ggplot_theme(brand$color$background, brand$color$foreground)
+}
+
+united_theme <- brand_ggplot("united-brand.yml")
+slate_theme <- brand_ggplot("slate-brand.yml")
+
+colour_scale <- scale_colour_manual(values = c("darkorange", "purple", "cyan4"))
+```
+
+### no crossref, no caption
+
+```{r}
+ggplot(mtcars, aes(mpg, wt)) +
+  geom_point(aes(colour = factor(cyl))) +
+  united_theme +
+  colour_scale
+ggplot(mtcars, aes(mpg, wt)) +
+  geom_point(aes(colour = factor(cyl))) +
+  slate_theme +
+  colour_scale
+```
+
+### with crossref but no caption
+
+and `echo: true`
+
+::: {#fig-ggplot}
+
+```{r}
+#| echo: true
+#| renderings: [dark, light]
+
+# override renderings order
+ggplot(mtcars, aes(mpg, disp)) +
+  geom_point(aes(colour = factor(cyl))) +
+  slate_theme +
+  colour_scale
+ggplot(mtcars, aes(mpg, disp)) +
+  geom_point(aes(colour = factor(cyl))) +
+  united_theme +
+  colour_scale
+```
+
+:::
+
+
+### with caption but no crossref
+
+<div>
+
+```{r}
+#| renderings: [dark]
+
+# override number of renderings
+ggplot(mtcars, aes(mpg, disp)) +
+  geom_point(aes(colour = factor(cyl))) +
+  slate_theme +
+  colour_scale
+```
+
+ggplot - dark only
+
+</div>
+
+
+### with crossref and caption
+
+::: {#fig-ggplot-mpg-hp}
+```{r}
+ggplot(mtcars, aes(mpg, hp)) +
+  geom_point(aes(colour = factor(cyl))) +
+  united_theme +
+  colour_scale
+ggplot(mtcars, aes(mpg, hp)) +
+  geom_point(aes(colour = factor(cyl))) +
+  slate_theme +
+  colour_scale
+```
+
+mtcars - mpg vs hp
+:::
+
+Here's a [link](https://example.com).
+
+{{< lipsum 3 >}}


### PR DESCRIPTION
Instead of setting `renderings` on each cell, put it on the document instead.

This becomes a default which cells can override.

Fixes #12381