### PR TITLE
Use jsdelivr cdn for jupyter widgets dependencies

### DIFF
--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -91,6 +91,7 @@ All changes included in 1.8:
 
 - ([#12753](https://github.com/quarto-dev/quarto-cli/issues/12753)): Support change in IPython 9+ and import `set_matplotlib_formats` from `matplotlib_inline.backend_inline` in the internal `setup.py` script used to initialize rendering with Jupyter engine.
 - ([#12839](https://github.com/quarto-dev/quarto-cli/issues/12839)): Support for `plotly.py` 6+ which now loads plotly.js using a cdn in script as a module.
+- ([#13026](https://github.com/quarto-dev/quarto-cli/pulls/13026)): Use `jsdelivr` CDN for jupyter widgets dependencies.
 
 ### `knitr`
 

--- a/src/core/jupyter/widgets.ts
+++ b/src/core/jupyter/widgets.ts
@@ -101,10 +101,10 @@ export function includesForJupyterWidgetDependencies(
   const head: string[] = [];
   if (haveJavascriptWidgets || haveJupyterWidgets) {
     head.push(
-      '<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js" integrity="sha512-c3Nl8+7g4LMSTdrm621y7kf9v3SDPnhxLNhcjFJbKECVnmZHTdo+IRO05sNLTH/D3vA6u1X32ehoLC7WFVdheg==" crossorigin="anonymous"></script>',
+      '<script src="https://cdn.jsdelivr.net/npm/requirejs@2.3.6/require.min.js" integrity="sha384-c9c+LnTbwQ3aujuU7ULEPVvgLs+Fn6fJUvIGTsuu1ZcCf11fiEubah0ttpca4ntM" crossorigin="anonymous"></script>',
     );
     head.push(
-      '<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js" integrity="sha512-bLT0Qm9VnAYZDflyKcBaQ2gg0hSYNQrJ8RilYldYQ1FxQYoCLtUjuuRuZo+fjqhx/qtq/1itJ0C2ejDxltZVFg==" crossorigin="anonymous" data-relocate-top="true"></script>',
+      '<script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.min.js" integrity="sha384-ZvpUoO/+PpLXR1lu4jmpXWu80pZlYUAfxl5NsBMWOEPSjUn/6Z/hRTt8+pR6L4N2" crossorigin="anonymous"></script>',
     );
     head.push(
       "<script type=\"application/javascript\">define('jquery', [],function() {return window.jQuery;})</script>",
@@ -117,7 +117,7 @@ export function includesForJupyterWidgetDependencies(
   // jupyter widget runtime
   if (haveJupyterWidgets) {
     head.push(
-      '<script src="https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed-amd.js" crossorigin="anonymous"></script>',
+      '<script src="https://cdn.jsdelivr.net/npm/@jupyter-widgets/html-manager@*/dist/embed-amd.js" crossorigin="anonymous"></script>',
     );
   }
 

--- a/src/core/jupyter/widgets.ts
+++ b/src/core/jupyter/widgets.ts
@@ -104,7 +104,7 @@ export function includesForJupyterWidgetDependencies(
       '<script src="https://cdn.jsdelivr.net/npm/requirejs@2.3.6/require.min.js" integrity="sha384-c9c+LnTbwQ3aujuU7ULEPVvgLs+Fn6fJUvIGTsuu1ZcCf11fiEubah0ttpca4ntM" crossorigin="anonymous"></script>',
     );
     head.push(
-      '<script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.min.js" integrity="sha384-ZvpUoO/+PpLXR1lu4jmpXWu80pZlYUAfxl5NsBMWOEPSjUn/6Z/hRTt8+pR6L4N2" crossorigin="anonymous"></script>',
+      '<script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.min.js" integrity="sha384-ZvpUoO/+PpLXR1lu4jmpXWu80pZlYUAfxl5NsBMWOEPSjUn/6Z/hRTt8+pR6L4N2" crossorigin="anonymous" data-relocate-top="true"></script>',
     );
     head.push(
       "<script type=\"application/javascript\">define('jquery', [],function() {return window.jQuery;})</script>",

--- a/tests/docs/smoke-all/2023/09/29/test.qmd
+++ b/tests/docs/smoke-all/2023/09/29/test.qmd
@@ -7,7 +7,7 @@ _quarto:
   tests: 
     html:
       ensureHtmlElements:
-        - ['script:first-of-type[src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"]']
+        - ['script:first-of-type[src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.min.js"]']
 
 ---
 


### PR DESCRIPTION
This PR replaces the use of cdnjs.cloudflare.com and unpkg.com with cdn.jsdelivr.net for jupyter widgets. The motivation is to bring more uniformity to JS CDN's for people defining content security policies for quarto websites. Since we already use jsdelivr for MathJax, Katex, and Algolia this brings Juptyer Widgets in line with those uses.

