### PR TITLE
brand processData: pass logo urls unchanged

### DIFF
--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -23,6 +23,7 @@ All changes included in 1.8:
 - ([#10983](https://github.com/quarto-dev/quarto-cli/issues/10983)): Fix spacing inconsistency between paras and first section headings.
 - ([#12259](https://github.com/quarto-dev/quarto-cli/issues/12259)): Fix conflict between `html-math-method: katex` and crossref popups (author: @benkeks).
 - ([#12341](https://github.com/quarto-dev/quarto-cli/issues/12341)): Enable light and dark logos for html formats (sidebar, navbar, dashboard).
+- ([#12643](https://github.com/quarto-dev/quarto-cli/issues/12643)): Ensure brand.yml logos using urls are rendered correctly by passing them through when resolving brand `processedData`, and not processing them as paths.
 - ([#12734](https://github.com/quarto-dev/quarto-cli/issues/12734)): `highlight-style` now correctly supports setting a different `light` and `dark`.
 - ([#12747](https://github.com/quarto-dev/quarto-cli/issues/12747)): Ensure `th` elements are properly restored when Quarto's HTML table processing is happening.
 - ([#12766](https://github.com/quarto-dev/quarto-cli/issues/12766)): Use consistent equation numbering display for `html-math-method` and `html-math-method.method` for MathJax and KaTeX (author: @mcanouil)

--- a/src/core/brand/brand.ts
+++ b/src/core/brand/brand.ts
@@ -32,7 +32,6 @@ import { InternalError } from "../lib/error.ts";
 import { join, relative } from "../../deno_ral/path.ts";
 import { warnOnce } from "../log.ts";
 import { isCssColorName } from "../css/color-names.ts";
-import { assert } from "testing/asserts";
 import {
   LogoLightDarkSpecifierPathOptional,
   LogoOptionsPathOptional,
@@ -246,11 +245,13 @@ export class Brand {
   resolvePath(entry: BrandLogoResource) {
     const pathPrefix = relative(this.projectDir, this.brandDir);
     if (typeof entry === "string") {
-      return { path: join(pathPrefix, entry) };
+      return { path: isExternalPath(entry) ? entry : join(pathPrefix, entry) };
     }
     return {
       ...entry,
-      path: join(pathPrefix, entry.path),
+      path: isExternalPath(entry.path)
+        ? entry.path
+        : join(pathPrefix, entry.path),
     };
   }
 
@@ -268,6 +269,10 @@ export class Brand {
     }
     return this.getLogoResource(entry);
   }
+}
+
+function isExternalPath(path: string) {
+  return /^\w+:/.test(path);
 }
 
 export type LightDarkBrand = {

--- a/tests/docs/smoke-all/brand/logo/url-logo.qmd
+++ b/tests/docs/smoke-all/brand/logo/url-logo.qmd
@@ -1,0 +1,49 @@
+---
+title: "Reproducible Quarto Document"
+format:
+  html: default
+  dashboard: default
+  revealjs: default
+  typst:
+    keep-typ: true
+brand:
+  logo:
+    images:
+      quarto-logo:
+        path: https://quarto.org/quarto.png
+        alt: "Quarto icon"
+    small: quarto-logo
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        -
+          - 'img[class*="light-content"][src="https://quarto.org/quarto.png"][alt="Quarto icon"]'
+        -
+          - 'img[class*="dark-content"]'
+    dashboard:
+      ensureHtmlElements:
+        -
+          - 'img[src="https://quarto.org/quarto.png"][alt="Quarto icon"][class="navbar-logo light-content d-inline-block"]'
+          - 'img[class*="dark-content"]' # oops
+        - []
+    revealjs:
+      ensureHtmlElements:
+        -
+          - 'img[src="https://quarto.org/quarto.png"][alt="Quarto icon"]'
+        -
+          - 'img[class*="dark-content"]'
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - 'background: align\(left\+top, box\(inset: 0.75in, image\("url-logo_files(/|\\)mediabag(/|\\)quarto.png", width: 1\.5in, alt: "Quarto icon"\)\)'
+        - []
+---
+
+This is a reproducible Quarto document using `format: html`. It is written in Markdown and contains embedded Python code. When you run the code, it will produce a message.
+
+{{< lipsum 1 >}}
+
+{{< brand logo small>}}
+
+The end.


### PR DESCRIPTION
fixes #12643

When populating brand `processedData` with logo paths, we need to skip URLs.

Later processing does this already, as demonstrated by tests.

Replaces #13214 — let's see if copying a utility function instead of importing it avoids this error.