### PR TITLE
lua - use `cli_path()` information instead of building the path with the environment variable

### DIFF
--- a/src/resources/filters/normalize/astpipeline.lua
+++ b/src/resources/filters/normalize/astpipeline.lua
@@ -64,7 +64,7 @@ function quarto_ast_pipeline()
         local jin = assert(io.open(juice_in, 'w'))
         jin:write(htmltext)
         jin:flush()
-        local quarto_path = pandoc.path.join({os.getenv('QUARTO_BIN_PATH'), 'quarto'})
+        local quarto_path = quarto.config.cli_path()
         local jout, jerr = io.popen(quarto_path .. ' run ' ..
             pandoc.path.join({os.getenv('QUARTO_SHARE_PATH'), 'scripts', 'juice.ts'}) .. ' ' ..
             juice_in, 'r')


### PR DESCRIPTION
Follow up on https://github.com/quarto-dev/quarto-cli/pull/13053#issuecomment-3057244940

We have `quarto.config.cli_path()` set to the Quarto Binary path to used in filter. 

This ensures that the same Path as the quarto binary is used. 

I just wonder if `io.popen` to work correctly with `quarto.cmd` on Windows. 

Let's see if the CI passes.