### PR TITLE
fix wrong ordering of highlighting stylesheets for dark mode, and also nojs highlight bleeding

### DIFF
--- a/src/resources/formats/html/templates/quarto-html-before-body.ejs
+++ b/src/resources/formats/html/templates/quarto-html-before-body.ejs
@@ -172,7 +172,8 @@
     <% } %>
 
     <% if (!darkModeDefault) { %>
-    document.querySelector('link.quarto-color-scheme-extra').rel = 'disabled-stylesheet';
+      document.querySelector('link#quarto-text-highlighting-styles.quarto-color-scheme-extra').rel = 'disabled-stylesheet';
+      document.querySelector('link#quarto-bootstrap.quarto-color-scheme-extra').rel = 'disabled-stylesheet';
     <% } %>
       
     let localAlternateSentinel = darkModeDefault ? 'alternate' : 'default';

--- a/src/resources/pandoc/highlight-styles/a11y-dark.theme
+++ b/src/resources/pandoc/highlight-styles/a11y-dark.theme
@@ -155,7 +155,6 @@
             "underline": false
         },
         "Import": {
-            "text-color": "#f8f8f2",
             "background-color": null,
             "bold": false,
             "italic": false,

--- a/src/resources/pandoc/highlight-styles/arrow-dark.theme
+++ b/src/resources/pandoc/highlight-styles/arrow-dark.theme
@@ -1,8 +1,6 @@
 {
     "text-styles": {
         "Alert": {
-            "background-color": "#2a0f15",
-            "bold": true,
             "selected-text-color": "#f07178",
             "text-color": "#f07178"
         },

--- a/tests/docs/playwright/html/dark-brand/syntax-highlighting/a11y-syntax-highlighting.qmd
+++ b/tests/docs/playwright/html/dark-brand/syntax-highlighting/a11y-syntax-highlighting.qmd
@@ -1,0 +1,47 @@
+---
+title: a11y syntax highlighting
+execute:
+  echo: false
+  warning: false
+theme:
+  light: [cosmo, theme.scss]
+  dark: [cosmo, theme-dark.scss]
+highlight-style: a11y
+---
+
+
+```markdown
+![asdf](asd.png)
+```
+
+
+```python
+#| label: fig-polar
+#| fig-cap: "A line plot on a polar axis"
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+r = np.arange(0, 2, 0.01)
+theta = 2 * np.pi * r
+fig, ax = plt.subplots(
+  subplot_kw = {'projection': 'polar'} 
+)
+ax.plot(theta, r)
+ax.set_rticks([0.5, 1, 1.5, 2])
+ax.grid(True)
+plt.show()
+```
+
+```r
+nycflights13::flights %>% 
+  mutate(
+    cancelled = is.na(dep_time),
+    sched_hour = sched_dep_time %/% 100,
+    sched_min = sched_dep_time %% 100,
+    sched_dep_time = sched_hour + sched_min / 60
+  ) %>% 
+  ggplot(mapping = aes(sched_dep_time)) + 
+    geom_freqpoly(mapping = aes(colour = cancelled), binwidth = 1/4) +
+    labs (x = "Scheduled Departure Time")
+```

--- a/tests/docs/playwright/html/dark-brand/syntax-highlighting/arrow-syntax-highlighting.qmd
+++ b/tests/docs/playwright/html/dark-brand/syntax-highlighting/arrow-syntax-highlighting.qmd
@@ -1,0 +1,52 @@
+---
+format: html
+title: arrow syntax highlighting
+theme:
+  light: united
+  dark: slate
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - []
+        - ["link[href*=\"-dark-\"]"]
+---
+
+## Hello
+
+```markdown
+![asdf](asd.png)
+```
+
+
+```python
+#| label: fig-polar
+#| fig-cap: "A line plot on a polar axis"
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+r = np.arange(0, 2, 0.01)
+theta = 2 * np.pi * r
+fig, ax = plt.subplots(
+  subplot_kw = {'projection': 'polar'} 
+)
+ax.plot(theta, r)
+ax.set_rticks([0.5, 1, 1.5, 2])
+ax.grid(True)
+plt.show()
+```
+
+```r
+nycflights13::flights %>% 
+  mutate(
+    cancelled = is.na(dep_time),
+    sched_hour = sched_dep_time %/% 100,
+    sched_min = sched_dep_time %% 100,
+    sched_dep_time = sched_hour + sched_min / 60
+  ) %>% 
+  ggplot(mapping = aes(sched_dep_time)) + 
+    geom_freqpoly(mapping = aes(colour = cancelled), binwidth = 1/4) +
+    labs (x = "Scheduled Departure Time")
+```
+

--- a/tests/integration/playwright/tests/html-dark-mode-nojs.spec.ts
+++ b/tests/integration/playwright/tests/html-dark-mode-nojs.spec.ts
@@ -22,6 +22,29 @@ test('Light brand default, no JS', async ({ page }) => {
 });
 
 
+test('Syntax highlighting, a11y, no JS', async ({ page }) => {
+  // This document use a custom theme file that change the background color of the title banner
+  // Same user defined color should be used in both dark and light theme
+  await page.goto('./html/dark-brand/syntax-highlighting/a11y-syntax-highlighting.html');
+  const locatr = await page.locator('body').first();
+  await expect(locatr).toHaveClass('fullcontent quarto-light');
+  await expect(locatr).toHaveCSS('background-color', 'rgb(255, 255, 255)');
+  const importKeyword = await page.locator('span.im').first();
+  await expect(importKeyword).toHaveCSS('color', 'rgb(84, 84, 84)');
+});
+
+
+test('Syntax highlighting, arrow, no JS', async ({ page }) => {
+  // This document use a custom theme file that change the background color of the title banner
+  // Same user defined color should be used in both dark and light theme
+  await page.goto('./html/dark-brand/syntax-highlighting/arrow-syntax-highlighting.html');
+  const locatr = await page.locator('body').first();
+  await expect(locatr).toHaveClass('fullcontent quarto-light');
+  await expect(locatr).toHaveCSS('background-color', 'rgb(255, 255, 255)');
+  const link = await page.locator('span.al').first();
+  await expect(link).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+});
+
 test('Project dark brand default, no JS', async ({ page }) => {
   // This document use a custom theme file that change the background color of the title banner
   // Same user defined color should be used in both dark and light theme

--- a/tests/integration/playwright/tests/html-dark-mode.spec.ts
+++ b/tests/integration/playwright/tests/html-dark-mode.spec.ts
@@ -33,3 +33,31 @@ test('Brand false remove project brand', async ({ page }) => {
   // no toggle
   expect(await page.locator('a.quarto-color-scheme-toggle').count()).toEqual(0);
 });
+
+
+test('Syntax highlighting, a11y, with JS', async ({ page }) => {
+  // This document use a custom theme file that change the background color of the title banner
+  // Same user defined color should be used in both dark and light theme
+  await page.goto('./html/dark-brand/syntax-highlighting/a11y-syntax-highlighting.html');
+  const locatr = await page.locator('body').first();
+  await expect(locatr).toHaveClass('fullcontent quarto-light');
+  await expect(locatr).toHaveCSS('background-color', 'rgb(255, 255, 255)');
+  const importKeyword = await page.locator('span.im').first();
+  // light highlight stylesheet 
+  await expect(importKeyword).toHaveCSS('color', 'rgb(84, 84, 84)');
+  await page.locator("a.quarto-color-scheme-toggle").click();
+  // dark highlight stylesheet
+  await expect(importKeyword).toHaveCSS('color', 'rgb(248, 248, 242)');
+});
+
+
+test('Syntax highlighting, arrow, with JS', async ({ page }) => {
+  // This document use a custom theme file that change the background color of the title banner
+  // Same user defined color should be used in both dark and light theme
+  await page.goto('./html/dark-brand/syntax-highlighting/arrow-syntax-highlighting.html');
+  const locatr = await page.locator('body').first();
+  await expect(locatr).toHaveClass('fullcontent quarto-light');
+  await expect(locatr).toHaveCSS('background-color', 'rgb(255, 255, 255)');
+  const link = await page.locator('span.al').first();
+  await expect(link).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+});


### PR DESCRIPTION
Currently we have a very bad bug with syntax highlighting in dark mode

<img width="714" alt="image" src="https://github.com/user-attachments/assets/5cdd5468-f0c4-4b44-a6ad-e14c92bc3386" />

This is because we no longer disable the light highlight stylesheet due to honoring the dark = light + dark convention.

The last commit in this PR fixes this by following the light, dark, light stylesheet pattern we are following for the main stylesheet.

I prefer this because it is consistent with our old behavior (except in nojs) and the other stylesheet. However, if others prefer a simpler approach, we could handle this case differently and disable the light highlight stylesheet instead.

The first commit is the tests, which fail on their own.

The second commit is the fixes to the highlighting styles, so that dark + light does not have the artifacts we saw for arrow, a11y

fixes #12399
fixes #12522
