### PR TITLE
Fix R code cells with empty lang option producing invalid class attributes

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -61,3 +61,4 @@ All changes included in 1.9:
 - ([#13402](https://github.com/quarto-dev/quarto-cli/issues/13402)): `nfpm` (<https://nfpm.goreleaser.com/>) is now used to create the `.deb` package, and new `.rpm` package. Both Linux packages are also now built for `x86_64` (`amd64`) and `aarch64` (`arm64`) architectures.
 - ([#13528](https://github.com/quarto-dev/quarto-cli/pull/13528)): Adds support for table specification using nested lists and the `list-table` class.
 - ([#13575](https://github.com/quarto-dev/quarto-cli/pull/13575)): Improve CPU architecture detection/reporting in macOS to allow quarto to run in virtualized environments such as OpenAI's `codex`.
+- ([#13656](https://github.com/quarto-dev/quarto-cli/issues/13656)): Fix R code cells with empty `lang: ""` option producing invalid markdown class attributes.

--- a/src/resources/rmd/hooks.R
+++ b/src/resources/rmd/hooks.R
@@ -1120,8 +1120,10 @@ is_label_type <- function(type, label) {
 
 block_attr <- function(id = NULL, lang = NULL, class = NULL, attr = NULL) {
   id <- labelId(id)
-  if (!is.null(lang)) {
+  if (!is.null(lang) && nzchar(lang)) {
     lang <- paste0(".", lang)
+  } else {
+    lang <- NULL
   }
   if (!is.null(class)) {
     class <- paste(block_class(class))

--- a/tests/docs/smoke-all/2025/11/07/13656.qmd
+++ b/tests/docs/smoke-all/2025/11/07/13656.qmd
@@ -1,0 +1,20 @@
+---
+title: "Empty lang option should not produce invalid class (#13656)"
+format: html
+keep-md: true
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - []
+        - ['\{\. \.cell-code\}']  # Should NOT have invalid literal class in HTML
+---
+
+## Test Case
+
+R code cell with empty lang option should not produce invalid class:
+
+```{r}
+#| lang: ""
+23
+```


### PR DESCRIPTION
When rendering R code cells with `lang: ""`, Quarto would produce invalid class attributes that appeared as literal text in output instead of being parsed correctly.

## Root Cause

The `block_attr()` function in `src/resources/rmd/hooks.R` was adding a dot prefix to empty string language values, creating invalid attributes like `{. .cell-code}` (space after period with no language).

Empty strings were treated differently from NULL, even though both represent "no language".

## Fix

Modified `block_attr()` to check both `!is.null(lang)` AND `nzchar(lang)` before adding the dot prefix. Empty strings are now treated the same as NULL (omitted from attributes).

Fixes #13656