### PR TITLE
bugfix: minimal: true would assert when combined with brand

### DIFF
--- a/src/command/render/pandoc-html.ts
+++ b/src/command/render/pandoc-html.ts
@@ -325,11 +325,11 @@ export async function resolveSassBundles(
       "dark",
       defaultStyle,
     );
-    if (defaultStyle === "light") {
+    if (defaultStyle === "light" && lightEntry) {
       const dep2 = extras.html?.[kDependencies]?.find((extraDep) =>
         extraDep.name === kQuartoHtmlDependency
       );
-      assert(dep2?.stylesheets && lightEntry);
+      assert(dep2?.stylesheets);
       dep2.stylesheets.push({
         ...lightEntry,
         attribs: {

--- a/tests/docs/smoke-all/brand/minimal-brand.qmd
+++ b/tests/docs/smoke-all/brand/minimal-brand.qmd
@@ -1,0 +1,11 @@
+---
+title: "Reproducible Quarto Document"
+format:
+  html:
+    minimal: true
+brand:
+  color:
+    background: '#cfc'
+---
+
+This is minimal


### PR DESCRIPTION
fixes #13383

v1.7 introduced this code implementing the light, dark, light stylesheet trick for syntax highlighting css.

it should not try to do this if there are no stylesheets!

we did not see the bug trigger until v1.8 which treats brand data as possibly implementing both light and dark
decided when we see theme

PR for CI; want to investigate a little further whether this means we're passing around  `hasDark` / `hasDarkStyles` that are always true.