### PR TITLE
heading-family should default to mainfont in typst-brand-yaml.lua

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -23,6 +23,7 @@ All changes included in 1.9:
 ### `typst`
 
 - ([#13362](https://github.com/quarto-dev/quarto-cli/issues/13362)): Remove unused `blockquote` definitions from template.
+- ([#13474](https://github.com/quarto-dev/quarto-cli/issues/13474)): Heading font for title should default to `mainfont`.
 
 ## `publish`
 

--- a/src/resources/filters/quarto-post/typst-brand-yaml.lua
+++ b/src/resources/filters/quarto-post/typst-brand-yaml.lua
@@ -329,7 +329,9 @@ function render_typst_brand_yaml()
       end
       meta.brand.typography = meta.brand.typography or {}
       local base = _quarto.modules.brand.get_typography(brandMode, 'base')
-      if base and next(base) then
+      if base and next(base) or meta['mainfont'] then
+        if not base then base = {} end
+        if meta['mainfont'] then base.family = inlinesToString(meta['mainfont']) end
         meta.brand.typography.base = {
           family = base.family and pandoc.RawInline('typst', _quarto.modules.typst.css.translate_font_family_list(base.family)),
           size = base.size,

--- a/src/resources/formats/typst/pandoc/quarto/typst-show.typ
+++ b/src/resources/formats/typst/pandoc/quarto/typst-show.typ
@@ -29,9 +29,7 @@ $if(abstract)$
   abstract: [$abstract$],
   abstract-title: "$labels.abstract$",
 $endif$
-$if(mainfont)$
-  font: ("$mainfont$",),
-$elseif(brand.typography.base.family)$
+$if(brand.typography.base.family)$
   font: $brand.typography.base.family$,
 $endif$
 $if(fontsize)$

--- a/tests/docs/smoke-all/typst/brand-yaml/typography/basefont-typst.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/typography/basefont-typst.qmd
@@ -1,0 +1,22 @@
+---
+title: "Header logic"
+format:
+  typst:
+    keep-typ: true
+brand:
+  typography:
+    base:
+      family: Comic Sans MS
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+      -
+        - 'heading-family: \("Comic Sans MS",\)'
+---
+
+Some text.
+
+# Header logic so we have the same letters
+
+More text.

--- a/tests/docs/smoke-all/typst/brand-yaml/typography/mainfont-typst.qmd
+++ b/tests/docs/smoke-all/typst/brand-yaml/typography/mainfont-typst.qmd
@@ -1,0 +1,19 @@
+---
+title: "Header logic"
+format:
+  typst:
+    keep-typ: true
+mainfont: Comic Sans MS
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+      -
+        - 'heading-family: \("Comic Sans MS",\)'
+---
+
+Some text.
+
+# Header logic so we have the same letters
+
+More text.


### PR DESCRIPTION
fixes
* #13474

Alternative PR to #13475.

A simpler approach, but one that diverges further from the Pandoc `default.typst`.

Process `mainfont` as if it sets `brand.typography.base.family`.

I think this is cleaner and safer, and doesn't have any questions of precedence.

But I'll sleep on it before merging this or the other one.