### PR TITLE
dev-call make-ast-diagram

### DIFF
--- a/src/command/dev-call/cmd.ts
+++ b/src/command/dev-call/cmd.ts
@@ -4,6 +4,7 @@ import { commands } from "../command.ts";
 import { buildJsCommand } from "./build-artifacts/cmd.ts";
 import { validateYamlCommand } from "./validate-yaml/cmd.ts";
 import { showAstTraceCommand } from "./show-ast-trace/cmd.ts";
+import { makeAstDiagramCommand } from "./make-ast-diagram/cmd.ts";
 
 type CommandOptionInfo = {
   name: string;
@@ -73,4 +74,5 @@ export const devCallCommand = new Command()
   .command("cli-info", generateCliInfoCommand)
   .command("validate-yaml", validateYamlCommand)
   .command("build-artifacts", buildJsCommand)
-  .command("show-ast-trace", showAstTraceCommand);
+  .command("show-ast-trace", showAstTraceCommand)
+  .command("make-ast-diagram", makeAstDiagramCommand);

--- a/src/command/dev-call/make-ast-diagram/cmd.ts
+++ b/src/command/dev-call/make-ast-diagram/cmd.ts
@@ -1,0 +1,32 @@
+/*
+ * cmd.ts
+ *
+ * Copyright (C) 2025 Posit Software, PBC
+ */
+
+import { Command } from "cliffy/command/mod.ts";
+import { join } from "../../../deno_ral/path.ts";
+import { resourcePath } from "../../../core/resources.ts";
+import { execProcess } from "../../../core/process.ts";
+
+export const makeAstDiagramCommand = new Command()
+  .name("make-ast-diagram")
+  .hidden()
+  .arguments("<arguments...>")
+  .description(
+    "Creates a diagram of the Pandoc AST.\n\n",
+  )
+  .action(async (_options: unknown, ...args: string[]) => {
+    const renderOpts = {
+      cmd: Deno.execPath(),
+      args: [
+        "run",
+        "--allow-read",
+        "--allow-write",
+        "--allow-run",
+        resourcePath(join("tools", "ast-diagram", "main.ts")),
+        ...args,
+      ],
+    };
+    await execProcess(renderOpts);
+  });

--- a/src/resources/tools/ast-diagram/README.md
+++ b/src/resources/tools/ast-diagram/README.md
@@ -1,0 +1,3 @@
+This is currently copied over from https://github.com/cscheid/pandoc-ast-block-diagram
+
+Ideally that becomes a whole set of NPM packages, and we then import from that directly.

--- a/src/resources/tools/ast-diagram/ast-diagram.ts
+++ b/src/resources/tools/ast-diagram/ast-diagram.ts
@@ -1,0 +1,1074 @@
+/*
+ * ast-diagram.ts
+ *
+ * (C) Posit, PBC 2025
+ */
+
+import { PandocAST, MetaValue, Inline } from "./types.ts";
+
+/**
+ * Converts a Pandoc AST JSON to an HTML block diagram
+ * @param json The Pandoc AST JSON object
+ * @param renderMode The rendering mode: "block" (default), "inline" (detailed inline AST), or "full" (all nodes including Str/Space)
+ * @returns HTML string representing the block diagram
+ */
+export function convertToBlockDiagram(json: PandocAST, mode = "block"): string {
+  
+  // Start with a container
+  let html = '<div class="pandoc-block-diagram">\n';
+  
+  // Process metadata if it exists
+  if (Object.keys(json.meta).length > 0) {
+    html += processMetadata(json.meta, mode);
+  }
+  
+  // Process the blocks
+  html += processBlocks(json.blocks, mode);
+  
+  // Close container
+  html += '</div>\n';
+  
+  return html;
+}
+
+export function renderPandocAstToBlockDiagram(
+  pandocAst: PandocAST, 
+  cssContent: string,
+  mode = "block"
+): string {
+    
+    // Convert to HTML block diagram
+    console.log("Converting to HTML block diagram...");
+    const html = convertToBlockDiagram(pandocAst, mode);
+    
+    // Add HTML wrapper and CSS
+    const fullHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,opsz,wght@0,6..12,200..1000;1,6..12,200..1000&display=swap" rel="stylesheet">
+  <title>Pandoc AST Block Diagram</title>
+  <style>
+  ${cssContent}
+  </style>
+  <script>
+  // Add event handler for toggling blocks and inlines
+  document.addEventListener('DOMContentLoaded', () => {
+    // Add click handlers to all block headers
+    document.querySelectorAll('.block-type').forEach(header => {
+      header.addEventListener('click', () => {
+        // Toggle the 'folded' class on the parent block
+        header.closest('.block').classList.toggle('folded');
+      });
+    });
+    
+    // Add click handlers to all inline headers
+    document.querySelectorAll('.inline-type').forEach(header => {
+      header.addEventListener('click', () => {
+        // Toggle the 'folded' class on the parent inline
+        header.closest('.inline').classList.toggle('folded');
+      });
+    });
+    
+    // Markdown source is no longer foldable
+    
+    // Initialize all toggle buttons to have the correct event handling
+    document.querySelectorAll('.toggle-button').forEach(button => {
+      // Prevent event propagation when clicking the button itself
+      button.addEventListener('click', (event) => {
+        // This ensures the parent handler above still runs
+        // but prevents double-toggling due to bubbling
+        event.stopPropagation();
+        
+        // Toggle the 'folded' class on the parent element (block or inline)
+        const parent = button.closest('.block') || button.closest('.inline');
+        if (parent) {
+          parent.classList.toggle('folded');
+        }
+      });
+    });
+    
+    // Add global fold/unfold controls
+    const controls = document.createElement('span');
+    controls.className = 'fold-controls';
+    controls.innerHTML = '<span class="control-group"><span>Blocks:</span><button id="fold-all-blocks">Fold</button><button id="unfold-all-blocks">Unfold</button></span><span class="control-group"><span>Inlines:</span><button id="fold-all-inlines">Fold</button><button id="unfold-all-inlines">Unfold</button></span>';
+    
+    document.getElementById('ast-diagram-heading').appendChild(controls);
+    
+    // Block controls
+    document.getElementById('fold-all-blocks').addEventListener('click', () => {
+      document.querySelectorAll('.block').forEach(block => {
+        block.classList.add('folded');
+      });
+    });
+    
+    document.getElementById('unfold-all-blocks').addEventListener('click', () => {
+      document.querySelectorAll('.block').forEach(block => {
+        block.classList.remove('folded');
+      });
+    });
+    
+    // Inline controls
+    document.getElementById('fold-all-inlines').addEventListener('click', () => {
+      document.querySelectorAll('.inline').forEach(inline => {
+        inline.classList.add('folded');
+      });
+    });
+    
+    document.getElementById('unfold-all-inlines').addEventListener('click', () => {
+      document.querySelectorAll('.inline').forEach(inline => {
+        inline.classList.remove('folded');
+      });
+    });
+  });
+  </script>
+</head>
+<body>
+  <h2 id="ast-diagram-heading">Diagram</h2>
+  ${html}
+</body>
+</html>`;
+    return fullHtml;
+}
+
+
+/**
+ * Process document metadata
+ */
+function processMetadata(meta: Record<string, MetaValue>, mode: string): string {
+  let html = `<div class="block block-metadata">
+  <div class="block-type">
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+    Metadata
+  </div>
+  <div class="block-content">`;
+  
+  // Process each metadata key
+  for (const [key, value] of Object.entries(meta)) {
+    html += `<div class="metadata-entry">
+      <div class="metadata-key">${escapeHtml(key)}</div>
+      <div class="metadata-value">${processMetaValue(value, mode)}</div>
+    </div>`;
+  }
+  
+  html += `</div>
+</div>\n`;
+  
+  return html;
+}
+
+/**
+ * Process a metadata value of any type
+ */
+function processMetaValue(value: MetaValue, mode: string): string {
+  switch (value.t) {
+    case "MetaMap":
+      return processMetaMap(value, mode);
+    case "MetaList":
+      return processMetaList(value, mode);
+    case "MetaBlocks":
+      return processMetaBlocks(value, mode);
+    case "MetaInlines":
+      return processMetaInlines(value, mode);
+    case "MetaBool":
+      return processMetaBool(value, mode);
+    case "MetaString":
+      return processMetaString(value, mode);
+    default:
+      // deno-lint-ignore no-explicit-any
+      return `<div class="meta-unknown">Unknown metadata type: ${(value as any).t}</div>`;
+  }
+}
+
+/**
+ * Process a MetaMap metadata value
+ */
+function processMetaMap(value: Extract<MetaValue, { t: "MetaMap" }>, mode: string): string {
+  const map = value.c;
+  
+  let html = `<div class="meta-map">
+    <div class="meta-type">Map</div>
+    <div class="meta-content">`;
+  
+  for (const [key, mapValue] of Object.entries(map)) {
+    html += `<div class="meta-map-entry">
+      <div class="meta-map-key">${escapeHtml(key)}</div>
+      <div class="meta-map-value">${processMetaValue(mapValue, mode)}</div>
+    </div>`;
+  }
+  
+  html += `</div>
+  </div>`;
+  
+  return html;
+}
+
+/**
+ * Process a MetaList metadata value
+ */
+function processMetaList(value: Extract<MetaValue, { t: "MetaList" }>, mode: string): string {
+  const list = value.c;
+  
+  let html = `<div class="meta-list">
+    <div class="meta-type">List</div>
+    <div class="meta-content">
+      <ul class="meta-list-items">`;
+  
+  for (const item of list) {
+    html += `<li class="meta-list-item">${processMetaValue(item, mode)}</li>`;
+  }
+  
+  html += `</ul>
+    </div>
+  </div>`;
+  
+  return html;
+}
+
+/**
+ * Process a MetaBlocks metadata value
+ */
+function processMetaBlocks(value: Extract<MetaValue, { t: "MetaBlocks" }>, mode: string): string {
+  const blocks = value.c;
+  
+  const html = `<div class="meta-blocks">
+    <div class="meta-type">Blocks</div>
+    <div class="meta-content">${processBlocks(blocks, mode)}</div>
+  </div>`;
+  
+  return html;
+}
+
+/**
+ * Process a MetaInlines metadata value
+ */
+function processMetaInlines(value: Extract<MetaValue, { t: "MetaInlines" }>, mode: string): string {
+  const inlines = value.c;
+  
+  const html = `<div class="meta-inlines">
+    <div class="meta-content">${processInlines(inlines, mode)}</div>
+  </div>`;
+  
+  return html;
+}
+
+/**
+ * Process a MetaBool metadata value
+ */
+function processMetaBool(value: Extract<MetaValue, { t: "MetaBool" }>, _mode: string): string {
+  const bool = value.c;
+  
+  return `<div class="meta-bool">
+    <div class="meta-content">${bool ? 'true' : 'false'}</div>
+  </div>`;
+}
+
+/**
+ * Process a MetaString metadata value
+ */
+function processMetaString(value: Extract<MetaValue, { t: "MetaString" }>, _mode: string): string {
+  const str = value.c;
+  
+  return `<div class="meta-string">
+    <div class="meta-content">${escapeHtml(str)}</div>
+  </div>`;
+}
+
+/**
+ * Process an array of block elements
+ */
+function processBlocks(blocks: PandocAST["blocks"], mode: string): string {
+  let html = '';
+  
+  for (const block of blocks) {
+    html += processBlock(block, mode);
+  }
+  
+  return html;
+}
+
+/**
+ * Process a block element with no content
+ */
+function processNoContentBlock(block: Extract<PandocAST["blocks"][0], { t: "HorizontalRule" }>, _mode: string): string {
+  return `<div class="block block-${block.t.toLowerCase()}">
+  <div class="block-type block-type-no-content">
+    ${block.t}
+  </div>
+</div>\n`;
+}
+
+/**
+ * Process a single block element
+ */
+function processBlock(block: PandocAST["blocks"][0], mode: string): string {
+  switch (block.t) {
+    case "Header":
+      return processHeader(block, mode);
+    case "Para":
+      return processPara(block, mode);
+    case "Plain":
+      return processPlain(block, mode);
+    case "BulletList":
+      return processBulletList(block, mode);
+    case "Div":
+      return processDiv(block, mode);
+    case "CodeBlock":
+      return processCodeBlock(block, mode);
+    case "HorizontalRule":
+      return processNoContentBlock(block, mode);
+    case "DefinitionList":
+      return processDefinitionList(block, mode);
+    case "Figure":
+      return processFigure(block, mode);
+    case "OrderedList":
+      return processOrderedList(block, mode);
+    case "LineBlock":
+      return processLineBlock(block, mode);
+    case "RawBlock":
+      return processRawBlock(block, mode);
+    case "BlockQuote":
+      return processBlockQuote(block, mode);
+    // Add other block types as needed
+    default:
+      return `<div class="block block-type-unknown block-type-${block.t}">
+  <div class="block-type">
+    ${block.t}
+  </div>
+  <div class="block-content">Unknown block type</div>
+</div>\n`;
+  }
+}
+
+/**
+ * Process a header block
+ */
+function processHeader(block: Extract<PandocAST["blocks"][0], { t: "Header" }>, mode: string): string {
+  const [level, [id, classes, attrs], content] = block.c;
+  
+  const classAttr = classes.length > 0 ? ` class="${classes.join(' ')}"` : '';
+  const idAttr = id ? ` id="${id}"` : '';
+  
+  const nodeAttrs = formatNodeAttributes(id, classes, attrs);
+  
+  return `<div class="block block-header level-${level}"${idAttr}${classAttr}>
+  <div class="block-type">
+    Header (${level})${nodeAttrs}
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="block-content">${processInlines(content, mode)}</div>
+</div>\n`;
+}
+
+/**
+ * Process a paragraph block
+ */
+function processPara(block: Extract<PandocAST["blocks"][0], { t: "Para" }>, mode: string): string {
+  return `<div class="block block-para">
+  <div class="block-type">
+    Paragraph
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="block-content">${processInlines(block.c, mode)}</div>
+</div>\n`;
+}
+
+/**
+ * Process a plain block
+ */
+function processPlain(block: Extract<PandocAST["blocks"][0], { t: "Plain" }>, mode: string): string {
+  return `<div class="block block-plain">
+  <div class="block-type">
+    Plain
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="block-content">${processInlines(block.c, mode)}</div>
+</div>\n`;
+}
+
+/**
+ * Process a bullet list block
+ */
+function processBulletList(block: Extract<PandocAST["blocks"][0], { t: "BulletList" }>, mode: string): string {
+  const items = block.c;
+  
+  let html = `<div class="block block-bullet-list">
+  <div class="block-type">
+    Bullet List
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="block-content">`;
+  
+  for (const item of items) {
+    html += `<div class="list-item">${processBlocks(item, mode)}</div>`;
+  }
+  
+  html += `</div>
+</div>\n`;
+  
+  return html;
+}
+
+/**
+ * Process a div block
+ */
+function processDiv(block: Extract<PandocAST["blocks"][0], { t: "Div" }>, mode: string): string {
+  const [[id, classes, attrs], content] = block.c;
+  
+  const classAttr = classes.length > 0 ? ` class="${classes.join(' ')}"` : '';
+  const idAttr = id ? ` id="${id}"` : '';
+  
+  let attrsText = '';
+  if (attrs.length > 0) {
+    attrsText = ` data-attrs="${attrs.map(([k, v]) => `${k}=${v}`).join(', ')}"`;
+  }
+  
+  const nodeAttrs = formatNodeAttributes(id, classes, attrs);
+  
+  return `<div class="block block-div"${idAttr}${classAttr}${attrsText}>
+  <div class="block-type">
+    Div${nodeAttrs}
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="block-content">${processBlocks(content, mode)}</div>
+</div>\n`;
+}
+
+/**
+ * Process a code block
+ */
+function processCodeBlock(block: Extract<PandocAST["blocks"][0], { t: "CodeBlock" }>, mode: string): string {
+  const [[id, classes, attrs], code] = block.c;
+  
+  const language = classes.length > 0 ? classes[0] : '';
+  const classAttr = classes.length > 0 ? ` class="${classes.join(' ')}"` : '';
+  const idAttr = id ? ` id="${id}"` : '';
+  
+  const nodeAttrs = formatNodeAttributes(id, classes, attrs);
+  
+  return `<div class="block block-code"${idAttr}${classAttr}>
+  <div class="block-type">
+    Code Block${language ? ` (${language})` : ''}${nodeAttrs}
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="block-content"><pre>${escapeHtml(code)}</pre></div>
+</div>\n`;
+}
+
+/**
+ * Process a definition list block
+ */
+function processDefinitionList(block: Extract<PandocAST["blocks"][0], { t: "DefinitionList" }>, mode: string): string {
+  const items = block.c;
+  
+  let html = `<div class="block block-definition-list">
+  <div class="block-type">
+    Definition List
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="block-content">`;
+  
+  for (const [term, definitions] of items) {
+    html += `<div class="definition-item">
+      <div class="definition-term">${processInlines(term, mode)}</div>`;
+    
+    for (const definition of definitions) {
+      html += `<div class="definition-description">${processBlocks(definition, mode)}</div>`;
+    }
+    
+    html += `</div>`;
+  }
+  
+  html += `</div>
+</div>\n`;
+  
+  return html;
+}
+
+/**
+ * Process a figure block
+ */
+function processFigure(block: Extract<PandocAST["blocks"][0], { t: "Figure" }>, mode: string): string {
+  const [attr, [_, caption], content] = block.c;
+  const [id, classes, attrs] = attr;
+  
+  const classAttr = classes.length > 0 ? ` class="${classes.join(' ')}"` : '';
+  const idAttr = id ? ` id="${id}"` : '';
+  
+  const nodeAttrs = formatNodeAttributes(id, classes, attrs);
+  
+  let html = `<div class="block block-figure"${idAttr}${classAttr}>
+  <div class="block-type">
+    Figure${nodeAttrs}
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="block-content">`;
+  
+  // Add caption if present
+  if (caption && caption.length > 0) {
+    html += `<div class="figure-caption">${processBlocks(caption, mode)}</div>`;
+  }
+  
+  // Add figure content
+  html += `<div class="figure-content">${processBlocks(content, mode)}</div>`;
+  
+  html += `</div>
+</div>\n`;
+  
+  return html;
+}
+
+/**
+ * Process an ordered list block
+ */
+function processOrderedList(block: Extract<PandocAST["blocks"][0], { t: "OrderedList" }>, mode: string): string {
+  const [[startNumber, style, delimiter], items] = block.c;
+  
+  // Extract style and delimiter values from their objects
+  const styleStr = style.t;
+  const delimiterStr = delimiter.t;
+  
+  let html = `<div class="block block-ordered-list">
+  <div class="block-type">
+    Ordered List (start: ${startNumber}, style: ${styleStr}, delimiter: ${delimiterStr})
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="block-content">`;
+  
+  for (const item of items) {
+    html += `<div class="list-item">${processBlocks(item, mode)}</div>`;
+  }
+  
+  html += `</div>
+</div>\n`;
+  
+  return html;
+}
+
+/**
+ * Process a line block
+ */
+function processLineBlock(block: Extract<PandocAST["blocks"][0], { t: "LineBlock" }>, mode: string): string {
+  const lines = block.c;
+  
+  let html = `<div class="block block-line-block">
+  <div class="block-type">
+    Line Block
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="block-content">`;
+  
+  for (const line of lines) {
+    html += `<div class="line-block-line">${processInlines(line, mode)}</div>`;
+  }
+  
+  html += `</div>
+</div>\n`;
+  
+  return html;
+}
+
+/**
+ * Process a RawBlock element
+ */
+function processRawBlock(block: Extract<PandocAST["blocks"][0], { t: "RawBlock" }>, mode: string): string {
+  const [format, content] = block.c;
+  
+  return `<div class="block block-rawblock">
+  <div class="block-type">
+    RawBlock (${format})
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="block-content">
+    <pre>${escapeHtml(content)}</pre>
+  </div>
+</div>\n`;
+}
+
+/**
+ * Process a BlockQuote element
+ */
+function processBlockQuote(block: Extract<PandocAST["blocks"][0], { t: "BlockQuote" }>, mode: string): string {
+  const content = block.c;
+  
+  return `<div class="block block-blockquote">
+  <div class="block-type">
+    BlockQuote
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="block-content">${processBlocks(content, mode)}</div>
+</div>\n`;
+}
+
+/**
+ * Process a Code inline element in verbose mode
+ */
+function processCodeInline(inline: Extract<Inline, { t: "Code" }>, mode: string): string {
+  const [[id, classes, attrs], codeText] = inline.c;
+
+  const classAttr = classes.length > 0 ? ` class="${classes.join(' ')}"` : '';
+  const idAttr = id ? ` id="${id}"` : '';
+
+  const nodeAttrs = formatNodeAttributes(id, classes, attrs);
+
+  return `<div class="inline inline-code"${idAttr}${classAttr}>
+  <div class="inline-type">
+    Code${nodeAttrs}
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="inline-content">${escapeHtml(codeText)}</div>
+</div>`;
+}
+
+/**
+ * Process a Link inline element in verbose mode
+ */
+function processLinkInline(inline: Extract<Inline, { t: "Link" }>, mode: string): string {
+  const [[id, classes, attrs], linkText, [url, title]] = inline.c;
+
+  const classAttr = classes.length > 0 ? ` class="${classes.join(' ')}"` : '';
+  const idAttr = id ? ` id="${id}"` : '';
+  
+  const nodeAttrs = formatNodeAttributes(id, classes, attrs);
+
+  return `<div class="inline inline-link"${idAttr}${classAttr}>
+  <div class="inline-type">
+    Link${nodeAttrs}
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="inline-url"><a href="${url}" title="${title || ''}">${escapeHtml(url)}</a></div>
+  ${title ? `<div class="inline-title">${escapeHtml(title)}</div>` : ''}
+  <div class="inline-content">
+    <div class="inline-text-content">${processInlines(linkText, mode)}</div>
+  </div>
+</div>`;
+}
+
+/**
+ * Process an Image inline element in verbose mode
+ */
+function processImageInline(inline: Extract<Inline, { t: "Image" }>, mode: string): string {
+  const [[id, classes, attrs], altText, [url, title]] = inline.c;
+
+  const classAttr = classes.length > 0 ? ` class="${classes.join(' ')}"` : '';
+  const idAttr = id ? ` id="${id}"` : '';
+  
+  const nodeAttrs = formatNodeAttributes(id, classes, attrs);
+
+  return `<div class="inline inline-image"${idAttr}${classAttr}>
+  <div class="inline-type">
+    Image${nodeAttrs}
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="inline-url"><a href="${url}" title="${title || ''}">${escapeHtml(url)}</a></div>
+  ${title ? `<div class="inline-title">${escapeHtml(title)}</div>` : ''}
+  <div class="inline-content">
+    <div class="inline-alt-text">${processInlines(altText, mode)}</div>
+  </div>
+</div>`;
+}
+
+/**
+ * Process a Math inline element in verbose mode
+ */
+function processMathInline(inline: Extract<Inline, { t: "Math" }>, mode: string): string {
+  const [mathType, content] = inline.c;
+  
+  // The mathType object has a property 't' that is either 'InlineMath' or 'DisplayMath'
+  const type = mathType.t;
+  const isDisplay = type === 'DisplayMath';
+  
+  return `<div class="inline inline-math inline-math-${isDisplay ? 'display' : 'inline'}">
+  <div class="inline-type">
+    Math (${isDisplay ? 'Display' : 'Inline'})
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="inline-content">
+    <div class="math-content"><code>${escapeHtml(content)}</code></div>
+  </div>
+</div>`;
+}
+
+/**
+ * Process a Quoted inline element in verbose mode
+ */
+function processQuotedInline(inline: Extract<Inline, { t: "Quoted" }>, mode: string): string {
+  const [quoteType, content] = inline.c;
+  
+  // The quoteType object has a property 't' that is either 'SingleQuote' or 'DoubleQuote'
+  const type = quoteType.t;
+  const isSingle = type === 'SingleQuote';
+  
+  return `<div class="inline inline-quoted inline-quoted-${isSingle ? 'single' : 'double'}">
+  <div class="inline-type">
+    Quoted (${isSingle ? 'Single' : 'Double'})
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="inline-content">
+    <div class="quoted-content">${processInlines(content, mode)}</div>
+  </div>
+</div>`;
+}
+
+/**
+ * Process a Note inline element in verbose mode
+ */
+function processNoteInline(inline: Extract<Inline, { t: "Note" }>, mode: string): string {
+  const content = inline.c;
+  
+  return `<div class="inline inline-note">
+  <div class="inline-type">
+    Note
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="inline-content">
+    <div class="note-content">${processBlocks(content, mode)}</div>
+  </div>
+</div>`;
+}
+
+/**
+ * Process a Cite inline element in verbose mode
+ */
+function processCiteInline(inline: Extract<Inline, { t: "Cite" }>, mode: string): string {
+  const [citations, text] = inline.c;
+  
+  let html = `<div class="inline inline-cite">
+  <div class="inline-type">
+    Cite
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="inline-content">`;
+  
+  // Display text representation
+  html += `<div class="cite-text">${processInlines(text, mode)}</div>`;
+  
+  // Display each citation
+  html += `<div class="cite-citations">`;
+  for (const citation of citations) {
+    const citationMode = citation.citationMode.t;
+    html += `<div class="cite-citation">
+      <div class="cite-id">${escapeHtml(citation.citationId)}</div>
+      <div class="cite-mode">${escapeHtml(citationMode)}</div>`;
+    
+    // Display prefix if present
+    if (citation.citationPrefix.length > 0) {
+      html += `<div class="cite-prefix">${processInlines(citation.citationPrefix, mode)}</div>`;
+    }
+    
+    // Display suffix if present
+    if (citation.citationSuffix.length > 0) {
+      html += `<div class="cite-suffix">${processInlines(citation.citationSuffix, mode)}</div>`;
+    }
+    
+    html += `</div>`;
+  }
+  html += `</div>`;
+  
+  html += `</div>
+</div>`;
+  
+  return html;
+}
+
+/**
+ * Process a RawInline element in verbose mode
+ */
+function processRawInlineInline(inline: Extract<Inline, { t: "RawInline" }>, mode: string): string {
+  const [format, content] = inline.c;
+  
+  return `<div class="inline inline-rawinline">
+  <div class="inline-type">
+    RawInline (${format})
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="inline-content">
+    <code class="raw-content">${escapeHtml(content)}</code>
+  </div>
+</div>`;
+}
+
+/**
+ * Process a Span inline element in verbose mode
+ */
+function processSpanInline(inline: Extract<Inline, { t: "Span" }>, mode: string): string {
+  const [[id, classes, attrs], spanContent] = inline.c;
+
+  const classAttr = classes.length > 0 ? ` class="${classes.join(' ')}"` : '';
+  const idAttr = id ? ` id="${id}"` : '';
+
+  const nodeAttrs = formatNodeAttributes(id, classes, attrs);
+
+  return `<div class="inline inline-span"${idAttr}${classAttr}>
+  <div class="inline-type">
+    Span${nodeAttrs}
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="inline-content">${processInlines(spanContent, mode)}</div>
+</div>`;
+}
+
+/**
+ * Process simple inline elements (Emph, Strong, SmallCaps, etc.) in verbose mode
+ */
+function processSimpleInline(inline: Extract<Inline, { t: string, c: Inline[] }>, mode: string): string {
+  const nodeType = inline.t; // Get the type name (Emph, Strong, etc.)
+  const content = inline.c;  // Get the content (array of Inline elements)
+
+  return `<div class="inline inline-${nodeType.toLowerCase()}">
+  <div class="inline-type">
+    ${nodeType}
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="inline-content">${processInlines(content, mode)}</div>
+</div>`;
+}
+
+/**
+ * Process a Str inline element in full mode
+ */
+function processStrInline(inline: Extract<Inline, { t: "Str" }>, mode: string): string {
+  const content = inline.c; // Get the string content
+
+  return `<div class="inline inline-str">
+  <div class="inline-type">
+    Str
+    <button class="toggle-button" aria-label="Toggle content">▼</button>
+  </div>
+  <div class="inline-content language-markdown">${escapeHtml(content)}</div>
+</div>`;
+}
+
+const foldedOnlyString = (type: string) => {
+  switch (type) {
+    case "Space": return "⏘";
+    default: return type;
+  }
+}
+
+/**
+ * Process inline elements with no content
+ */
+function processNoContentInline(inline: Extract<Inline, { t: "Space" | "SoftBreak" | "LineBreak" }>, mode: string): string {
+  return `<div class="inline inline-${inline.t.toLowerCase()}">
+  <div class="inline-type inline-type-no-content">${inline.t}</div>
+  <div class="inline-type inline-type-no-content-folded-only">${foldedOnlyString(inline.t)}</div>
+</div>`;
+}
+
+/**
+ * Process inline elements
+ */
+// deno-lint-ignore no-explicit-any
+function processInlines(inlines: any[], mode: string): string {
+  let html = '';
+  
+  for (const inline of inlines) {
+    switch (inline.t) {
+      case "Str":
+        if (mode === "full") {
+          html += processStrInline(inline, mode);
+        } else {
+          html += escapeHtml(inline.c);
+        }
+        break;
+      case "Space":
+        if (mode === "full") {
+          html += processNoContentInline(inline, mode);
+        } else {
+          html += ' ';
+        }
+        break;
+      case "SoftBreak":
+        if (mode === "full") {
+          html += processNoContentInline(inline, mode);
+        } else {
+          html += ' ';
+        }
+        break;
+      case "LineBreak":
+        if (mode === "full") {
+          html += processNoContentInline(inline, mode);
+        } else {
+          html += '<br>';
+        }
+        break;
+      case "Code":
+        if (mode === "inline" || mode === "full") {
+          html += processCodeInline(inline, mode);
+        } else {
+          const [[, codeClasses], codeText] = inline.c;
+          html += `<code class="${codeClasses.join(' ')}">${escapeHtml(codeText)}</code>`;
+        }
+        break;
+      case "RawInline":
+        if (mode === "inline" || mode === "full") {
+          html += processRawInlineInline(inline, mode);
+        } else {
+          const [format, content] = inline.c;
+          html += `<code class="raw-${format}">${escapeHtml(content)}</code>`;
+        }
+        break;
+      case "Link":
+        if (mode === "inline" || mode === "full") {
+          html += processLinkInline(inline, mode);
+        } else {
+          const [[, linkClasses], linkText, [url, title]] = inline.c;
+          html += `<a href="${url}" title="${title}" class="${linkClasses.join(' ')}">${processInlines(linkText, mode)}</a>`;
+        }
+        break;
+      case "Image":
+        if (mode === "inline" || mode === "full") {
+          html += processImageInline(inline, mode);
+        } else {
+          const [[imgId, imgClasses, imgAttrs], altText, [url, title]] = inline.c;
+          // In block mode, represent the image as markdown-like syntax in a code tag
+          let imgMarkdown = `![${processInlines(altText, mode)}](${url}`;
+          if (title) {
+            imgMarkdown += ` "${title}"`;
+          }
+          imgMarkdown += ')';
+          
+          // Add attributes if present
+          if (imgId || imgClasses.length > 0 || imgAttrs.length > 0) {
+            imgMarkdown += '{';
+            if (imgId) {
+              imgMarkdown += `#${imgId}`;
+            }
+            for (const cls of imgClasses) {
+              imgMarkdown += ` .${cls}`;
+            }
+            for (const [k, v] of imgAttrs) {
+              imgMarkdown += ` ${k}=${v}`;
+            }
+            imgMarkdown += '}';
+          }
+          
+          html += `<code class="image-markdown">${escapeHtml(imgMarkdown)}</code>`;
+        }
+        break;
+      case "Math":
+        if (mode === "inline" || mode === "full") {
+          html += processMathInline(inline, mode);
+        } else {
+          const [mathType, content] = inline.c;
+          const type = mathType.t;
+          const isDisplay = type === 'DisplayMath';
+          
+          // In block mode, represent the math as TeX/LaTeX in a code tag
+          const delimiter = isDisplay ? '$$' : '$';
+          html += `<code class="math-${isDisplay ? 'display' : 'inline'}">${delimiter}${escapeHtml(content)}${delimiter}</code>`;
+        }
+        break;
+      case "Quoted":
+        if (mode === "inline" || mode === "full") {
+          html += processQuotedInline(inline, mode);
+        } else {
+          const [quoteType, content] = inline.c;
+          const type = quoteType.t;
+          const isSingle = type === 'SingleQuote';
+          
+          // In block mode, represent the quoted text with actual quote marks
+          const quote = isSingle ? "'" : '"';
+          html += `${quote}${processInlines(content, mode)}${quote}`;
+        }
+        break;
+      case "Note":
+        // Note is a special inline element that contains block elements
+        // We always use processNoteInline regardless of mode to properly visualize its structure
+        html += processNoteInline(inline, mode);
+        break;
+      case "Cite":
+        if (mode === "inline" || mode === "full") {
+          html += processCiteInline(inline, mode);
+        } else {
+          // In block mode, just use the text representation
+          const [_, text] = inline.c;
+          html += processInlines(text, mode);
+        }
+        break;
+      case "Span":
+        if (mode === "inline" || mode === "full") {
+          html += processSpanInline(inline, mode);
+        } else {
+          const [[spanId, spanClasses], spanContent] = inline.c;
+          const spanClassAttr = spanClasses.length > 0 ? ` class="${spanClasses.join(' ')}"` : '';
+          const spanIdAttr = spanId ? ` id="${spanId}"` : '';
+          html += `<span${spanIdAttr}${spanClassAttr}>${processInlines(spanContent, mode)}</span>`;
+        }
+        break;
+      // Simple inline types processed with the generic function
+      case "Emph":
+      case "Strong":
+      case "SmallCaps":
+      case "Strikeout": 
+      case "Subscript":
+      case "Superscript":
+      case "Underline":
+        if (mode === "inline" || mode === "full") {
+          html += processSimpleInline(inline, mode);
+        } else {
+          const tag = inline.t === "Emph" ? "em" : 
+                     inline.t === "Strong" ? "strong" :
+                     inline.t === "SmallCaps" ? "span class=\"small-caps\"" :
+                     inline.t === "Strikeout" ? "s" :
+                     inline.t === "Subscript" ? "sub" :
+                     inline.t === "Superscript" ? "sup" :
+                     inline.t === "Underline" ? "u" : "span";
+          html += `<${tag}>${processInlines(inline.c, mode)}</${tag.split(" ")[0]}>`;
+        }
+        break;
+      // Add other inline types as needed
+      default:
+        html += `<div class="inline inline-unknown inline-${inline.t}">
+        <div class="inline-type">
+          <button class="toggle-button" aria-label="Toggle content">▼</button>
+          ${inline.t}
+        </div>
+        <div class="inline-content">Unknown inline type</div>
+      </div>`;
+    }
+  }
+  
+  return html;
+}
+
+
+/**
+ * Format node ID, classes, and attributes for display
+ */
+function formatNodeAttributes(id: string, classes: string[], attrs: [string, string][]): string {
+  let result = '';
+  
+  // Add ID if present
+  if (id) {
+    result += ` <code class="node-id">#${id}</code>`;
+  }
+  
+  // Add classes if present
+  if (classes.length > 0) {
+    result += ` <code class="node-classes">${classes.map(c => `.${c}`).join(' ')}</code>`;
+  }
+  
+  // Add attributes if present
+  if (attrs.length > 0) {
+    result += ` <code class="node-attrs">${attrs.map(([k, v]) => `${k}="${v}"`).join(' ')}</code>`;
+  }
+  
+  return result;
+}
+
+/**
+ * Simple HTML escape function
+ */
+function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}

--- a/src/resources/tools/ast-diagram/main.ts
+++ b/src/resources/tools/ast-diagram/main.ts
@@ -1,0 +1,119 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-run
+
+import { join } from "https://deno.land/std/path/mod.ts";
+import { renderPandocAstToBlockDiagram } from "./ast-diagram.ts";
+import { PandocAST } from "./types.ts";
+
+/**
+ * Convert a markdown file to an HTML block diagram
+ */
+async function renderMarkdownToBlockDiagram(
+  markdownFile: string,
+  outputFile: string,
+  mode = "block",
+) {
+  console.log(`Processing ${markdownFile}...`);
+
+  try {
+    // Read the markdown file content
+    console.log("Reading markdown source file...");
+    // Read the CSS file
+    const scriptDir = new URL(".", import.meta.url).pathname;
+    const cssPath = join(scriptDir, "style.css");
+    const cssContent = await Deno.readTextFile(cssPath);
+
+    // Run pandoc to convert markdown to JSON
+    console.log("Running pandoc to convert to JSON...");
+    const command = new Deno.Command("quarto", {
+      args: ["pandoc", "-t", "json", markdownFile],
+      stdout: "piped",
+    });
+
+    const { code, stdout } = await command.output();
+    if (code !== 0) {
+      throw new Error(`Pandoc command failed with exit code ${code}`);
+    }
+
+    const jsonOutput = new TextDecoder().decode(stdout);
+
+    // Parse the JSON
+    console.log("Parsing Pandoc JSON...");
+    const pandocAst = JSON.parse(jsonOutput) as PandocAST;
+    const fullHtml = renderPandocAstToBlockDiagram(pandocAst, cssContent, mode);
+
+    // Write the result to the output file
+    console.log(`Writing output to ${outputFile}...`);
+    await Deno.writeTextFile(outputFile, fullHtml);
+
+    console.log("Done!");
+    return true;
+  } catch (err) {
+    // deno-lint-ignore no-explicit-any
+    console.error("Error:", (err as unknown as any).message);
+    return false;
+  }
+}
+
+// Check if script is run directly
+if (import.meta.main) {
+  // Get markdown file from command line arguments
+  const args = Deno.args;
+
+  // Check for --mode flag and its value
+  let mode = "block";
+  const modeIndex = args.indexOf("--mode");
+  if (modeIndex !== -1 && modeIndex + 1 < args.length) {
+    const modeValue = args[modeIndex + 1];
+    if (
+      modeValue === "block" || modeValue === "inline" || modeValue === "full"
+    ) {
+      mode = modeValue;
+    } else {
+      console.error(
+        "Invalid mode value. Must be 'block', 'inline', or 'full'.",
+      );
+      Deno.exit(1);
+    }
+  }
+
+  // Backwards compatibility for --verbose flag
+  const verboseIndex = args.indexOf("--verbose");
+  if (verboseIndex !== -1) {
+    mode = "inline";
+  }
+
+  // Remove the --mode flag and its value, or --verbose flag for the rest of argument processing
+  const cleanedArgs = [...args];
+  if (modeIndex !== -1) {
+    cleanedArgs.splice(modeIndex, 2); // Remove both flag and value
+  } else if (verboseIndex !== -1) {
+    cleanedArgs.splice(verboseIndex, 1); // Remove just the flag
+  }
+
+  if (cleanedArgs.length < 1) {
+    console.log(
+      "Usage: main.ts [--mode <block|inline|full>] <markdown-file> [output-html-file]",
+    );
+    console.log("Options:");
+    console.log(
+      "  --mode block|inline|full   Rendering mode: 'block' (default), 'inline' (detailed AST), or 'full' (all nodes)",
+    );
+    console.log(
+      "  --verbose                 (Legacy) Equivalent to --mode inline",
+    );
+    console.log(
+      "\nIf output file is not specified, it will use the input filename with .html extension",
+    );
+    Deno.exit(1);
+  }
+
+  const markdownFile = cleanedArgs[0];
+  let outputFile = cleanedArgs[1];
+
+  if (!outputFile) {
+    // Default output file is input file with .html extension
+    outputFile = markdownFile.replace(/\.[^\.]+$/, "") + ".html";
+  }
+
+  renderMarkdownToBlockDiagram(markdownFile, outputFile, mode);
+}

--- a/src/resources/tools/ast-diagram/style.css
+++ b/src/resources/tools/ast-diagram/style.css
@@ -1,0 +1,498 @@
+/* Pandoc AST Block Diagram Styles */
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: "Nunito Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-optical-sizing: auto;
+  font-weight: 400;
+  font-style: normal;
+  line-height: 1.5;
+  color: #333;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.pandoc-block-diagram {
+  /* inherits styles from body */
+  margin-left: 15px;
+}
+
+/* Block elements */
+.block {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  margin: 2px 0;
+  padding: 5px 10px;
+  background-color: #f9f9f9;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  display: grid;
+  grid-template-columns: 120px 1fr;
+}
+
+.block-type {
+  font-weight: 600;
+  color: #666;
+  font-size: 0.9em;
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+/* Toggle button styles */
+.toggle-button {
+  background: none;
+  border: none;
+  color: #666;
+  font-size: 0.9em;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+  position: relative;
+  top: -0.1em;
+}
+
+/* Folded state */
+.block.folded .block-content {
+  display: none;
+}
+
+.block.folded .toggle-button {
+  transform: rotate(-90deg);
+}
+
+.block-content {
+  padding-left: 15px;
+  border-left: 3px solid #eee;
+  line-height: 2em;
+}
+
+.block.block-bullet-list .block-content {
+  padding-left: 0;
+  border-left: none;
+}
+
+/* Specific Block Types */
+.block-header {
+  background-color: #f3f7fd;
+  border-color: #c5d7f2;
+}
+
+.block-para {
+  background-color: #f9f9f9;
+}
+
+.block-bullet-list {
+  background-color: #f5f9f5;
+  border-color: #d1e7d1;
+}
+
+.block-div {
+  background-color: #fff8f5;
+  border-color: #f5d3bf;
+}
+
+.block-code {
+  background-color: #f5f5f7;
+  border-color: #cfd2e0;
+}
+
+.block-metadata {
+  background-color: #f2f9fd;
+  border-color: #bde0f3;
+}
+
+/* Metadata styling */
+.metadata-entry {
+  margin: 8px 0;
+  padding: 8px;
+  border-left: 3px solid #ddf;
+  background-color: rgba(255, 255, 255, 0.5);
+  border-radius: 4px;
+}
+
+.metadata-key {
+  font-weight: 600;
+  color: #446;
+  margin-bottom: 5px;
+  font-size: 0.95em;
+}
+
+.meta-map, .meta-list, .meta-blocks, .meta-inlines, .meta-bool, .meta-string {
+  padding: 5px;
+  border-radius: 3px;
+}
+
+.meta-map {
+  background-color: #f0f8ff;
+  border: 1px solid #e0f0ff;
+}
+
+.meta-list {
+  background-color: #f8f8ff;
+  border: 1px solid #e8e8ff;
+}
+
+.meta-blocks {
+  background-color: #fff8f8;
+  border: 1px solid #ffe8e8;
+}
+
+.meta-inlines {
+  background-color: #f8fff8;
+  border: 1px solid #e8ffe8;
+}
+
+.meta-bool {
+  background-color: #fffff8;
+  border: 1px solid #ffffe8;
+}
+
+.meta-string {
+  background-color: #fff8ff;
+  border: 1px solid #ffe8ff;
+}
+
+.meta-type {
+  font-size: 0.85em;
+  color: #777;
+  margin-bottom: 5px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.meta-map-entry {
+  margin: 6px 0;
+  padding: 5px;
+  border-left: 2px solid #ddf;
+}
+
+.meta-map-key {
+  font-weight: 600;
+  color: #557;
+  font-size: 0.9em;
+  margin-bottom: 3px;
+}
+
+.meta-list-items {
+  margin: 5px 0 5px 20px;
+  padding-left: 10px;
+}
+
+.meta-list-item {
+  margin: 5px 0;
+}
+
+.meta-content {
+  padding-left: 10px;
+}
+
+/* Header Levels */
+.level-1 .block-type,
+.level-2 .block-type,
+.level-3 .block-type,
+.level-4 .block-type {
+  color: #666;
+}
+
+/* List Items */
+.list-item {
+  margin: 8px 0;
+  padding-left: 15px;
+  border-left: 3px solid #eee;
+}
+
+/* Code Formatting */
+pre {
+  background-color: #f5f5f5;
+  padding: 10px;
+  border-radius: 3px;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.9em;
+  overflow-x: auto;
+}
+
+code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  background-color: #f5f5f5;
+  padding: 2px 4px;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+
+/* Nested Elements */
+.block .block {
+  margin-left: 5px;
+}
+
+/* Unknown Elements */
+.block-type-unknown, .inline-unknown {
+  background-color: #fcf8e3;
+  border-color: #faebcc;
+  color: #8a6d3b;
+}
+
+/* Inline Elements */
+.inline {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  margin: 5px;
+  padding: 0 2px 0 2px;
+  background-color: #f9f9f9;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  display: inline;
+}
+
+.inline-type {
+  font-weight: 600;
+  color: #666;
+  font-size: 0.6em;
+  text-transform: uppercase;
+  display: inline;
+  align-items: center;
+  cursor: pointer;
+  top: -0.15em;
+  position: relative;
+  margin-left: 5px;
+  margin-right: 2px;
+}
+
+.inline-type .toggle-button {
+  padding: 0;
+}
+
+/* Override for inline-type with no content */
+.inline-type.inline-type-no-content {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+div .inline-type.inline-type-no-content-folded-only {
+  display: none;
+}
+
+div.folded .inline-type.inline-type-no-content {
+  display: none;
+}
+div.folded .inline-type.inline-type-no-content-folded-only {
+  display: inherit;
+}
+
+/* Folded state for inline elements */
+.inline.folded .inline-content,
+.inline.folded .inline-classes,
+.inline.folded .inline-attrs,
+.inline.folded .inline-url,
+.inline.folded .inline-title {
+  display: none;
+}
+
+.inline.folded .toggle-button {
+  transform: rotate(-90deg);
+}
+
+.inline-content {
+  display: inline;
+}
+
+/* Link styles with pseudo-elements */
+.inline-url, .inline-title {
+  padding-left: 15px;
+  border-left: 3px solid #eee;
+  margin-bottom: 6px;
+}
+
+.inline-url::before {
+  content: "URL: ";
+  font-weight: 600;
+  color: #666;
+  margin-right: 4px;
+}
+
+.inline-title::before {
+  content: "Title: ";
+  font-weight: 600;
+  color: #666;
+}
+
+.inline-text-content::before {
+  content: "Text: ";
+  font-weight: 600;
+  color: #666;
+}
+
+/* Special link styling */
+.inline-url a {
+  display: inline-block;
+  padding: 4px 8px;
+  margin-left: 4px;
+  background-color: #f0f7ff;
+  border: 1px solid #d0e0f7;
+  border-radius: 3px;
+  word-break: break-all;
+  max-width: calc(100% - 50px);
+}
+
+/* Simple inline element styling */
+.inline-emph {
+  background-color: #f7f9f4;
+  border-color: #dbe7c9;
+}
+
+.inline-strong {
+  background-color: #f9f4f4;
+  border-color: #e7c9c9;
+}
+
+.inline-smallcaps {
+  background-color: #f4f9f9;
+  border-color: #c9e7e7;
+}
+
+.inline-strikeout {
+  background-color: #f9f8f4;
+  border-color: #e7e2c9;
+}
+
+.inline-subscript {
+  background-color: #f4f4f9;
+  border-color: #c9c9e7;
+}
+
+.inline-superscript {
+  background-color: #f9f4f9;
+  border-color: #e7c9e7;
+}
+
+.inline-underline {
+  background-color: #f4f9f4;
+  border-color: #c9e7c9;
+}
+
+a {
+  color: #337ab7;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+h2#ast-diagram-heading {
+  display: flex;  
+  justify-content: space-between;
+  align-items: center; /* Optional: vertically centers content */
+}
+
+/* Fold controls */
+.fold-controls {
+  margin: 15px 0 15px 15px;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 15px;
+}
+
+.control-group {
+  display: flex;
+  align-items: center;
+  border: 1px solid #eee;
+  border-radius: 4px;
+  padding: 5px 10px;
+  background-color: #f9f9f9;
+}
+
+.control-group span {
+  font-weight: 600;
+  margin-right: 10px;
+  color: #666;
+}
+
+.fold-controls button {
+  background-color: #f0f0f0;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  padding: 4px 8px;
+  margin-right: 6px;
+  cursor: pointer;
+  font-size: 0.85em;
+}
+
+.fold-controls button:hover {
+  background-color: #e0e0e0;
+}
+
+.fold-controls button:active {
+  background-color: #d0d0d0;
+}
+
+/* Page Layout and Headings */
+h1, h2 {
+  margin-left: 15px;
+  color: #555;
+}
+
+h1 {
+  font-size: 1.6em;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 10px;
+  margin-bottom: 10px;
+}
+
+.source-path {
+  margin-left: 15px;
+  color: #777;
+  font-style: italic;
+  margin-bottom: 20px;
+}
+
+h2 {
+  font-size: 1.3em;
+  margin-top: 30px;
+  margin-bottom: 15px;
+}
+
+/* Markdown source code */
+.source-info {
+  margin: 20px 0 20px 15px;
+}
+
+/* Source info heading styles removed as they're now redundant 
+   and inheriting properly from the general h2 styling */
+
+.markdown-source {
+  margin: 15px 0;
+}
+
+/* Clean up: markdown header styles removed since folding is no longer needed */
+
+.markdown-source pre {
+  max-height: 300px;
+  overflow-y: auto;
+  background-color: #f5f5f5;
+  padding: 15px;
+  border-radius: 4px;
+  border: 1px solid #ddd;
+  white-space: pre-wrap;
+}
+
+.language-markdown {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.9em;
+}
+
+/* Node attribute styling */
+.node-id, .node-classes, .node-attrs {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.85em;
+  border-radius: 3px;
+  display: inline-block;
+  margin-left: 5px;
+  margin-right: 5px;
+  padding: 0 4px;
+  text-transform: none;
+  color: #666;
+  background-color: #f7f7f7;
+}

--- a/src/resources/tools/ast-diagram/types.ts
+++ b/src/resources/tools/ast-diagram/types.ts
@@ -1,0 +1,276 @@
+// TypeScript definitions for Pandoc AST
+
+export interface PandocAST {
+  "pandoc-api-version": number[];
+  meta: Record<string, MetaValue>;
+  blocks: Block[];
+}
+
+// Meta value types
+export type MetaValue = 
+  | MetaMap
+  | MetaList
+  | MetaBlocks
+  | MetaInlines
+  | MetaBool
+  | MetaString;
+
+export interface MetaMap {
+  t: "MetaMap";
+  c: Record<string, MetaValue>;
+}
+
+export interface MetaList {
+  t: "MetaList";
+  c: MetaValue[];
+}
+
+export interface MetaBlocks {
+  t: "MetaBlocks";
+  c: Block[];
+}
+
+export interface MetaInlines {
+  t: "MetaInlines";
+  c: Inline[];
+}
+
+export interface MetaBool {
+  t: "MetaBool";
+  c: boolean;
+}
+
+export interface MetaString {
+  t: "MetaString";
+  c: string;
+}
+
+// Block element types
+export type Block = 
+  | HeaderBlock
+  | ParaBlock
+  | BulletListBlock
+  | DivBlock
+  | CodeBlockBlock
+  | PlainBlock
+  | OrderedListBlock
+  | BlockQuoteBlock
+  | RawBlockBlock
+  | HorizontalRuleBlock
+  | TableBlock
+  | DefinitionListBlock
+  | FigureBlock
+  | LineBlockBlock;
+
+// Inline element types
+export type Inline = 
+  | StrInline
+  | SpaceInline
+  | CodeInline
+  | LinkInline
+  | SpanInline
+  | EmphInline
+  | StrongInline
+  | StrikeoutInline
+  | SubscriptInline
+  | SuperscriptInline
+  | SmallCapsInline
+  | UnderlineInline
+  | QuotedInline
+  | RawInlineInline
+  | MathInline
+  | ImageInline
+  | SoftBreakInline
+  | LineBreakInline
+  | NoteInline
+  | CiteInline;
+
+// Attributes type
+export type Attr = [string, string[], [string, string][]];
+
+// Block type definitions
+export interface HeaderBlock {
+  t: "Header";
+  c: [number, Attr, Inline[]];
+}
+
+export interface ParaBlock {
+  t: "Para";
+  c: Inline[];
+}
+
+export interface BulletListBlock {
+  t: "BulletList";
+  c: Block[][];
+}
+
+export interface DivBlock {
+  t: "Div";
+  c: [Attr, Block[]];
+}
+
+export interface CodeBlockBlock {
+  t: "CodeBlock";
+  c: [Attr, string];
+}
+
+export interface PlainBlock {
+  t: "Plain";
+  c: Inline[];
+}
+
+export interface OrderedListBlock {
+  t: "OrderedList";
+  c: [[number, { t: string }, { t: string }], Block[][]];
+}
+
+export interface BlockQuoteBlock {
+  t: "BlockQuote";
+  c: Block[];
+}
+
+export interface RawBlockBlock {
+  t: "RawBlock";
+  c: [string, string];
+}
+
+export interface HorizontalRuleBlock {
+  t: "HorizontalRule";
+  c?: [];
+}
+
+export interface TableBlock {
+  t: "Table";
+  c: any[]; // Complex structure simplified
+}
+
+export interface DefinitionListBlock {
+  t: "DefinitionList";
+  c: [Inline[], Block[][]][];
+}
+
+export interface FigureBlock {
+  t: "Figure";
+  c: [Attr, [null, Block[]], Block[]];
+}
+
+export interface LineBlockBlock {
+  t: "LineBlock";
+  c: Inline[][];
+}
+
+// Inline type definitions
+export interface StrInline {
+  t: "Str";
+  c: string;
+}
+
+export interface SpaceInline {
+  t: "Space";
+  c?: [];
+}
+
+export interface CodeInline {
+  t: "Code";
+  c: [Attr, string];
+}
+
+export interface LinkInline {
+  t: "Link";
+  c: [Attr, Inline[], [string, string]];
+}
+
+export interface SpanInline {
+  t: "Span";
+  c: [Attr, Inline[]];
+}
+
+export interface EmphInline {
+  t: "Emph";
+  c: Inline[];
+}
+
+export interface StrongInline {
+  t: "Strong";
+  c: Inline[];
+}
+
+export interface StrikeoutInline {
+  t: "Strikeout";
+  c: Inline[];
+}
+
+export interface SubscriptInline {
+  t: "Subscript";
+  c: Inline[];
+}
+
+export interface SuperscriptInline {
+  t: "Superscript";
+  c: Inline[];
+}
+
+export interface UnderlineInline {
+  t: "Underline";
+  c: Inline[];
+}
+
+export interface QuotedInline {
+  t: "Quoted";
+  c: [{ t: "SingleQuote" | "DoubleQuote" }, Inline[]];
+}
+
+export interface SmallCapsInline {
+  t: "SmallCaps";
+  c: Inline[];
+}
+
+export interface RawInlineInline {
+  t: "RawInline";
+  c: [string, string];
+}
+
+export interface MathInline {
+  t: "Math";
+  c: [{ t: "InlineMath" | "DisplayMath" }, string]; // [MathType, Content]
+}
+
+export interface ImageInline {
+  t: "Image";
+  c: [Attr, Inline[], [string, string]]; // [Attr, Alt, [URL, Title]]
+}
+
+export interface SoftBreakInline {
+  t: "SoftBreak";
+  c?: [];
+}
+
+export interface LineBreakInline {
+  t: "LineBreak";
+  c?: [];
+}
+
+export interface NoteInline {
+  t: "Note";
+  c: Block[]; // Content of the footnote as block elements
+}
+
+// Citation mode type
+export interface CitationMode {
+  t: "AuthorInText" | "SuppressAuthor" | "NormalCitation";
+}
+
+// Citation type
+export interface Citation {
+  citationId: string;
+  citationPrefix: Inline[];
+  citationSuffix: Inline[];
+  citationMode: CitationMode;
+  citationNoteNum: number;
+  citationHash: number;
+}
+
+export interface CiteInline {
+  t: "Cite";
+  c: [Citation[], Inline[]]; // [Citations array, Text representation]
+}


### PR DESCRIPTION
Not for advertised consumption, but `quarto dev-call make-ast-diagram hello.md hello.html` produces an HTML file with an interactive diagram for the Pandoc AST.

This is pretty incomplete. For example, it doesn't do anything special with Quarto's custom AST nodes.

Still, it can be useful to explain how the AST works in a teaching context.