### PR TITLE
preview - don't set options as a const to avoid conflict with Global Scope

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -179,3 +179,4 @@ All changes included in 1.7:
 - ([#12369](https://github.com/quarto-dev/quarto-cli/pull/12369)): `quarto preview` correctly throws a YAML validation error when a `format` key does not conform.
 - ([#12459](https://github.com/quarto-dev/quarto-cli/pull/12459)): Add `.page-inset-*` classes to completions.
 - ([#12492](https://github.com/quarto-dev/quarto-cli/pull/12492)): Improve shortcode extension template with new parameters and a link to docs.
+- ([#12513](https://github.com/quarto-dev/quarto-cli/issues/12513)): Fix an issue with `quarto preview` when using **DiagrammeR** R package for Graphiz diagram.

--- a/src/resources/preview/quarto-preview.html
+++ b/src/resources/preview/quarto-preview.html
@@ -1,15 +1,19 @@
-
-<script>window.backupDefine = window.define; window.define = undefined;</script>
+<script>
+  window.backupDefine = window.define;
+  window.define = undefined;
+</script>
 <script type="text/javascript" src="quarto-preview.js"></script>
-<script>window.define = window.backupDefine; window.backupDefine = undefined;</script>
+<script>
+  window.define = window.backupDefine;
+  window.backupDefine = undefined;
+</script>
 <script type="text/javascript">
-  const options = {
-    origin: "<%- origin %>",
-    search: "<%- search %>",
-    inputFile: "<%- inputFile %>",
-    isPresentation: <%= isPresentation %>
-  }
   document.addEventListener("DOMContentLoaded", function () {
-    window.QuartoPreview.init(options);
-  });
+    window.QuartoPreview.init({
+      origin: "<%- origin %>",
+      search: "<%- search %>",
+      inputFile: "<%- inputFile %>",
+      isPresentation: <%= isPresentation %>
+    });
+  })
 </script>

--- a/src/webui/quarto-preview/src/index.tsx
+++ b/src/webui/quarto-preview/src/index.tsx
@@ -4,37 +4,34 @@
  * Copyright (C) 2023 Posit Software, PBC
  */
 
-import { connectToServer } from './server/connection';
-import { navigationHandler } from './server/navigation';
-import { progressHandler } from './server/progress';
+import { connectToServer } from "./server/connection";
+import { navigationHandler } from "./server/navigation";
+import { progressHandler } from "./server/progress";
 
 import { handleExternalLinks } from "./frame/links";
-import { handleMecaLinks } from './frame/meca';
+import { handleMecaLinks } from "./frame/meca";
 import { handleRevealMessages } from "./frame/reveal";
 import { handleViewerMessages } from "./frame/viewer";
-import { handleCommands } from './frame/commands';
+import { handleCommands } from "./frame/commands";
 
-import './ui/fluent.css'
-
+import "./ui/fluent.css";
 
 export interface Options {
-  origin: string | null,
-  search: string | null,
-  inputFile: string | null,
+  origin: string | null;
+  search: string | null;
+  inputFile: string | null;
   isPresentation: boolean;
 }
 
 function init(options: Options) {
-  
   try {
-
     // detect dark mode
     const darkMode = detectDarkMode();
 
     // server connection
     const disconnect = connectToServer([
       progressHandler(darkMode),
-      navigationHandler()
+      navigationHandler(),
     ]);
 
     // handle commands
@@ -50,11 +47,10 @@ function init(options: Options) {
 
     // handle messages as approprate for format
     if (options.isPresentation) {
-      handleRevealMessages(disconnect)
+      handleRevealMessages(disconnect);
     } else {
       handleViewerMessages(options.inputFile);
     }
-
   } catch (error) {
     console.error(error);
   }
@@ -69,8 +65,4 @@ function detectDarkMode() {
   }
 }
 
-export { init }
-
-
-
-
+export { init };

--- a/src/webui/quarto-preview/src/index.tsx
+++ b/src/webui/quarto-preview/src/index.tsx
@@ -23,7 +23,13 @@ export interface Options {
   isPresentation: boolean;
 }
 
+// Store the current options
+let currentOptions: Options | null = null;
+
 function init(options: Options) {
+  // Store the options for export
+  currentOptions = options;
+
   try {
     // detect dark mode
     const darkMode = detectDarkMode();
@@ -51,6 +57,13 @@ function init(options: Options) {
     } else {
       handleViewerMessages(options.inputFile);
     }
+
+    // Dispatch event when initialized
+    const event = new CustomEvent("quarto-preview-initialized", {
+      detail: options,
+    });
+
+    document.dispatchEvent(event);
   } catch (error) {
     console.error(error);
   }
@@ -65,4 +78,9 @@ function detectDarkMode() {
   }
 }
 
-export { init };
+// Export the current options
+function getOptions() {
+  return currentOptions;
+}
+
+export { init, getOptions };


### PR DESCRIPTION
fixes #12513 

Currently `quarto preview` script will define `const` that is available in Global scope in the previewed HTML

https://github.com/quarto-dev/quarto-cli/blob/73805d39bf0a75aa76e53e89b908e3c27e0053f8/src/resources/preview/quarto-preview.html#L6-L14

Here is an example of the options being seen in JS

````markdown
---
title: "my board"
format: html
engine: knitr
---

# content

```{js}
//| echo: false
document.addEventListener("DOMContentLoaded", function() {
  const pElement = document.createElement("p");
  const codeElement = document.createElement("code")
  codeElement.textContent = JSON.stringify(options);
  pElement.appendChild(codeElement)
  document.querySelector("#content").appendChild(pElement);
})
```

````

![image](https://github.com/user-attachments/assets/e5945281-6480-408c-a992-9aca388e52d4)

It does not seem like a good thing that is defined globally and impact any JS script. 

This PR is here as a draft to discuss this idea. 

I don't know if some other tools can rely on these generic `options` being available. Hopefully not because it could be redefined too. If this should be made available, it should probably be namespaced.

````markdown
---
title: "my board"
format: html
engine: knitr
---

# content

```{js}
//| echo: false
document.addEventListener("DOMContentLoaded", function() {
  const options = "{new: 'hello'}"
  const pElement = document.createElement("p");
  const codeElement = document.createElement("code")
  codeElement.textContent = JSON.stringify(options);
  pElement.appendChild(codeElement)
  document.querySelector("#content").appendChild(pElement);
})
```
````

![image](https://github.com/user-attachments/assets/9b8a09b2-62c6-478b-80e7-799eff701eec)

