### PR TITLE
Use multiple integrity attributes for require.min.js

### DIFF
--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -103,7 +103,7 @@ All changes included in 1.8:
 
 - ([#12753](https://github.com/quarto-dev/quarto-cli/issues/12753)): Support change in IPython 9+ and import `set_matplotlib_formats` from `matplotlib_inline.backend_inline` in the internal `setup.py` script used to initialize rendering with Jupyter engine.
 - ([#12839](https://github.com/quarto-dev/quarto-cli/issues/12839)): Support for `plotly.py` 6+ which now loads plotly.js using a cdn in script as a module.
-- ([#13026](https://github.com/quarto-dev/quarto-cli/pulls/13026), [#13151](https://github.com/quarto-dev/quarto-cli/pulls/13151)): Use `jsdelivr` CDN for jupyter widgets dependencies. 
+- ([#13026](https://github.com/quarto-dev/quarto-cli/pulls/13026), [#13151](https://github.com/quarto-dev/quarto-cli/pulls/13151)), [#13184](https://github.com/quarto-dev/quarto-cli/pull/13184): Use `jsdelivr` CDN for jupyter widgets dependencies.
 
 ### `knitr`
 

--- a/src/core/jupyter/widgets.ts
+++ b/src/core/jupyter/widgets.ts
@@ -101,7 +101,7 @@ export function includesForJupyterWidgetDependencies(
   const head: string[] = [];
   if (haveJavascriptWidgets || haveJupyterWidgets) {
     head.push(
-      '<script src="https://cdn.jsdelivr.net/npm/requirejs@2.3.6/require.min.js" integrity="sha384-6V1/AdqZRWk1KAlWbKBlGhN7VG4iE/yAZcO6NZPMF8od0vukrvr0tg4qY6NSrItx" crossorigin="anonymous"></script>',
+      '<script src="https://cdn.jsdelivr.net/npm/requirejs@2.3.6/require.min.js" integrity="sha384-c9c+LnTbwQ3aujuU7ULEPVvgLs+Fn6fJUvIGTsuu1ZcCf11fiEubah0ttpca4ntM sha384-6V1/AdqZRWk1KAlWbKBlGhN7VG4iE/yAZcO6NZPMF8od0vukrvr0tg4qY6NSrItx" crossorigin="anonymous"></script>',
     );
     head.push(
       '<script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.min.js" integrity="sha384-ZvpUoO/+PpLXR1lu4jmpXWu80pZlYUAfxl5NsBMWOEPSjUn/6Z/hRTt8+pR6L4N2" crossorigin="anonymous" data-relocate-top="true"></script>',


### PR DESCRIPTION
We observed that VS Code and Chrome each compute different integrity values. This is apparently expected behavior in some cases: https://claude.ai/share/7c3437d9-664e-4e82-aa92-6bdf37ff9025

Possible mitigations include:

1) Define multiple values for `integrity` (what we did here); or 
2) Remove the `integrity` attribute if you trust the host and are running over https; or
3) Bundle our own version of require.js
