### PR TITLE
brand logo shortcode: don't add class if variant specified

### DIFF
--- a/src/resources/filters/quarto-pre/shortcodes-handlers.lua
+++ b/src/resources/filters/quarto-pre/shortcodes-handlers.lua
@@ -174,12 +174,14 @@ function initShortcodeHandlers()
       end
       local images = {}
       if lightLogo then
+        local classes = brandMode == 'both' and {"light-content"} or {}
         table.insert(images, pandoc.Image(pandoc.Inlines {}, add_leading_slash(lightLogo.path), "",
-          pandoc.Attr("", {"light-content"}, {alt = lightLogo.alt})))
+          pandoc.Attr("", classes, {alt = lightLogo.alt})))
       end
       if darkLogo then
+        local classes = brandMode == 'both' and {"dark-content"} or {}
         table.insert(images, pandoc.Image(pandoc.Inlines {}, add_leading_slash(darkLogo.path), "",
-          pandoc.Attr("", {"dark-content"}, {alt = darkLogo.alt})))
+          pandoc.Attr("", classes, {alt = darkLogo.alt})))
       end
       if context == "block" then
         return pandoc.Blocks(images)

--- a/tests/docs/smoke-all/shortcodes/brand-logo-dark.qmd
+++ b/tests/docs/smoke-all/shortcodes/brand-logo-dark.qmd
@@ -13,7 +13,7 @@ _quarto:
     html:
       ensureFileRegexMatches:
         -
-          - '<img src="\.(/|\\)moon\.png" class="dark-content.*>'
+          - '<img src="\.(/|\\)moon\.png" class="img-fluid.*>'
         - []
 ---
 

--- a/tests/docs/smoke-all/shortcodes/brand-logo-fallback-light.qmd
+++ b/tests/docs/smoke-all/shortcodes/brand-logo-fallback-light.qmd
@@ -6,26 +6,20 @@ brand:
     logo:
       small: dark-logo.png
       medium: dark-medium-logo.png
-      # No light logo specified
+      large: dark-large-logo.png
 _quarto:
   tests:
     html:
       ensureFileRegexMatches:
         - 
-          # When requesting dark mode explicitly, should get dark logo
-          - '<img src="\.(/|\\)dark-logo\.png" class="dark-content.*>'
-          # When requesting light mode explicitly (which doesn't exist), should fall back to dark logo but with light-content class
-          - '<img src="\.(/|\\)dark-logo\.png" class="light-content.*>'
-          # When requesting medium size with light mode (doesn't exist), should fall back to dark-medium with light-content class
-          - '<img src="\.(/|\\)dark-medium-logo\.png" class="light-content.*>'
+          - '<img src="\.(/|\\)dark-logo\.png" class="img-fluid.*>'
+          - '<img src="\.(/|\\)dark-medium-logo\.png" class="img-fluid.*>'
+          - '<img src="\.(/|\\)dark-large-logo\.png" class="img-fluid.*>'
         - []
 ---
 
-### Dark Logo (Dark Mode)
 {{< brand logo small dark >}}
 
-### Dark Logo (Light Mode - should fall back)
-{{< brand logo small light >}}
-
-### Medium Logo (Light Mode - should fall back)
 {{< brand logo medium light >}}
+
+{{< brand logo large light >}}

--- a/tests/docs/smoke-all/shortcodes/brand-logo-fallback.qmd
+++ b/tests/docs/smoke-all/shortcodes/brand-logo-fallback.qmd
@@ -6,26 +6,20 @@ brand:
     logo:
       small: light-logo.png
       medium: light-medium-logo.png
-      # No dark logo specified
+      large: light-large-logo.png
 _quarto:
   tests:
     html:
       ensureFileRegexMatches:
         - 
-          # When requesting light mode explicitly, should get light logo
-          - '<img src="\.(/|\\)light-logo\.png" class="light-content.*>'
-          # When requesting dark mode explicitly (which doesn't exist), should fall back to light logo but with dark-content class
-          - '<img src="\.(/|\\)light-logo\.png" class="dark-content.*>'
-          # When requesting medium size with dark mode (doesn't exist), should fall back to light-medium with dark-content class
-          - '<img src="\.(/|\\)light-medium-logo\.png" class="dark-content.*>'
+          - '<img src="\.(/|\\)light-logo\.png" class="img-fluid.*>'
+          - '<img src="\.(/|\\)light-medium-logo\.png" class="img-fluid.*>'
+          - '<img src="\.(/|\\)light-large-logo\.png" class="img-fluid.*>'
         - []
 ---
 
-### Light Logo (Light Mode)
 {{< brand logo small light >}}
 
-### Light Logo (Dark Mode - should fall back)
-{{< brand logo small dark >}}
-
-### Medium Logo (Dark Mode - should fall back)
 {{< brand logo medium dark >}}
+
+{{< brand logo large dark >}}

--- a/tests/docs/smoke-all/shortcodes/brand-logo-light.qmd
+++ b/tests/docs/smoke-all/shortcodes/brand-logo-light.qmd
@@ -13,7 +13,7 @@ _quarto:
     html:
       ensureFileRegexMatches:
         -
-          - '<img src="\.(/|\\)sun\.png" class="light-content.*>'
+          - '<img src="\.(/|\\)sun\.png" class="img-fluid.*>'
         - []
 ---
 


### PR DESCRIPTION
It's a potential footgun to emit an unpaired image with only one of `.light-content`, `.dark-content` and anyone who wants that can build it themself.

Will follow up with backport and changelog.