### PR TITLE
Fix draft pages showing blank with pre-render scripts

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -54,6 +54,7 @@ All changes included in 1.9:
 - ([#13525](https://github.com/quarto-dev/quarto-cli/issues/13525)): Algolia Insights now uses privacy-friendly defaults: `useCookie: false` with random session tokens when cookie consent is not configured. When `cookie-consent: true` is enabled, Algolia scripts are deferred and only use cookies after user grants "tracking" consent, ensuring GDPR compliance.
 - ([#13547](https://github.com/quarto-dev/quarto-cli/issues/13547))`cookie-content: { type: express }` is now the default. Previously it was `type: implied`. It now means this will block cookies until the user expressly agrees to allow them (or continue blocking them if the user doesn't agree).
 - ([#13570](https://github.com/quarto-dev/quarto-cli/pull/13570)): Replace Twitter with Bluesky in default blog template and documentation examples. New blog projects now include Bluesky social links instead of Twitter.
+- ([#13716](https://github.com/quarto-dev/quarto-cli/issues/13716)): Fix draft pages showing blank during preview when pre-render scripts are configured.
 
 ## `publish`
 

--- a/src/project/project-context.ts
+++ b/src/project/project-context.ts
@@ -353,6 +353,7 @@ export async function projectContext(
             return projectFileMetadata(result, file, force);
           },
           isSingleFile: false,
+          previewServer: renderOptions?.previewServer,
           diskCache: await createProjectCache(join(dir, ".quarto")),
           temp,
           cleanup: once(() => {
@@ -447,6 +448,7 @@ export async function projectContext(
           },
           notebookContext,
           isSingleFile: false,
+          previewServer: renderOptions?.previewServer,
           diskCache: await createProjectCache(join(dir, ".quarto")),
           temp,
           cleanup: once(() => {
@@ -526,6 +528,7 @@ export async function projectContext(
               return projectFileMetadata(context, file, force);
             },
             isSingleFile: false,
+            previewServer: renderOptions?.previewServer,
             diskCache: await createProjectCache(join(temp.baseDir, ".quarto")),
             temp,
             cleanup: once(() => {

--- a/src/project/serve/serve.ts
+++ b/src/project/serve/serve.ts
@@ -623,6 +623,7 @@ async function internalPreviewServer(
                     services,
                     useFreezer: true,
                     devServerReload: true,
+                    previewServer: true,
                     flags: renderFlags,
                     pandocArgs: renderPandocArgs,
                   },

--- a/src/project/serve/watch.ts
+++ b/src/project/serve/watch.ts
@@ -38,10 +38,6 @@ import { existsSync1 } from "../../core/file.ts";
 import { watchForFileChanges } from "../../core/watch.ts";
 import { extensionFilesFromDirs } from "../../extension/extension.ts";
 import { notebookContext } from "../../render/notebook/notebook-context.ts";
-import {
-  kDraftMode,
-  kDraftModeVisible,
-} from "../types/website/website-constants.ts";
 
 interface WatchChanges {
   config: boolean;
@@ -68,16 +64,6 @@ export function watchProject(
     project =
       (await projectContext(project.dir, nbContext, renderOptions, false))!;
   };
-
-  // See if we're in draft mode
-  if (project.config) {
-    // If this is a website
-    if (project.config.website) {
-      // Switch
-      (project.config.website as Record<string, unknown>)[kDraftMode] =
-        kDraftModeVisible;
-    }
-  }
 
   // proj dir
   const projDir = normalizePath(project.dir);

--- a/src/project/types.ts
+++ b/src/project/types.ts
@@ -122,6 +122,7 @@ export interface ProjectContext extends Cloneable<ProjectContext> {
   environment: () => Promise<ProjectEnvironment>;
 
   isSingleFile: boolean;
+  previewServer?: boolean;
 
   diskCache: ProjectCache;
   temp: TempContext;

--- a/src/project/types/website/website-utils.ts
+++ b/src/project/types/website/website-utils.ts
@@ -15,7 +15,12 @@ import { ProjectContext } from "../../types.ts";
 import { warning } from "../../../deno_ral/log.ts";
 import { dirname, extname, join, relative } from "../../../deno_ral/path.ts";
 import { websiteConfigArray, websiteConfigString } from "./website-config.ts";
-import { kDraftMode, kDraftModeGone, kDrafts } from "./website-constants.ts";
+import {
+  kDraftMode,
+  kDraftModeGone,
+  kDraftModeVisible,
+  kDrafts,
+} from "./website-constants.ts";
 
 export function removeChapterNumber(item: Element) {
   const numberSpan = item.querySelector(".chapter-number");
@@ -39,6 +44,11 @@ export function isProjectDraft(
 }
 
 export function projectDraftMode(project: ProjectContext) {
+  // Preview server always shows drafts
+  if (project.previewServer) {
+    return kDraftModeVisible;
+  }
+  // Otherwise read from config
   const draftMode = websiteConfigString(kDraftMode, project.config);
   return draftMode || kDraftModeGone;
 }


### PR DESCRIPTION
When a website project uses pre-render scripts in _quarto.yml and a qmd file has draft: true, the generated page shows blank during quarto preview instead of showing the draft content.

## Root Cause

During quarto preview, the preview server sets draft-mode="visible" to show draft pages. When pre-render scripts are configured, each page render triggers projectContextForDirectory() to reload the project context from disk. This reload loses the draft-mode mutation, causing filterParams() to see draft-mode="gone" (default) and filter out draft content.

## Fix

This PR adds a previewServer field to ProjectContext that persists through context reloads. The field is set from RenderOptions.previewServer during context creation (project-context.ts) and used by projectDraftMode() (website-utils.ts) to return "visible" draft mode when preview server is running.

The fix also removes the config mutation approach in watch.ts that was attempting to solve this by directly modifying project config.

Fixes #13716