### PR TITLE
Small fdiv argument fixes

### DIFF
--- a/tests/docs/manuscript/ipynb-full/notebooks/seismic-monitoring-stations.qmd
+++ b/tests/docs/manuscript/ipynb-full/notebooks/seismic-monitoring-stations.qmd
@@ -48,6 +48,6 @@ The following decommissioned stations were previously part of the seismic networ
 : Decommissioned seismic monitoring stations on La Palma {#tbl-inactive}
 
 
-::: {note}
+::: {.note}
 For more information on the monitoring network in the Canary Islands visit <https://www.ign.es/web/ign/portal/vlc-area-volcanologia>
 :::

--- a/tests/docs/smoke-all/2024/05/06/9582.qmd
+++ b/tests/docs/smoke-all/2024/05/06/9582.qmd
@@ -3,7 +3,7 @@ keep-tex: true
 format: pdf
 ---
 
-::: {.column-margin #fig-example-image}
+::: {#fig-example-image .column-margin}
 ![](https://placehold.co/600x400.png)
 
 Example of an Image 1

--- a/tests/docs/smoke-all/2025/03/21/issue-12344.qmd
+++ b/tests/docs/smoke-all/2025/03/21/issue-12344.qmd
@@ -4,7 +4,7 @@ format:
     keep-tex: true
 ---
 
-::: {layout-ncol="2" .column-page-right}
+::: {.column-page-right layout-ncol="2"}
 ``` {.markdown filename="01-import.qmd"}
 ---
 title: Data Import and Cleaning


### PR DESCRIPTION
## Description

These are just minor fixes to fenced div argument issues I came across in some of the test files.

`seismic-monitoring-stations.qmd` - missing `.` from the note class

`2024/05/06/9582.qmd` - identifier should be before class

`2025/03/21/issue-12344.qmd` - class should be before key-value

I don't think any of the above are meant to test this pandoc requirement and so should be safe to correct.

## Checklist

I don't believe any of the below are applicable in this case.

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
