### PR TITLE
publish, connect - fix tar bundle creation using temp context

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -1,7 +1,10 @@
 All changes included in 1.9:
 
+## Regression fixes
+
+- ([#13396](https://github.com/quarto-dev/quarto-cli/issues/13396)): Fix `quarto publish connect` regression.
+
 ## Dependencies
 
 - Update `esbuild` to 0.25.10
 - Update `deno` to 2.4.5
-

--- a/src/deno_ral/tar.ts
+++ b/src/deno_ral/tar.ts
@@ -6,36 +6,46 @@
  * Abstraction layer over Deno's `tar` utilities.
  */
 
-import { TarStream, type TarStreamInput } from "jsr:@std/tar/tar-stream";
+import { TarStream, type TarStreamInput } from "tar/tar-stream";
+import { join } from "../deno_ral/path.ts";
 
 /**
  * Creates a tar archive from the specified files and directories.
  * @param outputPath The path where the tar archive will be created.
- * @param filePaths An array of file and directory paths to include in the tar archive. Paths are relative to outputPath.
+ * @param filePaths An array of file and directory paths to include in the tar archive.
+ * @param options Optional configuration for tar creation.
+ * @param options.baseDir Base directory for resolving relative paths in the archive.
  * @returns A promise that resolves when the tar archive is created.
  */
 export async function createTarFromFiles(
   outputPath: string,
   filePaths: string[],
+  options?: { baseDir?: string },
 ) {
+  const baseDir = options?.baseDir;
+
   // Create array of TarStreamInput objects from file paths
   const inputs: TarStreamInput[] = await Promise.all(
     filePaths.map(async (path) => {
-      const stat = await Deno.stat(path);
+      const fullPath = baseDir ? join(baseDir, path) : path;
+      const stat = await Deno.stat(fullPath);
+
+      // Use original path for archive, full path for reading
+      const archivePath = path;
 
       if (stat.isDirectory) {
         // Handle directory
         return {
           type: "directory",
-          path: path + (path.endsWith("/") ? "" : "/"),
+          path: archivePath + (archivePath.endsWith("/") ? "" : "/"),
         };
       } else {
         // Handle file
         return {
           type: "file",
-          path: path,
+          path: archivePath,
           size: stat.size,
-          readable: (await Deno.open(path)).readable,
+          readable: (await Deno.open(fullPath)).readable,
         };
       }
     }),

--- a/src/deno_ral/tar.ts
+++ b/src/deno_ral/tar.ts
@@ -8,6 +8,7 @@
 
 import { TarStream, type TarStreamInput } from "tar/tar-stream";
 import { join } from "../deno_ral/path.ts";
+import { pathWithForwardSlashes } from "../core/path.ts";
 
 /**
  * Creates a tar archive from the specified files and directories.
@@ -31,7 +32,7 @@ export async function createTarFromFiles(
       const stat = await Deno.stat(fullPath);
 
       // Use original path for archive, full path for reading
-      const archivePath = path;
+      const archivePath = pathWithForwardSlashes(path);
 
       if (stat.isDirectory) {
         // Handle directory

--- a/src/publish/common/bundle.ts
+++ b/src/publish/common/bundle.ts
@@ -10,10 +10,7 @@ import { ensureDirSync } from "../../deno_ral/fs.ts";
 import { PublishFiles } from "../provider-types.ts";
 import { TempContext } from "../../core/temp-types.ts";
 import { md5HashBytes } from "../../core/hash.ts";
-import { pathWithForwardSlashes } from "../../core/path.ts";
 
-import { copy } from "io/copy";
-import { TarStream, type TarStreamInput } from "tar/tar-stream";
 import { createTarFromFiles } from "../../deno_ral/tar.ts";
 
 interface ManifestMetadata {
@@ -110,7 +107,7 @@ export async function createBundle(
   // await copy(tar.getReader(), writer);
   // writer.close();
 
-  await createTarFromFiles(tarFile, tarFiles);
+  await createTarFromFiles(tarFile, tarFiles, { baseDir: stageDir });
 
   // compress to tar.gz
   const targzFile = `${tarFile}.gz`;


### PR DESCRIPTION
This PR fix the tar creation in bundle for connect. 

The new function was not correctly handling filepaths, as the output tar is not in a relative place compared to the file to include, and also the tar creation command needs to be run in the same place as the file itself to be found

So now full path is used for files to include