### PR TITLE
typst - Remove blockquote definition leftover in template

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -19,6 +19,10 @@ All changes included in 1.9:
 
 - ([#13413](https://github.com/quarto-dev/quarto-cli/issues/13413)): Fix uncentered play button in `video` shortcodes from cross-reference divs. (author: @bruvellu)
 
+### `typst`
+
+- ([#13362](https://github.com/quarto-dev/quarto-cli/issues/13362)): Remove unused `blockquote` definitions from template.
+
 ## `publish`
 
 ### Confluence

--- a/src/resources/formats/typst/pandoc/quarto/definitions.typ
+++ b/src/resources/formats/typst/pandoc/quarto/definitions.typ
@@ -1,9 +1,4 @@
 // Some definitions presupposed by pandoc's typst output.
-#let blockquote(body) = [
-  #set text( size: 0.92em )
-  #block(inset: (left: 1.5em, top: 0.2em, bottom: 0.2em))[#body]
-]
-
 #let horizontalrule = line(start: (25%,0%), end: (75%,0%))
 
 #let endnote(num, contents) = [


### PR DESCRIPTION
it has been removed in Pandoc 3.1.10, as the writer is now using `quote()` directly.

Change done upstream at https://github.com/jgm/pandoc/commit/aa9577074357c7938c5a4a7e820bd12c90c0d32b

closes #13362