### PR TITLE
restore 1.7 behavior on invalid exception percolating

### DIFF
--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -7,6 +7,7 @@ All changes included in 1.8:
 - ([#12657](https://github.com/quarto-dev/quarto-cli/pull/12657)): Load Giscus in generated script tag, to avoid wrong-theming in Chrome.
 - ([#12780](https://github.com/quarto-dev/quarto-cli/issues/12780)): `keep-ipynb: true` now works again correctly and intermediate `.quarto_ipynb` is not removed.
 - ([#13051](https://github.com/quarto-dev/quarto-cli/issues/13051)): Fixed support for captioned Markdown table inside Div syntax for crossref. This is special handling, but this could be output by function like `knitr::kable()` with old option support.
+- ([#13441](https://github.com/quarto-dev/quarto-cli/pull/13441)): Catch `undefined` exceptions in Pandoc failure to avoid spurious error message.
 
 ## Backwards-compatibility breaking changes
 

--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -7,7 +7,6 @@ All changes included in 1.8:
 - ([#12657](https://github.com/quarto-dev/quarto-cli/pull/12657)): Load Giscus in generated script tag, to avoid wrong-theming in Chrome.
 - ([#12780](https://github.com/quarto-dev/quarto-cli/issues/12780)): `keep-ipynb: true` now works again correctly and intermediate `.quarto_ipynb` is not removed.
 - ([#13051](https://github.com/quarto-dev/quarto-cli/issues/13051)): Fixed support for captioned Markdown table inside Div syntax for crossref. This is special handling, but this could be output by function like `knitr::kable()` with old option support.
-- ([#13441](https://github.com/quarto-dev/quarto-cli/pull/13441)): Catch `undefined` exceptions in Pandoc failure to avoid spurious error message.
 
 ## Backwards-compatibility breaking changes
 

--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -3,6 +3,7 @@ All changes included in 1.9:
 ## Regression fixes
 
 - ([#13396](https://github.com/quarto-dev/quarto-cli/issues/13396)): Fix `quarto publish connect` regression.
+- ([#13441](https://github.com/quarto-dev/quarto-cli/pull/13441)): Catch `undefined` exceptions in Pandoc failure to avoid spurious error message.
 
 ## Dependencies
 

--- a/src/command/render/render-files.ts
+++ b/src/command/render/render-files.ts
@@ -351,13 +351,9 @@ export async function renderFiles(
 
     return await pandocRenderer.onComplete(false, options.flags?.quiet);
   } catch (error) {
-    if (!(error instanceof Error)) {
-      warn("Should not have arrived here:", error);
-      throw error;
-    }
     return {
       files: (await pandocRenderer.onComplete(true)).files,
-      error: error || new Error(),
+      error: error instanceof Error ? error : new Error(),
     };
   } finally {
     tempContext.cleanup();
@@ -408,13 +404,9 @@ export async function renderFile(
     }
     return await pandocRenderer.onComplete(false, options.flags?.quiet);
   } catch (error) {
-    if (!(error instanceof Error)) {
-      warn("Should not have arrived here:", error);
-      throw error;
-    }
     return {
       files: (await pandocRenderer.onComplete(true)).files,
-      error: error || new Error(),
+      error: error instanceof Error ? error : new Error(),
     };
   } finally {
     if (Deno.env.get("QUARTO_PROFILER_OUTPUT")) {

--- a/src/command/render/render-files.ts
+++ b/src/command/render/render-files.ts
@@ -351,9 +351,14 @@ export async function renderFiles(
 
     return await pandocRenderer.onComplete(false, options.flags?.quiet);
   } catch (error) {
+    if (!(error instanceof Error)) {
+      warn(`Error encountered when rendering files`);
+    }
     return {
       files: (await pandocRenderer.onComplete(true)).files,
-      error: error instanceof Error ? error : new Error(),
+      error: error instanceof Error
+        ? error
+        : new Error(error ? String(error) : undefined),
     };
   } finally {
     tempContext.cleanup();
@@ -404,9 +409,14 @@ export async function renderFile(
     }
     return await pandocRenderer.onComplete(false, options.flags?.quiet);
   } catch (error) {
+    if (!(error instanceof Error)) {
+      warn(`Error encountered when rendering ${file.path}`);
+    }
     return {
       files: (await pandocRenderer.onComplete(true)).files,
-      error: error instanceof Error ? error : new Error(),
+      error: error instanceof Error
+        ? error
+        : new Error(error ? String(error) : undefined),
     };
   } finally {
     if (Deno.env.get("QUARTO_PROFILER_OUTPUT")) {


### PR DESCRIPTION
I _think_ this might solve some of the weirdness/hard-to-replicate bugs we're seeing in `quarto preview` in 1.8.