### PR TITLE
fix(website-listing): Avoid type error if `item.description` is not a string

### DIFF
--- a/src/project/types/website/listing/website-listing-template.ts
+++ b/src/project/types/website/listing/website-listing-template.ts
@@ -127,7 +127,7 @@ export function templateMarkdownHandler(
         }
       }
 
-      if (item.description !== undefined && !isPlaceHolder(item.description)) {
+      if (typeof item.description === "string" && !isPlaceHolder(item.description)) {
         const maxDescLength = listing[kMaxDescLength] as number ||
           -1;
         if (maxDescLength > 0) {


### PR DESCRIPTION

## Description

When using custom listings with a custom template, e.g. 

```md
---
listing:
  id: my-listing
  template: my-listing.ejs
  contents: my-listing.yml
---
```

template authors control how the contents are processed and may make odd decisions like including an item like this:

```yml
- title: Superzip explorer
  description: null
  href: https://gallery.shinyapps.io/superzip/
  code: https://github.com/posit-dev/py-shinywidgets/tree/main/examples/superzip/
  thumbnail: /gallery/superzip.png
```

Their template code is handling the rendering, so they may process `item.description` conditionally and the `null` is an okay value.

However, Quarto's internal `isPlaceHolder(item.description)` calls `.match()` on the description, which may not be a string, causing a type error.

```
TypeError: Cannot read properties of null (reading 'match')
```

This PR fixes this by checking not just that `item.description` is defined but also that it's a string before calling `isPlaceholder()`.

(Sidenote: I'm not sure why this code path is triggered in the presence of a custom listing template, but I'm confident this would avoid the type error I encountered.)

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog in the PR
- [x] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
