### PR TITLE
honor the dark = light + dark stylesheet convention

### DIFF
--- a/src/command/render/pandoc-html.ts
+++ b/src/command/render/pandoc-html.ts
@@ -142,7 +142,7 @@ export async function resolveSassBundles(
       )
       ? "dark"
       : "light";
-    const targets: SassTarget[] = [{
+    let targets: SassTarget[] = [{
       name: `${dependency}.min.css`,
       bundles: (bundles as any),
       attribs: {
@@ -175,10 +175,22 @@ export async function resolveSassBundles(
           ...attribForThemeStyle("dark"),
         },
       };
-      if (defaultStyle === "dark") {
+      if (defaultStyle === "dark") { // light, dark
         targets.push(darkTarget);
-      } else {
-        targets.unshift(darkTarget);
+      } else { // light, dark, light
+        const lightTargetExtra = {
+          ...targets[0],
+          attribs: {
+            ...targets[0].attribs,
+            class: "quarto-color-scheme-extra",
+          },
+        };
+
+        targets = [
+          targets[0],
+          darkTarget,
+          lightTargetExtra,
+        ];
       }
 
       hasDarkStyles = true;

--- a/src/resources/formats/html/templates/quarto-html-before-body.ejs
+++ b/src/resources/formats/html/templates/quarto-html-before-body.ejs
@@ -41,7 +41,7 @@
       const alternateStylesheets = window.document.querySelectorAll('link.quarto-color-scheme.quarto-color-alternate');
       manageTransitions('#quarto-margin-sidebar .nav-link', false);
       if (alternate) {
-        disableStylesheet(primaryStylesheets)
+        // note: dark is layered on light, we don't disable primary!
         enableStylesheet(alternateStylesheets);
         for (const sheetNode of alternateStylesheets) {
           if (sheetNode.id === "quarto-bootstrap") {
@@ -169,6 +169,10 @@
     const darkModeDefault = queryPrefersDark.matches;
     <% } else { %>
     const darkModeDefault = <%= darkModeDefault %>;
+    <% } %>
+
+    <% if (!darkModeDefault) { %>
+    document.querySelector('link.quarto-color-scheme-extra').rel = 'disabled-stylesheet';
     <% } %>
       
     let localAlternateSentinel = darkModeDefault ? 'alternate' : 'default';


### PR DESCRIPTION
By using  light, dark, light stylesheets for author preference: light 

Then disable the final light stylesheet in the before-body script.

Do not disable the initial light stylesheet when entering dark mode.

Test website with quarto-web deployed:
https://gordonwoodhull.github.io/quarto-web-safari-bugless/

Note that author-prefers-light is now the "weird case", even though it is the common case. So this deployment exercises all the changes. author-prefers-dark webpages are unchanged by this PR.