### PR TITLE
Prefer `text/latex` and `application/pdf` mime types when rendering latex

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -199,6 +199,7 @@ All changes included in 1.9:
 
 ### `jupyter`
 
+- ([#13582](https://github.com/quarto-dev/quarto-cli/pull/13582)): Fix `application/pdf` and `text/latex` MIME types not being preferred over `image/svg+xml` when rendering Jupyter notebooks to PDF, which caused errors when `rsvg-convert` was not available.
 - ([#13748](https://github.com/quarto-dev/quarto-cli/pull/13748)): Fix stdin encoding to UTF-8 on Windows to correctly handle JSON in documents containing non-ASCII characters.
 - ([#13936](https://github.com/quarto-dev/quarto-cli/pull/13936)): Add support for q/kdb+ programming language in percent format notebooks and code cell options. (author: @benlubas)
 - ([#13936](https://github.com/quarto-dev/quarto-cli/pull/13936)): Fix `isJupyterPercentScript` regex to correctly detect percent scripts with `[raw]` cells and cells not at the start of the file. The regex now properly groups the alternation `(markdown|raw)` and uses multiline mode.

--- a/src/core/jupyter/display-data.ts
+++ b/src/core/jupyter/display-data.ts
@@ -75,7 +75,8 @@ export function displayDataMimeType(
       kTextHtml,
     );
   } else if (options.toLatex) {
-    displayPriority.push(
+    // latex and pdf should be preferred over the other mime types
+    displayPriority.unshift(
       kTextLatex,
       kApplicationPdf,
     );

--- a/tests/docs/smoke-all/2026/03/24/13582.ipynb
+++ b/tests/docs/smoke-all/2026/03/24/13582.ipynb
@@ -1,0 +1,58 @@
+{
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10.0"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5,
+  "cells": [
+    {
+      "id": "1",
+      "cell_type": "raw",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "title: \"Issue 13582: PDF MIME priority for LaTeX\"\n",
+        "format: latex\n",
+        "use-rsvg-convert: false\n",
+        "execute:\n",
+        "  enabled: false\n",
+        "_quarto:\n",
+        "  tests:\n",
+        "    latex:\n",
+        "      ensureFileRegexMatches:\n",
+        "        - [\"\\\\\\\\includegraphics[^\\\\n]*\\\\.pdf\"]\n",
+        "        - [\"\\\\\\\\includesvg\"]\n",
+        "---\n"
+      ]
+    },
+    {
+      "id": "2",
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Synthetic cell: outputs contain both application/pdf and image/svg+xml.\n",
+        "# With the fix, application/pdf should be preferred for LaTeX output."
+      ],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 1,
+          "data": {
+            "application/pdf": "JVBERi0xLjAKMSAwIG9iajw8L1R5cGUvQ2F0YWxvZy9QYWdlcyAyIDAgUj4+ZW5kb2JqCjIgMCBvYmo8PC9UeXBlL1BhZ2VzL0tpZHNbMyAwIFJdL0NvdW50IDE+PmVuZG9iagozIDAgb2JqPDwvVHlwZS9QYWdlL01lZGlhQm94WzAgMCAxMDAgMTAwXS9QYXJlbnQgMiAwIFI+PmVuZG9iagp4cmVmCjAgNAowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAwMDkgMDAwMDAgbiAKMDAwMDAwMDA1OCAwMDAwMCBuIAowMDAwMDAwMTE1IDAwMDAwIG4gCnRyYWlsZXI8PC9TaXplIDQvUm9vdCAxIDAgUj4+CnN0YXJ0eHJlZgoxOTAKJSVFT0Y=",
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"100\" height=\"100\">\n<rect fill=\"red\" width=\"100\" height=\"100\"/>\n</svg>"
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 1
+    }
+  ]
+}


### PR DESCRIPTION
Currently, rendering a qmd which creates a CairoMakie plot to pdf via LaTeX can error if `rsvg-convert` is not available on the path. 

```
FATAL (/Users/user/dev/quarto-cli/src/resources/filters/./quarto-post/pdf-images.lua:22) An error occurred:
Could not convert a SVG to a PDF for output. Please ensure that rsvg-convert is available on the path.
Error running filter /Users/user/dev/quarto-cli/src/resources/filters/main.lua:
...o-cli/src/resources/filters/./quarto-post/pdf-images.lua:46: FATAL QUARTO ERROR
stack traceback:
        ...el/dev/quarto-cli/src/resources/filters/./common/log.lua:34: in function 'fatal'
        .../dev/quarto-cli/src/resources/filters/./common/error.lua:14: in function 'fail'
        ...o-cli/src/resources/filters/./quarto-post/pdf-images.lua:22: in upvalue 'call_rsvg_convert'
        ...o-cli/src/resources/filters/./quarto-post/pdf-images.lua:46: in function <...o-cli/src/resources/filters/./quarto-post/pdf-images.lua:28>
```

An example qmd for this is

````
---
engine: julia
---

```{julia}
using CairoMakie

Figure(backgroundcolor = :tomato)
```
````

Now I was wondering how this could happen if CairoMakie is able to produce both svg and pdf outputs. I would have expected this error to only appear when only svg was available. However, I confirmed that with default settings, the julia engine sends back svg, pdf and png within the jupyter notebook JSON.

I then checked why the pdf output was apparently ignored and I noticed that the `text/latex` and `application/pdf` MIME types were added to the end of the priority queue for latex, which meant that any other MIME type would take priority. I've fixed this by changing `push` to `unshift` following the earlier entry for markdown.

I'll need some help in adding a simple test for this, having rsvg-convert on the PATH will hide the problem.

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
