### PR TITLE
bugfix: safari flashing with complex project

### DIFF
--- a/src/format/html/format-html-bootstrap.ts
+++ b/src/format/html/format-html-bootstrap.ts
@@ -78,9 +78,7 @@ import {
   documentTitleScssLayer,
   processDocumentTitle,
 } from "./format-html-title.ts";
-import {
-  darkModeDefault,
-} from "./format-html-info.ts";
+import { darkModeDefault } from "./format-html-info.ts";
 
 import { kTemplatePartials } from "../../command/render/template.ts";
 import { isHtmlOutput } from "../../config/format.ts";
@@ -519,6 +517,14 @@ function bootstrapHtmlPostprocessor(
       doc,
     );
     resources.push(...titleResourceFiles);
+
+    // put quarto-html-before-body script at top of body
+    const beforeBodyScript = doc.querySelector(
+      "script#quarto-html-before-body",
+    );
+    if (beforeBodyScript) {
+      doc.body.insertBefore(beforeBodyScript, doc.body.firstChild);
+    }
 
     // Process the elements of this document into an appendix
     if (


### PR DESCRIPTION
Put `quarto-html-before-body` script really at top at top of body.

We don't have complete control over where Pandoc's 'before body' really is, with so many components contributing to the array via mergeConfigs.

So use an HTML postprocessor for this.

Not sure how to automatically test this, but here is a demo using GitHub Pages.

quarto-web built without this fix
https://gordonwoodhull.github.io/quarto-web-safari-bug/

quarto-web built with this fix
https://gordonwoodhull.github.io/quarto-web-safari-bugless/

