### PR TITLE
feat(lua-api): expose Typst path in Lua API

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -70,7 +70,7 @@ All changes included in 1.9:
 
 ## Quarto Lua API
 
-- Add `quarto.paths.typst()` to Quarto's Lua API to resolve Typst binary path in Lua filters and extensions consistently with Quarto itself. (author: @mcanouil)
+- ([#13762](https://github.com/quarto-dev/quarto-cli/issues/13762)): Add `quarto.paths.typst()` to Quarto's Lua API to resolve Typst binary path in Lua filters and extensions consistently with Quarto itself. (author: @mcanouil)
 
 ## Other fixes and improvements
 

--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -68,7 +68,7 @@ All changes included in 1.9:
 
 - ([#13414](https://github.com/quarto-dev/quarto-cli/issues/13414)): Be more forgiving when Confluence server returns malformed JSON response. (author: @m1no)
 
-## Quarto Lua API
+## Lua API
 
 - ([#13762](https://github.com/quarto-dev/quarto-cli/issues/13762)): Add `quarto.paths.typst()` to Quarto's Lua API to resolve Typst binary path in Lua filters and extensions consistently with Quarto itself. (author: @mcanouil)
 

--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -68,9 +68,9 @@ All changes included in 1.9:
 
 - ([#13414](https://github.com/quarto-dev/quarto-cli/issues/13414)): Be more forgiving when Confluence server returns malformed JSON response. (author: @m1no)
 
-## Lua Filters and extensions
+## Quarto Lua API
 
-- Add `quarto.paths.typst()` to Quarto's Lua API to resolve Typst binary path in Lua filters and extensions consistently with Quarto itself.
+- Add `quarto.paths.typst()` to Quarto's Lua API to resolve Typst binary path in Lua filters and extensions consistently with Quarto itself. (author: @mcanouil)
 
 ## Other fixes and improvements
 

--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -68,6 +68,10 @@ All changes included in 1.9:
 
 - ([#13414](https://github.com/quarto-dev/quarto-cli/issues/13414)): Be more forgiving when Confluence server returns malformed JSON response. (author: @m1no)
 
+## Lua Filters and extensions
+
+- Add `quarto.paths.typst()` to Quarto's Lua API to resolve Typst binary path in Lua filters and extensions consistently with Quarto itself.
+
 ## Other fixes and improvements
 
 - ([#13402](https://github.com/quarto-dev/quarto-cli/issues/13402)): `nfpm` (<https://nfpm.goreleaser.com/>) is now used to create the `.deb` package, and new `.rpm` package. Both Linux packages are also now built for `x86_64` (`amd64`) and `aarch64` (`arm64`) architectures.

--- a/src/command/render/filters.ts
+++ b/src/command/render/filters.ts
@@ -95,6 +95,7 @@ import { pythonExec } from "../../core/jupyter/exec.ts";
 import { kTocIndent } from "../../config/constants.ts";
 import { isWindows } from "../../deno_ral/platform.ts";
 import { tinyTexBinDir } from "../../tools/impl/tinytex-info.ts";
+import { typstBinaryPath } from "../../core/typst.ts";
 
 const kQuartoParams = "quarto-params";
 
@@ -204,6 +205,7 @@ async function quartoEnvironmentParams(_options: PandocOptions) {
     "paths": {
       "Rscript": await rBinaryPath("Rscript"),
       "TinyTexBinDir": tinyTexBinDir(), // will be undefined if no tinytex found and quarto will look in PATH
+      "Typst": typstBinaryPath(),
     },
   };
 }

--- a/src/resources/lua-types/quarto/paths.lua
+++ b/src/resources/lua-types/quarto/paths.lua
@@ -13,3 +13,11 @@ Returns the path to the `TinyTeX` bin directory that `quarto install tinytex` in
 ]]
 ---@return string|nil # Path to `TinyTeX` bin directory
 function quarto.paths.tinytex_bin_dir() end
+
+--[[
+Returns the path to the Typst binary that Quarto itself would use for rendering Typst documents.
+This will be the value of the QUARTO_TYPST environment variable if set, or the path to the
+Typst binary bundled with Quarto.
+]]
+---@return string # Path to Typst binary
+function quarto.paths.typst() end

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -990,6 +990,9 @@ quarto = {
     tinytex_bin_dir = function()
       return param('quarto-environment', nil).paths.TinyTexBinDir
     end,
+    typst = function()
+      return param('quarto-environment', nil).paths.Typst
+    end,
   },
   json = json,
   base64 = base64,

--- a/tests/docs/smoke-all/2025/12/05/typst-path-api.lua
+++ b/tests/docs/smoke-all/2025/12/05/typst-path-api.lua
@@ -1,7 +1,5 @@
-function typst_path()
-  return quarto.paths.typst()
+function Pandoc(doc)
+  if quarto.paths.typst() == nil then
+    crash()
+  end
 end
-
-return {
-  ["typst"] = typst_path
-}

--- a/tests/docs/smoke-all/2025/12/05/typst-path-api.lua
+++ b/tests/docs/smoke-all/2025/12/05/typst-path-api.lua
@@ -1,0 +1,7 @@
+function typst_path()
+  return quarto.paths.typst()
+end
+
+return {
+  ["typst"] = typst_path
+}

--- a/tests/docs/smoke-all/2025/12/05/typst-path-api.qmd
+++ b/tests/docs/smoke-all/2025/12/05/typst-path-api.qmd
@@ -1,0 +1,12 @@
+---
+format: html
+shortcodes:
+  - typst-path-api.lua
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - ["<p>The Typst path is .+.</p>"]
+---
+
+The Typst path is "{{< typst >}}".

--- a/tests/docs/smoke-all/2025/12/05/typst-path-api.qmd
+++ b/tests/docs/smoke-all/2025/12/05/typst-path-api.qmd
@@ -1,12 +1,7 @@
 ---
 format: html
-shortcodes:
+filters:
   - typst-path-api.lua
-_quarto:
-  tests:
-    html:
-      ensureFileRegexMatches:
-        - ["<p>The Typst path is <code>.+typst</code>.</p>"]
 ---
 
-The Typst path is `{{< typst >}}`.
+The Typst path is accessible.

--- a/tests/docs/smoke-all/2025/12/05/typst-path-api.qmd
+++ b/tests/docs/smoke-all/2025/12/05/typst-path-api.qmd
@@ -6,7 +6,7 @@ _quarto:
   tests:
     html:
       ensureFileRegexMatches:
-        - ["<p>The Typst path is .+.</p>"]
+        - ["<p>The Typst path is <code>.+typst</code>.</p>"]
 ---
 
-The Typst path is "{{< typst >}}".
+The Typst path is `{{< typst >}}`.


### PR DESCRIPTION
Add `quarto.paths.typst()` to the Lua API to provide a consistent way to access the Typst binary path.
Include unit tests to verify the new functionality and update the changelog accordingly.

This change allows users to use Typst inside a filter or shortcode to process diagrams or other components in Typst.

