### PR TITLE
[GHA] Running ffmatrix requires globstar to be enabled in bash.

### DIFF
--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -235,7 +235,7 @@ jobs:
           readarray -t my_array < <(echo '${{ inputs.buckets }}' | jq -rc '.[]')
           for file in "${my_array[@]}"; do 
             echo ">>> ./run-tests.sh ${file}"
-            ./run-tests.sh $file
+            shopt -s globstar && ./run-tests.sh $file
             status=$?
             [ $status -eq 0 ] && echo ">>> No error in this test file" || haserror=1
           done


### PR DESCRIPTION
Otherwise, not all tests will be run, like on windows.

This is an oversight from 
- #12989

when I reorganised the work. 

Windows was running all tests, but not Linux. This should fix it. 