### PR TITLE
revealjs: use common resolveLogo, implement alt text

### DIFF
--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -33,6 +33,7 @@ All changes included in 1.8:
 
 ### `revealjs`
 
+- ([#10933](https://github.com/quarto-dev/quarto-cli/issues/10933)): Revealjs supports alt text on logo, as well as customization of light and dark logos at the document level, consistent with other formats.
 - ([#12550](https://github.com/quarto-dev/quarto-cli/issues/12550)): Revealjs supports `brand-mode`, allowing to select either the light or the dark brand.
 - ([#12598](https://github.com/quarto-dev/quarto-cli/pull/12598)): Ensure `.fragment` on an image with caption applies to whole figure.
 - ([#12716](https://github.com/quarto-dev/quarto-cli/issues/12716)): Correctly resolve `"brand"` set in `theme` configuration for document in subdirectory from project root.

--- a/src/resources/schema/document-reveal-content.yml
+++ b/src/resources/schema/document-reveal-content.yml
@@ -2,7 +2,7 @@
   tags:
     formats: [revealjs]
   schema:
-    ref: logo-specifier
+    ref: logo-light-dark-specifier
   description: "Logo image (placed in bottom right corner of slides)"
 
 - name: footer

--- a/tests/docs/smoke-all/revealjs/brand-mode/brand-logo-alt-override.qmd
+++ b/tests/docs/smoke-all/revealjs/brand-mode/brand-logo-alt-override.qmd
@@ -1,0 +1,47 @@
+---
+title: brand-mode and revealjs
+format: revealjs
+brand:
+  logo:
+    images:
+      sun:
+        path: sun-face.png
+        alt: sun face
+      moon:
+        path: moon-face.png
+        alt: moon face
+    medium:
+      light: sun
+      dark: moon
+  color:
+    foreground: 
+      light: '#222'
+      dark: '#eee'
+    background:
+      light: '#eee'
+      dark: '#222'
+  typography:
+    headings:
+      color:
+        light: '#429'
+        dark: '#54e'
+logo:
+  light:
+    path: sun
+    alt: SUN
+  dark:
+    path: moon
+    alt: MOON
+_quarto:
+  tests:
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="sun-face.png"][alt="SUN"]'
+        -
+          - 'img[src="moon-face.png"][alt="MOON"]'
+---
+
+## Here's a slide
+
+- in {{< meta brand-mode >}} mode!

--- a/tests/docs/smoke-all/revealjs/brand-mode/brand-logo-alt.qmd
+++ b/tests/docs/smoke-all/revealjs/brand-mode/brand-logo-alt.qmd
@@ -1,0 +1,40 @@
+---
+title: brand-mode and revealjs
+format: revealjs
+brand:
+  logo:
+    images:
+      sun:
+        path: sun-face.png
+        alt: sun face
+      moon:
+        path: moon-face.png
+        alt: moon face
+    medium:
+      light: sun
+      dark: moon
+  color:
+    foreground: 
+      light: '#222'
+      dark: '#eee'
+    background:
+      light: '#eee'
+      dark: '#222'
+  typography:
+    headings:
+      color:
+        light: '#429'
+        dark: '#54e'
+_quarto:
+  tests:
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="sun-face.png"][alt="sun face"]'
+        -
+          - 'img[src="moon-face.png"][alt="moon face"]'
+---
+
+## Here's a slide
+
+- in {{< meta brand-mode >}} mode!

--- a/tests/docs/smoke-all/revealjs/brand-mode/brand-logo-reverse-dark.qmd
+++ b/tests/docs/smoke-all/revealjs/brand-mode/brand-logo-reverse-dark.qmd
@@ -1,0 +1,40 @@
+---
+title: brand-mode and revealjs
+format: revealjs
+brand:
+  logo:
+    images:
+      sun: sun-face.png
+      moon: moon-face.png
+    medium:
+      light: sun
+      dark: moon
+  color:
+    foreground: 
+      light: '#222'
+      dark: '#eee'
+    background:
+      light: '#eee'
+      dark: '#222'
+  typography:
+    headings:
+      color:
+        light: '#429'
+        dark: '#54e'
+brand-mode: dark
+logo:
+  light: moon
+  dark: sun
+_quarto:
+  tests:
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="sun-face.png"]'
+        -
+          - 'img[src="moon-face.png"]'
+---
+
+## Here's a slide
+
+- in {{< meta brand-mode >}} mode!

--- a/tests/docs/smoke-all/revealjs/brand-mode/brand-logo-reverse.qmd
+++ b/tests/docs/smoke-all/revealjs/brand-mode/brand-logo-reverse.qmd
@@ -1,0 +1,39 @@
+---
+title: brand-mode and revealjs
+format: revealjs
+brand:
+  logo:
+    images:
+      sun: sun-face.png
+      moon: moon-face.png
+    medium:
+      light: sun
+      dark: moon
+  color:
+    foreground: 
+      light: '#222'
+      dark: '#eee'
+    background:
+      light: '#eee'
+      dark: '#222'
+  typography:
+    headings:
+      color:
+        light: '#429'
+        dark: '#54e'
+logo:
+  light: moon
+  dark: sun
+_quarto:
+  tests:
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="moon-face.png"]'
+        -
+          - 'img[src="sun-face.png"]'
+---
+
+## Here's a slide
+
+- in {{< meta brand-mode >}} mode!


### PR DESCRIPTION
Fixes
- #10933

Allows customization of light and dark logos in document consistent with rest of formats.

Deletes 25 lines of code.
