### PR TITLE
typst: page partial

### DIFF
--- a/src/format/typst/format-typst.ts
+++ b/src/format/typst/format-typst.ts
@@ -92,6 +92,7 @@ export function typstFormat(): Format {
         partials: [
           "definitions.typ",
           "typst-template.typ",
+          "page.typ",
           "typst-show.typ",
           "notes.typ",
           "biblio.typ",

--- a/src/resources/filters/quarto-post/typst-brand-yaml.lua
+++ b/src/resources/filters/quarto-post/typst-brand-yaml.lua
@@ -239,102 +239,103 @@ function render_typst_brand_yaml()
             ', content)'
           }))
         end
-  
-        -- logo
-        local logo = param('logo')
-        local logoOptions = {}
-        local foundLogo = null
-         if logo then
-          if type(logo) == 'string' then
-            foundLogo = _quarto.modules.brand.get_logo(brandMode, logo) or {path=logo}
-          elseif type(logo) == 'table' then
-            for k, v in pairs(logo) do
-              logoOptions[k] = v
-            end
-            if logo.path then
-              foundLogo =  _quarto.modules.brand.get_logo(brandMode, logo.path) or {path=logo}
-            end
-          end
-        end
-        if not foundLogo and brand.processedData.logo then
-          local tries = {'large', 'small', 'medium'} -- low to high priority
-          foundLogo = _quarto.modules.brand.get_logo(brandMode, 'medium')
-            or _quarto.modules.brand.get_logo(brandMode, 'small')
-            or _quarto.modules.brand.get_logo(brandMode, 'large')
-        end
-        if foundLogo then
-          logoOptions.path = foundLogo.path
-          logoOptions.alt = foundLogo.alt
-
-          local pads = {}
-          for k, v in _quarto.utils.table.sortedPairs(logoOptions) do
-            if k == 'padding' then
-              local widths = {}
-              _quarto.modules.typst.css.parse_multiple(v, 5, function(s, start)
-                local width, newstart = _quarto.modules.typst.css.consume_width(s, start)
-                table.insert(widths, width)
-                return newstart
-              end)
-              local sides = _quarto.modules.typst.css.expand_side_shorthand(
-                widths,
-                'widths in padding list: ' .. v)
-              pads.top = sides.top
-              pads.right = sides.right
-              pads.bottom = sides.bottom
-              pads.left = sides.left
-            elseif k:find '^padding-' then
-              local _, ndash = k:gsub('-', '')
-              if ndash == 1 then
-                local side = k:match('^padding--(%a+)')
-                local padding_sides = {'left', 'top', 'right', 'bottom'}
-                if tcontains(padding_sides, side) then
-                  pads[side] = _quarto.modules.typst.css.translate_length(v)
-                else
-                  quarto.log.warning('invalid padding key ' .. k)
-                end
-              else
-                quarto.log.warning('invalid padding key ' .. k)
-              end
-            end
-          end
-          local inset = nil
-          if next(pads) then
-            if pads.top == pads.right and
-              pads.right == pads.bottom and
-              pads.bottom == pads.left
-            then
-              inset = pads.top
-            elseif pads.top == pads.bottom and pads.left == pads.right then
-              inset = _quarto.modules.typst.as_typst_dictionary({x = pads.left, y = pads.top})
-            else
-              inset = _quarto.modules.typst.as_typst_dictionary(pads)
-            end
-          else
-            inset = '0.75in'
-          end
-          logoOptions.width = _quarto.modules.typst.css.translate_length(logoOptions.width or '1.5in')
-          logoOptions.location = logoOptions.location and
-            location_to_typst_align(logoOptions.location) or 'left+top'
-          quarto.log.debug('logo options', logoOptions)
-          local altProp = logoOptions.alt and (', alt: "' .. logoOptions.alt .. '"') or ''
-          local imageFilename = logoOptions.path
-          if _quarto.modules.mediabag.should_mediabag(imageFilename) then
-            imageFilename = _quarto.modules.mediabag.resolved_url_cache[logoOptions.path] or _quarto.modules.mediabag.fetch_and_store_image(logoOptions.path)
-            imageFilename = _quarto.modules.mediabag.write_mediabag_entry(imageFilename) or imageFilename
-          else
-            -- backslashes need to be doubled for Windows
-            imageFilename = string.gsub(imageFilename, '\\', '\\\\')
-          end
-          quarto.doc.include_text('in-header',
-            '#set page(background: align(' .. logoOptions.location .. ', box(inset: ' .. inset .. ', image("' .. imageFilename .. '", width: ' .. logoOptions.width .. altProp .. '))))')
-        end  
       end
     end,
     Meta = function(meta)
+      local brand = param('brand')
       local brandMode = param('brand-mode') or 'light'
+      brand = brand and brand[brandMode]
       -- it can contain the path but we want to store an object here
       if not meta.brand or pandoc.utils.type(meta.brand) == 'Inlines' then
         meta.brand = {}
+      end
+      -- logo
+      local logo = param('logo')
+      local logoOptions = {}
+      local foundLogo = null
+      if logo then
+        if type(logo) == 'string' then
+          foundLogo = _quarto.modules.brand.get_logo(brandMode, logo) or {path=logo}
+        elseif type(logo) == 'table' then
+          for k, v in pairs(logo) do
+            logoOptions[k] = v
+          end
+          if logo.path then
+            foundLogo = _quarto.modules.brand.get_logo(brandMode, logo.path) or {path=logo}
+          end
+        end
+      end
+      if not foundLogo and brand and brand.processedData and brand.processedData.logo then
+        foundLogo = _quarto.modules.brand.get_logo(brandMode, 'medium')
+          or _quarto.modules.brand.get_logo(brandMode, 'small')
+          or _quarto.modules.brand.get_logo(brandMode, 'large')
+      end
+      if foundLogo then
+        logoOptions.path = foundLogo.path
+        logoOptions.alt = foundLogo.alt
+
+        local pads = {}
+        for k, v in _quarto.utils.table.sortedPairs(logoOptions) do
+          if k == 'padding' then
+            local widths = {}
+            _quarto.modules.typst.css.parse_multiple(v, 5, function(s, start)
+              local width, newstart = _quarto.modules.typst.css.consume_width(s, start)
+              table.insert(widths, width)
+              return newstart
+            end)
+            local sides = _quarto.modules.typst.css.expand_side_shorthand(
+              widths,
+              'widths in padding list: ' .. v)
+            pads.top = sides.top
+            pads.right = sides.right
+            pads.bottom = sides.bottom
+            pads.left = sides.left
+          elseif k:find '^padding-' then
+            local _, ndash = k:gsub('-', '')
+            if ndash == 1 then
+              local side = k:match('^padding--(%a+)')
+              local padding_sides = {'left', 'top', 'right', 'bottom'}
+              if tcontains(padding_sides, side) then
+                pads[side] = _quarto.modules.typst.css.translate_length(v)
+              else
+                quarto.log.warning('invalid padding key ' .. k)
+              end
+            else
+              quarto.log.warning('invalid padding key ' .. k)
+            end
+          end
+        end
+        local inset = nil
+        if next(pads) then
+          if pads.top == pads.right and
+            pads.right == pads.bottom and
+            pads.bottom == pads.left
+          then
+            inset = pads.top
+          elseif pads.top == pads.bottom and pads.left == pads.right then
+            inset = _quarto.modules.typst.as_typst_dictionary({x = pads.left, y = pads.top})
+          else
+            inset = _quarto.modules.typst.as_typst_dictionary(pads)
+          end
+        else
+          inset = '0.75in'
+        end
+        logoOptions.width = _quarto.modules.typst.css.translate_length(logoOptions.width or '1.5in')
+        logoOptions.inset = inset
+        logoOptions.location = logoOptions.location and
+          location_to_typst_align(logoOptions.location) or 'left+top'
+        quarto.log.debug('logo options', logoOptions)
+        local imageFilename = logoOptions.path
+        if _quarto.modules.mediabag.should_mediabag(imageFilename) then
+          imageFilename = _quarto.modules.mediabag.resolved_url_cache[logoOptions.path] or _quarto.modules.mediabag.fetch_and_store_image(logoOptions.path)
+          imageFilename = _quarto.modules.mediabag.write_mediabag_entry(imageFilename) or imageFilename
+          imageFilename = imageFilename and imageFilename:gsub('\\_', '_')
+        else
+          -- backslashes need to be doubled for Windows
+          imageFilename = string.gsub(imageFilename, '\\', '\\\\')
+        end
+        logoOptions.path = pandoc.RawInline('typst', imageFilename)
+        meta.logo = logoOptions
       end
       meta.brand.typography = meta.brand.typography or {}
       local base = _quarto.modules.brand.get_typography(brandMode, 'base')

--- a/src/resources/formats/typst/pandoc/quarto/page.typ
+++ b/src/resources/formats/typst/pandoc/quarto/page.typ
@@ -1,0 +1,8 @@
+#set page(
+  paper: $if(papersize)$"$papersize$"$else$"us-letter"$endif$,
+  margin: $if(margin)$($for(margin/pairs)$$margin.key$: $margin.value$,$endfor$)$else$(x: 1.25in, y: 1.25in)$endif$,
+  numbering: $if(page-numbering)$"$page-numbering$"$else$none$endif$,
+)
+$if(logo)$
+#set page(background: align($logo.location$, box(inset: $logo.inset$, image("$logo.path$", width: $logo.width$$if(logo.alt)$, alt: "$logo.alt$"$endif$))))
+$endif$

--- a/src/resources/formats/typst/pandoc/quarto/template.typ
+++ b/src/resources/formats/typst/pandoc/quarto/template.typ
@@ -6,6 +6,8 @@ $for(header-includes)$
 $header-includes$
 $endfor$
 
+$page.typ()$
+
 $typst-show.typ()$
 
 $for(include-before)$

--- a/src/resources/formats/typst/pandoc/quarto/typst-show.typ
+++ b/src/resources/formats/typst/pandoc/quarto/typst-show.typ
@@ -29,12 +29,6 @@ $if(abstract)$
   abstract: [$abstract$],
   abstract-title: "$labels.abstract$",
 $endif$
-$if(margin)$
-  margin: ($for(margin/pairs)$$margin.key$: $margin.value$,$endfor$),
-$endif$
-$if(papersize)$
-  paper: "$papersize$",
-$endif$
 $if(mainfont)$
   font: ("$mainfont$",),
 $elseif(brand.typography.base.family)$
@@ -65,7 +59,6 @@ $endif$
 $if(section-numbering)$
   sectionnumbering: "$section-numbering$",
 $endif$
-  pagenumbering: $if(page-numbering)$"$page-numbering$"$else$none$endif$,
 $if(toc)$
   toc: $toc$,
 $endif$

--- a/src/resources/formats/typst/pandoc/quarto/typst-template.typ
+++ b/src/resources/formats/typst/pandoc/quarto/typst-template.typ
@@ -8,8 +8,6 @@
   abstract: none,
   abstract-title: none,
   cols: 1,
-  margin: (x: 1.25in, y: 1.25in),
-  paper: "us-letter",
   lang: "en",
   region: "US",
   font: "libertinus serif",
@@ -22,18 +20,12 @@
   heading-color: black,
   heading-line-height: 0.65em,
   sectionnumbering: none,
-  pagenumbering: "1",
   toc: false,
   toc_title: none,
   toc_depth: none,
   toc_indent: 1.5em,
   doc,
 ) = {
-  set page(
-    paper: paper,
-    margin: margin,
-    numbering: pagenumbering,
-  )
   set par(justify: true)
   set text(lang: lang,
            region: region,


### PR DESCRIPTION
The page partial takes page layout and numbering set-rules out of the `article()` function and puts them at top-level.

It also takes the logo set page background rule, which was previously generated in `typst-brand-yaml.lua`.

The partial gives users an easier way to customize page and logo options, or combine them with other page background properties.
