### PR TITLE
light/dark toggle: fire window resize event

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -1,4 +1,10 @@
-All changes included in 1.7:
+# v1.8 backports
+
+## In this release
+
+- ([#12625](https://github.com/quarto-dev/quarto-cli/pull/12625)): Fire resize event on window when light/dark toggle is clicked, to tell widgets to resize.
+
+# v1.7 changes
 
 ## Regression fixes
 

--- a/src/resources/formats/html/templates/quarto-html-before-body.ejs
+++ b/src/resources/formats/html/templates/quarto-html-before-body.ejs
@@ -186,6 +186,7 @@
       toggleColorMode(toAlternate);
       setStyleSentinel(toAlternate);
       toggleGiscusIfUsed(toAlternate, darkModeDefault);
+      window.dispatchEvent(new Event('resize'));
     };
 
     <% if (respectUserColorScheme) { %>


### PR DESCRIPTION
This is a backport PR for v1.7

The light/dark toggle is now hiding and showing all of the plots and tables via `.light-content`,  `.dark-content`. Some of these plots and tables may be widgets which need to check their size. 

Technique found in `ShinyResizeObserver`: fire a resize event on the window. 

This fixes sizing issues in plotly-python[^1] and heatmaply, and it fixes leaflet not displaying when toggling between light and dark modes.


[^1]: plotly-python jitters on first toggle