### PR TITLE
brand logo shortcode takes brandMode

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -153,6 +153,7 @@ All changes included in 1.7:
 - ([#12326](https://github.com/quarto-dev/quarto-cli/issues/12326)): Add `quarto.shortcode.*` API entry points for shortcode developers.
 - ([#12365](https://github.com/quarto-dev/quarto-cli/pull/12365)): `brand color` shortcode takes an optional `brandMode` second parameter, default `light`.
 - ([#12453](https://github.com/quarto-dev/quarto-cli/issues/12453)): Expose `_quarto.modules.brand` as `quarto.brand` and add `has_mode()` function.
+- ([#12564](https://github.com/quarto-dev/quarto-cli/issues/12564)): `brand logo` shortcode also takes an optional `brandMode` second parameter, default `light`.
 
 ### Conditional Content
 

--- a/src/core/brand/brand.ts
+++ b/src/core/brand/brand.ts
@@ -158,12 +158,12 @@ export class Brand {
       if (v) {
         logo[size] = v;
       }
-      for (const [key, value] of Object.entries(data.logo?.images ?? {})) {
-        if (typeof value === "string") {
-          logo.images[key] = { path: value };
-        } else {
-          logo.images[key] = value;
-        }
+    }
+    for (const [key, value] of Object.entries(data.logo?.images ?? {})) {
+      if (typeof value === "string") {
+        logo.images[key] = { path: value };
+      } else {
+        logo.images[key] = value;
       }
     }
 

--- a/src/resources/filters/quarto-pre/shortcodes-handlers.lua
+++ b/src/resources/filters/quarto-pre/shortcodes-handlers.lua
@@ -128,7 +128,11 @@ function initShortcodeHandlers()
 
     if brandCommand == "logo" then
       local logo_name = read_arg(args, 2)
-      local logo_value = brand.get_logo(logo_name)
+      local brandMode = 'light'
+      if #args > 2 then
+        brandMode = read_arg(args, 3) or brandMode
+      end
+      local logo_value = brand.get_logo(brandMode, logo_name)
       local entry = { path = nil }
 
       if type(logo_value) ~= "table" then

--- a/tests/docs/shortcodes/brand-logo-dark.qmd
+++ b/tests/docs/shortcodes/brand-logo-dark.qmd
@@ -1,0 +1,28 @@
+---
+title: Test brand light/dark shortcodes
+format: html
+brand:
+  light:
+    logo:
+      small:
+        light: sun.png
+        dark: sun.png
+  dark:
+    logo:
+      small:
+        light: moon.png
+        dark: moon.png
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        -
+          - 'img[src="moon.png"]'
+        - []
+---
+
+::: {}
+
+{{< brand logo small dark >}}
+
+:::

--- a/tests/docs/shortcodes/brand-logo-light.qmd
+++ b/tests/docs/shortcodes/brand-logo-light.qmd
@@ -1,0 +1,30 @@
+---
+title: Test brand light/dark shortcodes
+format: html
+brand:
+  light:
+    logo:
+      small:
+        # light/dark don't work here yet,
+        # but brand.ts will drop entries that don't have both
+        light: sun.png
+        dark: sun.png
+  dark:
+    logo:
+      small:
+        light: moon.png
+        dark: moon.png
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        -
+          - 'img[src="sun.png"]'
+        - []
+---
+
+::: {}
+
+{{< brand logo small >}}
+
+:::

--- a/tests/docs/shortcodes/brand-logo-one-brand.qmd
+++ b/tests/docs/shortcodes/brand-logo-one-brand.qmd
@@ -1,0 +1,22 @@
+---
+title: Test brand light/dark shortcodes
+format: html
+brand:
+  logo:
+    small:
+      # light/dark don't work here yet,
+      # but brand.ts will drop entries that don't have both
+      light: sun.png
+      dark: moon.png
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        -
+          - 'img[src="sun.png"]'
+        - []
+---
+
+
+{{< brand logo small >}}
+


### PR DESCRIPTION
Fixes #12564 and allows choosing the dark brand.

Note that we still don't really resolve dark logos; this only chooses properly chooses the light brand or dark brand, but still pulls *the light logo* from there.

In 1.8 I argue we should repurpose this parameter to actually find a dark logo if requested, when there is a more sensible search provided in #12341 dark logo.

This PR includes an unrelated code cleanup in `brand.ts`, pulling out an unintentionally nested loop for clarity. 