### PR TITLE
leave search terms highlighted if user scrolls

### DIFF
--- a/src/resources/projects/website/search/quarto-search.js
+++ b/src/resources/projects/website/search/quarto-search.js
@@ -63,18 +63,6 @@ window.document.addEventListener("DOMContentLoaded", function (_event) {
     }
   };
 
-  // Clear search highlighting when the user scrolls sufficiently
-  const resetFn = () => {
-    resetHighlighting("");
-    window.removeEventListener("quarto-hrChanged", resetFn);
-    window.removeEventListener("quarto-sectionChanged", resetFn);
-  };
-
-  // Register this event after the initial scrolling and settling of events
-  // on the page
-  window.addEventListener("quarto-hrChanged", resetFn);
-  window.addEventListener("quarto-sectionChanged", resetFn);
-
   // Responsively switch to overlay mode if the search is present on the navbar
   // Note that switching the sidebar to overlay mode requires more coordinate (not just
   // the media query since we generate different HTML for sidebar overlays than we do


### PR DESCRIPTION
Welcome to the quarto GitHub repo!

We are always happy to hear feedback from our users.

To file a _pull request_, please follow these instructions carefully: <https://yihui.org/issue/#bug-reports>

If you're a collaborator from outside `quarto-dev` making changes larger than a typo, please make sure you have filed an [individual](https://posit.co/wp-content/uploads/2023/04/2023-03-13_TC_Indiv_contrib_agreement.pdf) or [corporate](https://posit.co/wp-content/uploads/2023/04/2023-03-13_TC_Corp_contrib_agreement.pdf) contributor agreement. You can send the signed copy to <jj@rstudio.com>.

Also, please complete and keep the checklist below.

## Description

Currently search term highlighting is completely broken and has been for quite some time: 
https://github.com/quarto-dev/quarto-cli/issues/9802

This pull request fixes the problem by not bothering to clear the highlights just because the user scrolled the page. There might be a number of places on the screen or page that contain the search term, and they should all remain highlighted as the user scrolls. And if anybody disagrees, I would only say that it is better for them to remain highlighted than to never be highlighted at all. :)

## Checklist

I have (if applicable):

- [ x ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ x ] referenced the GitHub issue this PR closes
- [ x ] updated the appropriate changelog in the PR
- [ x ] ensured the present test suite passes
- [  ] added new tests
- [ N/A - bug fix ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
