### PR TITLE
This commit fixes error when updating multiple confluence attachments

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -135,6 +135,7 @@ All changes included in 1.9:
 
 ### Confluence
 
+- ([#12558](https://github.com/quarto-dev/quarto-cli/issues/12558)): Fix 500 error when updating multiple Confluence attachments. Attachments are now uploaded sequentially instead of concurrently. (author: @fkgruber)
 - ([#13414](https://github.com/quarto-dev/quarto-cli/issues/13414)): Be more forgiving when Confluence server returns malformed JSON response. (author: @m1no)
 
 ### `gh-pages`

--- a/src/publish/confluence/confluence.ts
+++ b/src/publish/confluence/confluence.ts
@@ -435,26 +435,26 @@ async function publish(
         LogPrefix.ATTACHMENT,
       );
 
-	const uploadAttachmentsResult: unknown[] = [];
+      const uploadAttachmentsResult: unknown[] = [];
 
-	for (const att of attachmentsToUpload) {
-	    // Start exactly ONE upload by calling the helper with a single attachment
-	    const tasks = uploadAttachments(
-		publishFiles.baseDir,
-		[att],                    // <-- one at a time
-		toUpdate.id,
-		fileName,
-		existingAttachments,
-	    ) as Promise<unknown>[];    // uploadAttachments returns an array of Promises
+      for (const att of attachmentsToUpload) {
+        // Start exactly ONE upload by calling the helper with a single attachment
+        const tasks = uploadAttachments(
+          publishFiles.baseDir,
+          [att],                    // <-- one at a time
+          toUpdate.id,
+          fileName,
+          existingAttachments,
+        ) as Promise<unknown>[];    // uploadAttachments returns an array of Promises
 
-	    const res = await tasks[0];
-	    uploadAttachmentsResult.push(res);
+        const res = await tasks[0];
+        uploadAttachmentsResult.push(res);
 
-	    // short backoff (milliseconds)
-	    const t0 = performance.now();
-	    await new Promise<void>(r => setTimeout(r, 800)); // 0.8s
-	    trace("[ATTACHMENT] sleptMs", { ms: Math.round(performance.now() - t0) }, LogPrefix.ATTACHMENT);
-	}
+        // short backoff (milliseconds)
+        const t0 = performance.now();
+        await new Promise<void>(r => setTimeout(r, 800)); // 0.8s
+        trace("[ATTACHMENT] sleptMs", { ms: Math.round(performance.now() - t0) }, LogPrefix.ATTACHMENT);
+      }
       trace(
         "uploadAttachmentsResult",
         uploadAttachmentsResult,

--- a/src/publish/confluence/confluence.ts
+++ b/src/publish/confluence/confluence.ts
@@ -435,15 +435,26 @@ async function publish(
         LogPrefix.ATTACHMENT,
       );
 
-      const uploadAttachmentsResult = await Promise.all(
-        uploadAttachments(
-          publishFiles.baseDir,
-          attachmentsToUpload,
-          toUpdate.id,
-          fileName,
-          existingAttachments,
-        ),
-      );
+	const uploadAttachmentsResult: unknown[] = [];
+
+	for (const att of attachmentsToUpload) {
+	    // Start exactly ONE upload by calling the helper with a single attachment
+	    const tasks = uploadAttachments(
+		publishFiles.baseDir,
+		[att],                    // <-- one at a time
+		toUpdate.id,
+		fileName,
+		existingAttachments,
+	    ) as Promise<unknown>[];    // uploadAttachments returns an array of Promises
+
+	    const res = await tasks[0];
+	    uploadAttachmentsResult.push(res);
+
+	    // short backoff (milliseconds)
+	    const t0 = performance.now();
+	    await new Promise<void>(r => setTimeout(r, 800)); // 0.8s
+	    trace("[ATTACHMENT] sleptMs", { ms: Math.round(performance.now() - t0) }, LogPrefix.ATTACHMENT);
+	}
       trace(
         "uploadAttachmentsResult",
         uploadAttachmentsResult,

--- a/src/publish/confluence/confluence.ts
+++ b/src/publish/confluence/confluence.ts
@@ -87,6 +87,7 @@ import {
 } from "./confluence-verify.ts";
 import {
   DELETE_DISABLED,
+  ATTACHMENT_UPLOAD_DELAY_MS,
   DELETE_SLEEP_MILLIS,
   DESCENDANT_PAGE_SIZE,
   EXIT_ON_ERROR,
@@ -452,7 +453,7 @@ async function publish(
 
         // short backoff between uploads
         const t0 = performance.now();
-        await sleep(800);
+        await sleep(ATTACHMENT_UPLOAD_DELAY_MS);
         trace("[ATTACHMENT] sleptMs", { ms: Math.round(performance.now() - t0) }, LogPrefix.ATTACHMENT);
       }
       trace(

--- a/src/publish/confluence/confluence.ts
+++ b/src/publish/confluence/confluence.ts
@@ -450,9 +450,9 @@ async function publish(
         const res = await tasks[0];
         uploadAttachmentsResult.push(res);
 
-        // short backoff (milliseconds)
+        // short backoff between uploads
         const t0 = performance.now();
-        await new Promise<void>(r => setTimeout(r, 800)); // 0.8s
+        await sleep(800);
         trace("[ATTACHMENT] sleptMs", { ms: Math.round(performance.now() - t0) }, LogPrefix.ATTACHMENT);
       }
       trace(

--- a/src/publish/confluence/confluence.ts
+++ b/src/publish/confluence/confluence.ts
@@ -452,10 +452,7 @@ async function publish(
         uploadAttachmentsResult.push(res);
 
         if (i < attachmentsToUpload.length - 1) {
-          // short backoff between uploads
-          const t0 = performance.now();
           await sleep(ATTACHMENT_UPLOAD_DELAY_MS);
-          trace("[ATTACHMENT] sleptMs", { ms: Math.round(performance.now() - t0) }, LogPrefix.ATTACHMENT);
         }
       }
       trace(

--- a/src/publish/confluence/confluence.ts
+++ b/src/publish/confluence/confluence.ts
@@ -436,7 +436,7 @@ async function publish(
         LogPrefix.ATTACHMENT,
       );
 
-      const uploadAttachmentsResult: unknown[] = [];
+      const uploadAttachmentsResult: (AttachmentSummary | null)[] = [];
 
       for (let i = 0; i < attachmentsToUpload.length; i++) {
         // Start exactly ONE upload by calling the helper with a single attachment
@@ -446,7 +446,7 @@ async function publish(
           toUpdate.id,
           fileName,
           existingAttachments,
-        ) as Promise<unknown>[];    // uploadAttachments returns an array of Promises
+        );
 
         const res = await tasks[0];
         uploadAttachmentsResult.push(res);

--- a/src/publish/confluence/confluence.ts
+++ b/src/publish/confluence/confluence.ts
@@ -438,11 +438,11 @@ async function publish(
 
       const uploadAttachmentsResult: unknown[] = [];
 
-      for (const att of attachmentsToUpload) {
+      for (let i = 0; i < attachmentsToUpload.length; i++) {
         // Start exactly ONE upload by calling the helper with a single attachment
         const tasks = uploadAttachments(
           publishFiles.baseDir,
-          [att],                    // <-- one at a time
+          [attachmentsToUpload[i]],  // <-- one at a time
           toUpdate.id,
           fileName,
           existingAttachments,
@@ -451,10 +451,12 @@ async function publish(
         const res = await tasks[0];
         uploadAttachmentsResult.push(res);
 
-        // short backoff between uploads
-        const t0 = performance.now();
-        await sleep(ATTACHMENT_UPLOAD_DELAY_MS);
-        trace("[ATTACHMENT] sleptMs", { ms: Math.round(performance.now() - t0) }, LogPrefix.ATTACHMENT);
+        if (i < attachmentsToUpload.length - 1) {
+          // short backoff between uploads
+          const t0 = performance.now();
+          await sleep(ATTACHMENT_UPLOAD_DELAY_MS);
+          trace("[ATTACHMENT] sleptMs", { ms: Math.round(performance.now() - t0) }, LogPrefix.ATTACHMENT);
+        }
       }
       trace(
         "uploadAttachmentsResult",

--- a/src/publish/confluence/constants.ts
+++ b/src/publish/confluence/constants.ts
@@ -18,6 +18,9 @@ export const V2EDITOR_METADATA = {
 
 export const DELETE_SLEEP_MILLIS = 1000; //TODO replace with polling
 
+// Empirically determined delay to avoid Confluence 500 errors on concurrent attachment updates
+export const ATTACHMENT_UPLOAD_DELAY_MS = 800;
+
 export const CAN_SET_PERMISSIONS_DISABLED = "CONFLUENCE_LOCAL_STORAGE_CAN_SET_PERMISSIONS_DISABLED";
 
 export const CAN_SET_PERMISSIONS_ENABLED_CACHED = "CONFLUENCE_LOCAL_STORAGE_CAN_SET_PERMISSIONS_ENABLED_CACHED"


### PR DESCRIPTION
## Description
This PR fixes the problem described in #12558. Essentially you can't update more than 1 attachment at a time because you get a 500 error. The issue appears to be fixed if you upload attachments one at a time on a for loop with a delay im between. 

## Checklist

I have (if applicable):

- [ X] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ X] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
