### PR TITLE
check, knitr - Add .exe to binary on Windows for correct check 

### DIFF
--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -69,6 +69,10 @@ All changes included in 1.8:
 
 - ([#12753](https://github.com/quarto-dev/quarto-cli/issues/12753)): Support change in IPython 9+ and import `set_matplotlib_formats` from `matplotlib_inline.backend_inline` in the internal `setup.py` script used to initialize rendering with Jupyter engine.
 
+### `knitr`
+
+- Correctly detect R binary on Windows when `R_HOME` is set - this fixes issue with `quarto::quarto_render()` that will now correctly use the same R version as the R session it is called from.
+
 ## Other fixes and improvements
 
 - ([#11321](https://github.com/quarto-dev/quarto-cli/issues/11321)): Follow [recommendation from LaTeX project](https://latex-project.org/news/latex2e-news/ltnews40.pdf) and use `lualatex` instead of `xelatex` as the default PDF engine.

--- a/src/core/resources.ts
+++ b/src/core/resources.ts
@@ -117,7 +117,7 @@ export async function rBinaryPath(
   const rHome = Deno.env.get("R_HOME");
   debug(`Looking for '${binary}' in R_HOME: ${rHome}`);
   if (rHome) {
-    let rHomeBin = join(rHome, "bin", binary);
+    let rHomeBin = join(rHome, "bin", isWindows ? binary + ".exe" : binary);
     if (safeExistsSync(rHomeBin)) {
       debug(`Found in ${rHomeBin}`);
       return setPath(rHomeBin);


### PR DESCRIPTION
This is a bad problem when you run `quarto` CLI from another process having `R_HOME` set (like running from an R session): another R version would be used; 

This solves quarto-dev/quarto-r#204, but also problem on Windows

````
❯ $env:R_HOME="C:/Program Files/R/R-4.5.0"

❯ quarto check knitr
Quarto 99.9.9
[>] Checking R installation...........OK
      Version: 4.3.2
      Path: C:/PROGRA~1/R/R-43~1.2
      LibPaths:
        - C:/Users/chris/AppData/Local/R/win-library/4.3
        - C:/Program Files/R/R-4.3.2/library
      knitr: (None)
      rmarkdown: (None)

      The knitr package is not available in this R installation.
      Install with install.packages("knitr")
      The rmarkdown package is not available in this R installation.
      Install with install.packages("rmarkdown")
````

This is because we append `bin` and `Rscript` and test the path

https://github.com/quarto-dev/quarto-cli/blob/84c6cba2c213191b6f44a94755853d9f661bfa04/src/core/resources.ts#L116-L121

We need to add `.exe` on Windows if we test path existence. 

Note: I really would like to backport this as this is a bad issue. 