### PR TITLE
Chore/1.9 dependency refresh

### DIFF
--- a/configuration
+++ b/configuration
@@ -16,7 +16,7 @@ export DENO=v2.3.1
 export DENO_DOM=v0.1.41-alpha-artifacts
 export PANDOC=3.6.3
 export DARTSASS=1.87.0
-export ESBUILD=0.25.3
+export ESBUILD=0.25.10
 export TYPST=0.13.0
 
 

--- a/configuration
+++ b/configuration
@@ -11,7 +11,7 @@
 # in src/command/check/check.ts
 
 # Binary dependencies
-export DENO=v2.3.1
+export DENO=v2.4.5
 # TODO figure out where 0.1.41 apple silicon libs are available
 export DENO_DOM=v0.1.41-alpha-artifacts
 export PANDOC=3.6.3

--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -3,4 +3,5 @@ All changes included in 1.9:
 ## Dependencies
 
 - Update `esbuild` to 0.25.10
+- Update `deno` to 2.4.5
 

--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -1,3 +1,6 @@
 All changes included in 1.9:
 
+## Dependencies
+
+- Update `esbuild` to 0.25.10
 


### PR DESCRIPTION
Currently, this bumps

- esbuild to latest
- deno to 2.4.5 (not 2.5+ because of typed array changes that break the LSP. Until homebrew offers 2.5, we're holding it back)