### PR TITLE
check for cell and cell-output-display classes defensively

### DIFF
--- a/src/resources/filters/quarto-post/cell-renderings.lua
+++ b/src/resources/filters/quarto-post/cell-renderings.lua
@@ -12,7 +12,7 @@ function choose_cell_renderings()
   return {
     Div = function(div)
       -- Only process cell div with renderings attr
-      if not div.classes:includes("cell") or not div.attributes["renderings"] then
+      if not div.classes or not div.classes:includes("cell") or not div.attributes["renderings"] then
         return nil
       end
       local renderingsJson = div.attributes['renderings']
@@ -24,7 +24,7 @@ function choose_cell_renderings()
       local cods = {}
       local firstCODIndex = nil
       for i, cellOutput in ipairs(div.content) do
-        if cellOutput.classes:includes("cell-output-display") then
+        if cellOutput.classes and cellOutput.classes:includes("cell-output-display") then
           if not firstCODIndex then
             firstCODIndex = i
           end

--- a/tests/docs/smoke-all/dark-mode/gt-capcross.qmd
+++ b/tests/docs/smoke-all/dark-mode/gt-capcross.qmd
@@ -1,0 +1,51 @@
+---
+title: "knitr dark mode - gt"
+brand:
+  light: united-brand.yml
+  dark: slate-brand.yml
+execute:
+  echo: false
+  warning: false
+---
+
+```{r}
+#| echo: false
+#| warning: false
+library(gt)
+
+gt_brand <- function(brand_yml) {
+  brand <- yaml::yaml.load_file(brand_yml)
+  return(function(table) {
+    table |>
+      tab_options(
+        table.background.color = brand$color$background,
+        table.font.color = brand$color$foreground,
+      )
+  })
+}
+united_theme <- gt_brand("united-brand.yml")
+slate_theme <- gt_brand("slate-brand.yml")
+```
+
+This example will lose the caption, because combining `tbl-cap` with `renderings` is not supported.
+
+But it should not crash.
+
+
+::: {#tbl-cap-cross}
+
+```{r}
+#| renderings: [light, dark]
+#| tbl-cap: a caption
+caws <- head(mtcars) %>% gt()
+
+caws |> united_theme()
+
+caws |> slate_theme()
+```
+
+:::
+
+Here's a [link](https://example.com).
+
+{{< lipsum 3 >}}


### PR DESCRIPTION
Fixes a crash with unsupported tbl-cap/renderings combo.

(The test example won't work right but it shouldn't crash.)
