### PR TITLE
chore(issue-template): add id for description to allow URL query

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -29,6 +29,7 @@ body:
       required: true
 
   - type: textarea
+    id: description
     attributes:
       label: Description
       description: Describe the issue, give feedback or suggest an improvement.


### PR DESCRIPTION
This pull request introduces a small improvement to the documentation issue template by adding the missing `id` field for the description text area.

Related to #13530 discussion

(The "bug report" issue template does not have all the IDs but not sure it's a good idea to allow filling those from URL query)