### PR TITLE
typst logo partial

### DIFF
--- a/src/core/brand/brand.ts
+++ b/src/core/brand/brand.ts
@@ -10,6 +10,7 @@ import {
   BrandColorLightDark,
   BrandFont,
   BrandLogoExplicitResource,
+  BrandLogoResource,
   BrandLogoSingle,
   BrandLogoUnified,
   BrandNamedLogo,
@@ -143,11 +144,7 @@ export class Brand {
       }
     }
     for (const [key, value] of Object.entries(data.logo?.images ?? {})) {
-      if (typeof value === "string") {
-        logo.images[key] = { path: value };
-      } else {
-        logo.images[key] = value;
-      }
+      logo.images[key] = this.resolvePath(value);
     }
 
     return {
@@ -240,11 +237,7 @@ export class Brand {
     return fonts ?? [];
   }
 
-  getLogoResource(name: string): BrandLogoExplicitResource {
-    const entry = this.data.logo?.images?.[name];
-    if (!entry) {
-      return { path: name };
-    }
+  resolvePath(entry: BrandLogoResource) {
     const pathPrefix = relative(this.projectDir, this.brandDir);
     if (typeof entry === "string") {
       return { path: join(pathPrefix, entry) };
@@ -255,6 +248,13 @@ export class Brand {
     };
   }
 
+  getLogoResource(name: string): BrandLogoExplicitResource {
+    const entry = this.data.logo?.images?.[name];
+    if (!entry) {
+      return { path: name };
+    }
+    return this.resolvePath(entry);
+  }
   getLogo(name: BrandNamedLogo): BrandLogoExplicitResource | undefined {
     const entry = this.data.logo?.[name];
     if (!entry) {

--- a/src/format/typst/format-typst.ts
+++ b/src/format/typst/format-typst.ts
@@ -92,6 +92,7 @@ export function typstFormat(): Format {
         partials: [
           "definitions.typ",
           "typst-template.typ",
+          "logo.typ",
           "typst-show.typ",
           "notes.typ",
           "biblio.typ",

--- a/src/resources/filters/quarto-post/typst-brand-yaml.lua
+++ b/src/resources/filters/quarto-post/typst-brand-yaml.lua
@@ -96,6 +96,33 @@ function render_typst_brand_yaml()
           local decl = '#let brand-color-background = ' .. to_typst_dict_indent(themebk)
           quarto.doc.include_text('in-header', decl)
         end
+        if brand.processedData.logo and next(brand.processedData.logo) then
+          local logo = brand.processedData.logo
+          if logo.images then
+            local declImage = {}
+            for name, image in pairs(logo.images) do
+              declImage[name] = {
+                path = quote_string(image.path),
+                alt = quote_string(image.alt),
+              }
+            end
+            if next(declImage) then
+              quarto.doc.include_text('in-header', '#let brand-logo-images = ' .. to_typst_dict_indent(declImage))
+            end
+          end
+          local declLogo = {}
+          for _, size in pairs({'small', 'medium', 'large'}) do
+            if logo[size] then
+              declLogo[size] = {
+                path = quote_string(logo[size].path),
+                alt = quote_string(logo[size].alt),
+              }
+            end
+          end
+          if next(declLogo) then
+            quarto.doc.include_text('in-header', '#let brand-logo = ' .. to_typst_dict_indent(declLogo))
+          end
+        end
         local function conditional_entry(key, value, quote_strings)
           if quote_strings == null then quote_strings = true end
           if not value then return '' end
@@ -212,102 +239,103 @@ function render_typst_brand_yaml()
             ', content)'
           }))
         end
-  
-        -- logo
-        local logo = param('logo')
-        local logoOptions = {}
-        local foundLogo = null
-         if logo then
-          if type(logo) == 'string' then
-            foundLogo = _quarto.modules.brand.get_logo(brandMode, logo) or {path=logo}
-          elseif type(logo) == 'table' then
-            for k, v in pairs(logo) do
-              logoOptions[k] = v
-            end
-            if logo.path then
-              foundLogo =  _quarto.modules.brand.get_logo(brandMode, logo.path) or {path=logo}
-            end
-          end
-        end
-        if not foundLogo and brand.processedData.logo then
-          local tries = {'large', 'small', 'medium'} -- low to high priority
-          foundLogo = _quarto.modules.brand.get_logo(brandMode, 'medium')
-            or _quarto.modules.brand.get_logo(brandMode, 'small')
-            or _quarto.modules.brand.get_logo(brandMode, 'large')
-        end
-        if foundLogo then
-          logoOptions.path = foundLogo.path
-          logoOptions.alt = foundLogo.alt
-
-          local pads = {}
-          for k, v in _quarto.utils.table.sortedPairs(logoOptions) do
-            if k == 'padding' then
-              local widths = {}
-              _quarto.modules.typst.css.parse_multiple(v, 5, function(s, start)
-                local width, newstart = _quarto.modules.typst.css.consume_width(s, start)
-                table.insert(widths, width)
-                return newstart
-              end)
-              local sides = _quarto.modules.typst.css.expand_side_shorthand(
-                widths,
-                'widths in padding list: ' .. v)
-              pads.top = sides.top
-              pads.right = sides.right
-              pads.bottom = sides.bottom
-              pads.left = sides.left
-            elseif k:find '^padding-' then
-              local _, ndash = k:gsub('-', '')
-              if ndash == 1 then
-                local side = k:match('^padding--(%a+)')
-                local padding_sides = {'left', 'top', 'right', 'bottom'}
-                if tcontains(padding_sides, side) then
-                  pads[side] = _quarto.modules.typst.css.translate_length(v)
-                else
-                  quarto.log.warning('invalid padding key ' .. k)
-                end
-              else
-                quarto.log.warning('invalid padding key ' .. k)
-              end
-            end
-          end
-          local inset = nil
-          if next(pads) then
-            if pads.top == pads.right and
-              pads.right == pads.bottom and
-              pads.bottom == pads.left
-            then
-              inset = pads.top
-            elseif pads.top == pads.bottom and pads.left == pads.right then
-              inset = _quarto.modules.typst.as_typst_dictionary({x = pads.left, y = pads.top})
-            else
-              inset = _quarto.modules.typst.as_typst_dictionary(pads)
-            end
-          else
-            inset = '0.75in'
-          end
-          logoOptions.width = _quarto.modules.typst.css.translate_length(logoOptions.width or '1.5in')
-          logoOptions.location = logoOptions.location and
-            location_to_typst_align(logoOptions.location) or 'left+top'
-          quarto.log.debug('logo options', logoOptions)
-          local altProp = logoOptions.alt and (', alt: "' .. logoOptions.alt .. '"') or ''
-          local imageFilename = logoOptions.path
-          if _quarto.modules.mediabag.should_mediabag(imageFilename) then
-            imageFilename = _quarto.modules.mediabag.resolved_url_cache[logoOptions.path] or _quarto.modules.mediabag.fetch_and_store_image(logoOptions.path)
-            imageFilename = _quarto.modules.mediabag.write_mediabag_entry(imageFilename) or imageFilename
-          else
-            -- backslashes need to be doubled for Windows
-            imageFilename = string.gsub(imageFilename, '\\', '\\\\')
-          end
-          quarto.doc.include_text('in-header',
-            '#set page(background: align(' .. logoOptions.location .. ', box(inset: ' .. inset .. ', image("' .. imageFilename .. '", width: ' .. logoOptions.width .. altProp .. '))))')
-        end  
       end
     end,
     Meta = function(meta)
+      local brand = param('brand')
       local brandMode = param('brand-mode') or 'light'
+      brand = brand and brand[brandMode]
       -- it can contain the path but we want to store an object here
       if not meta.brand or pandoc.utils.type(meta.brand) == 'Inlines' then
         meta.brand = {}
+      end
+      -- logo
+      local logo = param('logo')
+      local logoOptions = {}
+      local foundLogo = null
+      if logo then
+        if type(logo) == 'string' then
+          foundLogo = _quarto.modules.brand.get_logo(brandMode, logo) or {path=logo}
+        elseif type(logo) == 'table' then
+          for k, v in pairs(logo) do
+            logoOptions[k] = v
+          end
+          if logo.path then
+            foundLogo = _quarto.modules.brand.get_logo(brandMode, logo.path) or {path=logo}
+          end
+        end
+      end
+      if not foundLogo and brand and brand.processedData and brand.processedData.logo then
+        foundLogo = _quarto.modules.brand.get_logo(brandMode, 'medium')
+          or _quarto.modules.brand.get_logo(brandMode, 'small')
+          or _quarto.modules.brand.get_logo(brandMode, 'large')
+      end
+      if foundLogo then
+        logoOptions.path = foundLogo.path
+        logoOptions.alt = foundLogo.alt
+
+        local pads = {}
+        for k, v in _quarto.utils.table.sortedPairs(logoOptions) do
+          if k == 'padding' then
+            local widths = {}
+            _quarto.modules.typst.css.parse_multiple(v, 5, function(s, start)
+              local width, newstart = _quarto.modules.typst.css.consume_width(s, start)
+              table.insert(widths, width)
+              return newstart
+            end)
+            local sides = _quarto.modules.typst.css.expand_side_shorthand(
+              widths,
+              'widths in padding list: ' .. v)
+            pads.top = sides.top
+            pads.right = sides.right
+            pads.bottom = sides.bottom
+            pads.left = sides.left
+          elseif k:find '^padding-' then
+            local _, ndash = k:gsub('-', '')
+            if ndash == 1 then
+              local side = k:match('^padding--(%a+)')
+              local padding_sides = {'left', 'top', 'right', 'bottom'}
+              if tcontains(padding_sides, side) then
+                pads[side] = _quarto.modules.typst.css.translate_length(v)
+              else
+                quarto.log.warning('invalid padding key ' .. k)
+              end
+            else
+              quarto.log.warning('invalid padding key ' .. k)
+            end
+          end
+        end
+        local inset = nil
+        if next(pads) then
+          if pads.top == pads.right and
+            pads.right == pads.bottom and
+            pads.bottom == pads.left
+          then
+            inset = pads.top
+          elseif pads.top == pads.bottom and pads.left == pads.right then
+            inset = _quarto.modules.typst.as_typst_dictionary({x = pads.left, y = pads.top})
+          else
+            inset = _quarto.modules.typst.as_typst_dictionary(pads)
+          end
+        else
+          inset = '0.75in'
+        end
+        logoOptions.width = _quarto.modules.typst.css.translate_length(logoOptions.width or '1.5in')
+        logoOptions.inset = inset
+        logoOptions.location = logoOptions.location and
+          location_to_typst_align(logoOptions.location) or 'left+top'
+        quarto.log.debug('logo options', logoOptions)
+        local imageFilename = logoOptions.path
+        if _quarto.modules.mediabag.should_mediabag(imageFilename) then
+          imageFilename = _quarto.modules.mediabag.resolved_url_cache[logoOptions.path] or _quarto.modules.mediabag.fetch_and_store_image(logoOptions.path)
+          imageFilename = _quarto.modules.mediabag.write_mediabag_entry(imageFilename) or imageFilename
+          imageFilename = imageFilename and imageFilename:gsub('\\_', '_')
+        else
+          -- backslashes need to be doubled for Windows
+          imageFilename = string.gsub(imageFilename, '\\', '\\\\')
+        end
+        logoOptions.path = pandoc.RawInline('typst', imageFilename)
+        meta.logo = logoOptions
       end
       meta.brand.typography = meta.brand.typography or {}
       local base = _quarto.modules.brand.get_typography(brandMode, 'base')

--- a/src/resources/filters/quarto-post/typst-brand-yaml.lua
+++ b/src/resources/filters/quarto-post/typst-brand-yaml.lua
@@ -102,7 +102,7 @@ function render_typst_brand_yaml()
             local declImage = {}
             for name, image in pairs(logo.images) do
               declImage[name] = {
-                path = quote_string(image.path),
+                path = quote_string(image.path):gsub('\\', '\\\\'),
                 alt = quote_string(image.alt),
               }
             end
@@ -114,7 +114,7 @@ function render_typst_brand_yaml()
           for _, size in pairs({'small', 'medium', 'large'}) do
             if logo[size] then
               declLogo[size] = {
-                path = quote_string(logo[size].path),
+                path = quote_string(logo[size].path):gsub('\\', '\\\\'),
                 alt = quote_string(logo[size].alt),
               }
             end

--- a/src/resources/formats/typst/pandoc/quarto/logo.typ
+++ b/src/resources/formats/typst/pandoc/quarto/logo.typ
@@ -1,0 +1,3 @@
+$if(logo)$
+#set page(background: align($logo.location$, box(inset: $logo.inset$, image("$logo.path$", width: $logo.width$$if(logo.alt)$, alt: "$logo.alt$"$endif$))))
+$endif$

--- a/src/resources/formats/typst/pandoc/quarto/template.typ
+++ b/src/resources/formats/typst/pandoc/quarto/template.typ
@@ -6,6 +6,8 @@ $for(header-includes)$
 $header-includes$
 $endfor$
 
+$logo.typ()$
+
 $typst-show.typ()$
 
 $for(include-before)$

--- a/tests/docs/smoke-all/typst/brand-yaml/logo/posit/brand-logo.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/logo/posit/brand-logo.qmd
@@ -9,6 +9,8 @@ _quarto:
     typst:
       ensureTypstFileRegexMatches:
       -
+        - '#let brand-logo-images = \(\s*brand-typst-with-good-padding: \(\s*path: "good-padding\.png"\s*\),\s*posit-logo-light-medium: \(\s*alt: "Posit Logo",\s*path: "posit-logo-2024.svg"\s*\)'
+        - '#let brand-logo = \(\s*medium: \(\s*alt: "Posit Logo",\s*path: "posit-logo-2024\.svg"\s*\)\s*\)'
         - '#set page\(background: align\(left\+top, box\(inset: 0.75in, image\("posit-logo-2024.svg", width: 1.5in, alt: "Posit Logo"\)\)\)\)'
       - []
 ---

--- a/tests/docs/smoke-all/typst/brand-yaml/logo/relative-path/brand-logo.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/logo/relative-path/brand-logo.qmd
@@ -11,8 +11,8 @@ _quarto:
     typst:
       ensureTypstFileRegexMatches:
       -
-        - '#let brand-logo-images = \(\s*large-light: \(\s*path: "resources/quarto.png"\s*\)\s*\)'
-        - '#let brand-logo = \(\s*large: \(\s*path: "brand_yaml/resources/quarto.png"\s*\)\s*\)'
+        - '#let brand-logo-images = \(\s*large-light: \(\s*path: "resources(/|\\\\)quarto.png"\s*\)\s*\)'
+        - '#let brand-logo = \(\s*large: \(\s*path: "brand_yaml(/|\\\\)resources(/|\\\\)quarto.png"\s*\)\s*\)'
         - '#set page\(background: align\(center\+top, box\(inset: 2em, image\("brand_yaml(/|\\\\)resources(/|\\\\)quarto.png", width: 225pt\)\)\)\)'
       - []
 ---

--- a/tests/docs/smoke-all/typst/brand-yaml/logo/relative-path/brand-logo.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/logo/relative-path/brand-logo.qmd
@@ -11,6 +11,8 @@ _quarto:
     typst:
       ensureTypstFileRegexMatches:
       -
+        - '#let brand-logo-images = \(\s*large-light: \(\s*path: "resources/quarto.png"\s*\)\s*\)'
+        - '#let brand-logo = \(\s*large: \(\s*path: "brand_yaml/resources/quarto.png"\s*\)\s*\)'
         - '#set page\(background: align\(center\+top, box\(inset: 2em, image\("brand_yaml(/|\\\\)resources(/|\\\\)quarto.png", width: 225pt\)\)\)\)'
       - []
 ---

--- a/tests/docs/smoke-all/typst/brand-yaml/logo/relative-path/brand-logo.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/logo/relative-path/brand-logo.qmd
@@ -11,11 +11,15 @@ _quarto:
     typst:
       ensureTypstFileRegexMatches:
       -
-        - '#let brand-logo-images = \(\s*large-light: \(\s*path: "resources(/|\\\\)quarto.png"\s*\)\s*\)'
+        - '#let brand-logo-images = \(\s*large-light: \(\s*path: "brand_yaml(/|\\\\)resources(/|\\\\)quarto.png"\s*\)\s*\)'
         - '#let brand-logo = \(\s*large: \(\s*path: "brand_yaml(/|\\\\)resources(/|\\\\)quarto.png"\s*\)\s*\)'
         - '#set page\(background: align\(center\+top, box\(inset: 2em, image\("brand_yaml(/|\\\\)resources(/|\\\\)quarto.png", width: 225pt\)\)\)\)'
+        - '#image\(brand-logo-images\.large-light\.path, alt:"from brand-logo-images"\)'
       - []
 ---
 
 {{< lipsum 4 >}}
 
+```{=typst}
+#image(brand-logo-images.large-light.path, alt:"from brand-logo-images")
+```


### PR DESCRIPTION
Fixes #13107 

This PR

* Moves the Typst logo declaration to a new partial.

   The `typst-brand-yaml.lua` filter populates the `logo` object in the pandoc metadata.

   So one can replace the partial, or change the `logo` properties after the Lua filter.

* Declares new `brand-logo` and `brand-logo-images` dictionaries in the Typst header, for access to all the resolved logos for the chosen `brand-mode`

Not sure if it's too late to add new Typst partials for 1.8. If not, we might also consider
* #11710