### PR TITLE
Switch to released 0.17.4 version of QuartoNotebookRunner

### DIFF
--- a/src/resources/julia/Project.toml
+++ b/src/resources/julia/Project.toml
@@ -1,8 +1,5 @@
 [deps]
 QuartoNotebookRunner = "4c0109c6-14e9-4c88-93f0-2b974d3468f4"
 
-# [compat]
-# QuartoNotebookRunner = "=0.17.3"
-
-[sources]
-QuartoNotebookRunner = {url = "https://github.com/PumasAI/QuartoNotebookRunner.jl", rev = "jk/source-ranges"}
+[compat]
+QuartoNotebookRunner = "=0.17.4"


### PR DESCRIPTION
Fixes the use of a dev branch of QuartoNotebookRunner introduced via the early merge of https://github.com/quarto-dev/quarto-cli/pull/13401