### PR TITLE
fix: add missing word to error message

### DIFF
--- a/src/execute/jupyter/jupyter-kernel.ts
+++ b/src/execute/jupyter/jupyter-kernel.ts
@@ -315,7 +315,7 @@ function kernelTransportFile(target: string) {
   try {
     transportsDir = quartoRuntimeDir("jt");
   } catch (e) {
-    console.error("Could create runtime directory for jupyter transport.");
+    console.error("Could not create runtime directory for jupyter transport.");
     console.error(
       "This is possibly a permission issue in the environment Quarto is running in.",
     );


### PR DESCRIPTION
## Description

An error message says "Could create runtime directory" when I believe it should say "Could not create runtime directory".

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
