### PR TITLE
Correctly check for sidebar.logo in EJS template 

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -5,6 +5,7 @@ All changes included in 1.9:
 - ([#13396](https://github.com/quarto-dev/quarto-cli/issues/13396)): Fix `quarto publish connect` regression.
 - ([#13441](https://github.com/quarto-dev/quarto-cli/pull/13441)): Catch `undefined` exceptions in Pandoc failure to avoid spurious error message.
 - ([#13046](https://github.com/quarto-dev/quarto-cli/issues/13046)): Use new url for multiplex socket.io server <https://multiplex.up.railway.app/> as default for `format: revealjs` and `revealjs.multiplex: true`.
+- ([#13506](https://github.com/quarto-dev/quarto-cli/issues/13506)): Fix navbar active state detection when sidebar has no logo configured. Prevents empty logo links from interfering with navigation highlighting.
 
 ## Dependencies
 

--- a/src/core/brand/brand.ts
+++ b/src/core/brand/brand.ts
@@ -344,9 +344,14 @@ export function resolveLogo(
     return logo;
   };
   if (!spec) {
+    const lightLogo = findLogo("light", order);
+    const darkLogo = findLogo("dark", order);
+    if (!lightLogo && !darkLogo) {
+      return undefined;
+    }
     return {
-      light: findLogo("light", order) || findLogo("dark", order),
-      dark: findLogo("dark", order) || findLogo("light", order),
+      light: lightLogo || darkLogo,
+      dark: darkLogo || lightLogo,
     };
   }
   if (typeof spec === "string") {

--- a/src/project/types/website/website-navigation.ts
+++ b/src/project/types/website/website-navigation.ts
@@ -559,7 +559,8 @@ function navigationHtmlPostprocessor(
       const navLinkHref = navLink.getAttribute("href");
 
       const sidebarLink = doc.querySelector(
-        '.sidebar-navigation a[href="' + navLinkHref + '"]',
+        '.sidebar-navigation a[href="' + navLinkHref +
+          '"]:not(.sidebar-logo-link)',
       );
       // if the link is either for the current window href or appears on the
       // sidebar then set it to active

--- a/src/resources/filters/quarto-post/typst-brand-yaml.lua
+++ b/src/resources/filters/quarto-post/typst-brand-yaml.lua
@@ -251,7 +251,7 @@ function render_typst_brand_yaml()
       end
       -- logo
       local logo = param('logo')
-      if not next(logo) then
+      if logo and not next(logo) then
         meta.logo = nil
       end
       local logoOptions = {}

--- a/src/resources/projects/website/templates/sidebar.ejs
+++ b/src/resources/projects/website/templates/sidebar.ejs
@@ -19,13 +19,11 @@
     // may be displayed in different locations, so this will determine where to display the tools
     // "logo", "title", "search", "fallthrough"
 
-    let hasLogo = sidebar.logo.light || sidebar.logo.dark;
-
     let toolsLocation;
     // Under the title if that will be displayed
     if (sidebar.title && !navbar) {
       toolsLocation = "title";
-    } else if (sidebar.logo.light || sidebar.logo.dark) {
+    } else if (sidebar.logo) {
       toolsLocation = "logo";
     } else if (sidebar.search && sidebar.search !== "overlay") {
       toolsLocation = "search";
@@ -34,9 +32,9 @@
     }
   %>
     
-  <% if (hasLogo || (sidebar.title && !navbar)) { %>
-    <div class="pt-lg-2 mt-2 <%= alignCss %> sidebar-header<%= hasLogo && sidebar.title ? ' sidebar-header-stacked' : '' %>">
-    <% if (hasLogo) { %>
+  <% if (sidebar.logo || (sidebar.title && !navbar)) { %>
+    <div class="pt-lg-2 mt-2 <%= alignCss %> sidebar-header<%= sidebar.logo && sidebar.title ? ' sidebar-header-stacked' : '' %>">
+    <% if (sidebar.logo) { %>
       <a href="<%- sidebar['logo-href'] || '/index.html' %>" class="sidebar-logo-link">
       <% if (sidebar.logo.light) { %>
       <img src="<%- sidebar.logo.light.path %>" alt="<%- sidebar.logo.light.alt || '' %>" class="sidebar-logo light-content py-0 d-lg-inline d-none"/>

--- a/src/resources/projects/website/templates/sidebar.ejs
+++ b/src/resources/projects/website/templates/sidebar.ejs
@@ -19,11 +19,13 @@
     // may be displayed in different locations, so this will determine where to display the tools
     // "logo", "title", "search", "fallthrough"
 
+    let hasLogo = sidebar.logo.light || sidebar.logo.dark;
+
     let toolsLocation;
     // Under the title if that will be displayed
     if (sidebar.title && !navbar) {
       toolsLocation = "title";
-    } else if (sidebar.logo) {
+    } else if (sidebar.logo.light || sidebar.logo.dark) {
       toolsLocation = "logo";
     } else if (sidebar.search && sidebar.search !== "overlay") {
       toolsLocation = "search";
@@ -32,9 +34,9 @@
     }
   %>
     
-  <% if (sidebar.logo || (sidebar.title && !navbar)) { %>
-    <div class="pt-lg-2 mt-2 <%= alignCss %> sidebar-header<%= sidebar.logo && sidebar.title ? ' sidebar-header-stacked' : '' %>">
-    <% if (sidebar.logo) { %>
+  <% if (hasLogo || (sidebar.title && !navbar)) { %>
+    <div class="pt-lg-2 mt-2 <%= alignCss %> sidebar-header<%= hasLogo && sidebar.title ? ' sidebar-header-stacked' : '' %>">
+    <% if (hasLogo) { %>
       <a href="<%- sidebar['logo-href'] || '/index.html' %>" class="sidebar-logo-link">
       <% if (sidebar.logo.light) { %>
       <img src="<%- sidebar.logo.light.path %>" alt="<%- sidebar.logo.light.alt || '' %>" class="sidebar-logo light-content py-0 d-lg-inline d-none"/>

--- a/tests/docs/smoke-all/website-sidebar/issue-13506-no-logo/.gitignore
+++ b/tests/docs/smoke-all/website-sidebar/issue-13506-no-logo/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/tests/docs/smoke-all/website-sidebar/issue-13506-no-logo/_quarto.yml
+++ b/tests/docs/smoke-all/website-sidebar/issue-13506-no-logo/_quarto.yml
@@ -1,0 +1,22 @@
+project:
+  type: website
+
+website:
+  title: "Issue 13506 - No Logo"
+  navbar:
+    left:
+      - text: "Section A"
+        href: index.qmd
+      - text: "Section B"
+        href: page2.qmd
+  sidebar:
+    - title: "Section A"
+      contents:
+        - index.qmd
+    - title: "Section B"
+      contents:
+        - page2.qmd
+
+format:
+  html:
+    theme: cosmo

--- a/tests/docs/smoke-all/website-sidebar/issue-13506-no-logo/index.qmd
+++ b/tests/docs/smoke-all/website-sidebar/issue-13506-no-logo/index.qmd
@@ -1,0 +1,24 @@
+---
+title: "Section A"
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        -
+          - 'nav.navbar a.nav-link[href$="index.html"].active'
+          - 'nav.navbar a.nav-link[href$="page2.html"]:not(.active)'
+        -
+          - 'a.sidebar-logo-link'
+---
+
+## Section A
+
+This is Section A. When NO logo is configured in the sidebar, the navbar active
+state should work correctly. The "Section A" navbar item should be active on this page.
+
+The bug (issue #13506): After PR #12996, `sidebar.logo` was normalized to
+`{light: undefined, dark: undefined}`, making `if(sidebar.logo)` always true.
+This created empty `<a class="sidebar-logo-link">` elements that interfered with
+the navbar active state detection logic.
+
+See also: [Section B](page2.qmd)

--- a/tests/docs/smoke-all/website-sidebar/issue-13506-no-logo/page2.qmd
+++ b/tests/docs/smoke-all/website-sidebar/issue-13506-no-logo/page2.qmd
@@ -1,0 +1,20 @@
+---
+title: "Section B"
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        -
+          - 'nav.navbar a.nav-link[href$="page2.html"].active'
+          - 'nav.navbar a.nav-link[href$="index.html"]:not(.active)'
+        -
+          - 'a.sidebar-logo-link'
+---
+
+## Section B
+
+This is Section B. The "Section B" navbar item should be active on this page,
+demonstrating that the navbar active state detection works correctly without
+empty logo links interfering.
+
+See also: [Section A](index.qmd)


### PR DESCRIPTION
sidebar.logo is now normalized as an object with light and dark properties

So `sidebar.logo` is never undefined - it may have light or dark undefined, but the object itself exists.

fix #13506 


