### PR TITLE
Reconfigure stdin encoding to UTF-8

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -114,6 +114,12 @@ All changes included in 1.9:
 
 - New **Engine Extensions**, to allow other execution engines than knitr, jupyter, julia. Julia is now a bundled extension. See [the prerelease notes](https://prerelease.quarto.org/docs/prerelease/1.9/) and [engine extension documentation](https://prerelease.quarto.org/docs/extensions/engine.html).
 
+## Engines
+
+### `jupyter`
+
+- ([#13748](https://github.com/quarto-dev/quarto-cli/pull/13748)): Fix stdin encoding to UTF-8 on Windows to correctly handle JSON in documents containing non-ASCII characters.
+
 ## Other fixes and improvements
 
 - ([#8730](https://github.com/quarto-dev/quarto-cli/issues/8730)): Detect x64 R crashes on Windows ARM and provide helpful error message directing users to install native ARM64 R instead of showing generic "check your R installation" error.

--- a/src/resources/jupyter/jupyter.py
+++ b/src/resources/jupyter/jupyter.py
@@ -255,6 +255,7 @@ if __name__ == "__main__":
             del os.environ["QUARTO_JUPYTER_OPTIONS"]
         # otherwise read from stdin
         else:
+            sys.stdin.reconfigure(encoding='utf-8')
             input = json.load(sys.stdin)
             command = input["command"]
             options = input["options"]


### PR DESCRIPTION
Welcome to the quarto GitHub repo!

We are always happy to hear feedback from our users.

To file a _pull request_, please follow these instructions carefully: <https://yihui.org/issue/#bug-reports>

If you're a collaborator from outside `quarto-dev` making changes larger than a typo, please make sure you have filed an [individual](https://posit.co/wp-content/uploads/2023/04/2023-03-13_TC_Indiv_contrib_agreement.pdf) or [corporate](https://posit.co/wp-content/uploads/2023/04/2023-03-13_TC_Corp_contrib_agreement.pdf) contributor agreement. You can send the signed copy to <jj@rstudio.com>.

Also, please complete and keep the checklist below.

## Description

Please describe your PR here.

On Windows, we need to use utf-8 to read the json correctly.

This one line change fixes the json load error on Windows writingdocuments containing Chinese for me.

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
