### PR TITLE
more brand logo tests

### DIFF
--- a/tests/docs/smoke-all/brand/brand-mode/brand-logo-image-path-alt.qmd
+++ b/tests/docs/smoke-all/brand/brand-mode/brand-logo-image-path-alt.qmd
@@ -1,0 +1,49 @@
+---
+title: brand-mode and logos
+format:
+  revealjs: default
+  typst:
+    keep-typ: true
+brand:
+  logo:
+    images:
+      sun:
+        path: sun-face.png
+        alt: "Sun face image"
+      moon:
+        path: moon-face.png
+        alt: "Moon face image"
+    medium:
+      light: sun
+      dark: moon
+  color:
+    foreground: 
+      light: '#222'
+      dark: '#eee'
+    background:
+      light: '#eee'
+      dark: '#222'
+  typography:
+    headings:
+      color:
+        light: '#429'
+        dark: '#54e'
+_quarto:
+  tests:
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="sun-face.png"][alt="Sun face image"]'
+        -
+          - 'img[src="moon-face.png"][alt="Moon face image"]'
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("sun-face\.png", width: 1\.5in, alt: "Sun face image"\)\)'
+        -
+          - 'background.*moon-face\.png'
+---
+
+## Here we go
+
+- Testing image definition with path and alt text

--- a/tests/docs/smoke-all/brand/brand-mode/brand-logo-image-path-only.qmd
+++ b/tests/docs/smoke-all/brand/brand-mode/brand-logo-image-path-only.qmd
@@ -1,0 +1,45 @@
+---
+title: brand-mode and logos
+format:
+  revealjs: default
+  typst:
+    keep-typ: true
+brand:
+  logo:
+    images:
+      sun: sun-face.png
+      moon: moon-face.png
+    medium:
+      light: sun
+      dark: moon
+  color:
+    foreground: 
+      light: '#222'
+      dark: '#eee'
+    background:
+      light: '#eee'
+      dark: '#222'
+  typography:
+    headings:
+      color:
+        light: '#429'
+        dark: '#54e'
+_quarto:
+  tests:
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="sun-face.png"]'
+        -
+          - 'img[src="moon-face.png"]'
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("sun-face\.png", width: 1\.5in\)\)'
+        -
+          - 'background.*moon-face\.png'
+---
+
+## Here we go
+
+- Testing image definition with just path

--- a/tests/docs/smoke-all/brand/brand-mode/brand-logo-large.qmd
+++ b/tests/docs/smoke-all/brand/brand-mode/brand-logo-large.qmd
@@ -1,0 +1,42 @@
+---
+title: brand-mode and logos
+format:
+  revealjs: default
+  typst:
+    keep-typ: true
+brand:
+  logo:
+    large:
+      light: sun-face.png
+      dark: moon-face.png
+  color:
+    foreground: 
+      light: '#222'
+      dark: '#eee'
+    background:
+      light: '#eee'
+      dark: '#222'
+  typography:
+    headings:
+      color:
+        light: '#429'
+        dark: '#54e'
+_quarto:
+  tests:
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="sun-face.png"]'
+        -
+          - 'img[src="moon-face.png"]'
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("sun-face\.png", width: 1\.5in\)\)'
+        -
+          - 'background.*moon-face\.png'
+---
+
+## Here we go
+
+- Testing large logo fallback when no medium logo is defined

--- a/tests/docs/smoke-all/brand/brand-mode/brand-logo-missing-mode.qmd
+++ b/tests/docs/smoke-all/brand/brand-mode/brand-logo-missing-mode.qmd
@@ -1,0 +1,38 @@
+---
+title: brand-mode and logos
+format:
+  revealjs: default
+  typst:
+    keep-typ: true
+brand:
+  logo:
+    medium:
+      light: sun-face.png
+      # dark mode missing
+  color:
+    foreground: 
+      light: '#222'
+      dark: '#eee'
+    background:
+      light: '#eee'
+      dark: '#222'
+  typography:
+    headings:
+      color:
+        light: '#429'
+        dark: '#54e'
+_quarto:
+  tests:
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="sun-face.png"]'
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("sun-face\.png", width: 1\.5in\)\)'
+---
+
+## Here we go
+
+- Testing missing dark mode logo

--- a/tests/docs/smoke-all/brand/brand-mode/brand-logo-mixed-paths.qmd
+++ b/tests/docs/smoke-all/brand/brand-mode/brand-logo-mixed-paths.qmd
@@ -1,0 +1,45 @@
+---
+title: brand-mode and logos
+format:
+  revealjs: default
+  typst:
+    keep-typ: true
+brand:
+  logo:
+    images:
+      sun: sun-face.png
+      moon: moon-face.png
+    medium:
+      light: sun           # Named reference
+      dark: moon-face.png  # Direct path
+  color:
+    foreground: 
+      light: '#222'
+      dark: '#eee'
+    background:
+      light: '#eee'
+      dark: '#222'
+  typography:
+    headings:
+      color:
+        light: '#429'
+        dark: '#54e'
+_quarto:
+  tests:
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="sun-face.png"]'
+        -
+          - 'img[src="moon-face.png"]'
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("sun-face\.png", width: 1\.5in\)\)'
+        -
+          - 'background.*moon-face\.png'
+---
+
+## Here we go
+
+- Testing mixed path types - named reference and direct path

--- a/tests/docs/smoke-all/brand/logo/choose-logo-resource.qmd
+++ b/tests/docs/smoke-all/brand/logo/choose-logo-resource.qmd
@@ -2,6 +2,9 @@
 title: brand and base logo
 format:
   dashboard: default
+  revealjs: default
+  typst:
+    output-ext: typ
 brand:
   logo:
     images:
@@ -25,6 +28,11 @@ _quarto:
       ensureHtmlElements:
         -
           - 'img[src="posit-logo-2024.svg"][class="slide-logo"]'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("posit-logo-2024.svg", width: 1\.5in, alt: "posit logo"\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/dark-logo.qmd
+++ b/tests/docs/smoke-all/brand/logo/dark-logo.qmd
@@ -2,6 +2,9 @@
 title: brand with dark and light logos
 format:
   dashboard: default
+  revealjs: default
+  typst:
+    keep-typ: true
 brand:
   logo:
     images:
@@ -30,6 +33,16 @@ _quarto:
         -
           - 'img[src="quarto.png"][alt="quarto logo"][class="navbar-logo light-content d-inline-block"]'
           - 'img[src="quarto-dark.png"][alt="quarto dark logo"][class="navbar-logo dark-content d-inline-block"]'
+        - []
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="quarto.png"][alt="quarto logo"]'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("quarto.png", width: 1\.5in, alt: "quarto logo"\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/dark-mode-no-dark-logo.qmd
+++ b/tests/docs/smoke-all/brand/logo/dark-mode-no-dark-logo.qmd
@@ -5,6 +5,9 @@ format:
     theme:
       light: default
       dark: darkly  # Explicitly enable dark mode
+  revealjs: default
+  typst:
+    keep-typ: true
 brand:
   color:
     foreground: 
@@ -30,6 +33,16 @@ _quarto:
           - 'img[src="quarto.png"][alt="light logo"][class="navbar-logo light-content d-inline-block"]'
           # For dark mode, should it use the light logo since no dark logo exists?
           - 'img[src="quarto.png"][alt="light logo"][class="navbar-logo dark-content d-inline-block"]'
+        - []
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="quarto.png"][alt="light logo"]'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("quarto.png", width: 1\.5in, alt: "light logo"\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/dark-mode-no-light-logo.qmd
+++ b/tests/docs/smoke-all/brand/logo/dark-mode-no-light-logo.qmd
@@ -4,7 +4,11 @@ format:
   dashboard:
     theme:
       light: default
-      dark: darkly  # Explicitly enable dark mode
+      dark: darkly
+  revealjs: default
+  typst:
+    keep-typ: true
+brand-mode: dark
 brand:
   color:
     foreground: 
@@ -20,16 +24,23 @@ brand:
         alt: dark logo
     medium:
       dark: dark-logo
-      # No light variant defined - what happens?
 _quarto:
   tests:
     dashboard:
       ensureHtmlElements:
         -
-          # Dark mode should use the dark logo
           - 'img[src="posit-logo-2024.svg"][alt="dark logo"][class="navbar-logo dark-content d-inline-block"]'
-          # For light mode, should it use the dark logo since no light logo exists?
           - 'img[src="posit-logo-2024.svg"][alt="dark logo"][class="navbar-logo light-content d-inline-block"]'
+        - []
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="posit-logo-2024.svg"][alt="dark logo"]'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("posit-logo-2024.svg", width: 1\.5in, alt: "dark logo"\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/dark-mode-search-priority.qmd
+++ b/tests/docs/smoke-all/brand/logo/dark-mode-search-priority.qmd
@@ -2,6 +2,10 @@
 title: Size Inheritance
 format:
   dashboard: default
+  revealjs: default
+  typst:
+    output-ext: typ
+brand-mode: dark
 brand:
   logo:
     images:
@@ -32,6 +36,17 @@ _quarto:
           # Dark mode: small and medium.dark are missing, should use large.dark (not any .light)
           - 'img[src="small-logo.png"][alt="small logo"][class="navbar-logo light-content d-inline-block"]'
           - 'img[src="dark-logo.png"][alt="dark logo"][class="navbar-logo dark-content d-inline-block"]'
+        - []
+    revealjs:
+      ensureHtmlElements:
+        -
+          # In dark mode with revealjs, should use large.dark
+          - 'img[src="dark-logo.png"][alt="dark logo"]'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("dark-logo.png", width: 1\.5in, alt: "dark logo"\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/default-logo.qmd
+++ b/tests/docs/smoke-all/brand/logo/default-logo.qmd
@@ -3,6 +3,8 @@ title: brand and base logo
 format:
   dashboard: default
   revealjs: default
+  typst:
+    output-ext: typ
 brand:
   logo:
     images:
@@ -25,6 +27,11 @@ _quarto:
       ensureHtmlElements:
         -
           - 'img[src="quarto.png"][class="slide-logo"]'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("quarto.png", width: 1\.5in, alt: "quarto logo"\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/document-brand-precedence.qmd
+++ b/tests/docs/smoke-all/brand/logo/document-brand-precedence.qmd
@@ -2,6 +2,9 @@
 title: Document vs Brand Logo Precedence
 format:
   dashboard: default
+  revealjs: default
+  typst:
+    keep-typ: true
 brand:
   logo:
     images:
@@ -25,6 +28,16 @@ _quarto:
           # Document-level logo should override brand-level logo
           - 'img[src="posit-logo-2024.svg"][alt=""][class="navbar-logo light-content d-inline-block"]'
           - 'img[src="quarto.png"][alt=""][class="navbar-logo dark-content d-inline-block"]'
+        - []
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="posit-logo-2024.svg"]:not([alt])'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("posit-logo-2024.svg", width: 1\.5in\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/document-dark-brand-dark-only.qmd
+++ b/tests/docs/smoke-all/brand/logo/document-dark-brand-dark-only.qmd
@@ -8,6 +8,13 @@ format:
     # Document level logo with only dark defined
     logo:
       dark: direct-dark-logo.png
+  revealjs:
+    logo:
+      dark: revealjs-dark-logo.png
+  typst:
+    output-ext: typ # refers to unknown pngs
+    logo:
+      dark: typst-dark-logo.png
 brand:
   color:
     foreground: 
@@ -33,6 +40,16 @@ _quarto:
           - 'img[src="direct-dark-logo.png"][alt=""][class="navbar-logo dark-content d-inline-block"]'
           # For light mode, should use same document-level dark logo for fallback
           - 'img[src="direct-dark-logo.png"][alt=""][class="navbar-logo light-content d-inline-block"]'
+        - []
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="revealjs-dark-logo.png"]:not([alt])'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("typst-dark-logo.png", width: 1\.5in\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/document-light-brand-light-only.qmd
+++ b/tests/docs/smoke-all/brand/logo/document-light-brand-light-only.qmd
@@ -8,6 +8,13 @@ format:
     # Document level logo with only light defined
     logo:
       light: direct-light-logo.png
+  revealjs:
+    logo:
+      light: revealjs-light-logo.png
+  typst:
+    output-ext: typ # refers to unknown pngs
+    logo:
+      light: typst-light-logo.png
 brand:
   color:
     foreground: 
@@ -24,6 +31,7 @@ brand:
     medium:
       light: brand-light-logo
       # No dark variant defined in brand
+brand-mode: dark
 _quarto:
   tests:
     dashboard:
@@ -33,6 +41,16 @@ _quarto:
           - 'img[src="direct-light-logo.png"][alt=""][class="navbar-logo light-content d-inline-block"]'
           # For dark mode, should use same document-level light logo for fallback
           - 'img[src="direct-light-logo.png"][alt=""][class="navbar-logo dark-content d-inline-block"]'
+        - []
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="revealjs-light-logo.png"]:not([alt])'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("typst-light-logo.png", width: 1\.5in\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/explicit-dark-light-paths.qmd
+++ b/tests/docs/smoke-all/brand/logo/explicit-dark-light-paths.qmd
@@ -2,6 +2,9 @@
 title: explicit dark and light logo paths
 format:
   dashboard: default
+  revealjs: default
+  typst:
+    output-ext: typ
 brand:
   logo:
     images:
@@ -25,6 +28,16 @@ _quarto:
         -
           - 'img[src="custom-light.png"][alt="custom light logo"][class="navbar-logo light-content d-inline-block"]'
           - 'img[src="custom-dark.png"][alt="custom dark logo"][class="navbar-logo dark-content d-inline-block"]'
+        - []
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="custom-light.png"][alt="custom light logo"]'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("custom-light.png", width: 1\.5in, alt: "custom light logo"\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/format-specific-logo.qmd
+++ b/tests/docs/smoke-all/brand/logo/format-specific-logo.qmd
@@ -5,6 +5,18 @@ format:
     logo:
       light: dashboard-light.png
       dark: dashboard-dark.png
+  revealjs:
+    logo:
+      light: 
+        path: revealjs-light.png
+        alt: revealjs light logo
+      dark: revealjs-dark.png
+  typst:
+    output-ext: typ
+    logo:
+      light:
+        path: typst-light.png
+        alt: typst light logo
 brand:
   logo:
     images:
@@ -29,6 +41,17 @@ _quarto:
           # Format-specific logo should take precedence over generic logo
           - 'img[src="dashboard-light.png"][alt=""][class="navbar-logo light-content d-inline-block"]'
           - 'img[src="dashboard-dark.png"][alt=""][class="navbar-logo dark-content d-inline-block"]'
+        - []
+    revealjs:
+      ensureHtmlElements:
+        -
+          # Format-specific logo should take precedence over generic logo
+          - 'img[src="revealjs-light.png"][alt="revealjs light logo"]'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("typst-light.png", width: 1\.5in, alt: "typst light logo"\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/legacy-logo-syntax.qmd
+++ b/tests/docs/smoke-all/brand/logo/legacy-logo-syntax.qmd
@@ -2,6 +2,9 @@
 title: Legacy Logo Syntax with Dark/Light Mode
 format:
   dashboard: default
+  revealjs: default
+  typst:
+    output-ext: typ
 brand:
   logo:
     images:
@@ -24,6 +27,16 @@ _quarto:
           # Legacy syntax should apply to both light and dark modes
           - 'img[src="legacy-logo.svg"][alt=""][class="navbar-logo light-content d-inline-block"]'
           - 'img[src="legacy-logo.svg"][alt=""][class="navbar-logo dark-content d-inline-block"]'
+        - []
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="legacy-logo.svg"]:not([alt])'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("legacy-logo.svg", width: 1\.5in\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/missing-medium-dark-fallback.qmd
+++ b/tests/docs/smoke-all/brand/logo/missing-medium-dark-fallback.qmd
@@ -2,6 +2,10 @@
 title: dark logo only with light fallback
 format:
   dashboard: default
+  revealjs: default
+  typst:
+    output-ext: typ
+brand-mode: dark
 brand:
   logo:
     images:
@@ -27,6 +31,16 @@ _quarto:
         -
           - 'img[src="posit-logo-2024.svg"][alt="posit logo"][class="navbar-logo light-content d-inline-block"]'
           - 'img[src="quarto-dark.png"][alt="quarto dark logo"][class="navbar-logo dark-content d-inline-block"]'
+        - []
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="quarto-dark.png"][alt="quarto dark logo"]'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("quarto-dark.png", width: 1\.5in, alt: "quarto dark logo"\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/mixed-resource-direct-path.qmd
+++ b/tests/docs/smoke-all/brand/logo/mixed-resource-direct-path.qmd
@@ -2,6 +2,9 @@
 title: mixed logo types
 format:
   dashboard: default
+  revealjs: default
+  typst:
+    output-ext: typ
 brand:
   logo:
     images:
@@ -17,6 +20,7 @@ brand:
     large:
       light: custom-light.svg
       dark: posit
+brand-mode: dark
 _quarto:
   tests:
     dashboard:
@@ -24,6 +28,16 @@ _quarto:
         -
           - 'img[src="quarto.png"][alt="quarto logo"][class="navbar-logo light-content d-inline-block"]'
           - 'img[src="custom-dark.png"][alt=""][class="navbar-logo dark-content d-inline-block"]'
+        - []
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="custom-dark.png"]:not([alt])'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("custom-dark.png", width: 1\.5in\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/mode-first-search-algorithm.qmd
+++ b/tests/docs/smoke-all/brand/logo/mode-first-search-algorithm.qmd
@@ -2,6 +2,10 @@
 title: Cross-Size Mode Fallbacks
 format:
   dashboard: default
+  revealjs: default
+  typst:
+    output-ext: typ
+brand-mode: dark
 brand:
   logo:
     images:
@@ -29,6 +33,16 @@ _quarto:
           # Medium is default, light is defined, dark should use cross-size fallback
           - 'img[src="light-small.png"][alt="light small logo"][class="navbar-logo light-content d-inline-block"]'
           - 'img[src="dark-large.png"][alt="dark large logo"][class="navbar-logo dark-content d-inline-block"]'
+        - []
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="dark-large.png"][alt="dark large logo"]'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("dark-large.png", width: 1\.5in, alt: "dark large logo"\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/override-dark-logo.qmd
+++ b/tests/docs/smoke-all/brand/logo/override-dark-logo.qmd
@@ -2,6 +2,10 @@
 title: override dark logo
 format:
   dashboard: default
+  revealjs: default
+  typst:
+    output-ext: typ
+brand-mode: dark
 brand:
   logo:
     images:
@@ -33,6 +37,16 @@ _quarto:
         -
           - 'img[src="posit-logo-2024.svg"][alt="posit logo"][class="navbar-logo light-content d-inline-block"]'
           - 'img[src="quarto-dark.png"][alt="quarto dark logo"][class="navbar-logo dark-content d-inline-block"]'
+        - []
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="quarto-dark.png"][alt="quarto dark logo"]'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("quarto-dark.png", width: 1\.5in, alt: "quarto dark logo"\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/override-logo-path-alt.qmd
+++ b/tests/docs/smoke-all/brand/logo/override-logo-path-alt.qmd
@@ -9,6 +9,11 @@ format:
     logo:
       path: posit-logo-2024.svg
       alt: posit logo
+  typst:
+    output-ext: typ
+    logo:
+      path: posit-logo-2024.svg
+      alt: posit logo
 brand:
   logo:
     images:
@@ -31,6 +36,11 @@ _quarto:
       ensureHtmlElements:
         -
           - 'img[src="posit-logo-2024.svg"][class="slide-logo"]'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("posit-logo-2024.svg", width: 1\.5in, alt: "posit logo"\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/override-logo-path.qmd
+++ b/tests/docs/smoke-all/brand/logo/override-logo-path.qmd
@@ -3,6 +3,8 @@ title: brand and base logo
 format:
   dashboard: default
   revealjs: default
+  typst:
+    output-ext: typ
 brand:
   logo:
     images:
@@ -26,6 +28,11 @@ _quarto:
       ensureHtmlElements:
         -
           - 'img[src="posit-logo-2024.svg"][class="slide-logo"]'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("posit-logo-2024.svg", width: 1\.5in\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/override-logo-resource-alt.qmd
+++ b/tests/docs/smoke-all/brand/logo/override-logo-resource-alt.qmd
@@ -2,6 +2,9 @@
 title: brand and base logo
 format:
   dashboard: default
+  revealjs: default
+  typst:
+    output-ext: typ
 brand:
   logo:
     images:
@@ -22,6 +25,16 @@ _quarto:
       ensureHtmlElements:
         -
           - 'img[src="posit-logo-2024.svg"][alt="logo of posit"]'
+        - []
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="posit-logo-2024.svg"][alt="logo of posit"]'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("posit-logo-2024.svg", width: 1\.5in, alt: "logo of posit"\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/override-logo-resource.qmd
+++ b/tests/docs/smoke-all/brand/logo/override-logo-resource.qmd
@@ -2,6 +2,9 @@
 title: brand and base logo
 format:
   dashboard: default
+  revealjs: default
+  typst:
+    output-ext: typ
 brand:
   logo:
     images:
@@ -26,6 +29,11 @@ _quarto:
       ensureHtmlElements:
         -
           - 'img[src="posit-logo-2024.svg"][class="slide-logo"]'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("posit-logo-2024.svg", width: 1\.5in, alt: "posit logo"\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/partial-document-override.qmd
+++ b/tests/docs/smoke-all/brand/logo/partial-document-override.qmd
@@ -2,6 +2,10 @@
 title: Partial Document-Level Override
 format:
   dashboard: default
+  revealjs: default
+  typst:
+    output-ext: typ
+brand-mode: dark
 brand:
   logo:
     images:
@@ -28,6 +32,16 @@ _quarto:
           # Light from document-level, dark from brand-level
           - 'img[src="custom.svg"][alt="custom logo"][class="navbar-logo light-content d-inline-block"]'
           - 'img[src="posit-logo-2024.svg"][alt="posit logo"][class="navbar-logo dark-content d-inline-block"]'
+        - []
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="posit-logo-2024.svg"][alt="posit logo"]'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("posit-logo-2024.svg", width: 1\.5in, alt: "posit logo"\)\)'
         - []
 ---
 

--- a/tests/docs/smoke-all/brand/logo/path-vs-object-specification.qmd
+++ b/tests/docs/smoke-all/brand/logo/path-vs-object-specification.qmd
@@ -2,6 +2,9 @@
 title: Mixed Logo Specification Formats
 format:
   dashboard: default
+  revealjs: default
+  typst:
+    output-ext: typ
 brand:
   logo:
     images:
@@ -26,6 +29,16 @@ _quarto:
           # Direct path has no alt, object has explicit alt
           - 'img[src="direct-path.png"][alt=""][class="navbar-logo light-content d-inline-block"]'
           - 'img[src="dark-custom.svg"][alt="dark custom logo"][class="navbar-logo dark-content d-inline-block"]'
+        - []
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="direct-path.png"]:not([alt])'
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("direct-path.png", width: 1\.5in\)\)'
         - []
 ---
 

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -219,7 +219,7 @@ function resolveTestSpecs(
           } else if (verifyMap[key]) {
             // FIXME: We should find another way that having this requirement of keep-* in the metadata
             if (key === "ensureTypstFileRegexMatches") {
-              if (!metadata.format?.typst?.['keep-typ'] && !metadata['keep-typ']) {
+              if (!metadata.format?.typst?.['keep-typ'] && !metadata['keep-typ'] && metadata.format?.typst?.['output-ext'] !== 'typ' && metadata['output-ext'] !== 'typ') {
                 throw new Error(`Using ensureTypstFileRegexMatches requires setting 'keep-typ: true' in file ${input}`);
               }
             } else if (key === "ensureLatexFileRegexMatches") {


### PR DESCRIPTION
This is perhaps excessive, but there were a bunch of dashboard tests checking every obscure interaction between brand.logo and document logo, and I worked with Claude to add revealjs and typst tests for those using `brand-mode`.

Excessive since all these formats use the same logic underneath. But it's kind of nice to see a whole block of tests running under multiple formats.