### PR TITLE
further improvement to kbd shortcode for unicode keys

### DIFF
--- a/src/resources/extensions/quarto/kbd/resources/kbd.js
+++ b/src/resources/extensions/quarto/kbd/resources/kbd.js
@@ -25,7 +25,7 @@
     "control": "⌃",
     "option": "⌥",
   };
-  const keyRegex = /^[a-z0-9_]+$/;
+  const keyRegex = /^[^\s]+$/;
     // use a non-capturing group to avoid capturing the key names
 
   const macosModifiersRegex = new RegExp(


### PR DESCRIPTION
This additional improvement to #5879 allows the mac modifier technique to work on keys that are described with unicode characters (eg arrow keys).