### PR TITLE
typst, template - remove non-valid brand.headings fields from typst template

### DIFF
--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -25,6 +25,7 @@ All changes included in 1.8:
 ### `typst`
 
 - ([#12554](https://github.com/quarto-dev/quarto-cli/pull/12554)): CSS properties `font-weight` and `font-style` are translated to Typst `text` properties.
+- ([#12739](https://github.com/quarto-dev/quarto-cli/pull/12739)): Remove unused variable `heading-background-color` and `heading-decoration` from Typst's templates. They are leftover from previous change, and not part of Brand.yml schema for typography of headings.
 
 ## Projects
 

--- a/src/resources/create/extensions/format-typst/_extensions/qstart-filesafename-qend/typst-show.typ
+++ b/src/resources/create/extensions/format-typst/_extensions/qstart-filesafename-qend/typst-show.typ
@@ -69,9 +69,6 @@ $endif$
 $if(brand.typography.headings.style)$
   heading-style: "$brand.typography.headings.style$",
 $endif$
-$if(brand.typography.headings.decoration)$
-  heading-decoration: "$brand.typography.headings.decoration$",
-$endif$
 $if(brand.typography.headings.color)$
   heading-color: $brand.typography.headings.color$,
 $endif$

--- a/src/resources/create/extensions/format-typst/_extensions/qstart-filesafename-qend/typst-template.typ
+++ b/src/resources/create/extensions/format-typst/_extensions/qstart-filesafename-qend/typst-template.typ
@@ -55,8 +55,7 @@
     align(center)[#block(inset: 2em)[
       #set par(leading: heading-line-height)
       #if (heading-family != none or heading-weight != "bold" or heading-style != "normal"
-           or heading-color != black or heading-decoration == "underline"
-           or heading-background-color != none) {
+           or heading-color != black) {
         set text(font: heading-family, weight: heading-weight, style: heading-style, fill: heading-color)
         text(size: title-size)[#title]
         if subtitle != none {

--- a/src/resources/formats/typst/pandoc/quarto/typst-show.typ
+++ b/src/resources/formats/typst/pandoc/quarto/typst-show.typ
@@ -55,9 +55,6 @@ $endif$
 $if(brand.typography.headings.style)$
   heading-style: "$brand.typography.headings.style$",
 $endif$
-$if(brand.typography.headings.decoration)$
-  heading-decoration: "$brand.typography.headings.decoration$",
-$endif$
 $if(brand.typography.headings.color)$
   heading-color: $brand.typography.headings.color$,
 $endif$

--- a/src/resources/formats/typst/pandoc/quarto/typst-template.typ
+++ b/src/resources/formats/typst/pandoc/quarto/typst-template.typ
@@ -44,8 +44,7 @@
     align(center)[#block(inset: 2em)[
       #set par(leading: heading-line-height)
       #if (heading-family != none or heading-weight != "bold" or heading-style != "normal"
-           or heading-color != black or heading-decoration == "underline"
-           or heading-background-color != none) {
+           or heading-color != black) {
         set text(font: heading-family, weight: heading-weight, style: heading-style, fill: heading-color)
         text(size: title-size)[#title]
         if subtitle != none {


### PR DESCRIPTION
Thanks @mcanouil for the report. 

This PR is removing leftover from changes that happened in previous PR 
- https://github.com/quarto-dev/quarto-cli/pull/10974/

Specifically, 

- `brand.typography.headings.decoration` and `brand.typography.headings.heading-color` were introduced 
- But they were also removed later in this same PR ([`13c8012` (#10974)](https://github.com/quarto-dev/quarto-cli/pull/10974/commits/13c8012f2b0807f432dc995edb848df9081084ca))
- And a later commit (5e37696347e928aa7c522be9e3072b0900d9ea4f)

This PR removes the variables from typst template are they are not valid brand yaml option. 


