### PR TITLE
revealjs - code line numbers not working when set to "1"

### DIFF
--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -71,6 +71,10 @@ All changes included in 1.8:
 
 - ([#12676](https://github.com/quarto-dev/quarto-cli/issues/12676)): Add support for rendering layout panels that are not floats.
 
+### `docusaurus-md`
+
+- [#13316](https://github.com/quarto-dev/quarto-cli/issues/13316): `code-line-numbers: "1"` correctly highlight the first line now.
+
 ## Projects
 
 ### `website`

--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -42,6 +42,7 @@ All changes included in 1.8:
 - ([#12598](https://github.com/quarto-dev/quarto-cli/pull/12598)): Ensure `.fragment` on an image with caption applies to whole figure.
 - ([#12716](https://github.com/quarto-dev/quarto-cli/issues/12716)): Correctly resolve `"brand"` set in `theme` configuration for document in subdirectory from project root.
 - Use `cdn.jsdelivr.net` for mathjax dependencies to ensure consistent CDN usage across formats. Previously, `cdnjs.cloudflare.com` was used for `revealjs` mathjax dependencies, while `cdn.jsdelivr.net` was used for html format.
+- [#13316](https://github.com/quarto-dev/quarto-cli/issues/13316): `code-line-numbers: "1"` correctly highlight the first line now.
 
 ### `docx`
 

--- a/src/resources/filters/quarto-pre/line-numbers.lua
+++ b/src/resources/filters/quarto-pre/line-numbers.lua
@@ -27,7 +27,7 @@ function lineNumbersAttribute(el)
   local default = param(constants.kCodeLineNumbers, false)
   local lineNumbers = attribute(el, constants.kCodeLineNumbers, default)
   -- format that do accept string for this attributes. "1" and "0" should not be parsed as TRUE / FALSE
-  local acceptStrings = _quarto.format.isRevealJsOutput() and not _quarto.format.isDocusaurusOutput()
+  local acceptStrings = _quarto.format.isRevealJsOutput() or _quarto.format.isDocusaurusOutput()
   if lineNumbers == true or lineNumbers == "true" or (lineNumbers == "1" and not acceptStrings) then
     return true
   elseif lineNumbers == false or lineNumbers == "false" or lineNumbers == "0" then

--- a/src/resources/filters/quarto-pre/line-numbers.lua
+++ b/src/resources/filters/quarto-pre/line-numbers.lua
@@ -26,7 +26,9 @@ end
 function lineNumbersAttribute(el)
   local default = param(constants.kCodeLineNumbers, false)
   local lineNumbers = attribute(el, constants.kCodeLineNumbers, default)
-  if lineNumbers == true or lineNumbers == "true" or lineNumbers == "1" then
+  -- format that do accept string for this attributes. "1" and "0" should not be parsed as TRUE / FALSE
+  local acceptStrings = _quarto.format.isRevealJsOutput() and not _quarto.format.isDocusaurusOutput()
+  if lineNumbers == true or lineNumbers == "true" or (lineNumbers == "1" and not acceptStrings) then
     return true
   elseif lineNumbers == false or lineNumbers == "false" or lineNumbers == "0" then
     return false

--- a/tests/docs/smoke-all/2025/09/02/13316.qmd
+++ b/tests/docs/smoke-all/2025/09/02/13316.qmd
@@ -1,0 +1,22 @@
+---
+format: html
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ['pre.sourceCode.number-lines']
+        - ['#cb1[data-code-line-numbers="1"]']
+    revealjs:
+      ensureHtmlElements:
+        - ['#cb1[data-code-line-numbers="1"]', 'pre.sourceCode.number-lines']
+        - []
+execute: 
+  echo: true
+---
+
+```{r}
+#| code-line-numbers: "1"
+mean(
+  c(1, 2, 3, 4, 5)
+)
+```

--- a/tests/docs/smoke-all/2025/09/02/13316.qmd
+++ b/tests/docs/smoke-all/2025/09/02/13316.qmd
@@ -1,4 +1,5 @@
 ---
+title: highlight first line
 format: html
 _quarto:
   tests:
@@ -9,6 +10,10 @@ _quarto:
     revealjs:
       ensureHtmlElements:
         - ['#cb1[data-code-line-numbers="1"]', 'pre.sourceCode.number-lines']
+        - []
+    docusaurus-md:
+      ensureFileRegexMatches:
+        - ['[`]{3}r \{1\} showLineNumbers']
         - []
 execute: 
   echo: true


### PR DESCRIPTION
because it was parsed as true.

fix #13316 

This is a scoped solution to format where providing `code-line-numbers: "1"` is expected to be a line to highlight.

Yes it will break `code-line-numbers: "1"` being interpreted as `code-line-numbers: true` in those formats. However, I don't see anyone using ``code-line-numbers: "1"`` in revealjs and expecting something else than first line to be highlighted