### PR TITLE
Fix TinyTeX detection for empty directories

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -46,6 +46,7 @@ All changes included in 1.9:
 - ([#13661](https://github.com/quarto-dev/quarto-cli/issues/13661)): Fix LaTeX compilation errors when using `mermaid-format: svg` with PDF/LaTeX output. SVG diagrams are now written directly without HTML script tags. Note: `mermaid-format: png` is recommended for best compatibility. SVG format requires `rsvg-convert` (or Inkscape with `use-rsvg-convert: false`) in PATH for conversion to PDF, and may experience text clipping in diagrams with multi-line labels.
 - ([rstudio/tinytex-releases#49](https://github.com/rstudio/tinytex-releases/issues/49)): Fix detection of LuaTeX-ja missing file errors by matching both "File" and "file" in error messages.
 - ([#13667](https://github.com/quarto-dev/quarto-cli/issues/13667)): Fix LaTeX compilation error with Python error output containing caret characters.
+- ([#13730](https://github.com/quarto-dev/quarto-cli/issues/13730)): Fix TinyTeX detection when `~/.TinyTeX/` directory exists without binaries. Quarto now verifies that the bin directory and tlmgr binary exist before reporting TinyTeX as available, allowing proper fallback to system PATH installations.
 
 ## Projects
 


### PR DESCRIPTION
When `~/.TinyTeX/` directory exists without actual binaries, `quarto check install` reports:

```
[✓] Checking LaTeX....................OK
      Using: TinyTex
      Path: /home/vscode/.TinyTeX/bin/x86_64-linux
      Version: undefined
```

The check passes with "Version: undefined", preventing fallback to valid TinyTeX installations in the system PATH.

## Root Cause

The detection logic in `src/tools/impl/tinytex-info.ts` only verified the install directory exists, not the binaries within.

- `hasTinyTex()` checked only if `~/.TinyTeX/` exists
- `tinyTexBinDir()` constructed bin paths without validation on Linux/Mac (Windows already validated)

## Fix

Added two-level validation:

1. `tinyTexBinDir()` now validates the bin directory exists before returning paths on Linux/Mac, matching Windows behavior
2. `hasTinyTex()` verifies the tlmgr binary exists within the bin directory

This ensures Quarto only reports TinyTeX as available when it contains working binaries, allowing proper fallback to PATH installations when the home directory installation is incomplete.

Fixes #13730