### PR TITLE
try out windows-2025  and macos-15 as this will be the new latest runners

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -349,7 +349,7 @@ jobs:
           quarto --version
 
   make-installer-win:
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: [configure]
 
     steps:
@@ -433,7 +433,7 @@ jobs:
           path: ./package/out/quarto-${{needs.configure.outputs.version}}-win.zip
 
   test-zip-win:
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: [configure, make-installer-win]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -481,7 +481,7 @@ jobs:
           quarto --version
 
   make-installer-mac:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: [configure]
     steps:
       - uses: actions/checkout@v4
@@ -550,7 +550,7 @@ jobs:
           security delete-keychain build.keychain
 
   test-zip-mac:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: [configure, make-installer-mac]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-quarto-latexmk.yml
+++ b/.github/workflows/test-quarto-latexmk.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: windows-latest }
+          - { os: windows-2025 }
           - { os: macOS-latest }
           - { os: ubuntu-latest }
 

--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -45,12 +45,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2025]
         time-test:
           - ${{ inputs.time-test }}
         exclude:
           # only run timed tests on Linux
-          - os: windows-latest
+          - os: windows-2025
             time-test: true
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
try out windows-2025 as this will be the new latest windows runner. GHA will use `windows-2025` as new `windows-latest`. 

- https://github.com/actions/runner-images/issues/12677

This PR is there to test that this is working as expected before they do the roll-out. 
Otherwise, we'll need to pin `windows-2022`. 