### PR TITLE
[backport] fix set_matplotlib_formats being removed from Ipython

### DIFF
--- a/news/changelog-1.7.md
+++ b/news/changelog-1.7.md
@@ -3,6 +3,7 @@
 ## In this release
 
 - ([#13051](https://github.com/quarto-dev/quarto-cli/issues/13051)): Fixed support for captioned Markdown table inside Div syntax for crossref. This is special handling, but this could be output by function like `knitr::kable()` with old option support.
+- ([#12753](https://github.com/quarto-dev/quarto-cli/issues/12753)): Support change in IPython 9+ and import `set_matplotlib_formats` from `matplotlib_inline.backend_inline` in the internal `setup.py` script used to initialize rendering with Jupyter engine.
 
 ## In previous releases
 

--- a/src/resources/jupyter/lang/python/setup.py
+++ b/src/resources/jupyter/lang/python/setup.py
@@ -22,7 +22,14 @@ try:
   plt.rcParams['figure.figsize'] = (fig_width, fig_height)
   plt.rcParams['figure.dpi'] = fig_dpi
   plt.rcParams['savefig.dpi'] = "figure"
-  from IPython.display import set_matplotlib_formats
+
+  # IPython 7.14 deprecated set_matplotlib_formats from IPython
+  try:
+    from matplotlib_inline.backend_inline import set_matplotlib_formats
+  except ImportError:
+    # Fall back to deprecated location for older IPython versions
+    from IPython.display import set_matplotlib_formats
+    
   set_matplotlib_formats(fig_format)
 except Exception:
   pass

--- a/tests/docs/smoke-all/jupyter/fig-format/matplotlib-svg.qmd
+++ b/tests/docs/smoke-all/jupyter/fig-format/matplotlib-svg.qmd
@@ -1,0 +1,28 @@
+---
+title: Get SVG from matplotlib
+format:
+  html:
+    fig-format: svg
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ['figure.figure img[src$=".svg"]']
+        - ['figure.figure img[src$=".png"]']
+---
+
+```{python}
+import matplotlib.pyplot as plt
+import numpy as np
+
+fig, ax = plt.subplots()
+
+x = np.linspace(0, 4 * np.pi, 100)
+y1 = np.sin(x)
+y2 = np.cos(x)
+
+ax.set_title("Sine and Cosine")
+ax.plot(x, y1)
+ax.plot(x, y2)
+ax.legend(["Sine", "Cosine"])
+```


### PR DESCRIPTION
> [!IMPORTANT]
> This is a PR for backport against v1.7 branch 

the function has been deprecated from IPython 7.14 and has been removed in IPython 9.0

cherry picked from commit 05958bc and a61d45dc2e7a8b0db55e1599b589e4997eeca9ba that were done in python environment update