### PR TITLE
brand processData: pass logo urls unchanged

### DIFF
--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -23,6 +23,7 @@ All changes included in 1.8:
 - ([#10983](https://github.com/quarto-dev/quarto-cli/issues/10983)): Fix spacing inconsistency between paras and first section headings.
 - ([#12259](https://github.com/quarto-dev/quarto-cli/issues/12259)): Fix conflict between `html-math-method: katex` and crossref popups (author: @benkeks).
 - ([#12341](https://github.com/quarto-dev/quarto-cli/issues/12341)): Enable light and dark logos for html formats (sidebar, navbar, dashboard).
+- ([#12643](https://github.com/quarto-dev/quarto-cli/issues/12643)): Ensure brand.yml logos using urls are rendered correctly by passing them through when resolving brand `processedData`, and not processing them as paths.
 - ([#12734](https://github.com/quarto-dev/quarto-cli/issues/12734)): `highlight-style` now correctly supports setting a different `light` and `dark`.
 - ([#12747](https://github.com/quarto-dev/quarto-cli/issues/12747)): Ensure `th` elements are properly restored when Quarto's HTML table processing is happening.
 - ([#12766](https://github.com/quarto-dev/quarto-cli/issues/12766)): Use consistent equation numbering display for `html-math-method` and `html-math-method.method` for MathJax and KaTeX (author: @mcanouil)

--- a/src/core/brand/brand.ts
+++ b/src/core/brand/brand.ts
@@ -39,6 +39,7 @@ import {
   LogoSpecifier,
   LogoSpecifierPathOptional,
 } from "../../resources/types/schema-types.ts";
+import { isExternalPath } from "../../project/types/website/website-navigation.ts";
 
 type ProcessedBrandData = {
   color: Record<string, string>;
@@ -246,11 +247,13 @@ export class Brand {
   resolvePath(entry: BrandLogoResource) {
     const pathPrefix = relative(this.projectDir, this.brandDir);
     if (typeof entry === "string") {
-      return { path: join(pathPrefix, entry) };
+      return { path: isExternalPath(entry) ? entry : join(pathPrefix, entry) };
     }
     return {
       ...entry,
-      path: join(pathPrefix, entry.path),
+      path: isExternalPath(entry.path)
+        ? entry.path
+        : join(pathPrefix, entry.path),
     };
   }
 

--- a/src/project/types/website/website-navigation.ts
+++ b/src/project/types/website/website-navigation.ts
@@ -1567,7 +1567,7 @@ function navigationDependency(resource: string) {
   };
 }
 
-function isExternalPath(path: string) {
+export function isExternalPath(path: string) {
   return /^\w+:/.test(path);
 }
 

--- a/tests/docs/smoke-all/brand/logo/url-logo.qmd
+++ b/tests/docs/smoke-all/brand/logo/url-logo.qmd
@@ -1,0 +1,49 @@
+---
+title: "Reproducible Quarto Document"
+format:
+  html: default
+  dashboard: default
+  revealjs: default
+  typst:
+    keep-typ: true
+brand:
+  logo:
+    images:
+      quarto-logo:
+        path: https://quarto.org/quarto.png
+        alt: "Quarto icon"
+    small: quarto-logo
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        -
+          - 'img[class*="light-content"][src="https://quarto.org/quarto.png"][alt="Quarto icon"]'
+        -
+          - 'img[class*="dark-content"]'
+    dashboard:
+      ensureHtmlElements:
+        -
+          - 'img[src="https://quarto.org/quarto.png"][alt="Quarto icon"][class="navbar-logo light-content d-inline-block"]'
+          - 'img[class*="dark-content"]' # oops
+        - []
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="https://quarto.org/quarto.png"][alt="Quarto icon"]'
+        -
+          - 'img[class*="dark-content"]'
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("url-logo_files(/|\\)mediabag(/|\\)quarto.png", width: 1\.5in, alt: "Quarto icon"\)\)'
+        - []
+---
+
+This is a reproducible Quarto document using `format: html`. It is written in Markdown and contains embedded Python code. When you run the code, it will produce a message.
+
+{{< lipsum 1 >}}
+
+{{< brand logo small>}}
+
+The end.


### PR DESCRIPTION
fixes #12643

When populating brand `processedData` with logo paths, we need to skip URLs.

Later processing does this already, as demonstrated by tests.

Replaces #13203 - I could not see past the spurious errors and I am stubborn.