### PR TITLE
feat: allow specification of height and width for landscape 

### DIFF
--- a/src/resources/filters/quarto-post/landscape.lua
+++ b/src/resources/filters/quarto-post/landscape.lua
@@ -1,34 +1,38 @@
 -- landscape.lua
 -- Copyright (C) 2024-2024 Posit Software, PBC
 --
--- Author: [Edvin Syk](https://github.com/edvinsyk/) 
+-- Author: [Edvin Syk](https://github.com/edvinsyk/)
 
 function landscape_div()
   local ooxml = function(s)
     return pandoc.RawBlock('openxml', s)
   end
-  
+
+  local function to_twips(x)
+    local num_unit = { x:match("([%d%.]+)%s*(%a+)") }
+    local num = tonumber(num_unit[1])
+    local unit = num_unit[2]
+    if unit == "cm" then
+      return num * 1440 / 2.54
+    elseif unit == "in" then
+      return num * 1440
+    else
+      error("Unsupported unit: " .. tostring(unit))
+    end
+  end
+
+  local docx_section_open = '<w:p><w:pPr><w:sectPr>'
+  local docx_section_close = '</w:sectPr></w:pPr></w:p>'
   -- Define the end of a portrait section for DOCX
-  local end_portrait_section = ooxml '<w:p><w:pPr><w:sectPr></w:sectPr></w:pPr></w:p>'
-  
-  -- Define the end of a landscape section for DOCX
-  local end_landscape_section = ooxml [[
-  <w:p>
-    <w:pPr>
-      <w:sectPr>
-        <w:pgSz w:h="11906" w:w="16838" w:orient="landscape" />
-      </w:sectPr>
-    </w:pPr>
-  </w:p>
-  ]]
-  
+  local end_portrait_section = ooxml(docx_section_open .. docx_section_close)
+
   -- LateX commands for starting and ending a landscape section
   local landscape_start_pdf = pandoc.RawBlock('latex', '\\begin{landscape}')
   local landscape_end_pdf = pandoc.RawBlock('latex', '\\end{landscape}')
-  
+
   local landscape_start_typst = pandoc.RawBlock('typst', '#set page(flipped: true)')
   local landscape_end_typst = pandoc.RawBlock('typst', '#set page(flipped: false)')
-  
+
   local function Meta(meta)
     metaInjectLatex(meta, function(inject)
       inject("\\usepackage{pdflscape}")
@@ -40,6 +44,15 @@ function landscape_div()
     if div.classes:includes('landscape') then
       if FORMAT:match 'docx' then
         -- DOCX-specific landscape orientation
+        local height = pandoc.utils.stringify(div.attributes.height) or "8.5cm"
+        local width = pandoc.utils.stringify(div.attributes.width) or "11cm"
+
+        -- Define the end of a landscape section for DOCX
+        local end_landscape_section = ooxml(
+          docx_section_open ..
+          '<w:pgSz w:h="' .. to_twips(height) .. '" w:w="' .. to_twips(width) .. '" w:orient="landscape" />' ..
+          docx_section_close
+        )
         div.content:insert(1, end_portrait_section)
         div.content:insert(end_landscape_section)
       elseif FORMAT:match 'latex' then

--- a/src/resources/filters/quarto-post/landscape.lua
+++ b/src/resources/filters/quarto-post/landscape.lua
@@ -44,8 +44,8 @@ function landscape_div()
     if div.classes:includes('landscape') then
       if FORMAT:match 'docx' then
         -- DOCX-specific landscape orientation
-        local height = pandoc.utils.stringify(div.attributes.height) or "8.5cm"
-        local width = pandoc.utils.stringify(div.attributes.width) or "11cm"
+        local height = div.attributes.height or "8.5in"
+        local width = div.attributes.width or "11in"
 
         -- Define the end of a landscape section for DOCX
         local end_landscape_section = ooxml(


### PR DESCRIPTION
Introduce the ability to set custom height and width for landscape sections in DOCX format, enhancing document formatting flexibility. Default values are provided if none are specified.


- [ ] Add tests
- [ ] Add changelog entry

Investigate https://github.com/quarto-dev/quarto-cli/issues/12917