### PR TITLE
Bugfix/quarto table postprocess

### DIFF
--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -14,6 +14,7 @@ All changes included in 1.8:
 - ([#10983](https://github.com/quarto-dev/quarto-cli/issues/10983)): Fix spacing inconsistency between paras and first section headings.
 - ([#12259](https://github.com/quarto-dev/quarto-cli/issues/12259)): Fix conflict between `html-math-method: katex` and crossref popups (author: @benkeks).
 - ([#12734](https://github.com/quarto-dev/quarto-cli/issues/12734)): `highlight-style` now correctly supports setting a different `light` and `dark`.
+- ([#12747](https://github.com/quarto-dev/quarto-cli/issues/12747)): Ensure `th` elements are properly restored when Quarto's HTML table processing is happening.
 
 ### `revealjs`
 

--- a/src/format/html/format-html.ts
+++ b/src/format/html/format-html.ts
@@ -817,15 +817,15 @@ function htmlFormatPostprocessor(
 
     // Process tables to restore th-vs-td markers
     const tables = doc.querySelectorAll(
-      'table[data-quarto-postprocess-tables="true"]',
+      'table[data-quarto-postprocess="true"]',
     );
-
     for (let i = 0; i < tables.length; ++i) {
       const table = tables[i] as Element;
-      if (table.getAttribute("data-quarto-disable-processing")) {
+      if (table.getAttribute("data-quarto-disable-processing") === "true") {
         continue;
       }
-      table.removeAttribute("data-quarto-postprocess-tables");
+      table.removeAttribute("data-quarto-postprocess");
+      table.removeAttribute("data-quarto-disable-processing");
       table.querySelectorAll("tr").forEach((tr) => {
         const { children } = tr as Element;
         for (let j = 0; j < children.length; ++j) {

--- a/tests/docs/smoke-all/2025/05/15/test-gt-axe.qmd
+++ b/tests/docs/smoke-all/2025/05/15/test-gt-axe.qmd
@@ -1,0 +1,18 @@
+---
+title: hello
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - []
+        - ['td[data-quarto-table-cell-role="th"]']
+---
+
+```{r}
+library(gt)
+library(dplyr)
+
+exibble %>%
+  dplyr::group_by(group) %>%
+  gt(groupname_col = "date")
+```


### PR DESCRIPTION
A couple of bad selector log meant we were not properly post-processing tables that went through Quarto-to-pandoc HTML processing. I caught that because it violates axe-core checks. This PR fixes that.