### PR TITLE
typst:no-figure is already added on all table

### DIFF
--- a/src/resources/filters/quarto-post/typst.lua
+++ b/src/resources/filters/quarto-post/typst.lua
@@ -31,23 +31,6 @@ function render_typst()
       end
     },
     {
-      FloatRefTarget = function(float)
-        if float.content == nil then
-          return float
-        end
-        if float.content.t == "Table" then
-          -- this needs the fix from https://github.com/jgm/pandoc/pull/9778
-          float.content.classes:insert("typst-no-figure")
-        else
-          float.content = _quarto.ast.walk(float.content, {
-            Table = function(tbl)
-              tbl.classes:insert("typst-no-figure")
-              return tbl
-            end
-          })
-        end
-        return float
-      end,
       Div = function(div)
         if div.classes:includes("block") then
           div.classes = div.classes:filter(function(c) return c ~= "block" end)


### PR DESCRIPTION
This was the wrong class but now unnecessary because of #11010

Test is already added in #11010: 
- tests/docs/smoke-all/2024/04/26/9365.qmd
- tests/docs/smoke-all/2024/10/08/issue-10438.qmd
- tests/docs/smoke-all/typst/tbl-align-issue10086.qmd

As discussed @cscheid , thanks !
