### PR TITLE
Cleanup leftover worktrees

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -162,6 +162,10 @@ All changes included in 1.7:
 
 - ([#12366](https://github.com/quarto-dev/quarto-cli/pull/12366)): Added Bulgarian translation for Quarto UI text (credit: @sakelariev)
 
+## `quarto publish`
+
+- ([#9929](https://github.com/quarto-dev/quarto-cli/issues/9929)): `quarto publish gh-pages` will now clean previous worktree directory leftover from previous deploys.
+
 ## Other Fixes and Improvements
 
 - A new folder `quarto-session-temp` can be created in `.quarto` to store temporary files created by Quarto during a rendering. Reminder: `.quarto` is for internal use of Quarto and should not be versioned (thus added to `.gitignore`).

--- a/src/publish/gh-pages/gh-pages.ts
+++ b/src/publish/gh-pages/gh-pages.ts
@@ -191,9 +191,10 @@ async function publish(
     type === "site" ? target?.url : undefined,
   );
 
+  const kPublishWorktreeDir = "quarto-publish-worktree-";
   // allocate worktree dir
   const temp = createTempContext(
-    { prefix: "quarto-publish-worktree-", dir: projectScratchPath(input) },
+    { prefix: kPublishWorktreeDir, dir: projectScratchPath(input) },
   );
   const tempDir = temp.baseDir;
   removeIfExists(tempDir);
@@ -202,7 +203,7 @@ async function publish(
   const worktreeDir = Deno.readDirSync(projectScratchPath(input));
   for (const entry of worktreeDir) {
     if (
-      entry.isDirectory && entry.name.startsWith("quarto-publish-worktree-")
+      entry.isDirectory && entry.name.startsWith(kPublishWorktreeDir)
     ) {
       debug(
         `Cleaning up leftover worktree folder ${entry.name} from past deploys`,


### PR DESCRIPTION
Add a prefix to worktree so that cleanup leftovers from past deploy is possible

It also moves the worktree into the `.quarto` scratch directory. It seems cleaner to hide it in this folder with is usually git ignored in quarto project. I have checked it works ok as worktrees are managed by git itself, and independant of main .gitignored. Also we now always call `worktree remove` for a new `quarto publish gh-pages` if there is a leftover

If that seems to be too dangerous, the worktree folder could still be moved in main project folder. 

This is hard to test as we need an interrupt to recreate the leftover problem...


