### PR TITLE
giscus.ejs needs to check for darkMode

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -2,6 +2,8 @@
 
 ## In this release
 
+- ([#12700](https://github.com/quarto-dev/quarto-cli/issues/12700)): Giscus not loading on a site without dark mode configured.
+
 ## In previous releases
 
 - ([#6607](https://github.com/quarto-dev/quarto-cli/issues/6607)): Add missing beamer template update for beamer theme options: `colorthemeoptions`, `fontthemeoptions`, `innerthemeoptions` and `outerthemeoptions`.

--- a/src/format/html/format-html.ts
+++ b/src/format/html/format-html.ts
@@ -609,7 +609,7 @@ export async function htmlFormatExtras(
       giscusAfterBody,
       renderEjs(
         formatResourcePath("html", join("giscus", "giscus.ejs")),
-        { giscus },
+        { giscus, darkMode: options.darkMode },
       ),
     );
     includeAfterBody.push(giscusAfterBody);

--- a/src/resources/formats/html/giscus/giscus.ejs
+++ b/src/resources/formats/html/giscus/giscus.ejs
@@ -6,9 +6,11 @@
     const getTheme = () => {
       let baseTheme = document.getElementById('giscus-base-theme').value;
       let altTheme = document.getElementById('giscus-alt-theme').value;
+      <% if (darkMode !== undefined) { %>
       if (authorPrefersDark) {
           [baseTheme, altTheme] = [altTheme, baseTheme];
       }
+      <% } %>
       return document.body.classList.contains('quarto-dark') ? altTheme : baseTheme;
     };
     const script = document.createElement("script");


### PR DESCRIPTION
And not use `authorPrefersDark` that won't be declared if dark mode not enabled.

fixes #12700

This is the `v1.7` backport.