### PR TITLE
Fix conflict in with KaTeX and Require.js 

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -120,6 +120,7 @@ All changes included in 1.7:
 ### `jupyter`
 
 - ([#9089](https://github.com/quarto-dev/quarto-cli/issues/9089)): Serialize compound `jupyter` metadata into a special key-value attribute to not break Pandoc's fenced div parsing.
+- ([#10113](https://github.com/quarto-dev/quarto-cli/issues/10113)): KaTeX will now load correctly in `engine: jupyter` documents using `emebed-resources: true`.
 - ([#12114](https://github.com/quarto-dev/quarto-cli/issues/12114)): `JUPYTERCACHE` environment variable from [Jupyter cache CLI](https://jupyter-cache.readthedocs.io/en/latest/using/cli.html) is now respected by Quarto when `cache: true` is used. This environment variable allows to change the path of the cache directory.
 - ([#12228](https://github.com/quarto-dev/quarto-cli/issues/12228)): `quarto render` will now fails if errors are detected at IPython display level. Setting `error: true` globally or at cell level will keep the error to show in output and not stop the rendering.
 - ([#12374](https://github.com/quarto-dev/quarto-cli/issues/12374)): Detect language properly in Jupyter notebooks that lack the `language` field in their `kernelspec`s.

--- a/tests/docs/playwright/html/math/katex/embed-except-math.qmd
+++ b/tests/docs/playwright/html/math/katex/embed-except-math.qmd
@@ -1,0 +1,12 @@
+---
+format: html
+html-math-method: katex
+embed-resources: true
+---
+
+$\alpha$
+
+```{python}
+import pandas as pd
+pd.DataFrame([1])
+```

--- a/tests/docs/playwright/html/math/katex/embed-with-math.qmd
+++ b/tests/docs/playwright/html/math/katex/embed-with-math.qmd
@@ -1,0 +1,13 @@
+---
+format: html
+html-math-method: katex
+embed-resources: true
+self-contained-math: true
+---
+
+$\alpha$
+
+```{python}
+import pandas as pd
+pd.DataFrame([1])
+```

--- a/tests/docs/playwright/html/math/katex/not-embed.qmd
+++ b/tests/docs/playwright/html/math/katex/not-embed.qmd
@@ -1,0 +1,11 @@
+---
+format: html
+html-math-method: katex
+---
+
+$\alpha$
+
+```{python}
+import pandas as pd
+pd.DataFrame([1])
+```

--- a/tests/integration/playwright/tests/html-math-katex.spec.ts
+++ b/tests/integration/playwright/tests/html-math-katex.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('KaTeX math rendering in Jupyter engine document', () => {
+  const testCases = [
+    { url: 'html/math/katex/not-embed.html', description: 'not embedding resources' },
+    { url: 'html/math/katex/embed-with-math.html', description: 'embedding resources including Math' },
+    { url: 'html/math/katex/embed-except-math.html', description: 'embedding resources except Math' }
+  ];
+  
+  for (const { url, description } of testCases) {
+    test(`KaTeX math is rendered while ${description}`, async ({ page }) => {
+      await page.goto(url);
+      // Check that math is rendered
+      await expect(page.locator("span.katex")).toContainText('α');
+    });
+  }
+});


### PR DESCRIPTION
When `embed-resources: true`, by default Math will evade embedding by adding back the JS script node in browser. 

However, KaTeX and Require.js does not play well together, and quarto does a postprocessing of HTML file to opt out require while loading KaTeX 
https://github.com/quarto-dev/quarto-cli/blob/2c6822c56ed4aee2569816a80b37a3361a8ee5a7/src/format/html/format-html-math.ts#L11-L36

This post-processing is not happening when `embed-resources` is used, as we do insert a script that will dynamically append loading `<script>` to `<head>`. 

This is the script tweaked in this PR to be context-aware of `require` conflict. 

The opt-out is narrower than the post-processor to disable the AMD detection only, and enable it at the right time after the script is loaded.  

- Require.js being loaded will trigger AMD detection for KaTeX, which prevents `widow.katex` to be defined
-  About KaTeX in browser: https://katex.org/docs/browser#module-loaders
- About AMD in JS: https://github.com/amdjs/amdjs-api/wiki/AMD#defineamd-property-

We could probably do the same but I didn't in this PR as tests are passing like this. 

fixes #10113 


