### PR TITLE
Fix notebook-view.url being ignored

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -9,6 +9,7 @@ All changes included in 1.9:
 - ([#13616](https://github.com/quarto-dev/quarto-cli/issues/13616)): Fix fatal error when rendering manuscript projects with custom blocks like ConditionalBlock.
 - ([#13625](https://github.com/quarto-dev/quarto-cli/issues/13625)): Fix Windows file locking error (os error 32) when rendering with `--output-dir` flag. Context cleanup now happens before removing the temporary `.quarto` directory, ensuring file handles are properly closed.
 - ([#13633](https://github.com/quarto-dev/quarto-cli/issues/13633)): Fix detection and auto-installation of babel language packages from newer error format that doesn't explicitly mention `.ldf` filename.
+- ([#13694](https://github.com/quarto-dev/quarto-cli/issues/13694)): Fix `notebook-view.url` being ignored - external notebook links now properly use specified URLs instead of local preview files.
 
 ## Dependencies
 

--- a/src/format/html/format-html-notebook-preview.ts
+++ b/src/format/html/format-html-notebook-preview.ts
@@ -252,7 +252,7 @@ export const notebookPreviewer = (
         // to form links to this notebook
         const nbPreview = {
           title: resolvedTitle,
-          href: relative(inputDir, renderedNotebook[kHtmlPreview].hrefPath),
+          href: descriptor?.url || relative(inputDir, renderedNotebook[kHtmlPreview].hrefPath),
           supporting,
           resources,
           order: work.order,

--- a/tests/docs/smoke-all/2023/01/05/notebook-preview-complex.qmd
+++ b/tests/docs/smoke-all/2023/01/05/notebook-preview-complex.qmd
@@ -29,7 +29,7 @@ _quarto:
   tests:
     html:
       ensureHtmlElements:
-        - ['a.quarto-notebook-link']
+        - ['a.quarto-notebook-link[href*="kaggle.com"]']
         - ['div.quarto-alternate-notebooks a']
       ensureFileRegexMatches:
         - ['Source: TEST NB']


### PR DESCRIPTION
When notebook-view.url is specified, notebook links should point to the
external URL instead of rendering a local preview. This was broken in v1.4.156 (commit faba7357a) when the notebook system was refactored and external URL handling was accidentally removed.

The fix restores the check for descriptor?.url before falling back to the local preview path in format-html-notebook-preview.ts.

Updated existing test to verify links contain the external URL.

fix #13694