### PR TITLE
Fix ConditionalBlock crash in manuscript projects

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -6,6 +6,7 @@ All changes included in 1.9:
 - ([#13441](https://github.com/quarto-dev/quarto-cli/pull/13441)): Catch `undefined` exceptions in Pandoc failure to avoid spurious error message.
 - ([#13046](https://github.com/quarto-dev/quarto-cli/issues/13046)): Use new url for multiplex socket.io server <https://multiplex.up.railway.app/> as default for `format: revealjs` and `revealjs.multiplex: true`.
 - ([#13506](https://github.com/quarto-dev/quarto-cli/issues/13506)): Fix navbar active state detection when sidebar has no logo configured. Prevents empty logo links from interfering with navigation highlighting.
+- ([#13616](https://github.com/quarto-dev/quarto-cli/issues/13616)): Fix fatal error when rendering manuscript projects with custom blocks like ConditionalBlock.
 - ([#13625](https://github.com/quarto-dev/quarto-cli/issues/13625)): Fix Windows file locking error (os error 32) when rendering with `--output-dir` flag. Context cleanup now happens before removing the temporary `.quarto` directory, ensuring file handles are properly closed.
 - ([#13633](https://github.com/quarto-dev/quarto-cli/issues/13633)): Fix detection and auto-installation of babel language packages from newer error format that doesn't explicitly mention `.ldf` filename.
 

--- a/src/resources/filters/layout/manuscript.lua
+++ b/src/resources/filters/layout/manuscript.lua
@@ -57,10 +57,10 @@ function manuscript()
         -- If this is a notebook embed cell, 'lift' the contents of any child divs
         -- up (unroll their contents), this will help us avoid
         -- labeling divs marked as `cells` more than once
-        local blocks = pandoc.List()
+        local blocks = pandoc.Blocks({})
         for _, childBlock in ipairs(divEl.content) do
           if is_regular_node(childBlock, "Div") then
-              tappend(blocks, childBlock.content)
+              blocks:extend(childBlock.content)
           else
             blocks:insert(childBlock)
           end

--- a/tests/docs/smoke-all/2025/10/27/13616/.gitignore
+++ b/tests/docs/smoke-all/2025/10/27/13616/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/tests/docs/smoke-all/2025/10/27/13616/13616.qmd
+++ b/tests/docs/smoke-all/2025/10/27/13616/13616.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Raw tex in content-visible div (#13616)"
+title: "Conditional Block in manuscript article"
 _quarto:
   tests:
     pdf:
@@ -8,8 +8,6 @@ _quarto:
 
 ::: {.content-visible when-format="pdf"}
 
-```{=tex}
-\textbf{Hello World}
-```
+Something
 
 :::

--- a/tests/docs/smoke-all/2025/10/27/13616/13616.qmd
+++ b/tests/docs/smoke-all/2025/10/27/13616/13616.qmd
@@ -1,0 +1,15 @@
+---
+title: "Raw tex in content-visible div (#13616)"
+_quarto:
+  tests:
+    pdf:
+      noErrors: true
+---
+
+::: {.content-visible when-format="pdf"}
+
+```{=tex}
+\textbf{Hello World}
+```
+
+:::

--- a/tests/docs/smoke-all/2025/10/27/13616/_quarto.yml
+++ b/tests/docs/smoke-all/2025/10/27/13616/_quarto.yml
@@ -1,0 +1,9 @@
+project:
+  type: manuscript
+
+manuscript:
+  article: 13616.qmd
+
+format:
+  pdf:
+    pdf-engine: xelatex


### PR DESCRIPTION
ConditionalBlock in manuscript projects would crash with a fatal error during rendering when using conditional content like `.content-visible when-format`.

Summary below, more details in 
- https://github.com/quarto-dev/quarto-cli/issues/13616#issuecomment-3457269696

## Root Cause

The manuscript filter built block collections using `pandoc.List()` and assigned them to `divEl.content`. This changed the content type from "Blocks" to "List". When ConditionalBlock's render function returned `el.content`, it returned a List without a `.walk()` method.

During custom node rendering, `has_custom_nodes()` attempts to walk the rendered result to check for nested custom nodes. The AST walker's `checked_walk()` function expects walkable Pandoc elements (Blocks, Inlines, Pandoc) and fails on plain Lua tables like List. This guard rail correctly caught the type mismatch.

## Why Manuscript Specifically?

Default projects don't run the manuscript filter, so Div.content remains type "Blocks" throughout. Only manuscript's flattening logic (which builds new block collections) exposed this type mismatch issue.

## Fix

Changed manuscript.lua to use `pandoc.Blocks({})` instead of `pandoc.List()` to maintain proper type throughout the filter chain.

Fixes #13616


A note that this bug was introduced in 1.7 and it was not failing in 1.6. So maybe we should consider backport... 🤔 