### PR TITLE
Fix LaTeX compilation error with Python error output containing caret characters

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -42,6 +42,7 @@ All changes included in 1.9:
 
 - ([#10291](https://github.com/quarto-dev/quarto-cli/issues/10291)): Fix detection of babel hyphenation warnings with straight-quote format instead of backtick-quote format.
 - ([rstudio/tinytex-releases#49](https://github.com/rstudio/tinytex-releases/issues/49)): Fix detection of LuaTeX-ja missing file errors by matching both "File" and "file" in error messages.
+- ([#13667](https://github.com/quarto-dev/quarto-cli/issues/13667)): Fix LaTeX compilation error with Python error output containing caret characters.
 
 ## Projects
 

--- a/src/resources/filters/quarto-post/latex.lua
+++ b/src/resources/filters/quarto-post/latex.lua
@@ -602,7 +602,7 @@ function render_latex_fixups()
 
         -- obtained by a local call to uuid and removing dashes
         local uuid = "edbdf4a3bc424f5b8ac0e95c92ef5015"
-        return line:gsub("[\\]", uuid):gsub("([{}$%&%_])", "\\%1"):gsub("[%^]", "\\textasciicaret{}"):gsub("[~]", "\\textasciitilde{}"):gsub(uuid, "\\textbackslash{}")
+        return line:gsub("[\\]", uuid):gsub("([{}$%&%_])", "\\%1"):gsub("[%^]", "\\textasciicircum{}"):gsub("[~]", "\\textasciitilde{}"):gsub(uuid, "\\textbackslash{}")
       end
       if code.text:match("\027%[[0-9;]+m") and #code.classes == 0 then
         local lines = split(code.text, "\n")

--- a/tests/docs/smoke-all/2025/11/12/issue-13667.qmd
+++ b/tests/docs/smoke-all/2025/11/12/issue-13667.qmd
@@ -1,0 +1,33 @@
+---
+title: "Python syntax error with caret (#13667)"
+format: pdf
+keep-tex: true
+_quarto:
+  tests:
+    pdf:
+      ensureLatexFileRegexMatches:
+        - ['\\textasciicircum\{\}']
+        - ['\\textasciicaret\{\}']
+---
+
+::: {.cell execution_count=1}
+``` {.python .cell-code}
+def my_func(a=10, b):
+    print(a)
+    print(b)
+
+my_func(5)
+```
+
+::: {.cell-output .cell-output-error}
+```
+SyntaxError: parameter without a default follows parameter with a default (1331601683.py, line 1)
+  [36mCell[39m[36m [39m[32mIn[2][39m[32m, line 1[39m
+[31m    [39m[31mdef my_func(a=10, b):[39m
+                      ^
+[31mSyntaxError[39m[31m:[39m parameter without a default follows parameter with a default
+```
+:::
+:::
+
+


### PR DESCRIPTION
When rendering Python code cells with syntax errors to PDF, LaTeX compilation would fail with:

```
Undefined control sequence.
<argument>                       \textasciicaret
                                      {}
l.231 ...2}{                      \textasciicaret{}}
```

## Root Cause

The ANSI escape code handling in `src/resources/filters/quarto-post/latex.lua` used an incorrect LaTeX command `\textasciicaret{}` when escaping caret characters (`^`). This command does not exist in LaTeX.

The correct command from the `textcomp` package is `\textasciicircum{}` (already loaded in Quarto templates).

## Fix

Changed line 605 of `src/resources/filters/quarto-post/latex.lua` to use `\textasciicircum{}` instead of `\textasciicaret{}`. Single-character typo fix.

Added comprehensive smoke-all test with Python syntax error output containing caret characters to prevent regression.

Fixes #13667