### PR TITLE
Beamer template update for new options

### DIFF
--- a/src/resources/formats/beamer/pandoc/template.tex
+++ b/src/resources/formats/beamer/pandoc/template.tex
@@ -72,29 +72,25 @@ $if(theme)$
 \usetheme[$for(themeoptions)$$themeoptions$$sep$,$endfor$]{$theme$}
 $endif$
 $if(colortheme)$
-\usecolortheme{$colortheme$}
+\usecolortheme[$for(colorthemeoptions)$$colorthemeoptions$$sep$,$endfor$]{$colortheme$}
 $endif$
 $if(fonttheme)$
-\usefonttheme{$fonttheme$}
+\usefonttheme[$for(fontthemeoptions)$$fontthemeoptions$$sep$,$endfor$]{$fonttheme$}
 $endif$
 $if(mainfont)$
 \usefonttheme{serif} % use mainfont rather than sansfont for slide text
 $endif$
 $if(innertheme)$
-\useinnertheme{$innertheme$}
+\useinnertheme[$for(innerthemeoptions)$$innerthemeoptions$$sep$,$endfor$]{$innertheme$}
 $endif$
 $if(outertheme)$
-\useoutertheme{$outertheme$}
+\useoutertheme[$for(outerthemeoptions)$$outerthemeoptions$$sep$,$endfor$]{$outertheme$}
 $endif$
 $font-settings.latex()$
 $common.latex()$
 
 $after-header-includes.latex()$
 $hypersetup.latex()$
-
-$if(nocite-ids)$
-\nocite{$for(nocite-ids)$$it$$sep$, $endfor$}
-$endif$
 
 $before-title.tex()$
 

--- a/src/resources/schema/document-options.yml
+++ b/src/resources/schema/document-options.yml
@@ -274,32 +274,60 @@
   schema: string
   tags:
     formats: [beamer]
-  description: The Beamer color theme for this presentation.
+  description: The Beamer color theme for this presentation, passed to `\usecolortheme`.
+
+- name: colorthemeoptions
+  schema:
+    maybeArrayOf: string
+  tags:
+    formats: [beamer]
+  description: The Beamer color theme options for this presentation, passed to `\usecolortheme`.
 
 - name: fonttheme
   schema: string
   tags:
     formats: [beamer]
-  description: The Beamer font theme for this presentation.
+  description: The Beamer font theme for this presentation, passed to `\usefonttheme`.
+
+- name: fontthemeoptions
+  schema:
+    maybeArrayOf: string
+  tags:
+    formats: [beamer]
+  description: The Beamer font theme options for this presentation, passed to `\usefonttheme`.
 
 - name: innertheme
   schema: string
   tags:
     formats: [beamer]
-  description: The Beamer inner theme for this presentation.
+  description: The Beamer inner theme for this presentation, passed to `\useinnertheme`.
+
+- name: innerthemeoptions
+  schema:
+    maybeArrayOf: string
+  tags:
+    formats: [beamer]
+  description: The Beamer inner theme options for this presentation, passed to `\useinnertheme`.
 
 - name: outertheme
   schema: string
   tags:
     formats: [beamer]
-  description: The Beamer outer theme for this presentation.
+  description: The Beamer outer theme for this presentation, passed to `\useoutertheme`.
+
+- name: outerthemeoptions
+  schema:
+    maybeArrayOf: string
+  tags:
+    formats: [beamer]
+  description: The Beamer outer theme options for this presentation, passed to `\useoutertheme`.
 
 - name: themeoptions
   schema:
     maybeArrayOf: string
   tags:
     formats: [beamer]
-  description: Options passed to LaTeX Beamer themes.
+  description: Options passed to LaTeX Beamer themes inside `\usetheme`.
 
 - name: section
   schema: number


### PR DESCRIPTION
Follow up on Beamer template update with new Pandoc in Quarto 1.7. Some new options where missing.

LaTeX template update was done in #12260 

closes #6607 

Thanks @cwickham ! 

This is candidate to backport as I missed this in the template update. I checked and it seems to be the only part I missed 😞 

Could we backport theme and some schema update @cscheid ? 