### PR TITLE
Fix Windows file locking error when rendering with --output-dir

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -6,6 +6,7 @@ All changes included in 1.9:
 - ([#13441](https://github.com/quarto-dev/quarto-cli/pull/13441)): Catch `undefined` exceptions in Pandoc failure to avoid spurious error message.
 - ([#13046](https://github.com/quarto-dev/quarto-cli/issues/13046)): Use new url for multiplex socket.io server <https://multiplex.up.railway.app/> as default for `format: revealjs` and `revealjs.multiplex: true`.
 - ([#13506](https://github.com/quarto-dev/quarto-cli/issues/13506)): Fix navbar active state detection when sidebar has no logo configured. Prevents empty logo links from interfering with navigation highlighting.
+- ([#13625](https://github.com/quarto-dev/quarto-cli/issues/13625)): Fix Windows file locking error (os error 32) when rendering with `--output-dir` flag. Context cleanup now happens before removing the temporary `.quarto` directory, ensuring file handles are properly closed.
 - ([#13633](https://github.com/quarto-dev/quarto-cli/issues/13633)): Fix detection and auto-installation of babel language packages from newer error format that doesn't explicitly mention `.ldf` filename.
 
 ## Dependencies
@@ -61,5 +62,4 @@ All changes included in 1.9:
 - ([#13402](https://github.com/quarto-dev/quarto-cli/issues/13402)): `nfpm` (<https://nfpm.goreleaser.com/>) is now used to create the `.deb` package, and new `.rpm` package. Both Linux packages are also now built for `x86_64` (`amd64`) and `aarch64` (`arm64`) architectures.
 - ([#13528](https://github.com/quarto-dev/quarto-cli/pull/13528)): Adds support for table specification using nested lists and the `list-table` class.
 - ([#13575](https://github.com/quarto-dev/quarto-cli/pull/13575)): Improve CPU architecture detection/reporting in macOS to allow quarto to run in virtualized environments such as OpenAI's `codex`.
-- ([#13625](https://github.com/quarto-dev/quarto-cli/issues/13625)): Fix Windows file locking error (os error 32) when rendering with `--output-dir` flag. Context cleanup now happens before removing the temporary `.quarto` directory, ensuring file handles are properly closed.
 - ([#13656](https://github.com/quarto-dev/quarto-cli/issues/13656)): Fix R code cells with empty `lang: ""` option producing invalid markdown class attributes.

--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -61,4 +61,5 @@ All changes included in 1.9:
 - ([#13402](https://github.com/quarto-dev/quarto-cli/issues/13402)): `nfpm` (<https://nfpm.goreleaser.com/>) is now used to create the `.deb` package, and new `.rpm` package. Both Linux packages are also now built for `x86_64` (`amd64`) and `aarch64` (`arm64`) architectures.
 - ([#13528](https://github.com/quarto-dev/quarto-cli/pull/13528)): Adds support for table specification using nested lists and the `list-table` class.
 - ([#13575](https://github.com/quarto-dev/quarto-cli/pull/13575)): Improve CPU architecture detection/reporting in macOS to allow quarto to run in virtualized environments such as OpenAI's `codex`.
+- ([#13625](https://github.com/quarto-dev/quarto-cli/issues/13625)): Fix Windows file locking error (os error 32) when rendering with `--output-dir` flag. Context cleanup now happens before removing the temporary `.quarto` directory, ensuring file handles are properly closed.
 - ([#13656](https://github.com/quarto-dev/quarto-cli/issues/13656)): Fix R code cells with empty `lang: ""` option producing invalid markdown class attributes.

--- a/src/command/render/project.ts
+++ b/src/command/render/project.ts
@@ -886,13 +886,20 @@ export async function renderProject(
     );
   }
 
-  // in addition to the cleanup above, if forceClean is set, we need to clean up the project scratch dir
-  // entirely. See options.forceClean in render-shared.ts
-  // .quarto is really a fiction created because of `--output-dir` being set on non-project
-  // renders
+  // Clean up synthetic project created for --output-dir
+  // When --output-dir is used without a project file, we create a temporary
+  // project context with a .quarto directory (see render-shared.ts).
+  // After rendering completes, we must remove this directory to avoid leaving
+  // debris in non-project directories (#9745).
   //
-  // cf https://github.com/quarto-dev/quarto-cli/issues/9745#issuecomment-2125951545
+  // Critical ordering for Windows: Close file handles BEFORE removing directory
+  // to avoid "The process cannot access the file because it is being used by
+  // another process" (os error 32) (#13625).
   if (projectRenderConfig.options.forceClean) {
+    // 1. Close all file handles (KV database, temp context, etc.)
+    context.cleanup();
+
+    // 2. Remove the temporary .quarto directory
     const scratchDir = join(projDir, kQuartoScratch);
     if (existsSync(scratchDir)) {
       safeRemoveSync(scratchDir, { recursive: true });

--- a/src/command/render/render-shared.ts
+++ b/src/command/render/render-shared.ts
@@ -48,12 +48,14 @@ export async function render(
   // determine target context/files
   let context = await projectContext(path, nbContext, options);
 
-  // if there is no project parent and an output-dir was passed, then force a project
+  // Create a synthetic project when --output-dir is used without a project file
+  // This creates a temporary .quarto directory to manage the render, which must
+  // be fully cleaned up afterward to avoid leaving debris (see #9745)
   if (!context && options.flags?.outputDir) {
-    // recompute context
     context = await projectContextForDirectory(path, nbContext, options);
 
-    // force clean as --output-dir implies fully overwrite the target
+    // forceClean signals this is a synthetic project that needs full cleanup
+    // including removing the .quarto scratch directory after rendering (#13625)
     options.forceClean = options.flags.clean !== false;
   }
 

--- a/tests/docs/render-output-dir/.gitignore
+++ b/tests/docs/render-output-dir/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/tests/docs/render-output-dir/test.qmd
+++ b/tests/docs/render-output-dir/test.qmd
@@ -1,0 +1,6 @@
+---
+title: "Test Output Dir"
+format: html
+---
+
+This is a simple document to test rendering with --output-dir flag.

--- a/tests/smoke/render/render-output-dir.test.ts
+++ b/tests/smoke/render/render-output-dir.test.ts
@@ -14,42 +14,41 @@ import { fileExists, pathDoNotExists } from "../../verify.ts";
 import { testRender } from "./render.ts";
 import type { Verify } from "../../test.ts";
 
-if (isWindows) {
-  const inputDir = docs("render-output-dir/");
-  const quartoDir = ".quarto";
-  const outputDir = "output-test-dir";
 
-  const cleanupDirs = async () => {
-    if (existsSync(outputDir)) {
-      safeRemoveSync(outputDir, { recursive: true });
-    }
-    if (existsSync(quartoDir)) {
-      safeRemoveSync(quartoDir, { recursive: true });
-    }
-  };
+const inputDir = docs("render-output-dir/");
+const quartoDir = ".quarto";
+const outputDir = "output-test-dir";
 
-  const testOutputDirRender = (
-    quartoVerify: Verify,
-    extraArgs: string[] = [],
-  ) => {
-    testRender(
-      "test.qmd",
-      "html",
-      false,
-      [quartoVerify],
-      {
-        cwd: () => inputDir,
-        setup: cleanupDirs,
-        teardown: cleanupDirs,
-      },
-      ["--output-dir", outputDir, ...extraArgs],
-      outputDir,
-    );
-  };
+const cleanupDirs = async () => {
+  if (existsSync(outputDir)) {
+    safeRemoveSync(outputDir, { recursive: true });
+  }
+  if (existsSync(quartoDir)) {
+    safeRemoveSync(quartoDir, { recursive: true });
+  }
+};
 
-  // Test 1: Default behavior (clean=true) - .quarto should be removed
-  testOutputDirRender(pathDoNotExists(quartoDir));
+const testOutputDirRender = (
+  quartoVerify: Verify,
+  extraArgs: string[] = [],
+) => {
+  testRender(
+    "test.qmd",
+    "html",
+    false,
+    [quartoVerify],
+    {
+      cwd: () => inputDir,
+      setup: cleanupDirs,
+      teardown: cleanupDirs,
+    },
+    ["--output-dir", outputDir, ...extraArgs],
+    outputDir,
+  );
+};
 
-  // Test 2: With --no-clean flag - .quarto should be preserved
-  testOutputDirRender(fileExists(quartoDir), ["--no-clean"]);
-}
+// Test 1: Default behavior (clean=true) - .quarto should be removed
+testOutputDirRender(pathDoNotExists(quartoDir));
+
+// Test 2: With --no-clean flag - .quarto should be preserved
+testOutputDirRender(fileExists(quartoDir), ["--no-clean"]);

--- a/tests/smoke/render/render-output-dir.test.ts
+++ b/tests/smoke/render/render-output-dir.test.ts
@@ -10,14 +10,15 @@
 import { existsSync, safeRemoveSync } from "../../../src/deno_ral/fs.ts";
 import { docs } from "../../utils.ts";
 import { isWindows } from "../../../src/deno_ral/platform.ts";
-import { pathDoNotExists } from "../../verify.ts";
+import { fileExists, pathDoNotExists } from "../../verify.ts";
 import { testRender } from "./render.ts";
 
 if (isWindows) {
-  const inputDir =  docs("render-output-dir/");
-  const quartoDir = ".quarto"
-  const outputDir = "output-test-dir"
+  const inputDir = docs("render-output-dir/");
+  const quartoDir = ".quarto";
+  const outputDir = "output-test-dir";
 
+  // Test 1: Default behavior (clean=true) - .quarto should be removed
   testRender(
     "test.qmd",
     "html",
@@ -39,11 +40,41 @@ if (isWindows) {
           safeRemoveSync(outputDir, { recursive: true });
         }
         if (existsSync(quartoDir)) {
-              safeRemoveSync(quartoDir, { recursive: true });
+          safeRemoveSync(quartoDir, { recursive: true });
         }
       },
-    },  
+    },
     ["--output-dir", outputDir],
+    outputDir,
+  );
+
+  // Test 2: With --no-clean flag - .quarto should be preserved
+  testRender(
+    "test.qmd",
+    "html",
+    false,
+    [fileExists(quartoDir)],
+    {
+      cwd: () => inputDir,
+      setup: async () => {
+        // Ensure output and quarto dirs are removed before test
+        if (existsSync(outputDir)) {
+          safeRemoveSync(outputDir, { recursive: true });
+        }
+        if (existsSync(quartoDir)) {
+          safeRemoveSync(quartoDir, { recursive: true });
+        }
+      },
+      teardown: async () => {
+        if (existsSync(outputDir)) {
+          safeRemoveSync(outputDir, { recursive: true });
+        }
+        if (existsSync(quartoDir)) {
+          safeRemoveSync(quartoDir, { recursive: true });
+        }
+      },
+    },
+    ["--output-dir", outputDir, "--no-clean"],
     outputDir,
   );
 }

--- a/tests/smoke/render/render-output-dir.test.ts
+++ b/tests/smoke/render/render-output-dir.test.ts
@@ -1,0 +1,50 @@
+/*
+* render-output-dir.test.ts
+*
+* Test for Windows file locking issue with --output-dir flag
+* Regression test for: https://github.com/quarto-dev/quarto-cli/issues/XXXXX
+*
+* Copyright (C) 2020-2025 Posit Software, PBC
+*
+*/
+import { dirname, join } from "../../../src/deno_ral/path.ts";
+import { existsSync, safeRemoveSync } from "../../../src/deno_ral/fs.ts";
+import { docs } from "../../utils.ts";
+import { isWindows } from "../../../src/deno_ral/platform.ts";
+import { pathDoNotExists } from "../../verify.ts";
+import { testRender } from "./render.ts";
+
+if (isWindows) {
+  const inputDir =  docs("render-output-dir/");
+  const quartoDir = ".quarto"
+  const outputDir = "output-test-dir"
+
+  testRender(
+    "test.qmd",
+    "html",
+    true,
+    [pathDoNotExists(quartoDir)],
+    {
+      cwd: () => inputDir,
+      setup: async () => {
+        // Ensure output and quarto dirs are removed before test
+        if (existsSync(outputDir)) {
+          safeRemoveSync(outputDir, { recursive: true });
+        }
+        if (existsSync(quartoDir)) {
+          safeRemoveSync(quartoDir, { recursive: true });
+        }
+      },
+      teardown: async () => {
+        if (existsSync(outputDir)) {
+          safeRemoveSync(outputDir, { recursive: true });
+        }
+        if (existsSync(quartoDir)) {
+              safeRemoveSync(quartoDir, { recursive: true });
+        }
+      },
+    },  
+    ["--output-dir", outputDir],
+    outputDir,
+  );
+}

--- a/tests/smoke/render/render-output-dir.test.ts
+++ b/tests/smoke/render/render-output-dir.test.ts
@@ -2,12 +2,11 @@
 * render-output-dir.test.ts
 *
 * Test for Windows file locking issue with --output-dir flag
-* Regression test for: https://github.com/quarto-dev/quarto-cli/issues/XXXXX
+* Regression test for: https://github.com/quarto-dev/quarto-cli/issues/13625
 *
 * Copyright (C) 2020-2025 Posit Software, PBC
 *
 */
-import { dirname, join } from "../../../src/deno_ral/path.ts";
 import { existsSync, safeRemoveSync } from "../../../src/deno_ral/fs.ts";
 import { docs } from "../../utils.ts";
 import { isWindows } from "../../../src/deno_ral/platform.ts";
@@ -22,7 +21,7 @@ if (isWindows) {
   testRender(
     "test.qmd",
     "html",
-    true,
+    false,
     [pathDoNotExists(quartoDir)],
     {
       cwd: () => inputDir,

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -146,9 +146,13 @@ export function outputForInput(
 
   const outputPath: string = projectRoot && projectOutDir !== undefined
       ? join(projectRoot, projectOutDir, dir, `${stem}.${outputExt}`)
+      : projectOutDir !== undefined
+      ? join(projectOutDir, dir, `${stem}.${outputExt}`)
       : join(dir, `${stem}.${outputExt}`);
   const supportPath: string = projectRoot && projectOutDir !== undefined
     ? join(projectRoot, projectOutDir, dir, `${stem}_files`)
+    : projectOutDir !== undefined
+    ? join(projectOutDir, dir, `${stem}_files`)
     : join(dir, `${stem}_files`);
 
   return {

--- a/tests/verify.ts
+++ b/tests/verify.ts
@@ -236,7 +236,7 @@ export const fileExists = (file: string): Verify => {
 
 export const pathDoNotExists = (path: string): Verify => {
   return {
-    name: `path ${path} exists`,
+    name: `path ${path} do not exists`,
     verify: (_output: ExecuteOutput[]) => {
       verifyNoPath(path);
       return Promise.resolve();


### PR DESCRIPTION
When rendering with `--output-dir` on Windows without a project file, Quarto would fail with:

```
ERROR: os error 32: remove 'path\.quarto'
```

## Root Cause

When `--output-dir` is used without a project file, Quarto creates a "synthetic" project context with a temporary `.quarto` directory to manage the render. The issue was a timing problem in cleanup ordering:

1. Rendering completes
2. Code tries to remove `.quarto` directory
3. But the Deno KV database file inside `.quarto` is still open
4. `context.cleanup()` (which closes the KV file) is called later by the caller
5. Windows doesn't allow deleting open files → error 32

## Fix

Call `context.cleanup()` before attempting to remove the `.quarto` directory. This ensures file handles are properly closed first.

The fix is minimal (5 lines) and safe because `cleanup()` is idempotent (wrapped with `once()`), so calling it early and again later has no side effects.

## Alternative Approach Considered

Initially implemented a path registration mechanism where code could register paths for cleanup at the point of decision. This added `cleanupPaths` array and `registerForCleanup()` method to `ProjectContext`, with cleanup logic duplicated across 4 locations.

This was deemed too complex for a single use case (82 lines across 6 files). The simpler ordering fix achieves the same result.

## Documentation

Added comments explaining the "synthetic project" pattern:

- When `--output-dir` is used without `_quarto.yml`, Quarto creates a temporary project context
- The `forceClean` flag signals this is temporary and needs cleanup
- Creation: `src/command/render/render-shared.ts:52-58`
- Cleanup: `src/command/render/project.ts:889-907`

Added tests in `tests/smoke/render/render-output-dir.test.ts` covering both default cleanup behavior and `--no-clean` flag preservation.

Fixes #13625

This should also probably be backported as this is common problem, and could explain `quarto preview` lock issue in positron (which I think use `--output-dir` for some files)
