### PR TITLE
create - force `--no-open` when inside Posit  Workbench

### DIFF
--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -75,6 +75,10 @@ All changes included in 1.8:
 
 - ([#12627](https://github.com/quarto-dev/quarto-cli/issues/12627)): Don't actually install extension when user responds `yes` to first prompt but `no` to second.
 
+### `create`
+
+- ([#12965](https://github.com/quarto-dev/quarto-cli/issues/12965)): Prevent automatic opening of new editor sessions when creating projects in Posit Workbench context. The `--open` flag is now ignored in this environment to avoid issues with Workbench session management.
+
 ## Engines
 
 ### `jupyter`

--- a/src/command/create/cmd.ts
+++ b/src/command/create/cmd.ts
@@ -8,7 +8,10 @@ import { extensionArtifactCreator } from "./artifacts/extension.ts";
 import { projectArtifactCreator } from "./artifacts/project.ts";
 import { kEditorInfos, scanForEditors } from "./editor.ts";
 
-import { isInteractiveTerminal } from "../../core/platform.ts";
+import {
+  isInteractiveTerminal,
+  isRStudioWorkbench,
+} from "../../core/platform.ts";
 import { runningInCI } from "../../core/ci-info.ts";
 
 import { Command } from "cliffy/command/mod.ts";
@@ -55,6 +58,16 @@ export const createCommand = new Command()
         // Compute a sane default for prompting
         const isInteractive = isInteractiveTerminal() && !runningInCI();
         const allowPrompt = isInteractive && !!options.prompt && !options.json;
+
+        // Specific case where opening automatically in an editor is not allowed
+        if (options.open !== false && isRStudioWorkbench()) {
+          if (options.open !== undefined) {
+            info(
+              `The --open option is not supported in Posit Workbench - ignoring`,
+            );
+          }
+          options.open = false;
+        }
 
         // Resolve the type into an artifact
         const resolved = await resolveArtifact(

--- a/src/command/create/cmd.ts
+++ b/src/command/create/cmd.ts
@@ -10,7 +10,7 @@ import { kEditorInfos, scanForEditors } from "./editor.ts";
 
 import {
   isInteractiveTerminal,
-  isRStudioWorkbench,
+  isPositWorkbench,
 } from "../../core/platform.ts";
 import { runningInCI } from "../../core/ci-info.ts";
 
@@ -60,7 +60,7 @@ export const createCommand = new Command()
         const allowPrompt = isInteractive && !!options.prompt && !options.json;
 
         // Specific case where opening automatically in an editor is not allowed
-        if (options.open !== false && isRStudioWorkbench()) {
+        if (options.open !== false && isPositWorkbench()) {
           if (options.open !== undefined) {
             info(
               `The --open option is not supported in Posit Workbench - ignoring`,

--- a/src/command/preview/preview.ts
+++ b/src/command/preview/preview.ts
@@ -76,8 +76,8 @@ import {
   safeExistsSync,
 } from "../../core/path.ts";
 import {
+  isPositWorkbench,
   isRStudio,
-  isRStudioWorkbench,
   isServerSession,
   isVSCodeServer,
   vsCodeServerProxyUri,
@@ -872,7 +872,7 @@ function pdfFileRequestHandler(
     const onRequest = pdfOptions.onRequest;
     pdfOptions.onRequest = async (req: Request) => {
       if (new URL(req.url).pathname === "/") {
-        const url = isRStudioWorkbench()
+        const url = isPositWorkbench()
           ? await rswURL(port, kPdfJsInitialPath)
           : isVSCodeServer()
           ? vsCodeServerProxyUri()!.replace("{{port}}", `${port}`) +

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -34,7 +34,7 @@ export function isVSCodeServer() {
   return !!vsCodeServerProxyUri();
 }
 
-export function isRStudioWorkbench() {
+export function isPositWorkbench() {
   // RS_SERVER_URL e.g. https://daily-rsw.soleng.rstudioservices.com/
   // RS_SESSION_URL e.g. /s/eae053c9ab5a71168ee19/
   return !!Deno.env.get("RS_SERVER_URL") && !!Deno.env.get("RS_SESSION_URL");
@@ -50,7 +50,7 @@ export function isPositronTerminal() {
 }
 
 export function isServerSession() {
-  return isRStudioServer() || isRStudioWorkbench() || isJupyterServer() ||
+  return isRStudioServer() || isPositWorkbench() || isJupyterServer() ||
     isJupyterHubServer() || isVSCodeServer();
 }
 

--- a/src/core/previewurl.ts
+++ b/src/core/previewurl.ts
@@ -10,8 +10,8 @@ import * as colors from "fmt/colors";
 import {
   isJupyterHubServer,
   isJupyterServer,
+  isPositWorkbench,
   isRStudioServer,
-  isRStudioWorkbench,
   isVSCodeServer,
   isVSCodeTerminal,
   jupyterHubHttpReferrer,
@@ -58,7 +58,7 @@ export async function printBrowsePreviewMessage(
   path: string,
 ) {
   if (
-    (isJupyterServer() || isVSCodeTerminal()) && isRStudioWorkbench()
+    (isJupyterServer() || isVSCodeTerminal()) && isPositWorkbench()
   ) {
     const url = await rswURL(port, path);
     info(`\nPreview server: ${previewURL(host, port, path = "")}`);


### PR DESCRIPTION
closes #12965 

@jthomasmock, @MariaSemple, this is simple tweak to force `--no-open` when inside workbench. 
I added info message in case a user is explicitly setting `--open <editor name>` to explain this is not permitted.  

I'll manually test it somewhere I can access. 

Is there any other specific behavior it should have in the Workbench context? Should we open automatically or prompt to open, but in a different way? 

You can also test this PR by cloning, switching branch and installing from source Quarto dev version