### PR TITLE
lua - Correctly check Lua is running on windows

### DIFF
--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -1,4 +1,4 @@
-if pandoc.system.os == "windows" then
+if pandoc.system.os == "mingw32" then
 
    local function get_windows_ansi_codepage()
       -- Reading the code page directly out of the registry was causing 

--- a/tests/docs/smoke-all/2025/05/23/12806.qmd
+++ b/tests/docs/smoke-all/2025/05/23/12806.qmd
@@ -1,0 +1,12 @@
+---
+title: Checking init.lua defines codepage stuff on windows
+format: native
+_quarto:
+  tests:
+    native: default
+filters: 
+  - at: pre-ast
+    path: check-init.lua
+---
+
+This document only serve to run the Lua filter to check init.lua correctly applies on Windows

--- a/tests/docs/smoke-all/2025/05/23/check-init.lua
+++ b/tests/docs/smoke-all/2025/05/23/check-init.lua
@@ -1,0 +1,9 @@
+Meta = function(m)
+  if (pandoc.system.os == "mingw32") then
+    -- IMPORTANT: This is only valid on windows
+    assert(_G.convert_from_utf8, "Required function 'convert_from_utf8' is missing from global scope on Windows. Something may be wrong with 'init.lua'")
+  else 
+    assert(not _G.convert_from_utf8, "Function 'convert_from_utf8' is in global scope on non-Windows. Something may be wrong with 'init.lua'")
+  end
+  return m
+end


### PR DESCRIPTION
Follow up on https://github.com/quarto-dev/quarto-cli/pull/12806#discussion_r2104302791 for 
- #12806

I added a test based on the fact that we add a new global only on Windows. 
