### PR TITLE
remove extra typst block

### DIFF
--- a/src/resources/filters/quarto-post/typst-css-property-processing.lua
+++ b/src/resources/filters/quarto-post/typst-css-property-processing.lua
@@ -284,17 +284,14 @@ function render_typst_css_property_processing()
     Table = function(tab)
       _warnings = new_table()
       local tabstyle = tab.attributes['style']
-      local has_typst_text = false
       if tabstyle ~= nil then
         for clause in tabstyle:gmatch('([^;]+)') do
           local k, v = to_kv(clause)
           if k == 'font-family' then
             tab.attributes['typst:text:font'] = translate_string_list(v)
-            has_typst_text = true
           end
           if k == 'font-size' then
             tab.attributes['typst:text:size'] = _quarto.format.typst.css.translate_length(v, _warnings)
-            has_typst_text = true
           end
         end
       end
@@ -314,13 +311,7 @@ function render_typst_css_property_processing()
       end
       aggregate_warnings()
       _warnings = nil
-      if not has_typst_text then return tab end
-      -- wrap in typst content block and return false to prevent processing its contents
-      return pandoc.Blocks({
-        pandoc.RawBlock("typst", "#["),
-        tab,
-        pandoc.RawBlock("typst", "]")
-      }), false
+      return tab
     end,
     Div = function(div)
       _warnings = new_table()


### PR DESCRIPTION
jgm/pandoc#10563 is merged, so Pandoc protects against `set text(...)` spill.

closes #11093

continuing #11113 which contains a good end-to-end test
