### PR TITLE
claude: Make Windows smoke tests fail-fast like Linux

### DIFF
--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -276,23 +276,15 @@ jobs:
           # Useful as TinyTeX latest release is checked in run-test.sh
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          $haserror=$false
           foreach ($file in ('${{ inputs.buckets }}' | ConvertFrom-Json)) {
             Write-Host ">>> ./run-tests.ps1 ${file}"
             ./run-tests.ps1 $file
-            $status=$LASTEXITCODE
-            if ($status -eq 1) {
-              Write-Host ">>> Error found in test file"
-              $haserror=$true
-            } else {
-              Write-Host ">>> No error in this test file"
+            if ($LASTEXITCODE -ne 0) {
+              Exit 1
             }
+            Write-Host ">>> No error in this test file"
           }
-          if ($haserror) {
-            Exit 1
-          } else {
-            Write-Host ">>> All tests have passed"
-          }
+          Write-Host ">>> All tests have passed"
         working-directory: tests
         shell: pwsh
 


### PR DESCRIPTION
This is a small quality-of-life change to the Windows tests, that I've been using in my branch for a while.

I find it convenient to see the error immediately when checking results in CI, rather than it printing a bunch of successes afterward. (And possibly more failures, I acknowledge.)

I think I got distracted one evening and asked Claude if it could figure out why this is, and it diagnosed it as "failing fast" in Linux but not on Windows. So I tried its suggestion.

@cderv, your choice whether to take or leave it. Maybe there are other reasons I don't know for logging errors and then continuing?

### Description

When a test fails on Windows, exit immediately instead of continuing through remaining tests in the bucket. This matches Linux behavior (bash -e flag) and keeps test failures at the end of the log where they're easy to find, instead of buried under 1000+ lines of subsequent test output.
