### PR TITLE
claude: Preserve custom IDs in panel-tabset tabs and add hash navigation

### DIFF
--- a/src/resources/formats/html/templates/quarto-html-after-body.ejs
+++ b/src/resources/formats/html/templates/quarto-html-after-body.ejs
@@ -27,14 +27,77 @@
     <% } %>
   
     <% if (tabby) {  %>
-  
+
     const tabsets =  window.document.querySelectorAll(".panel-tabset-tabby")
     tabsets.forEach(function(tabset) {
       const tabby = new Tabby('#' + tabset.id);
     });
-  
+
     <% } %>
-  
+
+    // Activate Bootstrap tab based on URL hash
+    const activateTabFromHash = function() {
+      if (!window.location.hash) return;
+
+      // Check if hash corresponds to a tab pane
+      const hash = window.location.hash;
+      const pane = document.querySelector(hash + '.tab-pane');
+
+      if (pane && window.bootstrap) {
+        // Find the tab link that targets this pane
+        const tabLink = document.querySelector('[data-bs-toggle="tab"][data-bs-target="' + hash + '"]');
+        if (tabLink) {
+          const tab = new window.bootstrap.Tab(tabLink);
+          tab.show();
+
+          // Scroll to the entire tabset after a brief delay to ensure it's shown
+          setTimeout(function() {
+            const tabset = pane.closest('.panel-tabset');
+            if (tabset) {
+              tabset.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+          }, 100);
+        }
+      }
+    };
+
+    // Activate on page load
+    activateTabFromHash();
+
+    // Activate on hash change (when clicking anchor links)
+    window.addEventListener('hashchange', activateTabFromHash);
+
+    // Handle clicks on links to tab panes (even if hash is already set)
+    document.addEventListener('click', function(event) {
+      const link = event.target.closest('a[href^="#"]');
+      if (!link) return;
+
+      const hash = link.getAttribute('href');
+      const pane = document.querySelector(hash + '.tab-pane');
+
+      if (pane && window.bootstrap) {
+        const tabLink = document.querySelector('[data-bs-toggle="tab"][data-bs-target="' + hash + '"]');
+        if (tabLink) {
+          event.preventDefault();
+          const tab = new window.bootstrap.Tab(tabLink);
+          tab.show();
+
+          // Update URL without triggering hashchange
+          if (window.location.hash !== hash) {
+            window.location.hash = hash;
+          }
+
+          // Scroll to the entire tabset
+          setTimeout(function() {
+            const tabset = pane.closest('.panel-tabset');
+            if (tabset) {
+              tabset.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+          }, 100);
+        }
+      }
+    });
+
     <% if (anchors) { %>
   
     const icon = "<%= anchors === true ? '' : anchors %>";


### PR DESCRIPTION
This is a vibe-coded bugfix for #3416

As such, I'll submit as draft. As I commented in the issue:

> Not sure if it's worth it:
> * quite a few changes to get id passing through
> * it still needs custom JS because Bootstrap doesn't have this feature
> * i have not reviewed changes to custom nodes (!) and it would be some effort to do so

#### claude's summary

Extends the panel-tabset custom node system to preserve user-specified IDs from markdown headers (e.g., ## Tab Title {#my-id}) through the entire rendering pipeline, enabling anchor-based navigation to specific tabs.

Custom Node Changes (panel-tabset.lua):
- Modified quarto.Tab constructor to accept and store identifier parameter
- Updated parse_tabset_contents to pass el.attr.identifier to quarto.Tab
- Modified render_quarto_tab to use tbl.identifier in header attributes
- Extended custom node metaobject system to store and expose identifiers array
- Updated render_tabset to use custom IDs with validation:
  * Warns on duplicate IDs and falls back to auto-generated IDs
  * Warns on conflicts with tabset- prefix pattern
  * Logs final ID used for each tab

Bootstrap Tab Navigation (quarto-html-after-body.ejs):
- Added activateTabFromHash() to activate tabs from URL hash on page load
- Added hashchange listener for anchor link navigation
- Added click handler to reliably activate tabs even when hash is already set
- Scrolls to show entire tabset container (.panel-tabset) on activation

This enables users to write [Link](#my-tab-id) to navigate to and activate specific tabs within panel-tabsets, with the custom ID flowing from markdown through the Lua filter system to the final HTML output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
