### PR TITLE
default background and foreground for inline code in dark mode

### DIFF
--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -20,6 +20,7 @@ All changes included in 1.8:
 - ([#726](https://github.com/quarto-dev/quarto-cli/issues/726)): a11y - Provide `.screen-reader-only` callout type when callout text doesn't naturally include the type.
 - ([#5538](https://github.com/quarto-dev/quarto-cli/issues/5538)): Fix code-copy button style so that scrolling behaves properly.
 - ([#5879](https://github.com/quarto-dev/quarto-cli/issues/5879)): Improve font rendering of `kbd` shortcode on macOS. `kbd` will now also be stricter in converting keyboard shortcuts to macOS icons.
+- ([#8568](https://github.com/quarto-dev/quarto-cli/issues/8568)) Default inline code background color to the code block background color if not specified; foreground color is `$pre-color` in dark mode and (remains) purple in light mode.
 - ([#10983](https://github.com/quarto-dev/quarto-cli/issues/10983)): Fix spacing inconsistency between paras and first section headings.
 - ([#12259](https://github.com/quarto-dev/quarto-cli/issues/12259)): Fix conflict between `html-math-method: katex` and crossref popups (author: @benkeks).
 - ([#12341](https://github.com/quarto-dev/quarto-cli/issues/12341)): Enable light and dark logos for html formats (sidebar, navbar, dashboard).
@@ -108,7 +109,7 @@ All changes included in 1.8:
 
 - ([#12753](https://github.com/quarto-dev/quarto-cli/issues/12753)): Support change in IPython 9+ and import `set_matplotlib_formats` from `matplotlib_inline.backend_inline` in the internal `setup.py` script used to initialize rendering with Jupyter engine.
 - ([#12839](https://github.com/quarto-dev/quarto-cli/issues/12839)): Support for `plotly.py` 6+ which now loads plotly.js using a cdn in script as a module.
-- ([#13026](https://github.com/quarto-dev/quarto-cli/pulls/13026), [#13151](https://github.com/quarto-dev/quarto-cli/pulls/13151)), [#13184](https://github.com/quarto-dev/quarto-cli/pull/13184): Use `jsdelivr` CDN for jupyter widgets dependencies.
+- ([#13026](https://github.com/quarto-dev/quarto-cli/pull/13026), [#13151](https://github.com/quarto-dev/quarto-cli/pull/13151)), [#13184](https://github.com/quarto-dev/quarto-cli/pull/13184): Use `jsdelivr` CDN for jupyter widgets dependencies.
 
 ### `knitr`
 

--- a/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
@@ -923,6 +923,26 @@ pre {
   border: initial;
 }
 
+p code.sourceCode,
+li code.sourceCode,
+td code.sourceCode {
+  $calculated-bg: if(
+    variable-exists(code-bg),
+    if(
+      $code-bg == $gray-100 and variable-exists(code-block-bg-color),
+      $code-block-bg-color,
+      $code-bg
+    ),
+    null
+  );
+
+  @if variable-exists(mono-background-color) {
+    background-color: $mono-background-color;
+  } @else if variable-exists(calculated-bg) {
+    background-color: $calculated-bg;
+  }
+}
+
 // Maps the pandoc 'monobackgroundcolor' to bootstrap
 // Note this only targets code outside of sourceCode blocks
 @if variable-exists(mono-background-color) {
@@ -942,14 +962,23 @@ pre code:not(.sourceCode) {
   background-color: initial;
 }
 
-// Default padding if background is set
 p code:not(.sourceCode),
 li code:not(.sourceCode),
 td code:not(.sourceCode) {
+  $calculated-bg: if(
+    variable-exists(code-bg),
+    if(
+      $code-bg == $gray-100 and variable-exists(code-block-bg-color),
+      $code-block-bg-color,
+      $code-bg
+    ),
+    null
+  );
+
   @if variable-exists(mono-background-color) {
     background-color: $mono-background-color;
-  } @else if variable-exists(code-bg) {
-    background-color: $code-bg;
+  } @else if variable-exists(calculated-bg) {
+    background-color: $calculated-bg;
   }
 
   @if variable-exists(code-padding) {
@@ -2197,12 +2226,12 @@ a {
 
 // screen-reader-only, cf https://github.com/quarto-dev/quarto-cli/issues/726#issuecomment-1112486100
 .screen-reader-only {
-    position: absolute;
-    clip: rect(0 0 0 0);
-    border: 0;
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    padding: 0;
-    width: 1px;
+  position: absolute;
+  clip: rect(0 0 0 0);
+  border: 0;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  width: 1px;
 }

--- a/src/resources/formats/html/bootstrap/_bootstrap-variables.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-variables.scss
@@ -38,7 +38,11 @@ $code-block-theme-dark-threshhold: 40% !default;
 
 /* Inline Code Formatting */
 // $code-bg, $code-color, $code-padding
-$code-color: #7d12ba !default;
+$code-color: if(
+  variable-exists(pre-color) and $pre-color != null,
+  $pre-color,
+  #7d12ba
+) !default;
 
 // Set a default body emphasis color
 $code-bg: $gray-100 !default;

--- a/tests/docs/playwright/html/dark-brand/syntax-highlighting/a11y-syntax-highlighting.qmd
+++ b/tests/docs/playwright/html/dark-brand/syntax-highlighting/a11y-syntax-highlighting.qmd
@@ -9,11 +9,16 @@ theme:
 highlight-style: a11y
 ---
 
+### Inline code
+
+* Python: `def identity(x): return x`{.python}
+* R: `identity <- function(x) x`{.r}
+
+### Code blocks
 
 ```markdown
 ![asdf](asd.png)
 ```
-
 
 ```python
 #| label: fig-polar

--- a/tests/docs/playwright/html/dark-brand/syntax-highlighting/a11y-syntax-highlighting.qmd
+++ b/tests/docs/playwright/html/dark-brand/syntax-highlighting/a11y-syntax-highlighting.qmd
@@ -5,12 +5,13 @@ execute:
   warning: false
 theme:
   light: [cosmo, theme.scss]
-  dark: [cosmo, theme-dark.scss]
+  dark: [solar, theme-dark.scss]
 highlight-style: a11y
 ---
 
 ### Inline code
 
+* No syntax highlighting: `foo(bar)`
 * Python: `def identity(x): return x`{.python}
 * R: `identity <- function(x) x`{.r}
 

--- a/tests/docs/playwright/html/dark-brand/syntax-highlighting/arrow-syntax-highlighting.qmd
+++ b/tests/docs/playwright/html/dark-brand/syntax-highlighting/arrow-syntax-highlighting.qmd
@@ -12,12 +12,16 @@ _quarto:
         - ["link[href*=\"-dark-\"]"]
 ---
 
-## Hello
+### Inline code
+
+* Python: `def identity(x): return x`{.python}
+* R: `identity <- function(x) x`{.r}
+
+### Code blocks
 
 ```markdown
 ![asdf](asd.png)
 ```
-
 
 ```python
 #| label: fig-polar

--- a/tests/docs/playwright/html/dark-brand/syntax-highlighting/arrow-syntax-highlighting.qmd
+++ b/tests/docs/playwright/html/dark-brand/syntax-highlighting/arrow-syntax-highlighting.qmd
@@ -14,6 +14,7 @@ _quarto:
 
 ### Inline code
 
+* No syntax highlighting: `foo(bar)`
 * Python: `def identity(x): return x`{.python}
 * R: `identity <- function(x) x`{.r}
 

--- a/tests/integration/playwright/tests/html-dark-mode.spec.ts
+++ b/tests/integration/playwright/tests/html-dark-mode.spec.ts
@@ -45,7 +45,7 @@ test('Syntax highlighting, a11y, with JS', async ({ page }) => {
   const importKeyword = await page.locator('span.im').first();
   // light inline code
   const pythonCode = await page.locator('li code.sourceCode.r');
-  await expect(pythonCode).toHaveCSS('background-color', 'rgb(248, 249, 250)');
+  await expect(pythonCode).toHaveCSS('background-color', 'rgba(233, 236, 239, 0.65)');
   await expect(pythonCode).toHaveCSS('color', 'rgb(125, 18, 186)');
   // light highlight stylesheet 
   await expect(importKeyword).toHaveCSS('color', 'rgb(84, 84, 84)');
@@ -53,7 +53,7 @@ test('Syntax highlighting, a11y, with JS', async ({ page }) => {
   await page.locator("a.quarto-color-scheme-toggle").click();
 
   // dark inline code
-  await expect(pythonCode).toHaveCSS('background-color', 'rgb(248, 249, 250)');
+  await expect(pythonCode).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
   await expect(pythonCode).toHaveCSS('color', 'rgb(192, 128, 216)');
   // dark highlight stylesheet
   await expect(importKeyword).toHaveCSS('color', 'rgb(248, 248, 242)');
@@ -69,7 +69,7 @@ test('Syntax highlighting, arrow, with JS', async ({ page }) => {
   await expect(locatr).toHaveCSS('background-color', 'rgb(255, 255, 255)');
   // light inline code
   const pythonCode = await page.locator('li code.sourceCode.python');
-  await expect(pythonCode).toHaveCSS('background-color', 'rgb(248, 249, 250)');
+  await expect(pythonCode).toHaveCSS('background-color', 'rgba(233, 236, 239, 0.65)');
   await expect(pythonCode).toHaveCSS('color', 'rgb(125, 18, 186)');
   // alert
   const link = await page.locator('span.al').first();
@@ -77,6 +77,6 @@ test('Syntax highlighting, arrow, with JS', async ({ page }) => {
 
   await page.locator("a.quarto-color-scheme-toggle").click();
   // dark inline code
-  await expect(pythonCode).toHaveCSS('background-color', 'rgb(248, 249, 250)');
-  await expect(pythonCode).toHaveCSS('color', 'rgb(125, 18, 186)');
+  await expect(pythonCode).toHaveCSS('background-color', 'rgba(37, 41, 46, 0.65)');
+  await expect(pythonCode).toHaveCSS('color', 'rgb(122, 130, 136)');
 });

--- a/tests/integration/playwright/tests/html-dark-mode.spec.ts
+++ b/tests/integration/playwright/tests/html-dark-mode.spec.ts
@@ -43,9 +43,18 @@ test('Syntax highlighting, a11y, with JS', async ({ page }) => {
   await expect(locatr).toHaveClass('fullcontent quarto-light');
   await expect(locatr).toHaveCSS('background-color', 'rgb(255, 255, 255)');
   const importKeyword = await page.locator('span.im').first();
+  // light inline code
+  const pythonCode = await page.locator('li code.sourceCode.r');
+  await expect(pythonCode).toHaveCSS('background-color', 'rgb(248, 249, 250)');
+  await expect(pythonCode).toHaveCSS('color', 'rgb(125, 18, 186)');
   // light highlight stylesheet 
   await expect(importKeyword).toHaveCSS('color', 'rgb(84, 84, 84)');
+
   await page.locator("a.quarto-color-scheme-toggle").click();
+
+  // dark inline code
+  await expect(pythonCode).toHaveCSS('background-color', 'rgb(248, 249, 250)');
+  await expect(pythonCode).toHaveCSS('color', 'rgb(192, 128, 216)');
   // dark highlight stylesheet
   await expect(importKeyword).toHaveCSS('color', 'rgb(248, 248, 242)');
 });
@@ -58,6 +67,16 @@ test('Syntax highlighting, arrow, with JS', async ({ page }) => {
   const locatr = await page.locator('body').first();
   await expect(locatr).toHaveClass('fullcontent quarto-light');
   await expect(locatr).toHaveCSS('background-color', 'rgb(255, 255, 255)');
+  // light inline code
+  const pythonCode = await page.locator('li code.sourceCode.python');
+  await expect(pythonCode).toHaveCSS('background-color', 'rgb(248, 249, 250)');
+  await expect(pythonCode).toHaveCSS('color', 'rgb(125, 18, 186)');
+  // alert
   const link = await page.locator('span.al').first();
-  await expect(link).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+  await expect(link).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)'); // transparent
+
+  await page.locator("a.quarto-color-scheme-toggle").click();
+  // dark inline code
+  await expect(pythonCode).toHaveCSS('background-color', 'rgb(248, 249, 250)');
+  await expect(pythonCode).toHaveCSS('color', 'rgb(125, 18, 186)');
 });


### PR DESCRIPTION
Default inline code background color, both with and with and without `sourceCode`, to the block background color and not `$grey-100`

| Before | After |
|---------|---------|
| <img width="657" height="175" alt="image" src="https://github.com/user-attachments/assets/f57747d9-1c7f-4083-8850-9b890614db16" /> | <img width="672" height="185" alt="image" src="https://github.com/user-attachments/assets/4a389165-dd37-4e7f-96d5-34a07224600d" /> |
|<img width="593" height="282" alt="image" src="https://github.com/user-attachments/assets/8ac70055-3dda-47d0-abd7-c4e939fcdac1" />|<img width="623" height="288" alt="image" src="https://github.com/user-attachments/assets/b4f7fa8f-41e8-4ede-b211-623c3558b50a" />|
|<img width="562" height="301" alt="image" src="https://github.com/user-attachments/assets/398bfc5a-3043-4e37-a856-1b50f9ac153b" />|<img width="555" height="292" alt="image" src="https://github.com/user-attachments/assets/cbedf6d1-be14-422c-9c66-2e350df06a56" />|


Fixes #8568

It leaves the inline code foreground color defaulted to purple in light mode, which seems to be intentional. In dark mode, it uses `$pre-color` which exists in that mode.

I think the fix is correct and safe but it may be more convoluted than we want. 

The problem is, `$code-bg`, which controls the inline code background color, has a bad default for dark mode of `$gray-100` (in `_bootstrap-variables.scss`) but the way to calculate the correct color for dark mode is not known until `_bootstrap-rules.scss`. 

I couldn't `!default` it, or set it outright, so Claude suggested this kludge of checking if `$code-bg` has its default setting. 😛 

I have tested this manually
* with light dark flatly/darkly and cosmo/solar
  *  both with and without `brand.typography.monospace-inline.background-color` (which is the current workaround for the original bug).
* with no theme
  * with and without brand
No warnings.

Includes playwright tests for a11y and arrow themes.

### Visual design considerations

This is the minimal change, but
* As shown in the after screenshot, visually the inline code background appears darker than the code block background, because it's smaller. So perhaps it should be lighter!
* There is no reason not to choose a more interesting default color for the dark mode foreground color for inline code, especially as our default in light mode is purple. (Surfing `git blame`, it took a while to settle on this color.)