### PR TITLE
Make Julia env copying robust against read-only scenarios

### DIFF
--- a/src/execute/julia.ts
+++ b/src/execute/julia.ts
@@ -397,7 +397,7 @@ async function ensureQuartoNotebookRunnerEnvironment(
 ) {
   const projectTomlTemplate = juliaResourcePath("Project.toml");
   const projectToml = join(juliaRuntimeDir(), "Project.toml");
-  Deno.copyFileSync(projectTomlTemplate, projectToml);
+  Deno.writeFileSync(projectToml, Deno.readFileSync(projectTomlTemplate));
   const command = new Deno.Command(juliaCmd(), {
     args: [
       "--startup-file=no",


### PR DESCRIPTION
I noticed that I got failures on this line when using `quarto_jll` in Julia to run quarto. This happens because `copyFileSync` copies permissions of the source file as well, and all jlls in Julia have their source files under read-only permissions. This causes the Project.toml in the quarto cache directory to become read-only as well, which will make the next server startup fail because quarto attempts to overwrite the file.