### PR TITLE
Update _language-zh.yml

### DIFF
--- a/src/resources/language/_language-zh.yml
+++ b/src/resources/language/_language-zh.yml
@@ -98,7 +98,7 @@ crossref-lof-title: "图索引"
 crossref-lot-title: "表索引"
 crossref-lol-title: "列表索引"
 
-environment-proof-title: "证"
+environment-proof-title: "证明"
 environment-remark-title: "注记"
 environment-solution-title: "解"
 


### PR DESCRIPTION
## Description

This commit fixed a minor inappropriate phrasing in the Chinese localization of `environment-proof-title`.

Previously it is abbreviated to "证", inconsistent with other theorem-like titles (which are not abbreviated). "证明" is also a much more common choice in mathematical textbooks written in Chinese.

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
