### PR TITLE
fenced div syntax for `Feature/list tables`

### DIFF
--- a/tests/docs/crossrefs/tables.qmd
+++ b/tests/docs/crossrefs/tables.qmd
@@ -1,5 +1,11 @@
 ---
 title: Table Crossref Test
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - []
+        - []
 ---
 
 ## Simple Crossref Table

--- a/tests/docs/smoke-all/crossrefs/tables/simple.qmd
+++ b/tests/docs/smoke-all/crossrefs/tables/simple.qmd
@@ -1,0 +1,86 @@
+---
+title: Table Crossref Test
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - - "div#tbl-list table"
+          - "div#tbl-list-2 table"
+          - "div#tbl-letters table"
+          - "div#tbl-panel table"
+          - "div#tbl-first table"
+          - "div#tbl-second table"
+        - []
+---
+
+## Simple Crossref Table
+
+| Col1 | Col2 | Col3 |
+|------|------|------|
+| A    | B    | C    |
+| E    | F    | G    |
+| A    | G    | G    |
+
+: My Caption {#tbl-letters}
+
+See @tbl-letters.
+
+## Sub tables
+
+::: {#tbl-panel layout-ncol=2}
+| Col1 | Col2 | Col3 |
+|------|------|------|
+| A    | B    | C    |
+| E    | F    | G    |
+| A    | G    | G    |
+
+: First Table {#tbl-first}
+
+| Col1 | Col2 | Col3 |
+|------|------|------|
+| A    | B    | C    |
+| E    | F    | G    |
+| A    | G    | G    |
+
+: Second Table {#tbl-second}
+
+Main Caption
+:::
+
+See @tbl-panel for details, especially @tbl-second.
+
+## List tables
+
+::: {#tbl-list .list-table}
+
+This is a table caption. {tbl-colwidths=[20,40,40]}
+
+* - Row 1, Col 1
+  - Row 1, Col 2
+  - Row 1, Col 3
+
+* - Row 2, Col 1
+  - Row 2, Col 2
+  - Row 2, Col 3
+
+:::
+
+see @tbl-list.
+
+Quarto syntax extension for `list-tables`: table ordering compatible with fenced-div crossrefs.
+
+::: {#tbl-list-2 .list-table}
+
+* - Row 1, Col 1
+  - Row 1, Col 2
+  - Row 1, Col 3
+
+* - Row 2, Col 1
+  - Row 2, Col 2
+  - Row 2, Col 3
+
+This is a table caption. {tbl-colwidths=[20,40,40]}
+
+:::
+
+See @tbl-list-2.

--- a/tests/docs/smoke-all/table/list_table.qmd
+++ b/tests/docs/smoke-all/table/list_table.qmd
@@ -4,7 +4,9 @@ _quarto:
   tests:
     html:
       ensureHtmlElements:
-        - ["table"]
+        - - "table"
+          - "div#fig-list-table table" # fenced div syntax using a different prefix
+          - "div#tbl-list-table-2 table"   # fenced div syntax inside list-table (ie, captions last)
         - ["div.list-table"]
 ---
 
@@ -57,3 +59,40 @@ _quarto:
     * `QUARTO_LOG_FORMAT` is the same as using `--log-format` at command line. It is used to set the format for the log. Possible values are `plain` (default) and `json-stream`.
 
 :::
+
+
+::: {#fig-list-table}
+
+::: {.list-table widths="0.2,0.4,0.4"}
+
+* - Row 1, Col 1
+  - Row 1, Col 2
+  - Row 1, Col 3
+
+* - Row 2, Col 1
+  - Row 2, Col 2
+  - Row 2, Col 3
+
+:::
+
+A caption.
+
+:::
+
+see @fig-list-table.
+
+::: {#tbl-list-table-2 .list-table}
+
+* - Row 1, Col 1
+  - Row 1, Col 2
+  - Row 1, Col 3
+
+* - Row 2, Col 1
+  - Row 2, Col 2
+  - Row 2, Col 3
+
+This has a caption. {tbl-colwidths=[20,40,40]}
+
+:::
+
+see @tbl-list-table-2.


### PR DESCRIPTION
This adds a slight syntax extension to list tables, allowing the caption to appear after the list. This syntax looks a lot closer to Quarto's fenced div syntax for floats.