### PR TITLE
light/dark toggle fire resize event

### DIFF
--- a/src/resources/formats/html/templates/quarto-html-before-body.ejs
+++ b/src/resources/formats/html/templates/quarto-html-before-body.ejs
@@ -186,6 +186,7 @@
       toggleColorMode(toAlternate);
       setStyleSentinel(toAlternate);
       toggleGiscusIfUsed(toAlternate, darkModeDefault);
+      window.dispatchEvent(new Event('resize'));
     };
 
     <% if (respectUserColorScheme) { %>


### PR DESCRIPTION
Fixes sizing issues in plotly-python and heatmaply

Fixes non-displaying leaflet on toggle.

this is the 1.8 port of #12625
