### PR TITLE
Bugfix/12167 pre: Figure label numbering for multiple figures not as subfigures

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -173,6 +173,7 @@ All changes included in 1.7:
 - ([#11951](https://github.com/quarto-dev/quarto-cli/issues/11951)): Raw LaTeX table without `tbl-` prefix label for using Quarto crossref are now correctly passed through unmodified.
 - ([#11967](https://github.com/quarto-dev/quarto-cli/issues/11967)): Produce a better error message when YAML metadata with `!expr` tags are used outside of `knitr` code cells.
 - ([#12117](https://github.com/quarto-dev/quarto-cli/issues/12117)): Color output to stdout and stderr is now correctly rendered for `html` format in the Jupyter and Julia engines.
+- ([#12167](https://github.com/quarto-dev/quarto-cli/issues/12167)): Figure numbering for multiple top-level figures and not as Sub-Figures.
 - ([#12264](https://github.com/quarto-dev/quarto-cli/issues/12264)): Upgrade `dart-sass` to 1.85.1.
 - ([#12238](https://github.com/quarto-dev/quarto-cli/issues/12238)): Do not truncate very long console errors (e.g. in Jupyter Notebook with backtrace).
 - ([#12338](https://github.com/quarto-dev/quarto-cli/issues/12338)): Add an additional workaround for the SCSS parser used in color variable extraction.

--- a/src/core/jupyter/jupyter.ts
+++ b/src/core/jupyter/jupyter.ts
@@ -1560,7 +1560,7 @@ async function mdFromCodeCell(
         : label;
       // If the user specifies a top-level array for images but also labels give a warning.
       if (labelCellContainer === false && Array.isArray(sortedOutputs) == true) {
-        warning("Warning: using top-level figures with labels might result in unwanted behaviour.")
+        warning("Warning: using multiple top-level figures with labels might result in unwanted behaviour.")
       }
       // If this output has been marked to not be displayed
       // just continue

--- a/src/core/jupyter/jupyter.ts
+++ b/src/core/jupyter/jupyter.ts
@@ -1555,11 +1555,18 @@ async function mdFromCodeCell(
 
     for (const { index, output } of sortedOutputs) {
       // compute output label
-      const outputLabel = label && (labelCellContainer || Array.isArray(sortedOutputs)) && isDisplayData(output)
+      const outputLabel = label &&
+        (
+          labelCellContainer ||
+          (Array.isArray(sortedOutputs) && (sortedOutputs.length > 1))
+        ) &&
+        isDisplayData(output)
         ? (label + "-" + nextOutputSuffix++)
         : label;
       // If the user specifies a top-level array for images but also labels give a warning.
-      if (labelCellContainer === false && Array.isArray(sortedOutputs) == true) {
+      if (labelCellContainer === false &&
+        (Array.isArray(sortedOutputs) == true && (sortedOutputs.length > 1))
+      ) {
         warning("Warning: using multiple top-level figures with labels might result in unwanted behaviour.")
       }
       // If this output has been marked to not be displayed

--- a/src/core/jupyter/jupyter.ts
+++ b/src/core/jupyter/jupyter.ts
@@ -1555,20 +1555,22 @@ async function mdFromCodeCell(
 
     for (const { index, output } of sortedOutputs) {
       // compute output label
-      const outputLabel = label &&
+      let outputLabel_tmp = label;
+      if (label &&
         (
           labelCellContainer ||
           (Array.isArray(sortedOutputs) && (sortedOutputs.length > 1))
         ) &&
-        isDisplayData(output)
-        ? (label + "-" + nextOutputSuffix++)
-        : label;
-      // If the user specifies a top-level array for images but also labels give a warning.
-      if (labelCellContainer === false &&
-        (Array.isArray(sortedOutputs) == true && (sortedOutputs.length > 1))
-      ) {
-        warning("Warning: using multiple top-level figures with labels might result in unwanted behaviour.")
+        isDisplayData(output)) {
+        outputLabel_tmp = label + "-" + nextOutputSuffix++;
+        // If the user specifies a top-level array for images but also labels give a warning.
+        if (labelCellContainer === false &&
+          (Array.isArray(sortedOutputs) == true && (sortedOutputs.length > 1))
+        ) {
+          warning("Warning: using multiple top-level figures with labels might result in unwanted behaviour: " + label)
+        }
       }
+      const outputLabel = outputLabel_tmp
       // If this output has been marked to not be displayed
       // just continue
       if (output.metadata?.[kQuartoOutputDisplay] === false) {

--- a/src/core/jupyter/jupyter.ts
+++ b/src/core/jupyter/jupyter.ts
@@ -8,6 +8,7 @@
 
 import { ensureDirSync, walkSync } from "../../deno_ral/fs.ts";
 import { dirname, extname, join, relative } from "../../deno_ral/path.ts";
+import { warning } from "../../deno_ral/log.ts";
 import * as colors from "fmt/colors";
 import { decodeBase64 as base64decode } from "encoding/base64";
 import { stringify } from "../yaml.ts";
@@ -1554,10 +1555,13 @@ async function mdFromCodeCell(
 
     for (const { index, output } of sortedOutputs) {
       // compute output label
-      const outputLabel = label && labelCellContainer && isDisplayData(output)
+      const outputLabel = label && (labelCellContainer || Array.isArray(sortedOutputs)) && isDisplayData(output)
         ? (label + "-" + nextOutputSuffix++)
         : label;
-
+      // If the user specifies a top-level array for images but also labels give a warning.
+      if (labelCellContainer === false && Array.isArray(sortedOutputs) == true) {
+        warning("Warning: using top-level figures with labels might result in unwanted behaviour.")
+      }
       // If this output has been marked to not be displayed
       // just continue
       if (output.metadata?.[kQuartoOutputDisplay] === false) {


### PR DESCRIPTION
## Description

As discussed in #12167 , the behavior for multiple top-level figures together with a label is not optimal. This might be a step in the direction of allowing this feature, at least it provides a warning if this combination is used. 

It works well in my setup but of course I only have a very limited view on the possibilities for _crossref, figures, subfigures, multiple figures, and layouts_. 

The main idea is to check if  `labelCellContainer === false` but  `sortedOutputs` is an array with more than 1 entry.
This allows to:
1. still define labels
   ```ts
   const outputLabel = label &&
        (
          labelCellContainer ||
          (Array.isArray(sortedOutputs) && (sortedOutputs.length > 1))
        ) &&
        isDisplayData(output)
        ? (label + "-" + nextOutputSuffix++)
        : label;
   ```
1. Emit a warning if a user combines multiple top-level figures with labels.
   ```ts
   if (labelCellContainer === false &&
        (Array.isArray(sortedOutputs) == true && (sortedOutputs.length > 1))
      ) {
        warning("Warning: using multiple top-level figures with labels might result in unwanted behaviour.")
      }
   ```

Downside, the variable naming `labelCellContainer === false` implies no more labels which is than contradicted.

## Extended test cases

````qm
--- 
title: "foo"
keep-tex: true
---

Example form the [docs](https://quarto.org/docs/authoring/figures.html#layout):

```{python}
#| label: fig-test
#| layout-ncol: 2
#| fig-cap: 
#|   - "Line Plot 1"
#|   - "Line Plot 2"

import matplotlib.pyplot as plt
plt.plot([1,23,2,4])
plt.show()

plt.plot([8,65,23,90])
plt.show()
```

Referencing the different Figures is not working correctly

- `@fig-test`: @fig-test
- `@fig-test-1`: @fig-test-1
- `@fig-test-1`: @fig-test-2

```{python}
#| label: fig-test2
#| fig-cap: "multiple plots"
#| fig-subcap:
#|   - "Line Plot 1"
#|   - "Line Plot 2"

import matplotlib.pyplot as plt
plt.plot([1,23,2,4])
plt.show()

plt.plot([8,65,23,90])
plt.show()
```

- `@fig-test2`: @fig-test2
- `@fig-test2-1`: @fig-test2-1
- `@fig-test2-1`: @fig-test2-2

```{python}
#| label: fig-test3
#| fig-cap: "multiple plots"

import matplotlib.pyplot as plt
plt.plot([1,23,2,4])
plt.show()
```

- `@fig-test3`: @fig-test3

```{python}
#| label: fig-test4
#| fig-cap: "multiple plots"

import matplotlib.pyplot as plt
plt.plot([1,23,2,4])
plt.show()

plt.plot([8,65,23,90])
plt.show()
```

- `@fig-test4`: @fig-test4
- `@fig-test4-1`: @fig-test4-1
- `@fig-test4-1`: @fig-test4-2

````
Provides the expected output and warnings.

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes -> #12167
- [x] updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
