### PR TITLE
a11y: fix keyboard navigation for tabset panels in websites when using an HTML theme

### DIFF
--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -66,6 +66,7 @@ All changes included in 1.8:
 
 ### `website`
 
+- ([#10284](https://github.com/quarto-dev/quarto-cli/issues/10284)): a11y - Fix keyboard navigation for tabset panels when using an HTML theme. Tabs now properly receive keyboard focus.
 - ([#12551](https://github.com/quarto-dev/quarto-cli/pull/12551)): Improve warning issued when `aliases` would overwrite an existing document.
 - ([#12616](https://github.com/quarto-dev/quarto-cli/issues/12616)): find SVG images in image discovery for listings.
 - ([#12693](https://github.com/quarto-dev/quarto-cli/issues/12693)): Prevent resource exhaustion on large websites by serializing `NotebookContext` information to file instead of the environment.

--- a/src/resources/filters/customnodes/panel-tabset.lua
+++ b/src/resources/filters/customnodes/panel-tabset.lua
@@ -286,7 +286,7 @@ function bootstrapTabs()
         active = " active"
         selected = "true"
       end
-      return 'class="nav-link' .. active .. '" id="' .. tablinkid .. '" data-bs-toggle="tab" data-bs-target="#' .. tabid .. '" role="tab" aria-controls="' .. tabid .. '" aria-selected="' .. selected .. '"'
+      return 'class="nav-link' .. active .. '" id="' .. tablinkid .. '" data-bs-toggle="tab" data-bs-target="#' .. tabid .. '" role="tab" aria-controls="' .. tabid .. '" aria-selected="' .. selected .. '" href=""'
     end,
     paneAttribs = function(tabid, isActive, headingAttribs)
       local tablinkid = tabid .. "-tab"


### PR DESCRIPTION
## Description

Proposed fix for #10284 that I've tested and confirmed works, but I don't know if it's the right solution. Feel free to edit or discard, and I didn't add tests because I'm not sure how this could be tested.

Add empty `href=""` attributes to Bootstrap tabset panel tabs to make the anchor elements keyboard accessible.

A weird thing is this never affected tabset panels in standalone HTML documents, only websites. Both formats seem to use the same `bootstrapTabs()` function, but the tabs in standalone HTML docs have an empty `href=""` that gets added by something else I could not figure out. Perhaps Pandoc is auto-fixing those anchors, but no idea why it doesn't happen for websites.

To test this, create a website:

```sh
quarto create project website mysite
```

Copy this into into `index.qmd` and render it:
```qmd
---
title: "mysite"
---

::: {.panel-tabset}

## First tab

1. Press Tab. "First tab" should be focused.
2. Press Right Arrow. "Second tab" should now be active and focused.

## Second tab

Other text might go here

:::
```

Press Tab and the tabset panel tab should now be focused.

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md). (not sure if I need to do this for a <1 line change)
- [x] referenced the GitHub issue this PR closes
- [x] updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
