### PR TITLE
Small fix of argument order for fenced code attributes

### DIFF
--- a/tests/docs/smoke-all/2023/10/04/content-hidden.qmd
+++ b/tests/docs/smoke-all/2023/10/04/content-hidden.qmd
@@ -8,11 +8,11 @@ _quarto:
         - [".do-not-be-here"]
 ---
 
-```{.content-visible when-format="html" .be-here}
+```{.content-visible .be-here when-format="html"}
 2+2
 ```
 
-```{.content-hidden when-format="html" .do-not-be-here}
+```{.content-hidden .do-not-be-here when-format="html"}
 2+2
 ```
 

--- a/tests/docs/smoke-all/2024/05/20/9724.qmd
+++ b/tests/docs/smoke-all/2024/05/20/9724.qmd
@@ -7,7 +7,7 @@ _quarto:
         - []
 ---
 
-```{.python filename="run_experiments.py" #lst-1 lst-cap="Corpus Loading/Generation Logic"}
+```{#lst-1 .python filename="run_experiments.py" lst-cap="Corpus Loading/Generation Logic"}
 line 1
 line 2
 ```


### PR DESCRIPTION
## Description

Similar fix to #13220 - just correcting two cases where attributes for a fenced code block did not follow the `#id .class key=value` ordering.

## Checklist

I don't believe any of the below are applicable in this case.

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
