### PR TITLE
Bugfix/kbd adoc bad input

### DIFF
--- a/src/resources/extensions/quarto/kbd/kbd.lua
+++ b/src/resources/extensions/quarto/kbd/kbd.lua
@@ -32,10 +32,30 @@ return {
       end
 
       return pandoc.RawInline('html', '<kbd aria-hidden="true" ' .. kwargs_str .. '>' .. default_arg_str .. '</kbd><span class="visually-hidden">' .. default_arg_str .. '</span>')
-    elseif quarto.doc.isFormat("asciidoc") and args and #args == 1 then
-      -- get the 'first' kbd shortcut as we can only produce on shortcut in asciidoc
-      local shortcutText = pandoc.utils.stringify(args[1]):gsub('-', '+')
-      return pandoc.RawInline("asciidoc", "kbd:[" .. shortcutText .. "]")
+    elseif quarto.doc.isFormat("asciidoc") then
+      if args and #args == 1 then
+        -- https://docs.asciidoctor.org/asciidoc/latest/macros/keyboard-macro/
+
+        -- get the 'first' kbd shortcut as we can only produce one shortcut in asciidoc
+        local shortcutText = pandoc.utils.stringify(args[1]):gsub('-', '+')
+
+        -- from the docs:
+        -- If the last key is a backslash (\), it must be followed by a space. 
+        -- Without this space, the processor will not recognize the macro. 
+        -- If one of the keys is a closing square bracket (]), it must be preceded by a backslash. 
+        -- Without the backslash escape, the macro will end prematurely.
+
+        if shortcutText:sub(-1) == "\\" then
+          shortcutText = shortcutText .. " "
+        end
+        if shortcutText:find("]") then
+          shortcutText = shortcutText:gsub("]", "\\]")
+        end
+
+        return pandoc.RawInline("asciidoc", "kbd:[" .. shortcutText .. "]")
+      else
+        return quarto.shortcode.error_output("kbd", "kbd only supports one positional argument", "inline")
+      end
     else
       -- example shortcodes
       -- {{< kbd Shift-Ctrl-P >}}

--- a/src/resources/extensions/quarto/kbd/kbd.lua
+++ b/src/resources/extensions/quarto/kbd/kbd.lua
@@ -52,7 +52,7 @@ return {
           shortcutText = shortcutText:gsub("]", "\\]")
         end
 
-        return pandoc.RawInline("asciidoc", "kbd:[" .. stringEscape(shortcutText, "asciidoc") .. "]")
+        return pandoc.RawInline("asciidoc", "kbd:[" .. shortcutText .. "]")
       else
         return quarto.shortcode.error_output("kbd", "kbd only supports one positional argument", "inline")
       end

--- a/src/resources/extensions/quarto/kbd/kbd.lua
+++ b/src/resources/extensions/quarto/kbd/kbd.lua
@@ -52,7 +52,7 @@ return {
           shortcutText = shortcutText:gsub("]", "\\]")
         end
 
-        return pandoc.RawInline("asciidoc", "kbd:[" .. shortcutText .. "]")
+        return pandoc.RawInline("asciidoc", "kbd:[" .. stringEscape(shortcutText, "asciidoc") .. "]")
       else
         return quarto.shortcode.error_output("kbd", "kbd only supports one positional argument", "inline")
       end

--- a/tests/docs/smoke-all/2025/04/09/kbd-adoc-bad-input.qmd
+++ b/tests/docs/smoke-all/2025/04/09/kbd-adoc-bad-input.qmd
@@ -1,0 +1,5 @@
+---
+format: asciidoc
+---
+
+{{< kbd key="\\" >}}


### PR DESCRIPTION
Calling the `kbd` shortcode in asciidoc format with bad inputs would cause a crash. This turns the crash into a shortcode error message.