### PR TITLE
Restrict cloudsmith publishing to 'open' repo only

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -784,7 +784,7 @@ jobs:
       matrix:
         arch: [x86_64, aarch64]
         format: [deb, rpm]
-        repo: [open, pro]
+        repo: [open]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Only publish to open for now