### PR TITLE
Fix font package detection for fonts with spaces in names

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -45,6 +45,7 @@ All changes included in 1.9:
 - ([#13661](https://github.com/quarto-dev/quarto-cli/issues/13661)): Fix LaTeX compilation errors when using `mermaid-format: svg` with PDF/LaTeX output. SVG diagrams are now written directly without HTML script tags. Note: `mermaid-format: png` is recommended for best compatibility. SVG format requires `rsvg-convert` (or Inkscape with `use-rsvg-convert: false`) in PATH for conversion to PDF, and may experience text clipping in diagrams with multi-line labels.
 - ([rstudio/tinytex-releases#49](https://github.com/rstudio/tinytex-releases/issues/49)): Fix detection of LuaTeX-ja missing file errors by matching both "File" and "file" in error messages.
 - ([#13667](https://github.com/quarto-dev/quarto-cli/issues/13667)): Fix LaTeX compilation error with Python error output containing caret characters.
+- ([#13732](https://github.com/quarto-dev/quarto-cli/issues/13732)): Fix automatic font package installation for fonts with spaces in their names (e.g., "Noto Emoji", "DejaVu Sans"). Font file search patterns now match both with and without spaces.
 
 ## Projects
 

--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -10,6 +10,7 @@ All changes included in 1.9:
 - ([#13625](https://github.com/quarto-dev/quarto-cli/issues/13625)): Fix Windows file locking error (os error 32) when rendering with `--output-dir` flag. Context cleanup now happens before removing the temporary `.quarto` directory, ensuring file handles are properly closed.
 - ([#13633](https://github.com/quarto-dev/quarto-cli/issues/13633)): Fix detection and auto-installation of babel language packages from newer error format that doesn't explicitly mention `.ldf` filename.
 - ([#13694](https://github.com/quarto-dev/quarto-cli/issues/13694)): Fix `notebook-view.url` being ignored - external notebook links now properly use specified URLs instead of local preview files.
+- ([#13732](https://github.com/quarto-dev/quarto-cli/issues/13732)): Fix automatic font package installation for fonts with spaces in their names (e.g., "Noto Emoji", "DejaVu Sans"). Font file search patterns now match both with and without spaces.
 
 ## Dependencies
 
@@ -45,7 +46,6 @@ All changes included in 1.9:
 - ([#13661](https://github.com/quarto-dev/quarto-cli/issues/13661)): Fix LaTeX compilation errors when using `mermaid-format: svg` with PDF/LaTeX output. SVG diagrams are now written directly without HTML script tags. Note: `mermaid-format: png` is recommended for best compatibility. SVG format requires `rsvg-convert` (or Inkscape with `use-rsvg-convert: false`) in PATH for conversion to PDF, and may experience text clipping in diagrams with multi-line labels.
 - ([rstudio/tinytex-releases#49](https://github.com/rstudio/tinytex-releases/issues/49)): Fix detection of LuaTeX-ja missing file errors by matching both "File" and "file" in error messages.
 - ([#13667](https://github.com/quarto-dev/quarto-cli/issues/13667)): Fix LaTeX compilation error with Python error output containing caret characters.
-- ([#13732](https://github.com/quarto-dev/quarto-cli/issues/13732)): Fix automatic font package installation for fonts with spaces in their names (e.g., "Noto Emoji", "DejaVu Sans"). Font file search patterns now match both with and without spaces.
 
 ## Projects
 

--- a/src/command/render/latexmk/parse-error.ts
+++ b/src/command/render/latexmk/parse-error.ts
@@ -297,7 +297,8 @@ const packageMatchers = [
 ];
 
 function fontSearchTerm(font: string): string {
-  return `${font}(-(Bold|Italic|Regular).*)?[.](tfm|afm|mf|otf|ttf)`;
+  const fontPattern = font.replace(/\s+/g, '\\s*');
+  return `${fontPattern}(-(Bold|Italic|Regular).*)?[.](tfm|afm|mf|otf|ttf)`;
 }
 
 function findMissingPackages(logFileText: string): string[] {

--- a/tests/unit/latexmk/parse-error.test.ts
+++ b/tests/unit/latexmk/parse-error.test.ts
@@ -10,7 +10,8 @@ import { unitTest } from "../../test.ts";
 import { assert } from "testing/asserts";
 
 function fontSearchTerm(font: string): string {
-  return `${font}(-(Bold|Italic|Regular).*)?[.](tfm|afm|mf|otf|ttf)`;
+  const fontPattern = font.replace(/\s+/g, '\\s*');
+  return `${fontPattern}(-(Bold|Italic|Regular).*)?[.](tfm|afm|mf|otf|ttf)`;
 }
 
 function assertFound(logText: string, expected: string, file?: string) {
@@ -32,6 +33,8 @@ unitTest("Detect missing files with `findMissingFontsAndPackages`", async () => 
   assertFound('!pdfTeX error: /usr/local/bin/pdflatex (file tcrm0700): Font tcrm0700 at 600 not found', fontSearchTerm("tcrm0700"))
   assertFound('(fontspec)                The font "LibertinusSerif-Regular" cannot be', fontSearchTerm("LibertinusSerif-Regular"));
   assertFound('! Font \\JY3/mc/m/n/10=file:HaranoAjiMincho-Regular.otf:-kern;jfm=ujis at 9.24713pt not loadable: metric data not found or bad.', "HaranoAjiMincho-Regular.otf");
+  assertFound('! The font "Noto Emoji" cannot be found.', fontSearchTerm("Noto Emoji"));
+  assertFound('! Package fontspec Error: The font "DejaVu Sans" cannot be found.', fontSearchTerm("DejaVu Sans"));
   assertFound("! LaTeX Error: File `framed.sty' not found.", "framed.sty");
   assertFound("! LaTeX Error: File 'framed.sty' not found.", "framed.sty");
   assertFound("/usr/local/bin/mktexpk: line 123: mf: command not found", "mf");


### PR DESCRIPTION
When rendering PDF with fonts that have spaces in names (e.g., "Noto Emoji", "DejaVu Sans"), automatic package installation fails:

```
finding package for Noto Emoji(-(Bold|Italic|Regular).*)?[.](tfm|afm|mf|otf|ttf)
ERROR: compilation failed- no matching packages
```

The `fontSearchTerm()` function preserves spaces, but font files concatenate names: `NotoEmoji-Regular.ttf`, `DejaVuSans-Bold.ttf`.

## Fix

Replace spaces with `\s*` regex pattern for tlmgr search. Pattern now matches both with and without spaces.

Verified with manual testing and unit tests.

Discovered while investigating #13726.

Opened upstream issue for R Markdown: rstudio/tinytex#478

Fixes #13732