### PR TITLE
Use latest uv in v1.8 branch too

### DIFF
--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Install uv for Python
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.7.4"
+          version: "0.9.5"
           enable-cache: true
           cache-dependency-glob: "tests/uv.lock"
 


### PR DESCRIPTION
Per security requirement following https://github.com/astral-sh/uv/security/advisories/GHSA-w476-p2h3-79g9

(cherry picked from commit 41d86c29d290d176aa62beb3d1f5edc34f7b4e75)

Follow up for release branch from #13599 


