### PR TITLE
fix(bug_report.yml): explicitly ask for latest stable Quarto version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
 
         This is the repository for the command-line program `quarto`:
 
-        - If you're reporting an issue with the **Visual Editor**, please visit https://github.com/quarto-dev/quarto
+        - If you're reporting an issue with the **Visual Editor** or with the **Visual Studio Code / Positron extension**, please visit https://github.com/quarto-dev/quarto
         - If you're reporting an issue inside **RStudio**, please visit https://github.com/rstudio/rstudio
         - If you're reporting an issue inside **Positron**, please visit https://github.com/posit-dev/positron
         - If you want to ask for a feature, please use the [Feature Requests GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/feature-requests).

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -58,9 +58,8 @@ body:
       label: "I Have checked the following"
       options:
         - label: I have searched the issue tracker for similar issues
-          required: true
         - label: I have (at least) the latest version of [Quarto CLI](https://github.com/quarto-dev/quarto-cli/releases/latest)
-          required: true
+        - label: I have properly formatted my issue following the [Bug Reports guide](https://quarto.org/bug-reports.html)
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
 
         This is the repository for the command-line program `quarto`:
 
-        - If you're reporting an issue with the **Visual Studio Code extension**, please visit https://github.com/quarto-dev/quarto
+        - If you're reporting an issue with the **Visual Editor**, please visit https://github.com/quarto-dev/quarto
         - If you're reporting an issue inside **RStudio**, please visit https://github.com/rstudio/rstudio
         - If you're reporting an issue inside **Positron**, please visit https://github.com/posit-dev/positron
         - If you want to ask for a feature, please use the [Feature Requests GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/feature-requests).
@@ -55,7 +55,7 @@ body:
 
   - type: checkboxes
     attributes:
-      label: "I Have"
+      label: "I have:"
       options:
         - label: searched the issue tracker for similar issues
         - label: installed the latest version of [Quarto CLI](https://github.com/quarto-dev/quarto-cli/releases/latest)

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -53,6 +53,15 @@ body:
             The end.
             ````
 
+  - type: checkboxes
+    attributes:
+      label: "I Have checked the following"
+      options:
+        - label: I have searched the issue tracker for similar issues
+          required: true
+        - label: I have (at least) the latest version of [Quarto CLI](https://github.com/quarto-dev/quarto-cli/releases/latest)
+          required: true
+
   - type: textarea
     attributes:
       label: Bug description

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -55,11 +55,11 @@ body:
 
   - type: checkboxes
     attributes:
-      label: "I Have checked the following"
+      label: "I Have"
       options:
-        - label: I have searched the issue tracker for similar issues
-        - label: I have (at least) the latest version of [Quarto CLI](https://github.com/quarto-dev/quarto-cli/releases/latest)
-        - label: I have properly formatted my issue following the [Bug Reports guide](https://quarto.org/bug-reports.html)
+        - label: searched the issue tracker for similar issues
+        - label: installed the latest version of [Quarto CLI](https://github.com/quarto-dev/quarto-cli/releases/latest)
+        - label: formatted my issue following the [Bug Reports guide](https://quarto.org/bug-reports.html)
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,8 +11,8 @@ body:
 
         This is the repository for the command-line program `quarto`:
 
-        - If you're reporting an issue with the VS Code extension, please visit https://github.com/quarto-dev/quarto
-        - If you're reporting an issue inside RStudio, please visit https://github.com/rstudio/rstudio
+        - If you're reporting an issue with the **Visual Studio Code extension**, please visit https://github.com/quarto-dev/quarto
+        - If you're reporting an issue inside **RStudio**, please visit https://github.com/rstudio/rstudio
         - If you're reporting an issue inside **Positron**, please visit https://github.com/posit-dev/positron
         - If you want to ask for a feature, please use the [Feature Requests GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/feature-requests).
         - If you want to ask for help, please use the [Q&A GitHub Discussions](https://github.com/quarto-dev/quarto-cli/discussions/categories/q-a).


### PR DESCRIPTION
Add a checkbox to the bug report template to confirm users have the latest version of Quarto CLI installed. This change aims to reduce issues related to outdated software versions.