### PR TITLE
Update `QuartoNotebookRunner.jl` versions to `v0.16.0`

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -122,7 +122,7 @@ All changes included in 1.7:
 ### `julia`
 
 - ([#11803](https://github.com/quarto-dev/quarto-cli/pull/11803)): Added subcommands `status`, `kill`, `close [--force]` and `log` under the new CLI command `quarto call engine julia`.
-- ([#12121](https://github.com/quarto-dev/quarto-cli/pull/12121)): Update QuartoNotebookRunner to 0.14.0. Support for evaluating Python cells via [PythonCall.jl](https://github.com/JuliaPy/PythonCall.jl) added. Support for notebook caching via `execute.cache` added.
+- ([#12121](https://github.com/quarto-dev/quarto-cli/pull/12121)): Update QuartoNotebookRunner to 0.16.0. Support for evaluating Python cells via [PythonCall.jl](https://github.com/JuliaPy/PythonCall.jl) added. Support for notebook caching via `execute.cache` added.
 - ([#12151](https://github.com/quarto-dev/quarto-cli/pull/12151)): Basic YAML validation is now active for documents using Julia engine.
 
 ### `jupyter`

--- a/src/resources/julia/Project.toml
+++ b/src/resources/julia/Project.toml
@@ -2,4 +2,4 @@
 QuartoNotebookRunner = "4c0109c6-14e9-4c88-93f0-2b974d3468f4"
 
 [compat]
-QuartoNotebookRunner = "=0.15.0"
+QuartoNotebookRunner = "=0.16.0"


### PR DESCRIPTION
Includes some minor improvements to `ojs_define`, https://github.com/PumasAI/QuartoNotebookRunner.jl/blob/main/CHANGELOG.md#v0160---2025-04-11, allowing it to pass any tabular data to ojs rather than just `DataFrame` objects.