### PR TITLE
Fix detection of LuaTeX-ja missing file errors

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -34,6 +34,10 @@ All changes included in 1.9:
 - ([#13589](https://github.com/quarto-dev/quarto-cli/issues/13589)): Fix callouts with invalid ID prefixes crashing with "attempt to index a nil value". Callouts with unknown reference types now render as non-crossreferenceable callouts with a warning, ignoring the invalid ID.
 - ([#13602](https://github.com/quarto-dev/quarto-cli/issues/13602)): Fix support for multiple files set in `bibliography` field in `biblio.typ` template partial.
 
+### `pdf`
+
+- ([rstudio/tinytex-releases#49](https://github.com/rstudio/tinytex-releases/issues/49)): Fix detection of LuaTeX-ja missing file errors by matching both "File" and "file" in error messages.
+
 ## Projects
 
 ### `website`

--- a/src/command/render/latexmk/parse-error.ts
+++ b/src/command/render/latexmk/parse-error.ts
@@ -269,7 +269,7 @@ const packageMatchers = [
   },
   { regex: /.* Loading '([^']+)' aborted!.*/g },
   { regex: /.*! LaTeX Error: File `([^']+)' not found.*/g },
-  { regex: /.* file ['`]?([^' ]+)'? not found.*/g },
+  { regex: /.* [fF]ile ['`]?([^' ]+)'? not found.*/g },
   { regex: /.*the language definition file ([^\s]*).*/g },
   { regex: /.* \\(file ([^)]+)\\): cannot open .*/g },
   { regex: /.*file `([^']+)' .*is missing.*/g },

--- a/tests/unit/latexmk/parse-error.test.ts
+++ b/tests/unit/latexmk/parse-error.test.ts
@@ -48,6 +48,7 @@ unitTest("Detect missing files with `findMissingFontsAndPackages`", async () => 
   assertFound("! Package fontenc Error: Encoding file `t2aenc.def' not found.", "t2aenc.def");
   assertFound("! I can't find file `hyph-de-1901.ec.tex'.", "hyph-de-1901.ec.tex");
   assertFound("luaotfload-features.lua:835: module 'lua-uni-normalize' not found:", "lua-uni-algos.lua");
+  assertFound("! LuaTeX-ja error: File 'jfm-zh_CN.lua' not found.", "jfm-zh_CN.lua");
 },{
   cwd: () => "unit/latexmk/"
 })


### PR DESCRIPTION
LuaTeX-ja errors use "File" with capital F in error messages like: "! LuaTeX-ja error: File 'jfm-zh_CN.lua' not found."

Updated regex pattern to match both "file" and "File" by using [fF]ile character class. Added test case to verify detection.

Fixes rstudio/tinytex-releases#49

