### PR TITLE
Fix manuscript rendering blocking on git remote errors

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -57,6 +57,10 @@ All changes included in 1.9:
 - ([#13570](https://github.com/quarto-dev/quarto-cli/pull/13570)): Replace Twitter with Bluesky in default blog template and documentation examples. New blog projects now include Bluesky social links instead of Twitter.
 - ([#13716](https://github.com/quarto-dev/quarto-cli/issues/13716)): Fix draft pages showing blank during preview when pre-render scripts are configured.
 
+### `manuscript`
+
+- ([#10031](https://github.com/quarto-dev/quarto-cli/issues/10031)): Fix manuscript rendering prompting for GitHub credentials when origin points to private repository. Auto-detection of manuscript URL now fails gracefully with a warning instead of blocking renders.
+
 ## `publish`
 
 ### Confluence

--- a/src/project/types/manuscript/manuscript.ts
+++ b/src/project/types/manuscript/manuscript.ts
@@ -85,6 +85,8 @@ import {
   shouldMakeMecaBundle,
 } from "./manuscript-meca.ts";
 import { readLines } from "../../../deno_ral/io.ts";
+import { debug } from "../../../deno_ral/log.ts";
+import { logLevel, warnOnce } from "../../../core/log.ts";
 import {
   computeProjectArticleFile,
   isArticle,
@@ -366,8 +368,22 @@ export const manuscriptProjectType: ProjectType = {
       if (manuscriptConfig) {
         let baseUrl = manuscriptConfig[kManuscriptUrl];
         if (baseUrl === undefined) {
-          const ghContext = await gitHubContext(options.project.dir);
-          baseUrl = ghContext.siteUrl;
+          try {
+            const ghContext = await gitHubContext(options.project.dir);
+            baseUrl = ghContext.siteUrl;
+          } catch (e) {
+            // git ls-remote failed (credentials, network, host key, etc.) - don't block rendering
+            const errorMessage = e instanceof Error ? e.message : String(e);
+            if (logLevel() === "DEBUG") {
+              debug(`Failed to auto-detect manuscript URL from GitHub: ${errorMessage}`);
+            }
+            const debugHint = logLevel() === "DEBUG" ? '' : ' Run with --log-level debug for details.';
+            warnOnce(
+              'Unable to auto-detect manuscript URL from GitHub Pages. ' +
+              'Set manuscript-url explicitly in your configuration if needed.' +
+              debugHint
+            );
+          }
         }
         if (baseUrl) {
           filterParams[kManuscriptUrl] = baseUrl;


### PR DESCRIPTION
When rendering manuscript projects with git origin pointing to a private repository, Quarto prompts for GitHub credentials or fails with an error:

```
Username for 'https://github.com': 
Password for 'https://...@github.com':
```

or

```
ERROR: There is an error while retrieving information from remote 'origin'.
 Git error: git@github.com: Permission denied (publickey).
...
```

This blocks renders and prevents users from working with manuscript projects that have private repositories as their git origin.

## Root Cause

The manuscript project type calls gitHubContext() in filterParams() to auto-detect the manuscript-url from GitHub Pages. This function runs `git ls-remote origin gh-pages`, which is a network operation requiring authentication for private repos. Any failure (credentials, network, host key verification, repository not found) throws an error that blocks rendering.

## Fix

Added try/catch in manuscript.ts filterParams() around the gitHubContext() call (line 371). When git operations fail:

- Error is caught gracefully without blocking the render
- Warning shown once per render using warnOnce(): "Unable to auto-detect manuscript URL from GitHub Pages. Set manuscript-url explicitly in your configuration if needed."
- Full error details logged when --log-level debug is used
- Conditional debug hint added to warning message in non-debug mode
- Properly typed error handling for TypeScript

The fix only modifies manuscript.ts - github.ts remains unchanged so publish workflows continue to receive thrown errors as expected.

## Manual Testing

Tested with manuscript-tutorial repository by changing origin to point to non-existent private repository:

```bash
cd /tmp
git clone https://github.com/cderv/manuscript-tutorial
cd manuscript-tutorial
git remote set-url origin https://github.com/cderv/private-manuscript-repo.git
quarto render
```

Verified:
- ✅ Rendering completes successfully without prompting for credentials
- ✅ Warning appears once (not repeated for every file): "WARN: Unable to auto-detect manuscript URL from GitHub Pages..."
- ✅ Debug mode shows full error details: "Failed to auto-detect manuscript URL from GitHub: There is an error while retrieving information from remote 'origin'..."
- ✅ Warning includes debug hint in normal mode, excludes it in debug mode
- ✅ Output created successfully: _manuscript/index.html

Fixes #10031