### PR TITLE
floatref - avoid caption duplication on Div Crossref with captioned Markdown table 

### DIFF
--- a/dev-docs/feature-format-matrix/qmd-files/crossref/float/table/document.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/crossref/float/table/document.qmd
@@ -32,16 +32,19 @@ _quarto:
           - "div#tbl-3.quarto-float figure.quarto-float.quarto-float-tbl table"
           - "div#tbl-4.quarto-float figure.quarto-float.quarto-float-tbl table"
           - "div#tbl-5.quarto-float figure.quarto-float.quarto-float-tbl table"
+          - "div#tbl-6.quarto-float figure.quarto-float.quarto-float-tbl table"
           - "div#tbl-1.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
           - "div#tbl-2.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
           - "div#tbl-3.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
           - "div#tbl-4.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
           - "div#tbl-5.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
+          - "div#tbl-6.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
           - "a[href=\"#tbl-1\"].quarto-xref"
           - "a[href=\"#tbl-2\"].quarto-xref"
           - "a[href=\"#tbl-3\"].quarto-xref"
           - "a[href=\"#tbl-4\"].quarto-xref"
           - "a[href=\"#tbl-5\"].quarto-xref"
+          - "a[href=\"#tbl-6\"].quarto-xref"
     dashboard: *dom-tests
     revealjs:
       ensureHtmlElements:
@@ -51,16 +54,19 @@ _quarto:
           - "div#tbl-3.quarto-float figure.quarto-float.quarto-float-tbl table"
           - "div#tbl-4.quarto-float figure.quarto-float.quarto-float-tbl table"
           - "div#tbl-5.quarto-float figure.quarto-float.quarto-float-tbl table"
+          - "div#tbl-6.quarto-float figure.quarto-float.quarto-float-tbl table"
           - "div#tbl-1.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
           - "div#tbl-2.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
           - "div#tbl-3.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
           - "div#tbl-4.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
           - "div#tbl-5.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
+          - "div#tbl-6.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
           - "a[href=\"#/tbl-1\"].quarto-xref"
           - "a[href=\"#/tbl-2\"].quarto-xref"
           - "a[href=\"#/tbl-3\"].quarto-xref"
           - "a[href=\"#/tbl-4\"].quarto-xref"
           - "a[href=\"#/tbl-5\"].quarto-xref"
+          - "a[href=\"#/tbl-6\"].quarto-xref"
     latex: &latex-tests
       ensureFileRegexMatches:
         - 
@@ -69,11 +75,13 @@ _quarto:
           - '\\ref\{tbl-3\}'
           - '\\ref\{tbl-4\}'
           - '\\ref\{tbl-5\}'
+          - '\\ref\{tbl-6\}'
           - '\label\{tbl-1\}'
           - '\label\{tbl-2\}'
           - '\label\{tbl-3\}'
           - '\label\{tbl-4\}'
           - '\label\{tbl-5\}'
+          - '\label\{tbl-6\}'
           - '\\begin\{longtable\}'
           - '\\includegraphics.*media.*table\.jpg'
     beamer: *latex-tests
@@ -85,11 +93,13 @@ _quarto:
           - '\<tbl-3\>'
           - '\<tbl-4\>'
           - '\<tbl-5\>'
+          - '\<tbl-6\>'
           - '#ref\(\<tbl-1\>, supplement: \[Table\]\)'
           - '#ref\(\<tbl-2\>, supplement: \[Table\]\)'
           - '#ref\(\<tbl-3\>, supplement: \[Table\]\)'
           - '#ref\(\<tbl-4\>, supplement: \[Table\]\)'
           - '#ref\(\<tbl-5\>, supplement: \[Table\]\)'
+          - '#ref\(\<tbl-6\>, supplement: \[Table\]\)'
     docusaurus-md:
       ensureFileRegexMatches:
         -
@@ -98,6 +108,7 @@ _quarto:
           - '\<div id="tbl-3"\>'
           - '\<div id="tbl-4"\>'
           - '\<div id="tbl-5"\>'
+          - '\<div id="tbl-6"\>'
           - 'text-align: left.*Left'
           - 'text-align: right.*Right'
           - 'text-align: center.*Center'
@@ -137,6 +148,7 @@ The crossref Div syntax can also be used to insert a markdown table
 - either using Quarto Caption syntax (paragraph below the table) - See @tbl-3
 - either using the Pandoc Table Caption syntax - See @tbl-4
 - either using `tbl-cap` attributes when this is an output of computations - See @tbl-5
+- either using `tbl-cap` attributes on Crossref Div - See @tbl-6
 
 ### Quarto Syntax in Div {#quarto-in-div}
 
@@ -178,8 +190,6 @@ knitr::kable(iris[1:6,])
 
 ::: {#tbl-5 .cell tbl-cap='This is the caption for the table'}
 
-::: {.cell-output-display}
-
 | Default | Left | Right | Center |
 |---------|:-----|------:|:------:|
 | 12      | 12   |    12 |   12   |
@@ -188,5 +198,15 @@ knitr::kable(iris[1:6,])
 
 :::
 
-::: 
 
+### Using Div attribute on Cross ref div
+
+::: {#tbl-6 tbl-cap='This is the caption for the table'}
+
+| Default | Left | Right | Center |
+|---------|:-----|------:|:------:|
+| 12      | 12   |    12 |   12   |
+| 123     | 123  |   123 |  123   |
+| 1       | 1    |     1 |   1    |
+
+:::

--- a/dev-docs/feature-format-matrix/qmd-files/crossref/float/table/document.qmd
+++ b/dev-docs/feature-format-matrix/qmd-files/crossref/float/table/document.qmd
@@ -15,6 +15,7 @@ format:
   revealjs: 
     quality: 2
     auto-stretch: false
+    slide-level: 3
   beamer: 
     output-ext: tex
     quality: 2
@@ -28,46 +29,79 @@ _quarto:
         - 
           - "div#tbl-1.quarto-float figure.quarto-float.quarto-float-tbl table"
           - "div#tbl-2.quarto-float figure.quarto-float.quarto-float-tbl img"
+          - "div#tbl-3.quarto-float figure.quarto-float.quarto-float-tbl table"
+          - "div#tbl-4.quarto-float figure.quarto-float.quarto-float-tbl table"
+          - "div#tbl-5.quarto-float figure.quarto-float.quarto-float-tbl table"
           - "div#tbl-1.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
           - "div#tbl-2.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
+          - "div#tbl-3.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
+          - "div#tbl-4.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
+          - "div#tbl-5.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
           - "a[href=\"#tbl-1\"].quarto-xref"
           - "a[href=\"#tbl-2\"].quarto-xref"
+          - "a[href=\"#tbl-3\"].quarto-xref"
+          - "a[href=\"#tbl-4\"].quarto-xref"
+          - "a[href=\"#tbl-5\"].quarto-xref"
     dashboard: *dom-tests
     revealjs:
       ensureHtmlElements:
         - 
           - "div#tbl-1.quarto-float figure.quarto-float.quarto-float-tbl table"
           - "div#tbl-2.quarto-float figure.quarto-float.quarto-float-tbl img"
+          - "div#tbl-3.quarto-float figure.quarto-float.quarto-float-tbl table"
+          - "div#tbl-4.quarto-float figure.quarto-float.quarto-float-tbl table"
+          - "div#tbl-5.quarto-float figure.quarto-float.quarto-float-tbl table"
           - "div#tbl-1.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
           - "div#tbl-2.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
+          - "div#tbl-3.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
+          - "div#tbl-4.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
+          - "div#tbl-5.quarto-float figure.quarto-float.quarto-float-tbl figcaption"
           - "a[href=\"#/tbl-1\"].quarto-xref"
           - "a[href=\"#/tbl-2\"].quarto-xref"
+          - "a[href=\"#/tbl-3\"].quarto-xref"
+          - "a[href=\"#/tbl-4\"].quarto-xref"
+          - "a[href=\"#/tbl-5\"].quarto-xref"
     latex: &latex-tests
       ensureFileRegexMatches:
         - 
-          - "\\\\ref\\{tbl-1\\}"
-          - "\\\\ref\\{tbl-2\\}"
-          - "\\\\label\\{tbl-1\\}"
-          - "\\\\label\\{tbl-2\\}"
-          - "\\\\begin\\{longtable\\}"
-          - "\\\\includegraphics.*media.*table\\.jpg"
+          - '\\ref\{tbl-1\}'
+          - '\\ref\{tbl-2\}'
+          - '\\ref\{tbl-3\}'
+          - '\\ref\{tbl-4\}'
+          - '\\ref\{tbl-5\}'
+          - '\label\{tbl-1\}'
+          - '\label\{tbl-2\}'
+          - '\label\{tbl-3\}'
+          - '\label\{tbl-4\}'
+          - '\label\{tbl-5\}'
+          - '\\begin\{longtable\}'
+          - '\\includegraphics.*media.*table\.jpg'
     beamer: *latex-tests
     typst:
       ensureTypstFileRegexMatches:
         - 
           - '\<tbl-1\>'
           - '\<tbl-2\>'
+          - '\<tbl-3\>'
+          - '\<tbl-4\>'
+          - '\<tbl-5\>'
           - '#ref\(\<tbl-1\>, supplement: \[Table\]\)'
           - '#ref\(\<tbl-2\>, supplement: \[Table\]\)'
+          - '#ref\(\<tbl-3\>, supplement: \[Table\]\)'
+          - '#ref\(\<tbl-4\>, supplement: \[Table\]\)'
+          - '#ref\(\<tbl-5\>, supplement: \[Table\]\)'
     docusaurus-md:
       ensureFileRegexMatches:
         -
-          - "\\<div id=\"tbl-1\"\\>"
-          - "\\<div id=\"tbl-2\"\\>"
-          - "text-align: left.*Left"
-          - "text-align: right.*Right"
-          - "text-align: center.*Center"
-          - "\\!\\[\\]\\(.*media.*table\\.jpg\\)"
+          - '\<div id="tbl-1"\>'
+          - '\<div id="tbl-2"\>'
+          - '\<div id="tbl-3"\>'
+          - '\<div id="tbl-4"\>'
+          - '\<div id="tbl-5"\>'
+          - 'text-align: left.*Left'
+          - 'text-align: right.*Right'
+          - 'text-align: center.*Center'
+          - '\!\[\]\(.*media.*table\.jpg\)'
 ---
 
 ## Crossreferenceable "Table"s
@@ -95,3 +129,64 @@ This is the caption for the table rendered as an image.
 :::
 
 See @tbl-2.
+
+## Markdown syntax
+
+The crossref Div syntax can also be used to insert a markdown table
+
+- either using Quarto Caption syntax (paragraph below the table) - See @tbl-3
+- either using the Pandoc Table Caption syntax - See @tbl-4
+- either using `tbl-cap` attributes when this is an output of computations - See @tbl-5
+
+### Quarto Syntax in Div {#quarto-in-div}
+
+::: {#tbl-3}
+
+| Default | Left | Right | Center |
+|---------|:-----|------:|:------:|
+| 12      | 12   |    12 |   12   |
+| 123     | 123  |   123 |  123   |
+| 1       | 1    |     1 |   1    |
+
+This is the caption for the table
+:::
+
+### Pandoc Table Caption Syntax {#pandoc-in-div}
+
+::: {#tbl-4}
+
+| Default | Left | Right | Center |
+|---------|:-----|------:|:------:|
+| 12      | 12   |    12 |   12   |
+| 123     | 123  |   123 |  123   |
+| 1       | 1    |     1 |   1    |
+
+: This is the caption for the table
+
+:::
+
+### Using Div attribute on .cell div {#div-attr}
+
+When using something like 
+
+```{{r}}
+#| tbl-cap: "My caption could run over several lines, if the world is round"
+#| label: tbl-my_cap
+
+knitr::kable(iris[1:6,])
+```
+
+::: {#tbl-5 .cell tbl-cap='This is the caption for the table'}
+
+::: {.cell-output-display}
+
+| Default | Left | Right | Center |
+|---------|:-----|------:|:------:|
+| 12      | 12   |    12 |   12   |
+| 123     | 123  |   123 |  123   |
+| 1       | 1    |     1 |   1    |
+
+:::
+
+::: 
+

--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -6,6 +6,7 @@ All changes included in 1.8:
 - ([#12625](https://github.com/quarto-dev/quarto-cli/pull/12625)): Fire resize event on window when light/dark toggle is clicked, to tell widgets to resize.
 - ([#12657](https://github.com/quarto-dev/quarto-cli/pull/12657)): Load Giscus in generated script tag, to avoid wrong-theming in Chrome.
 - ([#12780](https://github.com/quarto-dev/quarto-cli/issues/12780)): `keep-ipynb: true` now works again correctly and intermediate `.quarto_ipynb` is not removed.
+- ([#13051](https://github.com/quarto-dev/quarto-cli/issues/13051)): Fixed support for captioned Markdown table inside Div syntax for crossref. This is special handling, but this could be output by function like `knitr::kable()` with old option support.
 
 ## Dependencies
 

--- a/src/resources/filters/quarto-pre/parsefiguredivs.lua
+++ b/src/resources/filters/quarto-pre/parsefiguredivs.lua
@@ -268,7 +268,7 @@ function parse_floatreftargets()
             found_caption = true
             caption = table.caption.long[1] -- what if there's more than one entry here?
             -- table caption should be removed from the table as we'll handle it
-            table.caption.long = pandoc.Blocks({})
+            table.caption = pandoc.Caption{}
             return table
           end
         end

--- a/src/resources/filters/quarto-pre/parsefiguredivs.lua
+++ b/src/resources/filters/quarto-pre/parsefiguredivs.lua
@@ -267,6 +267,8 @@ function parse_floatreftargets()
           if table.caption.long and next(table.caption.long) then
             found_caption = true
             caption = table.caption.long[1] -- what if there's more than one entry here?
+            -- table caption should be removed from the table as we'll handle it
+            table.caption.long = pandoc.Blocks({})
             return table
           end
         end

--- a/tests/docs/smoke-all/2025/07/10/13051.qmd
+++ b/tests/docs/smoke-all/2025/07/10/13051.qmd
@@ -1,0 +1,74 @@
+---
+title: Crossref Div with Markdown captioned table do not duplicate caption
+format: html
+keep-tex: true
+keep-typ: true
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - 
+          - 'div#tbl-1.quarto-float figure.quarto-float.quarto-float-tbl table'
+          - 'div#tbl-2.quarto-float figure.quarto-float.quarto-float-tbl table'
+          - 'a[href="#tbl-1"].quarto-xref'
+          - 'a[href="#tbl-2"].quarto-xref'
+        -  
+           -  'div#tbl-1.quarto-float table caption'
+           -  'div#tbl-2.quarto-float table caption'
+    revealjs:
+      ensureHtmlElements:
+        - 
+          - 'div#tbl-1.quarto-float figure.quarto-float.quarto-float-tbl table'
+          - 'div#tbl-2.quarto-float figure.quarto-float.quarto-float-tbl table'
+          - 'a[href="#/tbl-1"].quarto-xref'
+          - 'a[href="#/tbl-2"].quarto-xref'
+        -  
+           -  'div#tbl-1.quarto-float table caption'
+           -  'div#tbl-2.quarto-float table caption'
+    docx:
+      ensureDocxXpath:
+        - 
+          - "//w:tbl//w:p//w:r//w:t[contains(text(), \"Table\u00a01\")]"
+          - "//w:tbl//w:p//w:r//w:t[contains(text(), \"Table\u00a02\")]"
+          - "//w:hyperlink[@w:anchor='tbl-1']"
+          - "//w:hyperlink[@w:anchor='tbl-2']"
+        - 
+          - "//w:tbl//w:tbl//w:tblCaption[contains(@w:val, 'caption for the table 1')]"
+          - "//w:tbl//w:tbl//w:tblCaption[contains(@w:val, 'caption for the table 2')]"
+---
+
+Pandoc's support Caption on Markdown table through a specific syntax: https://pandoc.org/MANUAL.html#extension-table_captions
+
+This test ensure we do catch the caption and do not duplicate
+
+## Using `:` syntax
+
+::: {#tbl-1}
+
+| Default | Left | Right | Center |
+|---------|:-----|------:|:------:|
+| 12      | 12   |    12 |   12   |
+| 123     | 123  |   123 |  123   |
+| 1       | 1    |     1 |   1    |
+
+: This is the caption for the table 1
+
+:::
+
+See @tbl-1
+
+## Using `Table:` syntax
+
+::: {#tbl-2}
+
+| Default | Left | Right | Center |
+|---------|:-----|------:|:------:|
+| 12      | 12   |    12 |   12   |
+| 123     | 123  |   123 |  123   |
+| 1       | 1    |     1 |   1    |
+
+Table: This is the caption for the table 2
+
+:::
+
+See @tbl-2

--- a/tests/new-smoke-all-test.ps1
+++ b/tests/new-smoke-all-test.ps1
@@ -62,7 +62,7 @@ _quarto:
       ensureDocxRegexMatches:
         - []
         - []
-      ensureDocxXPath:
+      ensureDocxXpath:
         - []
         - []
     pptx:

--- a/tests/new-smoke-all-test.sh
+++ b/tests/new-smoke-all-test.sh
@@ -60,7 +60,7 @@ _quarto:
       ensureDocxRegexMatches:
         - []
         - []
-      ensureDocxXPath:
+      ensureDocxXpath:
         - []
         - []
     pptx:


### PR DESCRIPTION
closes #13051 

when caption is taken on the table element, remove it from the table

this is because Quarto floatref processes the table caption and it needs to be removed from the table element so that it doesn't get inserted twice

This happens with syntax like 

````markdown
## Using `:` syntax

::: {#tbl-1}

| Default | Left | Right | Center |
|---------|:-----|------:|:------:|
| 12      | 12   |    12 |   12   |
| 123     | 123  |   123 |  123   |
| 1       | 1    |     1 |   1    |

: This is the caption for the table 1

:::

See @tbl-1

## Using `Table:` syntax

::: {#tbl-2}

| Default | Left | Right | Center |
|---------|:-----|------:|:------:|
| 12      | 12   |    12 |   12   |
| 123     | 123  |   123 |  123   |
| 1       | 1    |     1 |   1    |

Table: This is the caption for the table 2

:::

See @tbl-2
````

This PR adds also 

- Regression for this specific duplication
- More supported syntax in ff-matrix with test

> [!NOTE]
> The fix is a candidate for a backport as it was a regression in 1.7 from https://github.com/quarto-dev/quarto-cli/commit/8bec5e35f6a677a4ad41318a2b125f1204dec2da 
> I'll do a PR once validated