### PR TITLE
html - fix code-copy style (#5538)

### DIFF
--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -12,6 +12,7 @@ All changes included in 1.8:
 
 - ([#678](https://github.com/quarto-dev/quarto-cli/issues/678)): a11y - Provide appropriate `aria-label` to search button.
 - ([#726](https://github.com/quarto-dev/quarto-cli/issues/726)): a11y - Provide `.screen-reader-only` callout type when callout text doesn't naturally include the type.
+- ([#5538](https://github.com/quarto-dev/quarto-cli/issues/5538)): Fix code-copy button style so that scrolling behaves properly.
 - ([#10983](https://github.com/quarto-dev/quarto-cli/issues/10983)): Fix spacing inconsistency between paras and first section headings.
 - ([#12259](https://github.com/quarto-dev/quarto-cli/issues/12259)): Fix conflict between `html-math-method: katex` and crossref popups (author: @benkeks).
 - ([#12734](https://github.com/quarto-dev/quarto-cli/issues/12734)): `highlight-style` now correctly supports setting a different `light` and `dark`.

--- a/src/resources/formats/html/_quarto-rules.scss
+++ b/src/resources/formats/html/_quarto-rules.scss
@@ -282,8 +282,7 @@ details > summary > p:only-child {
 }
 
 // codeCopy
-pre.sourceCode,
-code.sourceCode {
+div.sourceCode {
   position: relative;
 }
 

--- a/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
@@ -877,7 +877,7 @@ pre.sourceCode {
     border: none;
   }
   font-size: $code-block-font-size;
-  overflow: visible !important;
+  overflow-y: auto !important;
   @if $code-block-bg {
     padding: $code-block-bg-padding;
   }
@@ -890,7 +890,7 @@ pre.sourceCode > code.sourceCode {
 }
 
 div.sourceCode {
-  overflow-y: hidden;
+  position: relative;
 }
 
 .callout div.sourceCode {


### PR DESCRIPTION
Closes #5538 (thanks, @gadenbuie and Jordan!).

We still would like to change the DOM so that the button is inside the surrounding div and not the `pre` element, but that goes in a separate PR.