### PR TITLE
Fix syntax highlighting specification using different highlight theme

### DIFF
--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -11,6 +11,7 @@ All changes included in 1.8:
 ### `html`
 
 - ([#12259](https://github.com/quarto-dev/quarto-cli/issues/12259)): Fix conflict between `html-math-method: katex` and crossref popups (author: @benkeks).
+- ([#12734](https://github.com/quarto-dev/quarto-cli/issues/12734)): `highlight-style` now correctly supports setting a different `light` and `dark`.
 
 ### `revealjs`
 

--- a/src/quarto-core/text-highlighting.ts
+++ b/src/quarto-core/text-highlighting.ts
@@ -41,8 +41,8 @@ export function textHighlightThemePath(
   // First try the style specific version of the theme, otherwise
   // fall back to the plain name
   const names = [
-    `${theme}-${style === "dark" ? kDarkSuffix : kLightSuffix}`,
-    theme,
+    `${resolvedTheme}-${style === "dark" ? kDarkSuffix : kLightSuffix}`,
+    resolvedTheme,
   ];
 
   const themePath = names.map((name) => {

--- a/tests/docs/playwright/html/code-highlight/_body.md
+++ b/tests/docs/playwright/html/code-highlight/_body.md
@@ -1,0 +1,15 @@
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
+
+```{.julia}
+function divide_floats(x::Float64, y::Float64)
+    return x / y
+end
+```
+
+And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/_quarto.yml
+++ b/tests/docs/playwright/html/code-highlight/_quarto.yml
@@ -1,3 +1,11 @@
 project:
   type: default
   title: "Quarto Code Highlighting"
+  output-dir: _docs
+
+format:
+  html:
+    theme:
+      light: flatly
+      dark: darkly
+    respect-user-color-scheme: true

--- a/tests/docs/playwright/html/code-highlight/code-highlight-a11y.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-a11y.qmd
@@ -3,18 +3,4 @@ title: Testing a11y code highlight
 highlight-style: a11y
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-a11y.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-a11y.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing a11y code highlight
 highlight-style: a11y
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-arrow.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-arrow.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing arrow code highlight
 highlight-style: arrow
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-arrow.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-arrow.qmd
@@ -3,18 +3,4 @@ title: Testing arrow code highlight
 highlight-style: arrow
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-atom-one.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-atom-one.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing atom-one code highlight
 highlight-style: atom-one
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-atom-one.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-atom-one.qmd
@@ -3,18 +3,4 @@ title: Testing atom-one code highlight
 highlight-style: atom-one
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-ayu-mirage.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-ayu-mirage.qmd
@@ -3,18 +3,4 @@ title: Testing ayu-mirage code highlight
 highlight-style: ayu-mirage
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-ayu-mirage.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-ayu-mirage.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing ayu-mirage code highlight
 highlight-style: ayu-mirage
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-ayu.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-ayu.qmd
@@ -3,18 +3,4 @@ title: Testing ayu code highlight
 highlight-style: ayu
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-ayu.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-ayu.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing ayu code highlight
 highlight-style: ayu
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-breeze.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-breeze.qmd
@@ -3,18 +3,4 @@ title: Testing breeze code highlight
 highlight-style: breeze
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-breeze.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-breeze.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing breeze code highlight
 highlight-style: breeze
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-breezedark.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-breezedark.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing breezedark code highlight
 highlight-style: breezedark
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-breezedark.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-breezedark.qmd
@@ -3,18 +3,4 @@ title: Testing breezedark code highlight
 highlight-style: breezedark
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-dracula.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-dracula.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing dracula code highlight
 highlight-style: dracula
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-dracula.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-dracula.qmd
@@ -3,18 +3,4 @@ title: Testing dracula code highlight
 highlight-style: dracula
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-espresso.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-espresso.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing espresso code highlight
 highlight-style: espresso
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-espresso.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-espresso.qmd
@@ -3,18 +3,4 @@ title: Testing espresso code highlight
 highlight-style: espresso
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-github.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-github.qmd
@@ -3,18 +3,4 @@ title: Testing github code highlight
 highlight-style: github
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-github.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-github.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing github code highlight
 highlight-style: github
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-gruvbox.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-gruvbox.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing gruvbox code highlight
 highlight-style: gruvbox
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-gruvbox.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-gruvbox.qmd
@@ -3,18 +3,4 @@ title: Testing gruvbox code highlight
 highlight-style: gruvbox
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-haddock.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-haddock.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing haddock code highlight
 highlight-style: haddock
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-haddock.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-haddock.qmd
@@ -3,18 +3,4 @@ title: Testing haddock code highlight
 highlight-style: haddock
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-kate.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-kate.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing kate code highlight
 highlight-style: kate
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-kate.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-kate.qmd
@@ -3,18 +3,4 @@ title: Testing kate code highlight
 highlight-style: kate
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-light-dark.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-light-dark.qmd
@@ -6,18 +6,4 @@ format:
         dark: kate
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-light-dark.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-light-dark.qmd
@@ -1,0 +1,23 @@
+---
+format:
+  html:
+    highlight-style:
+        light: pygments
+        dark: kate
+---
+
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
+
+```{.julia}
+function divide_floats(x::Float64, y::Float64)
+    return x / y
+end
+```
+
+And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-monochrome.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-monochrome.qmd
@@ -3,18 +3,4 @@ title: Testing monochrome code highlight
 highlight-style: monochrome
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-monochrome.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-monochrome.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing monochrome code highlight
 highlight-style: monochrome
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-monokai.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-monokai.qmd
@@ -1,9 +1,6 @@
 ---
 title: Testing monokai code highlight
 highlight-style: monokai
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
 ## Light and Dark Mode Testing

--- a/tests/docs/playwright/html/code-highlight/code-highlight-monokai.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-monokai.qmd
@@ -3,18 +3,4 @@ title: Testing monokai code highlight
 highlight-style: monokai
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-nord.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-nord.qmd
@@ -3,18 +3,4 @@ title: Testing nord code highlight
 highlight-style: nord
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-nord.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-nord.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing nord code highlight
 highlight-style: nord
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-oblivion.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-oblivion.qmd
@@ -3,18 +3,4 @@ title: Testing oblivion code highlight
 highlight-style: oblivion
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-oblivion.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-oblivion.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing oblivion code highlight
 highlight-style: oblivion
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-printing.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-printing.qmd
@@ -3,18 +3,4 @@ title: Testing printing code highlight
 highlight-style: printing
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-printing.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-printing.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing printing code highlight
 highlight-style: printing
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-pygments.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-pygments.qmd
@@ -3,18 +3,4 @@ title: Testing pygments code highlight
 highlight-style: pygments
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-pygments.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-pygments.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing pygments code highlight
 highlight-style: pygments
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-radical.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-radical.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing radical code highlight
 highlight-style: radical
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-radical.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-radical.qmd
@@ -3,18 +3,4 @@ title: Testing radical code highlight
 highlight-style: radical
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-solarized.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-solarized.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing solarized code highlight
 highlight-style: solarized
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-solarized.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-solarized.qmd
@@ -3,18 +3,4 @@ title: Testing solarized code highlight
 highlight-style: solarized
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-tango.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-tango.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing tango code highlight
 highlight-style: tango
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-tango.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-tango.qmd
@@ -3,18 +3,4 @@ title: Testing tango code highlight
 highlight-style: tango
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-vim-dark.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-vim-dark.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing vim-dark code highlight
 highlight-style: vim-dark
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-vim-dark.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-vim-dark.qmd
@@ -3,18 +3,4 @@ title: Testing vim-dark code highlight
 highlight-style: vim-dark
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/docs/playwright/html/code-highlight/code-highlight-zenburn.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-zenburn.qmd
@@ -1,11 +1,11 @@
 ---
 title: Testing zenburn code highlight
 highlight-style: zenburn
-theme: 
-  light: flatly
-  dark: darkly
 ---
 
+## Light and Dark Mode Testing
+
+This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
 
 ```{.julia}
 function divide_floats(x::Float64, y::Float64)
@@ -14,3 +14,7 @@ end
 ```
 
 And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
+
+::: {.callout-note}
+The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
+:::

--- a/tests/docs/playwright/html/code-highlight/code-highlight-zenburn.qmd
+++ b/tests/docs/playwright/html/code-highlight/code-highlight-zenburn.qmd
@@ -3,18 +3,4 @@ title: Testing zenburn code highlight
 highlight-style: zenburn
 ---
 
-## Light and Dark Mode Testing
-
-This document can be viewed in both light mode and dark mode to test code highlighting in both color schemes.
-
-```{.julia}
-function divide_floats(x::Float64, y::Float64)
-    return x / y
-end
-```
-
-And here the inline version `function divide_floats(x::Float64, y::Float64)`{.julia}.
-
-::: {.callout-note}
-The tests will automatically check the highlighting in both light and dark modes using Playwright's color scheme testing capabilities.
-:::
+{{< include _body.md >}}

--- a/tests/integration/playwright/src/utils.ts
+++ b/tests/integration/playwright/src/utils.ts
@@ -128,10 +128,37 @@ export type RGBColor = {
   alpha?: number;
 };
 
-export async function checkColor(element, cssProperty, rgbColors: RGBColor) {
-  const colorString = rgbColors.alpha !== undefined 
-    ? `rgba(${rgbColors.red}, ${rgbColors.green}, ${rgbColors.blue}, ${rgbColors.alpha})`
-    : `rgb(${rgbColors.red}, ${rgbColors.green}, ${rgbColors.blue})`;
+export type HexColor = string;
+
+export function isRGBColor(color: any): color is RGBColor {
+  return (
+    typeof color === 'object' && 
+    'red' in color && 
+    'green' in color && 
+    'blue' in color
+  );
+}
+
+export function isHexColor(color: any): color is HexColor {
+  return (
+    typeof color === 'string' &&
+    /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(color)
+  );
+}
+
+export async function checkColor(element, cssProperty, color: RGBColor | HexColor) {
+  let colorString: string;
+  // Check if the color is an RGBColor object or a string
+  if (isRGBColor(color)) {
+    colorString = color.alpha !== undefined
+      ? `rgba(${color.red}, ${color.green}, ${color.blue}, ${color.alpha})`
+      : `rgb(${color.red}, ${color.green}, ${color.blue})`;
+  } else if (isHexColor(color)) {
+    colorString = color as string;
+  } else {
+    throw new Error('Invalid color format. Use either RGBColor or HexColor.');
+  }
+  // Check the CSS property
   await expect(element).toHaveCSS(cssProperty, colorString);
 }
 

--- a/tests/integration/playwright/tests/html-code-highlight.spec.ts
+++ b/tests/integration/playwright/tests/html-code-highlight.spec.ts
@@ -39,7 +39,7 @@ for (const style of highlightStyles) {
         test.use({ ...useDarkLightMode(colorScheme) });
         
         test.beforeEach(async ({ page }) => {
-          await page.goto(`./html/code-highlight/code-highlight-${style}.html`);
+          await page.goto(`./html/code-highlight/_docs/code-highlight-${style}.html`);
         });
 
         test(`[${style}] Code highlighting for Inline and CodeBlock are the same`, async ({ page }) => {

--- a/tests/integration/playwright/tests/html-code-highlight.spec.ts
+++ b/tests/integration/playwright/tests/html-code-highlight.spec.ts
@@ -26,13 +26,36 @@ const highlightStyles = [
   'solarized',
   'tango',
   'vim-dark',
-  'zenburn'
+  'zenburn',
+  // specific alias for light-dark test
+  'light-dark'
 ];
 
 const colorSchemes: Array<'light' | 'dark'> = ['light', 'dark'];
 
+
+// This is a special case for light-dark theme
+// We test pygments and kate themes so we retrieve the colors from the themeConfig
+// in src\resources\pandoc\highlight-styles\*.theme
+const themeConfigLightDark = {
+  light: {
+    name: 'pygments',
+    colors: {
+      kw: '#007020',
+      fu: '#06287e'
+    }
+  },
+  dark: {
+    name: 'kate',
+    colors: {
+      kw: '#1f1c1b',
+      fu: '#644a9b'
+    }
+  }
+};
+
 for (const style of highlightStyles) {
-  test.describe(`Code highlighting for ${style} theme`, () => {
+  test.describe(`Code highlighting for '${style}' theme`, () => {
     
     for (const colorScheme of colorSchemes) {
       test.describe(`in ${colorScheme} mode`, () => {
@@ -62,6 +85,30 @@ for (const style of highlightStyles) {
 
           await checkColor(codeBlock, 'color', hexToRgb(keywordColor));
         });
+        if (style === 'light-dark') {
+          const themeUsed = themeConfigLightDark[colorScheme].name;
+          const colorUsed = themeConfigLightDark[colorScheme].colors;
+          test(`[${style}] Code highlighting for Inline and CodeBlock are using '${themeUsed}' theme`, async ({ page }) => {
+            const funName = page.locator('div pre.sourceCode code.julia span').getByText('function');
+            const divideFloats = page.locator('div pre.sourceCode code.julia span').getByText('divide_floats');
+            // Get specific syntax elements to test for color
+            // get the class on the span
+            const classNameFun = await funName.getAttribute('class') as string;
+            const classNameDivide = await divideFloats.getAttribute('class') as string;
+            // error if not found
+            if (!classNameFun || !classNameDivide) {
+              test.fail(true, 'Class name not found for code highlighting elements');
+            }
+            const funColor = colorUsed[classNameFun];
+            const divideColor = colorUsed[classNameDivide];
+            await checkColor(funName, 'color', hexToRgb(funColor));
+            await checkColor(divideFloats, 'color', hexToRgb(divideColor));
+            // check also root variable
+            await checkColor(page.locator('body'), `--quarto-hl-${classNameFun}-color`, funColor);
+            await checkColor(page.locator('body'), `--quarto-hl-${classNameDivide}-color`, divideColor);
+          });
+        }
+        
       });
     }
   });


### PR DESCRIPTION
````yaml
format:
  html:
    highlight-style:
        light: pygments
        dark: kate
````

Doing the above should work. We allow this in our schema
https://github.com/quarto-dev/quarto-cli/blob/061c065f922fd31200ef38d7fffc4a33c285772a/src/resources/schema/document-code.yml#L96-L105

But it was not working because such an object was only resolved for the user-provided theme. It was not at all correctly handled for the bundled ones. 

This PR solves this. It is really more an oversight and so a regression that goes as far as version 1.3, I think. 

So let's consider this a missing feature instead and only fix for 1.8. But this also easy enough to backport in 1.7 as it is a variable name change). 
