### PR TITLE
make the whole projectContext still a reference after safeCloneDeep

### DIFF
--- a/src/core/safe-clone-deep.ts
+++ b/src/core/safe-clone-deep.ts
@@ -6,6 +6,8 @@
  * Copyright (C) 2025 Posit Software, PBC
  */
 
+// This is used to create new interfaces that extend the Cloneable interface
+// to make the object having a clone method for specific cloning behavior in safeCloneDeep.
 export interface Cloneable<T> {
   clone(): T;
 }

--- a/src/project/project-context.ts
+++ b/src/project/project-context.ts
@@ -275,6 +275,7 @@ export async function projectContext(
         });
         const fileInformationCache = new FileInformationCacheMap();
         const result: ProjectContext = {
+          clone: () => result,
           resolveBrand: async (fileName?: string) =>
             projectResolveBrand(result, fileName),
           resolveFullMarkdownForFile: (
@@ -371,6 +372,7 @@ export async function projectContext(
         });
         const fileInformationCache = new FileInformationCacheMap();
         const result: ProjectContext = {
+          clone: () => result,
           resolveBrand: async (fileName?: string) =>
             projectResolveBrand(result, fileName),
           resolveFullMarkdownForFile: (
@@ -446,6 +448,7 @@ export async function projectContext(
           });
           const fileInformationCache = new FileInformationCacheMap();
           const context: ProjectContext = {
+            clone: () => context,
             resolveBrand: async (fileName?: string) =>
               projectResolveBrand(context, fileName),
             resolveFullMarkdownForFile: (

--- a/src/project/types.ts
+++ b/src/project/types.ts
@@ -22,6 +22,7 @@ import {
 import { ProjectEnvironment } from "./project-environment-types.ts";
 import { ProjectCache } from "../core/cache/cache-types.ts";
 import { TempContext } from "../core/temp-types.ts";
+import { Cloneable } from "../core/safe-clone-deep.ts";
 
 export {
   type NavigationItem as NavItem,
@@ -58,7 +59,7 @@ export type FileInformation = {
   brand?: LightDarkBrand;
 };
 
-export interface ProjectContext {
+export interface ProjectContext extends Cloneable<ProjectContext> {
   dir: string;
   engines: string[];
   files: ProjectFiles;

--- a/src/project/types/single-file/single-file.ts
+++ b/src/project/types/single-file/single-file.ts
@@ -41,6 +41,7 @@ export async function singleFileProjectContext(
   const projectCacheBaseDir = temp.createDir();
 
   const result: ProjectContext = {
+    clone: () => result,
     resolveBrand: (fileName?: string) => projectResolveBrand(result, fileName),
     dir: normalizePath(dirname(source)),
     engines: [],


### PR DESCRIPTION
projectContext should not be deep cloned. Only reference needs to be passed in the codebase.

This follows the works on
- #12793 
- #12812

It happens that the whole `projectContext` object should not be cloned. Only reference to the created object should be passed throughout our codebase. 

So a clone method is added as an identity function to work with our `safeCloneDeep()` logic. 

This PR is quite simple but is there to check all our tests are passing. 

This splits some changes from 
- #12809 

and this PR is required to merge #12809 