### PR TITLE
[backport] Fix issue with active nav state when no logo in sidebar

### DIFF
--- a/news/changelog-1.8.md
+++ b/news/changelog-1.8.md
@@ -3,6 +3,7 @@
 ## In this release
 
 - ([#13046](https://github.com/quarto-dev/quarto-cli/issues/13046)): Use new url for multiplex socket.io server <https://multiplex.up.railway.app/> as default for `format: revealjs` and `revealjs.multiplex: true`.
+- ([#13506](https://github.com/quarto-dev/quarto-cli/issues/13506)): Fix navbar active state detection when sidebar has no logo configured. Prevents empty logo links from interfering with navigation highlighting.
 
 ## In previous releases
 

--- a/src/core/brand/brand.ts
+++ b/src/core/brand/brand.ts
@@ -344,9 +344,14 @@ export function resolveLogo(
     return logo;
   };
   if (!spec) {
+    const lightLogo = findLogo("light", order);
+    const darkLogo = findLogo("dark", order);
+    if (!lightLogo && !darkLogo) {
+      return undefined;
+    }
     return {
-      light: findLogo("light", order) || findLogo("dark", order),
-      dark: findLogo("dark", order) || findLogo("light", order),
+      light: lightLogo || darkLogo,
+      dark: darkLogo || lightLogo,
     };
   }
   if (typeof spec === "string") {

--- a/src/project/types/website/website-navigation.ts
+++ b/src/project/types/website/website-navigation.ts
@@ -559,7 +559,8 @@ function navigationHtmlPostprocessor(
       const navLinkHref = navLink.getAttribute("href");
 
       const sidebarLink = doc.querySelector(
-        '.sidebar-navigation a[href="' + navLinkHref + '"]',
+        '.sidebar-navigation a[href="' + navLinkHref +
+          '"]:not(.sidebar-logo-link)',
       );
       // if the link is either for the current window href or appears on the
       // sidebar then set it to active

--- a/src/resources/filters/quarto-post/typst-brand-yaml.lua
+++ b/src/resources/filters/quarto-post/typst-brand-yaml.lua
@@ -251,7 +251,7 @@ function render_typst_brand_yaml()
       end
       -- logo
       local logo = param('logo')
-      if not next(logo) then
+      if logo and not next(logo) then
         meta.logo = nil
       end
       local logoOptions = {}

--- a/tests/docs/smoke-all/website-sidebar/issue-13506-no-logo/.gitignore
+++ b/tests/docs/smoke-all/website-sidebar/issue-13506-no-logo/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/tests/docs/smoke-all/website-sidebar/issue-13506-no-logo/_quarto.yml
+++ b/tests/docs/smoke-all/website-sidebar/issue-13506-no-logo/_quarto.yml
@@ -1,0 +1,22 @@
+project:
+  type: website
+
+website:
+  title: "Issue 13506 - No Logo"
+  navbar:
+    left:
+      - text: "Section A"
+        href: index.qmd
+      - text: "Section B"
+        href: page2.qmd
+  sidebar:
+    - title: "Section A"
+      contents:
+        - index.qmd
+    - title: "Section B"
+      contents:
+        - page2.qmd
+
+format:
+  html:
+    theme: cosmo

--- a/tests/docs/smoke-all/website-sidebar/issue-13506-no-logo/index.qmd
+++ b/tests/docs/smoke-all/website-sidebar/issue-13506-no-logo/index.qmd
@@ -1,0 +1,24 @@
+---
+title: "Section A"
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        -
+          - 'nav.navbar a.nav-link[href$="index.html"].active'
+          - 'nav.navbar a.nav-link[href$="page2.html"]:not(.active)'
+        -
+          - 'a.sidebar-logo-link'
+---
+
+## Section A
+
+This is Section A. When NO logo is configured in the sidebar, the navbar active
+state should work correctly. The "Section A" navbar item should be active on this page.
+
+The bug (issue #13506): After PR #12996, `sidebar.logo` was normalized to
+`{light: undefined, dark: undefined}`, making `if(sidebar.logo)` always true.
+This created empty `<a class="sidebar-logo-link">` elements that interfered with
+the navbar active state detection logic.
+
+See also: [Section B](page2.qmd)

--- a/tests/docs/smoke-all/website-sidebar/issue-13506-no-logo/page2.qmd
+++ b/tests/docs/smoke-all/website-sidebar/issue-13506-no-logo/page2.qmd
@@ -1,0 +1,20 @@
+---
+title: "Section B"
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        -
+          - 'nav.navbar a.nav-link[href$="page2.html"].active'
+          - 'nav.navbar a.nav-link[href$="index.html"]:not(.active)'
+        -
+          - 'a.sidebar-logo-link'
+---
+
+## Section B
+
+This is Section B. The "Section B" navbar item should be active on this page,
+demonstrating that the navbar active state detection works correctly without
+empty logo links interfering.
+
+See also: [Section A](index.qmd)


### PR DESCRIPTION
> [!IMPORTANT]
> Backport PR merged in 1.8 

backport PR for 
- https://github.com/quarto-dev/quarto-cli/pull/13507

This fixes the active state in the navbar introduced by brand logo support