### PR TITLE
Support for plotly.py 6+ 

### DIFF
--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -67,6 +67,7 @@ All changes included in 1.8:
 ### `jupyter`
 
 - ([#12753](https://github.com/quarto-dev/quarto-cli/issues/12753)): Support change in IPython 9+ and import `set_matplotlib_formats` from `matplotlib_inline.backend_inline` in the internal `setup.py` script used to initialize rendering with Jupyter engine.
+- ([#12839](https://github.com/quarto-dev/quarto-cli/issues/12839)): Support for `plotly.py` 6+ which now loads plotly.js using a cdn in script as a module.
 
 ## Other fixes and improvements
 

--- a/src/core/jupyter/widgets.ts
+++ b/src/core/jupyter/widgets.ts
@@ -190,11 +190,29 @@ function isWidgetIncludeHtml(html: string) {
 }
 
 function isPlotlyLibrary(html: string) {
-  return (/^\s*<script type="text\/javascript">/.test(html) &&
+  // Plotly before version 6 used require.js to load the library
+  const hasRequireScript = (
+    html: string,
+  ) => (/^\s*<script type="text\/javascript">/.test(html) &&
     (/require\.undef\(["']plotly["']\)/.test(html) ||
-      /define\('plotly'/.test(html))) ||
-    // also handle new module syntax from plotly.py 6+
+      /define\('plotly'/.test(html)));
+  // Plotly 6+ uses the new module syntax
+  const hasModuleScript = (html: string) =>
     /\s*<script type=\"module\">import .*plotly.*<\/script>/.test(html);
+  // notebook mode non connected embed plotly.js scripts like this:
+  //  * plotly.js v3.0.1
+  //  * Copyright 2012-2025, Plotly, Inc.
+  //  * All rights reserved.
+  //  * Licensed under the MIT license
+  const hasEmbedScript = (
+    html: string,
+  ) => (/\* plotly\.js v\d+\.\d+\.\d+\s*\n\s*\* Copyright \d{4}-\d{4}, Plotly, Inc\.\s*\n\s*\* All rights reserved\.\s*\n\s*\* Licensed under the MIT license/
+    .test(html));
+  return hasRequireScript(html) ||
+    // also handle new module syntax from plotly.py 6+
+    hasModuleScript(html) ||
+    // detect plotly by its copyright header
+    hasEmbedScript(html);
 }
 
 function htmlLibrariesText(htmlText: string) {

--- a/src/core/jupyter/widgets.ts
+++ b/src/core/jupyter/widgets.ts
@@ -190,9 +190,11 @@ function isWidgetIncludeHtml(html: string) {
 }
 
 function isPlotlyLibrary(html: string) {
-  return /^\s*<script type="text\/javascript">/.test(html) &&
+  return (/^\s*<script type="text\/javascript">/.test(html) &&
     (/require\.undef\(["']plotly["']\)/.test(html) ||
-      /define\('plotly'/.test(html));
+      /define\('plotly'/.test(html))) ||
+    // also handle new module syntax from plotly.py 6+
+    /\s*<script type=\"module\">import .*plotly.*<\/script>/.test(html);
 }
 
 function htmlLibrariesText(htmlText: string) {

--- a/tests/docs/smoke-all/jupyter/subfigures/plotly.qmd
+++ b/tests/docs/smoke-all/jupyter/subfigures/plotly.qmd
@@ -1,0 +1,45 @@
+---
+title: "Bugged plotly figure: phantom subfigure"
+keep-ipynb: true
+keep-md: true
+_quarto:
+  tests: 
+    html:
+      ensureHtmlElements:
+        - 
+          - 'figure.quarto-float-fig div#fig-gapminder-1 figure.quarto-subfloat-fig div.plotly-graph-div'
+          - 'figure.quarto-float-fig div#fig-gapminder-2 figure.quarto-subfloat-fig div.plotly-graph-div'
+      ensureHtmlElementContents:
+        selectors: 
+          - 'div#fig-gapminder-1 figcaption.quarto-subfloat-caption'
+          - 'div#fig-gapminder-2 figcaption.quarto-subfloat-caption'
+        matches: ['\((a|b)\) Gapminder: (1957|2007)']
+      ensureHtmlElementCount:
+        selectors: ['figure.quarto-float-fig figure.quarto-subfloat-fig']
+        counts: [2]
+---
+
+```{python}
+#| label: fig-gapminder
+#| fig-cap: "Life Expectancy and GDP"
+#| fig-subcap:
+#|   - "Gapminder: 1957"
+#|   - "Gapminder: 2007"
+#| layout-ncol: 2
+#| column: page
+
+import plotly.express as px
+import plotly.io as pio
+gapminder = px.data.gapminder()
+def gapminder_plot(year):
+    gapminderYear = gapminder.query("year == " + 
+                                    str(year))
+    fig = px.scatter(gapminderYear, 
+                     x="gdpPercap", y="lifeExp",
+                     size="pop", size_max=60,
+                     hover_name="country")
+    fig.show()
+    
+gapminder_plot(1957)
+gapminder_plot(2007)
+```

--- a/tests/docs/smoke-all/jupyter/subfigures/plotly.qmd
+++ b/tests/docs/smoke-all/jupyter/subfigures/plotly.qmd
@@ -1,10 +1,21 @@
 ---
 title: "Bugged plotly figure: phantom subfigure"
-keep-ipynb: true
-keep-md: true
 _quarto:
   tests: 
     html:
+      ensureHtmlElements:
+        - 
+          - 'figure.quarto-float-fig div#fig-gapminder-1 figure.quarto-subfloat-fig div.plotly-graph-div'
+          - 'figure.quarto-float-fig div#fig-gapminder-2 figure.quarto-subfloat-fig div.plotly-graph-div'
+      ensureHtmlElementContents:
+        selectors: 
+          - 'div#fig-gapminder-1 figcaption.quarto-subfloat-caption'
+          - 'div#fig-gapminder-2 figcaption.quarto-subfloat-caption'
+        matches: ['\((a|b)\) Gapminder: (1957|2007)']
+      ensureHtmlElementCount:
+        selectors: ['figure.quarto-float-fig figure.quarto-subfloat-fig']
+        counts: [2]
+    dashboard:
       ensureHtmlElements:
         - 
           - 'figure.quarto-float-fig div#fig-gapminder-1 figure.quarto-subfloat-fig div.plotly-graph-div'

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -18,4 +18,5 @@ dependencies = [
     "great-tables>=0.17.0",
     "polars>=1.29.0",
     "pyarrow>=20.0.0",
+    "plotly>=6.1.1",
 ]

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -36,7 +36,8 @@ import {
   ensureLatexFileRegexMatches,
   printsMessage,
   shouldError,
-  ensureHtmlElementContents
+  ensureHtmlElementContents,
+  ensureHtmlElementCount,
 } from "../verify.ts";
 import { readYamlFromMarkdown } from "../../src/core/yaml.ts";
 import { findProjectDir, findProjectOutputDir, outputForInput } from "../utils.ts";
@@ -130,6 +131,7 @@ function resolveTestSpecs(
     ensureEpubFileRegexMatches,
     ensureHtmlElements,
     ensureHtmlElementContents,
+    ensureHtmlElementCount,
     ensureFileRegexMatches,
     ensureLatexFileRegexMatches,
     ensureTypstFileRegexMatches,

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -1449,6 +1449,19 @@ wheels = [
 ]
 
 [[package]]
+name = "plotly"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/7c/f396bc817975252afbe7af102ce09cd12ac40a8e90b8699a857d1b15c8a3/plotly-6.1.1.tar.gz", hash = "sha256:84a4f3d36655f1328fa3155377c7e8a9533196697d5b79a4bc5e905bdd09a433", size = 7543694, upload-time = "2025-05-20T20:09:31.935Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/f3/f8cb7066f761e2530e1280889e3413769891e349fca35ee7290e4ace35f5/plotly-6.1.1-py3-none-any.whl", hash = "sha256:9cca7167406ebf7ff541422738402159ec3621a608ff7b3e2f025573a1c76225", size = 16118469, upload-time = "2025-05-20T20:09:26.196Z" },
+]
+
+[[package]]
 name = "polars"
 version = "1.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1954,6 +1967,7 @@ dependencies = [
     { name = "matplotlib" },
     { name = "pandas" },
     { name = "papermill" },
+    { name = "plotly" },
     { name = "polars" },
     { name = "pyarrow" },
     { name = "seaborn" },
@@ -1972,6 +1986,7 @@ requires-dist = [
     { name = "matplotlib", specifier = ">=3.9.2" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "papermill", specifier = ">=2.6.0" },
+    { name = "plotly", specifier = ">=6.1.1" },
     { name = "polars", specifier = ">=1.29.0" },
     { name = "pyarrow", specifier = ">=20.0.0" },
     { name = "seaborn", specifier = ">=0.13.2" },

--- a/tests/verify.ts
+++ b/tests/verify.ts
@@ -402,6 +402,39 @@ export const ensureHtmlElementContents = (
 
 }
 
+export const ensureHtmlElementCount = (
+  file: string,
+  options: {
+    selectors: string[] | string,
+    counts: number[] | number
+  }
+): Verify => {
+  return {
+    name: "Verify number of elements for selectors",
+    verify: async (_output: ExecuteOutput[]) => {
+      const htmlInput = await Deno.readTextFile(file);
+      const doc = new DOMParser().parseFromString(htmlInput, "text/html")!;
+      
+      // Convert single values to arrays for unified processing
+      const selectorsArray = Array.isArray(options.selectors) ? options.selectors : [options.selectors];
+      const countsArray = Array.isArray(options.counts) ? options.counts : [options.counts];
+      
+      if (selectorsArray.length !== countsArray.length) {
+        throw new Error("Selectors and counts arrays must have the same length");
+      }
+      
+      selectorsArray.forEach((selector, index) => {
+        const expectedCount = countsArray[index];
+        const elements = doc.querySelectorAll(selector);
+        assert(
+          elements.length === expectedCount,
+          `Selector '${selector}' matched ${elements.length} elements, expected ${expectedCount}.`
+        );
+      });
+    }
+  };
+};
+
 export const ensureSnapshotMatches = (
   file: string,
 ): Verify => {


### PR DESCRIPTION
Plotly.py 6+ has changed the way it includes the plotly.js library from 

````json
   "outputs": [
    {
     "data": {
      "text/html": [
       "        <script type=\"text/javascript\">\n",
       "        window.PlotlyConfig = {MathJaxConfig: 'local'};\n",
       "        if (window.MathJax && window.MathJax.Hub && window.MathJax.Hub.Config) {window.MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}\n",
       "        if (typeof require !== 'undefined') {\n",
       "        require.undef(\"plotly\");\n",
       "        requirejs.config({\n",
       "            paths: {\n",
       "                'plotly': ['https://cdn.plot.ly/plotly-2.35.2.min']\n",
       "            }\n",
       "        });\n",
       "        require(['plotly'], function(Plotly) {\n",
       "            window._Plotly = Plotly;\n",
       "        });\n",
       "        }\n",
       "        </script>\n",
       "        "
      ]
     },
     "metadata": {},
     "output_type": "display_data"
    },
````

to 
````json
   "outputs": [
    {
     "data": {
      "text/html": [
       "        <script type=\"text/javascript\">\n",
       "        window.PlotlyConfig = {MathJaxConfig: 'local'};\n",
       "        if (window.MathJax && window.MathJax.Hub && window.MathJax.Hub.Config) {window.MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}\n",
       "        </script>\n",
       "        <script type=\"module\">import \"https://cdn.plot.ly/plotly-3.0.1.min\"</script>\n",
       "        "
      ]
     },
     "metadata": {},
     "output_type": "display_data"
    },
````

So our Plotly library detection logic needs to adapt. I did not change it.

The logic we have in Quarto is to detect the cell with raw html containing this libary loading so that is moved in the content added to headers. The cell is cell removed and not shown in intermediate md.

This PR adds a test (with a new verify function) to ensure we have the expected structure with Plotly and subfigures (2 plotly graph should lead to 2 subfigures)

