### PR TITLE
bugfix: giscus light dark toggle on load

### DIFF
--- a/src/resources/formats/html/giscus/giscus.ejs
+++ b/src/resources/formats/html/giscus/giscus.ejs
@@ -22,7 +22,7 @@
           if(giscusIframe) {
             giscusIframe.addEventListener("load", function() {
               window.setTimeout(() => {
-                window.toggleGiscusIfUsed(window.hasAlternateSentinel(), authorPrefersDark);
+                toggleGiscusIfUsed(hasAlternateSentinel(), authorPrefersDark);
               }, 100);
             });
             giscusIframeObserver.disconnect();

--- a/src/resources/formats/html/giscus/giscus.ejs
+++ b/src/resources/formats/html/giscus/giscus.ejs
@@ -13,5 +13,15 @@
         <%- giscus.loading ? `data-loading=${giscus.loading}` : '' %>
         async>
 </script>
+<script type="application/javascript">
+  window.document.addEventListener("DOMContentLoaded", function (event) {
+    var giscusIframe = window.document.querySelector('iframe.giscus-frame');
+    giscusIframe.addEventListener("load", function() {
+      window.setTimeout(() => {
+        window.toggleGiscusIfUsed(window.hasAlternateSentinel(), authorPrefersDark);
+      }, 100);
+    });
+  });
+</script>
 <input type="hidden" id="giscus-base-theme" value="<%- giscus.baseTheme %>">
 <input type="hidden" id="giscus-alt-theme" value="<%- giscus.altTheme %>">

--- a/src/resources/formats/html/giscus/giscus.ejs
+++ b/src/resources/formats/html/giscus/giscus.ejs
@@ -14,14 +14,24 @@
         async>
 </script>
 <script type="application/javascript">
-  window.document.addEventListener("DOMContentLoaded", function (event) {
-    var giscusIframe = window.document.querySelector('iframe.giscus-frame');
-    giscusIframe.addEventListener("load", function() {
-      window.setTimeout(() => {
-        window.toggleGiscusIfUsed(window.hasAlternateSentinel(), authorPrefersDark);
-      }, 100);
+  const giscusIframeObserver = new MutationObserver(function (mutations) {
+    mutations.forEach(function (mutation) {
+      mutation.addedNodes.forEach(function (addedNode) {
+        if (addedNode.matches && addedNode.matches('div.giscus')) {
+          const giscusIframe = addedNode.querySelector('iframe.giscus-frame');
+          if(giscusIframe) {
+            giscusIframe.addEventListener("load", function() {
+              window.setTimeout(() => {
+                window.toggleGiscusIfUsed(window.hasAlternateSentinel(), authorPrefersDark);
+              }, 100);
+            });
+            giscusIframeObserver.disconnect();
+          }
+        }
+      });
     });
   });
+  giscusIframeObserver.observe(document.body, { childList: true, subtree: true });
 </script>
 <input type="hidden" id="giscus-base-theme" value="<%- giscus.baseTheme %>">
 <input type="hidden" id="giscus-alt-theme" value="<%- giscus.altTheme %>">

--- a/src/resources/formats/html/templates/quarto-html-after-body.ejs
+++ b/src/resources/formats/html/templates/quarto-html-after-body.ejs
@@ -22,7 +22,7 @@
   
       window.document.body.appendChild(a);
     }
-    window.setColorSchemeToggle(window.hasAlternateSentinel())
+    setColorSchemeToggle(hasAlternateSentinel())
 
     <% } %>
   

--- a/src/resources/formats/html/templates/quarto-html-before-body.ejs
+++ b/src/resources/formats/html/templates/quarto-html-before-body.ejs
@@ -21,7 +21,7 @@
       }
     }
 
-    window.setColorSchemeToggle = (alternate) => {
+    const setColorSchemeToggle = (alternate) => {
       const toggles = window.document.querySelectorAll('.quarto-color-scheme-toggle');
       for (let i=0; i < toggles.length; i++) {
         const toggle = toggles[i];
@@ -56,7 +56,7 @@
       manageTransitions('#quarto-margin-sidebar .nav-link', true);
 
       // Switch the toggles
-      window.setColorSchemeToggle(alternate)
+      setColorSchemeToggle(alternate)
 
       // Hack to workaround the fact that safari doesn't
       // properly recolor the scrollbar when toggling (#1455)
@@ -103,7 +103,7 @@
       return window.location.protocol === 'file:';
     }
 
-    window.hasAlternateSentinel = () => {
+    const hasAlternateSentinel = () => {
       let styleSentinel = getColorSchemeSentinel();
       if (styleSentinel !== null) {
         return styleSentinel === "alternate";
@@ -182,13 +182,11 @@
     // Dark / light mode switch
     window.quartoToggleColorScheme = () => {
       // Read the current dark / light value
-      let toAlternate = !window.hasAlternateSentinel();
+      let toAlternate = !hasAlternateSentinel();
       toggleColorMode(toAlternate);
       setStyleSentinel(toAlternate);
       toggleGiscusIfUsed(toAlternate, darkModeDefault);
     };
-
-    window.toggleGiscusIfUsed = toggleGiscusIfUsed;
 
     <% if (respectUserColorScheme) { %>
     queryPrefersDark.addEventListener("change", e => {
@@ -202,7 +200,7 @@
     <% } %>
 
     // Switch to dark mode if need be
-    if (window.hasAlternateSentinel()) {
+    if (hasAlternateSentinel()) {
       toggleColorMode(true);
     } else {
       toggleColorMode(false);

--- a/src/resources/formats/html/templates/quarto-html-before-body.ejs
+++ b/src/resources/formats/html/templates/quarto-html-before-body.ejs
@@ -188,6 +188,8 @@
       toggleGiscusIfUsed(toAlternate, darkModeDefault);
     };
 
+    window.toggleGiscusIfUsed = toggleGiscusIfUsed;
+
     <% if (respectUserColorScheme) { %>
     queryPrefersDark.addEventListener("change", e => {
       if(window.localStorage.getItem("quarto-color-scheme") !== null)

--- a/src/resources/formats/html/templates/quarto-html-before-body.ejs
+++ b/src/resources/formats/html/templates/quarto-html-before-body.ejs
@@ -136,7 +136,7 @@
   
       let newTheme = '';
   
-      if(darkModeDefault) {
+      if(authorPrefersDark) {
         newTheme = isAlternate ? baseTheme : alternateTheme;
       } else {
         newTheme = isAlternate ? alternateTheme : baseTheme;
@@ -164,11 +164,12 @@
       }
     };
 
+    const authorPrefersDark = <%= darkModeDefault %>;
     <% if (respectUserColorScheme) { %>
     const queryPrefersDark = window.matchMedia('(prefers-color-scheme: dark)');
     const darkModeDefault = queryPrefersDark.matches;
     <% } else { %>
-    const darkModeDefault = <%= darkModeDefault %>;
+    const darkModeDefault = authorPrefersDark;
     <% } %>
 
     <% if (!darkModeDefault) { %>


### PR DESCRIPTION
Simpler alternative to #12608

Wait for giscus to load and then set its light/dark toggle immediately.

This is failing on Safari. May still need a Mutation Observer for the iframe.