### PR TITLE
Make Julia env copying even more robust against read-only scenarios

### DIFF
--- a/src/execute/julia.ts
+++ b/src/execute/julia.ts
@@ -397,7 +397,9 @@ async function ensureQuartoNotebookRunnerEnvironment(
 ) {
   const projectTomlTemplate = juliaResourcePath("Project.toml");
   const projectToml = join(juliaRuntimeDir(), "Project.toml");
-  Deno.writeFileSync(projectToml, Deno.readFileSync(projectTomlTemplate));
+  Deno.writeFileSync(projectToml, Deno.readFileSync(projectTomlTemplate), {
+    mode: 0o644  // rw-r--r--
+  });
   const command = new Deno.Command(juliaCmd(), {
     args: [
       "--startup-file=no",


### PR DESCRIPTION
This is a follow up to #12895, where instead of copying the reference `Project.toml` file, which may be read only, it was changed to write a new file.  However, on my system the default write permissions seemed to still be read-only so I still ran into the same problem.  This PR explicitly sets the newly written file to be user writable.