### PR TITLE
jupyter: add environment variable for quarto base format

### DIFF
--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -101,6 +101,7 @@ All changes included in 1.8:
 - ([#12753](https://github.com/quarto-dev/quarto-cli/issues/12753)): Support change in IPython 9+ and import `set_matplotlib_formats` from `matplotlib_inline.backend_inline` in the internal `setup.py` script used to initialize rendering with Jupyter engine.
 - ([#12839](https://github.com/quarto-dev/quarto-cli/issues/12839)): Support for `plotly.py` 6+ which now loads plotly.js using a cdn in script as a module.
 - ([#13026](https://github.com/quarto-dev/quarto-cli/pulls/13026)): Use `jsdelivr` CDN for jupyter widgets dependencies.
+- ([#13150](https://github.com/quarto-dev/quarto-cli/pull/13150))): Add environment variable for quarto base format
 
 ### `knitr`
 

--- a/src/resources/jupyter/notebook.py
+++ b/src/resources/jupyter/notebook.py
@@ -121,6 +121,9 @@ def build_kernel_options(options):
 
 
 def set_env_vars(options):
+    os.environ["QUARTO_OUTPUT_BASE_FORMAT"] = str(
+        options["format"]["identifier"]["base-format"]
+    )
     os.environ["QUARTO_FIG_WIDTH"] = str(options["fig_width"])
     os.environ["QUARTO_FIG_HEIGHT"] = str(options["fig_height"])
     if options["fig_format"] == "retina":


### PR DESCRIPTION
Note that we already communicate this to the knitr engine via format$pandoc$to. Here we communicate the base-format which enables explicit detection of extended formats like dashboard and email.
