### PR TITLE
dev-call, show-ast - Use the same quarto binary as the one used to run the command

### DIFF
--- a/src/command/dev-call/show-ast-trace/cmd.ts
+++ b/src/command/dev-call/show-ast-trace/cmd.ts
@@ -44,7 +44,7 @@ export const showAstTraceCommand = new Command()
     const traceName = join(dir, `${base}-quarto-ast-trace.json`);
 
     const renderOpts = {
-      cmd: "quarto",
+      cmd: quartoConfig.cliPath(),
       env: {
         "QUARTO_TRACE_FILTERS": traceName,
       },
@@ -62,7 +62,7 @@ export const showAstTraceCommand = new Command()
     moveSync(traceName, join(toolsPath, basename(traceName)));
 
     const _previewResult = await execProcess({
-      cmd: "quarto",
+      cmd: quartoConfig.cliPath(),
       cwd: toolsPath,
       args: [
         "preview",


### PR DESCRIPTION
This change is using `quartoConfig.cliPath()` to get the quarto binary to use to be the same the one `quarto dev-call` was run. 

Otherwise, the quarto use could be the one on `PATH`, which can be different that the one used (dev version vs released version if both installed), and also on windows we need `quarto.exe` or `quarto.cmd` depending on which is used. `quarto` on PATH won't always work without the extension. 

and why we have this function for example
https://github.com/quarto-dev/quarto-cli/blob/fd54213c3e3f5fa929f6669b9ffb41547954f31c/tests/utils.ts#L192-L197

Opening the PR so that this is traced, and also for you to check this is ok to use that on Mac too. 