### PR TITLE
Center big play button in video divs

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -8,3 +8,9 @@ All changes included in 1.9:
 
 - Update `esbuild` to 0.25.10
 - Update `deno` to 2.4.5
+
+## Formats
+
+### `html`
+
+- ([#13413](https://github.com/quarto-dev/quarto-cli/issues/13413)): Fix uncentered play button in videos from cross-reference divs.

--- a/src/resources/extensions/quarto/video/video.lua
+++ b/src/resources/extensions/quarto/video/video.lua
@@ -160,7 +160,7 @@ local videoJSBuilder = function(params)
   VIDEO_SHORTCODE_NUM_VIDEOJS = VIDEO_SHORTCODE_NUM_VIDEOJS + 1
   local id = "video_shortcode_videojs_video" .. VIDEO_SHORTCODE_NUM_VIDEOJS
 
-  local SNIPPET = [[<video id="{id}"{width}{height} class="video-js vjs-default-skin {fluid}" controls preload="auto" data-setup='{}' title="{title}"><source src="{src}"></video>]]
+  local SNIPPET = [[<video id="{id}"{width}{height} class="video-js vjs-default-skin vjs-big-play-centered {fluid}" controls preload="auto" data-setup='{}' title="{title}"><source src="{src}"></video>]]
   local snippet = params.snippet or SNIPPET
   snippet = replaceCommonAttributes(snippet, params)
   snippet = interpolate {


### PR DESCRIPTION
## Description

This PR fixes the uncentered play button in videos rendered from cross-reference divs by adding a missing style class.

Addresses #13411.

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
