### PR TITLE
Chore/1.8 dependencies refresh

### DIFF
--- a/configuration
+++ b/configuration
@@ -16,7 +16,7 @@ export DENO=v1.46.3
 export DENO_DOM=v0.1.41-alpha-artifacts
 export PANDOC=3.6.3
 export DARTSASS=1.85.1
-export ESBUILD=0.19.12
+export ESBUILD=0.25.3
 export TYPST=0.13.0
 
 

--- a/configuration
+++ b/configuration
@@ -15,7 +15,7 @@ export DENO=v1.46.3
 # TODO figure out where 0.1.41 apple silicon libs are available
 export DENO_DOM=v0.1.41-alpha-artifacts
 export PANDOC=3.6.3
-export DARTSASS=1.85.1
+export DARTSASS=1.87.0
 export ESBUILD=0.25.3
 export TYPST=0.13.0
 

--- a/package/src/cmd/pkg-cmd.ts
+++ b/package/src/cmd/pkg-cmd.ts
@@ -7,7 +7,7 @@
 import { Command } from "cliffy/command/mod.ts";
 import { join } from "../../../src/deno_ral/path.ts";
 
-import { printConfiguration } from "../common/config.ts";
+import { configurationAST } from "../common/config.ts";
 
 import {
   Configuration,
@@ -15,6 +15,7 @@ import {
   kValidOS,
   readConfiguration,
 } from "../common/config.ts";
+import { logPandocJson } from "../../../src/core/log.ts";
 
 export const kLogLevel = "logLevel";
 export const kVersion = "setVersion";
@@ -49,7 +50,7 @@ export function packageCommand(run: (config: Configuration) => Promise<void>) {
       Deno.env.set("QUARTO_DEBUG", "true");
 
       // Print the configuration
-      printConfiguration(config);
+      await logPandocJson(configurationAST(config));
 
       // Run the command
       await run(config);

--- a/package/src/cmd/pkg-cmd.ts
+++ b/package/src/cmd/pkg-cmd.ts
@@ -7,7 +7,7 @@
 import { Command } from "cliffy/command/mod.ts";
 import { join } from "../../../src/deno_ral/path.ts";
 
-import { configurationAST } from "../common/config.ts";
+import { configurationAST, printConfiguration } from "../common/config.ts";
 
 import {
   Configuration,
@@ -50,7 +50,11 @@ export function packageCommand(run: (config: Configuration) => Promise<void>) {
       Deno.env.set("QUARTO_DEBUG", "true");
 
       // Print the configuration
-      await logPandocJson(configurationAST(config));
+      try {
+        await logPandocJson(configurationAST(config));
+      } catch (e) {
+        printConfiguration(config);
+      }
 
       // Run the command
       await run(config);

--- a/package/src/common/archive-binary-dependencies.ts
+++ b/package/src/common/archive-binary-dependencies.ts
@@ -5,6 +5,7 @@
  */
 import { join } from "../../../src/deno_ral/path.ts";
 import { info } from "../../../src/deno_ral/log.ts";
+import { logPandoc } from "../../../src/core/log.ts";
 
 import { execProcess } from "../../../src/core/process.ts";
 import { Configuration, withWorkingDir } from "./config.ts";
@@ -34,7 +35,7 @@ export function archiveUrl(
 // Archives dependencies (if they are not present in the archive already)
 export async function archiveBinaryDependencies(_config: Configuration) {
   await withWorkingDir(async (workingDir) => {
-    info(`Updating binary dependencies...\n`);
+    await logPandoc(`## Updating binary dependencies`);
 
     for (const dependency of kDependencies) {
       await archiveBinaryDependency(dependency, workingDir);
@@ -45,7 +46,7 @@ export async function archiveBinaryDependencies(_config: Configuration) {
 // Archives dependencies (if they are not present in the archive already)
 export async function checkBinaryDependencies(_config: Configuration) {
   await withWorkingDir(async (workingDir) => {
-    info(`Updating binary dependencies...\n`);
+    await logPandoc(`## Checking binary dependencies`);
 
     for (const dependency of kDependencies) {
       await checkBinaryDependency(dependency, workingDir);
@@ -99,10 +100,9 @@ export async function archiveBinaryDependency(
   dependency: Dependency,
   workingDir: string,
 ) {
-  info(`** ${dependency.name} ${dependency.version} **`);
+  await logPandoc(`## ${dependency.name} ${dependency.version}\n\nChecking archive status...`, "markdown");
 
   const dependencyBucketPath = `${dependency.bucket}/${dependency.version}`;
-  info("Checking archive status...\n");
 
   const archive = async (
     architectureDependency: ArchitectureDependency,
@@ -117,7 +117,7 @@ export async function archiveBinaryDependency(
         
         const dependencyAwsPath =
           `${kBucket}/${dependencyBucketPath}/${platformDep.filename}`;
-        info(`Checking ${dependencyAwsPath}`);
+        await logPandoc(`Checking \`${dependencyAwsPath}\``, "markdown");
         const response = await s3cmd("ls", [dependencyAwsPath]);
         if (response?.includes('Unable to locate credentials')) {
           throw new Error("Unable to locate S3 credentials, please try again.");
@@ -126,8 +126,8 @@ export async function archiveBinaryDependency(
 
         if (!response) {
           // This dependency doesn't exist, archive it
-          info(
-            `Archiving ${dependencyBucketPath} - ${platformDep.filename}`,
+          await logPandoc(
+            `Archiving \`${dependencyBucketPath}\` - ${platformDep.filename}`,
           );
 
           // Download the file
@@ -144,23 +144,18 @@ export async function archiveBinaryDependency(
             "--acl",
             "public-read",
           ]);
-          
-          info(`(Reponse): ${result}`);
-
+          info(`  (Response): ${result}`);
         } else {
-          info(`${dependencyAwsPath} already archived.`);
+          info(`  ${dependencyAwsPath.split("/").slice(-1)[0]} already archived.\n`);
         }
       }
     }
   };
 
   for (const arch of Object.keys(dependency.architectureDependencies)) {
-    info(`Archiving ${dependency.name}`);
     const archDep = dependency.architectureDependencies[arch];
     await archive(archDep);
   }
-
-  info("");
 }
 
 async function s3cmd(cmd: string, args: string[]) {

--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -470,11 +470,20 @@ export async function logPandocJson(
   return logPandoc(src, "json");
 }
 
+const getColumns = () => {
+  try {
+    // Catch error in none tty mode: Inappropriate ioctl for device (os error 25)
+    return Deno.consoleSize().columns ?? 130;
+  } catch (_error) {
+    return 130;
+  }
+};
+
 export async function logPandoc(
   src: string,
   format: string = "markdown",
 ) {
-  const cols = Deno.consoleSize().columns;
+  const cols = getColumns();
   const result = await execProcess({
     cmd: [
       pandocBinaryPath(),

--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -19,6 +19,9 @@ import { lines } from "./text.ts";
 import { debug, error, getLogger, setup, warning } from "../deno_ral/log.ts";
 import { asErrorEx, InternalError } from "./lib/error.ts";
 import { onCleanup } from "./cleanup.ts";
+import { execProcess } from "./process.ts";
+import { pandocBinaryPath } from "./resources.ts";
+import { Block, pandoc } from "./pandoc/json.ts";
 
 export type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
 
@@ -459,3 +462,33 @@ const levelMap: Record<
   warning: "WARN",
   error: "ERROR",
 };
+
+export async function logPandocJson(
+  blocks: Block[],
+) {
+  const src = JSON.stringify(pandoc({}, blocks), null, 2);
+  return logPandoc(src, "json");
+}
+
+export async function logPandoc(
+  src: string,
+  format: string = "markdown",
+) {
+  const cols = Deno.consoleSize().columns;
+  const result = await execProcess({
+    cmd: [
+      pandocBinaryPath(),
+      "-f",
+      format,
+      "-t",
+      "ansi",
+      `--columns=${cols}`,
+    ],
+    stdout: "piped",
+  }, src);
+  if (result.code !== 0) {
+    error(result.stderr);
+  } else {
+    log.info(result.stdout);
+  }
+}

--- a/src/core/pandoc/json.ts
+++ b/src/core/pandoc/json.ts
@@ -1,0 +1,580 @@
+/*
+ * json.ts
+ *
+ * Copyright (C) 2025 Posit Software, PBC
+ */
+
+// An EDSL for building Pandoc AST JSON
+
+// utilities
+export type Attr = [string, string[], string[][]];
+export type Caption = [null, Block[]];
+export type Alignment = { "t": "AlignLeft" } | { "t": "AlignCenter" } | {
+  "t": "AlignRight";
+};
+export type ColWidth = { "t": "ColWidthDefault" } | {
+  "t": "ColWidth";
+  c: number;
+};
+export type ColSpec = [Alignment, ColWidth];
+
+export type TableHead = [Attr, TableRow[]];
+export type TableRow = [Attr, TableCell[]];
+export type TableCell = [Attr, Alignment, number, number, Block[]];
+
+export type TableBody = [Attr, number, TableRow[], TableRow[]];
+export type TableFoot = [Attr, TableRow[]];
+export type Citation = {
+  citationId: string;
+  citationPrefix: Inline[];
+  citationSuffix: Inline[];
+  citationMode: { "t": "AuthorInText" | "SuppressAuthor" | "NormalCitation" };
+  citationNoteNum: number;
+  citationHash: number;
+};
+
+// Inlines
+export type Cite = {
+  "t": "Cite";
+  "c": [Citation[], Inline[]];
+};
+
+export type Code = {
+  "t": "Code";
+  "c": [Attr, string];
+};
+
+export type Emph = {
+  "t": "Emph";
+  "c": Inline[];
+};
+
+export type Image = {
+  "t": "Image";
+  "c": [Attr, Inline[], [string, string]];
+};
+
+export type LineBreak = { "t": "LineBreak" };
+
+export type Link = {
+  "t": "Link";
+  "c": [Attr, Inline[], [string, string]];
+};
+
+export type Math = {
+  "t": "Math";
+  "c": [{ "t": "DisplayMath" | "InlineMath" }, string];
+};
+
+export type Note = {
+  "t": "Note";
+  "c": Block[];
+};
+
+export type Quoted = {
+  "t": "Quoted";
+  "c": [{ "t": "DoubleQuote" | "SingleQuote" }, Inline[]];
+};
+
+export type RawInline = {
+  "t": "RawInline";
+  "c": [string, string];
+};
+
+export type SmallCaps = {
+  "t": "SmallCaps";
+  "c": Inline[];
+};
+
+export type SoftBreak = { "t": "SoftBreak" };
+
+export type Space = { "t": "Space" };
+
+export type Span = {
+  "t": "Span";
+  "c": [Attr, ...Span[]];
+};
+
+export type Str = {
+  "t": "Str";
+  "c": string;
+};
+
+export type Strikeout = {
+  "t": "Strikeout";
+  "c": Inline[];
+};
+
+export type Strong = {
+  "t": "Strong";
+  "c": Inline[];
+};
+
+export type Subscript = {
+  "t": "Subscript";
+  "c": Inline[];
+};
+
+export type Superscript = {
+  "t": "Superscript";
+  "c": Inline[];
+};
+
+export type Underline = {
+  "t": "Underline";
+  "c": Inline[];
+};
+
+export type Inline =
+  | Cite
+  | Code
+  | Emph
+  | Image
+  | LineBreak
+  | Link
+  | Math
+  | Note
+  | Quoted
+  | RawInline
+  | SmallCaps
+  | SoftBreak
+  | Space
+  | Span
+  | Str
+  | Strikeout
+  | Strong
+  | Subscript
+  | Superscript
+  | Underline;
+
+// Define a type for inline elements that have c: Inline[] structure
+type SimpleInlineType =
+  | "Emph"
+  | "SmallCaps"
+  | "Strikeout"
+  | "Strong"
+  | "Subscript"
+  | "Superscript"
+  | "Underline";
+
+// Type guard to check if an inline type is a SimpleInlineType
+type SimpleInline = Extract<Inline, { t: SimpleInlineType; c: Inline[] }>;
+
+// Blocks
+export type BlockQuote = {
+  "t": "BlockQuote";
+  "c": Block[];
+};
+
+export type BulletList = {
+  "t": "BulletList";
+  "c": Block[][];
+};
+
+export type CodeBlock = {
+  "t": "CodeBlock";
+  "c": [Attr, string];
+};
+
+export type DefinitionList = {
+  "t": "DefinitionList";
+  "c": [Inline[], Block[]][];
+};
+
+export type Div = {
+  "t": "Div";
+  "c": [Attr, ...Block[]];
+};
+
+export type Figure = {
+  "t": "Figure";
+  "c": [Attr, [null, Block[]], Block[]];
+};
+
+export type Header = {
+  "t": "Header";
+  "c": [number, Attr, Inline[]];
+};
+
+export type HorizontalRule = {
+  "t": "HorizontalRule";
+};
+
+export type LineBlock = {
+  t: "LineBlock";
+  c: Inline[][];
+};
+
+export type OrderedList = {
+  "t": "OrderedList";
+  "c": [[number, {
+    "t":
+      | "DefaultStyle"
+      | "Example"
+      | "Decimal"
+      | "LowerRoman"
+      | "UpperRoman"
+      | "LowerAlpha"
+      | "UpperAlpha";
+  }, { "t": "DefaultDelim" | "Period" | "Paren" }], Block[][]];
+};
+
+export type Para = {
+  "t": "Para";
+  "c": Inline[];
+};
+
+export type Plain = {
+  "t": "Plain";
+  "c": Inline[];
+};
+
+export type RawBlock = {
+  "t": "RawBlock";
+  "c": [string, string];
+};
+
+export type Table = {
+  "t": "Table";
+  "c": [
+    Attr,
+    Caption,
+    ColSpec[],
+    TableHead,
+    TableBody[],
+    TableFoot,
+  ];
+};
+
+export type Block =
+  | BlockQuote
+  | BulletList
+  | CodeBlock
+  | DefinitionList
+  | Div
+  | Figure
+  | Header
+  | HorizontalRule
+  | LineBlock
+  | OrderedList
+  | Para
+  | Plain
+  | RawBlock
+  | Table;
+
+export type Pandoc = {
+  "pandoc-api-version": [number, number, number];
+  meta: Record<string, string>;
+  blocks: Block[];
+};
+
+// inline constructors
+
+export function attr(
+  id?: string,
+  classes?: string[],
+  keyvals?: Record<string, string>,
+): Attr {
+  const keyvalsArray: string[][] = [];
+  if (keyvals) {
+    for (const [key, value] of Object.entries(keyvals)) {
+      keyvalsArray.push([key, value]);
+    }
+  }
+  return [id || "", classes || [], keyvalsArray];
+}
+
+const makeInlinesNode = <T extends SimpleInlineType>(name: T) =>
+(
+  content: Inline[],
+): SimpleInline => {
+  return {
+    t: name,
+    c: content,
+  } as SimpleInline;
+};
+const ensureAttr = (attr?: Attr): Attr => {
+  if (!attr) {
+    return ["", [], []];
+  }
+  return attr;
+};
+
+export const cite = (citations: Citation[], content: Inline[]): Cite => ({
+  t: "Cite",
+  c: [citations, content],
+});
+
+export const code = (content: string, attr?: Attr): Code => ({
+  t: "Code",
+  c: [ensureAttr(attr), content],
+});
+
+export const emph = makeInlinesNode("Emph");
+
+export const image = (
+  content: Inline[],
+  url: string,
+  description = "",
+  attr?: Attr,
+): Image => ({
+  t: "Image",
+  c: [ensureAttr(attr), content, [url, description]],
+});
+
+export const lineBreak = (): LineBreak => ({
+  t: "LineBreak",
+});
+
+export const link = (
+  attr: Attr,
+  content: Inline[],
+  url: string,
+  description = "",
+): Link => ({
+  t: "Link",
+  c: [attr, content, [url, description]],
+});
+
+export const math = (
+  type: "DisplayMath" | "InlineMath",
+  content: string,
+): Math => ({
+  t: "Math",
+  c: [{ t: type }, content],
+});
+
+export const note = (content: Block[]): Note => ({
+  t: "Note",
+  c: content,
+});
+
+export const quoted = (
+  type: "DoubleQuote" | "SingleQuote",
+  content: Inline[],
+): Quoted => ({
+  t: "Quoted",
+  c: [{ t: type }, content],
+});
+
+export const rawInline = (format: string, content: string): RawInline => ({
+  t: "RawInline",
+  c: [format, content],
+});
+
+export const smallCaps = makeInlinesNode("SmallCaps");
+
+export const softBreak = (): SoftBreak => ({
+  t: "SoftBreak",
+});
+
+export const space = (): Space => ({
+  t: "Space",
+});
+
+export const span = (attr: Attr, content: Span[]): Span => ({
+  t: "Span",
+  c: [attr, ...content],
+});
+
+export const str = (content: string): Str => ({
+  t: "Str",
+  c: content,
+});
+
+export const strikeout = makeInlinesNode("Strikeout");
+
+export const strong = makeInlinesNode("Strong");
+
+export const subscript = makeInlinesNode("Subscript");
+
+export const superscript = makeInlinesNode("Superscript");
+
+export const underline = makeInlinesNode("Underline");
+
+// block constructors
+
+export const blockQuote = (content: Block[]): BlockQuote => ({
+  t: "BlockQuote",
+  c: content,
+});
+
+export const bulletList = (content: Block[][]): BulletList => ({
+  t: "BulletList",
+  c: content,
+});
+
+export const codeBlock = (content: string, attr?: Attr): CodeBlock => ({
+  t: "CodeBlock",
+  c: [ensureAttr(attr), content],
+});
+
+export const definitionList = (
+  content: [Inline[], Block[]][],
+): DefinitionList => ({
+  t: "DefinitionList",
+  c: content,
+});
+
+export const div = (content: Block[], attr?: Attr): Div => ({
+  t: "Div",
+  c: [ensureAttr(attr), ...content],
+});
+
+export const figure = (
+  caption: Caption,
+  content: Block[],
+  attr?: Attr,
+): Figure => ({
+  t: "Figure",
+  c: [ensureAttr(attr), caption, content],
+});
+
+export const header = (
+  level: number,
+  content: Inline[],
+  attr?: Attr,
+): Header => ({
+  t: "Header",
+  c: [level, ensureAttr(attr), content],
+});
+
+export const horizontalRule = (): HorizontalRule => ({
+  t: "HorizontalRule",
+});
+
+export const lineBlock = (content: Inline[][]): LineBlock => ({
+  t: "LineBlock",
+  c: content,
+});
+
+export const orderedList = (
+  start: number,
+  style:
+    | "DefaultStyle"
+    | "Example"
+    | "Decimal"
+    | "LowerRoman"
+    | "UpperRoman"
+    | "LowerAlpha"
+    | "UpperAlpha",
+  delimiter: "DefaultDelim" | "Period" | "Paren",
+  content: Block[][],
+): OrderedList => ({
+  t: "OrderedList",
+  c: [[start, { t: style }, { t: delimiter }], content],
+});
+
+export const para = (content: Inline[]): Para => ({
+  t: "Para",
+  c: content,
+});
+
+export const plain = (content: Inline[]): Plain => ({
+  t: "Plain",
+  c: content,
+});
+
+export const rawBlock = (format: string, content: string): RawBlock => ({
+  t: "RawBlock",
+  c: [format, content],
+});
+
+export const table = (
+  caption: Caption,
+  colSpec: ColSpec[],
+  head: TableHead,
+  body: TableBody[],
+  foot?: TableFoot,
+  attr?: Attr,
+): Table => ({
+  t: "Table",
+  c: [
+    ensureAttr(attr),
+    caption,
+    colSpec,
+    head,
+    body,
+    foot || tableFoot([], ensureAttr()),
+  ],
+});
+
+export const colspec = (
+  alignment: "AlignLeft" | "AlignCenter" | "AlignRight",
+  colWidth: "ColWidthDefault" | { t: "ColWidth"; c: number },
+): ColSpec => {
+  const alignmentObj: Alignment = { t: alignment };
+  const colWidthObj: ColWidth = colWidth === "ColWidthDefault"
+    ? { t: "ColWidthDefault" }
+    : { t: "ColWidth", c: colWidth.c };
+  return [
+    alignmentObj,
+    colWidthObj,
+  ];
+};
+
+export const caption = (content: Block[]): Caption => [null, content];
+
+export const tableHead = (rows: TableRow[], attr?: Attr): TableHead => [
+  ensureAttr(attr),
+  rows,
+];
+
+export const tableRow = (cells: TableCell[], attr?: Attr): TableRow => [
+  ensureAttr(attr),
+  cells,
+];
+
+export const tableCell = (
+  content: Block[],
+  alignment: "AlignLeft" | "AlignCenter" | "AlignRight" = "AlignLeft",
+  colspan = 1,
+  rowspan = 1,
+  attr?: Attr,
+): TableCell => [
+  ensureAttr(attr),
+  { t: alignment },
+  colspan,
+  rowspan,
+  content,
+];
+
+export const tableBody = (
+  body: TableRow[],
+  head?: TableRow[],
+  rowHeadColumns: number = 0,
+  attr?: Attr,
+): TableBody => [ensureAttr(attr), rowHeadColumns, body, head || []];
+
+export const tableFoot = (rows: TableRow[], attr?: Attr): TableFoot => [
+  ensureAttr(attr),
+  rows,
+];
+
+export const citation = (
+  citationId: string,
+  citationPrefix: Inline[],
+  citationSuffix: Inline[],
+  citationMode:
+    | "AuthorInText"
+    | "SuppressAuthor"
+    | "NormalCitation",
+  citationNoteNum: number,
+  citationHash: number,
+): Citation => ({
+  citationId,
+  citationPrefix,
+  citationSuffix,
+  citationMode: { t: citationMode },
+  citationNoteNum,
+  citationHash,
+});
+
+export const pandoc = (
+  meta: Record<string, string>,
+  blocks: Block[],
+): Pandoc => ({
+  "pandoc-api-version": [1, 23, 1],
+  meta,
+  blocks,
+});

--- a/src/core/pandoc/table.ts
+++ b/src/core/pandoc/table.ts
@@ -1,0 +1,38 @@
+/*
+ * table.ts
+ *
+ * Helpers for creating Pandoc AST tables from JS objects
+ *
+ * Copyright (C) 2025 Posit Software, PBC
+ */
+
+import * as Pandoc from "./json.ts";
+
+export const fromObjects = (
+  objects: Record<string, Pandoc.Block[]>[],
+  keys?: string[],
+  colSpecs?: Pandoc.ColSpec[],
+): Pandoc.Table => {
+  if (keys === undefined) {
+    keys = Object.keys(objects[0]);
+  }
+  const header = Pandoc.tableHead([
+    Pandoc.tableRow(
+      keys.map((key) => Pandoc.tableCell([Pandoc.plain([Pandoc.str(key)])])),
+    ),
+  ]);
+  const result = Pandoc.table(
+    Pandoc.caption([]),
+    colSpecs ?? keys.map((_) => Pandoc.colspec("AlignLeft", "ColWidthDefault")),
+    header,
+    [Pandoc.tableBody(
+      objects.map((object) =>
+        Pandoc.tableRow(keys.map((key) => {
+          const value = object[key];
+          return Pandoc.tableCell(value, "AlignLeft");
+        }))
+      ),
+    )],
+  );
+  return result;
+};


### PR DESCRIPTION
This bumps esbuild and dart-sass to latest versions.

(It also changes the way we print the output of our packaging scripts and introduces a new helper EDSL for Pandoc AST. That work is separated into different commits.)