### PR TITLE
Test file syntax fix - missing space before shortcode close

### DIFF
--- a/dev-docs/feature-format-matrix/qmd-files/mermaid/document.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/mermaid/document.qmd
@@ -4,7 +4,7 @@ format:
   docusaurus-md: {}
 ---
 
-::: content-visible when-format="docusaurus-md"
+::: {.content-visible when-format="docusaurus-md"}
 This works, but emits a fairly-wonky markdown and doesn't use Javascript rendering.
 :::
 

--- a/tests/docs/smoke-all/video/video-smoke-test.qmd
+++ b/tests/docs/smoke-all/video/video-smoke-test.qmd
@@ -88,7 +88,7 @@ _quarto:
 {{< video https://www.youtube.com/embed/wo9vZccmqwc
   title="What is the CERN?"
   start="116"
-  aspect-ratio="21x9">}}
+  aspect-ratio="21x9" >}}
 
 :::
 


### PR DESCRIPTION
## Description

The multiline video shortcode in this test file is missing the space before the closing `>}}` which I believe is required.


## Checklist

None of the below seem applicable / necessary,

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
