### PR TITLE
feat(lua-api): add Lua API for retrieving Pandoc path

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -68,6 +68,10 @@ All changes included in 1.9:
 
 - ([#13414](https://github.com/quarto-dev/quarto-cli/issues/13414)): Be more forgiving when Confluence server returns malformed JSON response. (author: @m1no)
 
+## Lua API
+
+- Added `quarto.paths.pandoc()` to expose the path to the Pandoc binary that Quarto uses for rendering. This respects the `QUARTO_PANDOC` environment variable if set, or returns the path to the bundled Pandoc binary.
+
 ## Other fixes and improvements
 
 - ([#13402](https://github.com/quarto-dev/quarto-cli/issues/13402)): `nfpm` (<https://nfpm.goreleaser.com/>) is now used to create the `.deb` package, and new `.rpm` package. Both Linux packages are also now built for `x86_64` (`amd64`) and `aarch64` (`arm64`) architectures.

--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -70,7 +70,7 @@ All changes included in 1.9:
 
 ## Lua API
 
-- Added `quarto.paths.pandoc()` to expose the path to the Pandoc binary that Quarto uses for rendering. This respects the `QUARTO_PANDOC` environment variable if set, or returns the path to the bundled Pandoc binary.
+- ([#13763](https://github.com/quarto-dev/quarto-cli/issues/13763)): Add `quarto.paths.pandoc()` to expose the path to the Pandoc binary. (author: @mcanouil)
 
 ## Other fixes and improvements
 

--- a/src/command/render/filters.ts
+++ b/src/command/render/filters.ts
@@ -67,7 +67,7 @@ import { QuartoFilterSpec } from "./types.ts";
 import { Metadata } from "../../config/types.ts";
 import { kProjectType } from "../../project/types.ts";
 import { bibEngine } from "../../config/pdf.ts";
-import { rBinaryPath, resourcePath } from "../../core/resources.ts";
+import { rBinaryPath, resourcePath, pandocBinaryPath } from "../../core/resources.ts";
 import { crossrefFilterActive, crossrefFilterParams } from "./crossref.ts";
 import { layoutFilterParams } from "./layout.ts";
 import { pandocMetadataPath } from "./render-paths.ts";
@@ -204,6 +204,7 @@ async function quartoEnvironmentParams(_options: PandocOptions) {
     "paths": {
       "Rscript": await rBinaryPath("Rscript"),
       "TinyTexBinDir": tinyTexBinDir(), // will be undefined if no tinytex found and quarto will look in PATH
+      "Pandoc": pandocBinaryPath(),
     },
   };
 }

--- a/src/resources/lua-types/quarto/paths.lua
+++ b/src/resources/lua-types/quarto/paths.lua
@@ -13,3 +13,11 @@ Returns the path to the `TinyTeX` bin directory that `quarto install tinytex` in
 ]]
 ---@return string|nil # Path to `TinyTeX` bin directory
 function quarto.paths.tinytex_bin_dir() end
+
+--[[
+Returns the path to the Pandoc binary that Quarto itself would use for rendering documents.
+This will be the value of the QUARTO_PANDOC environment variable if set, or the path to the
+Pandoc binary bundled with Quarto.
+]]
+---@return string # Path to Pandoc binary
+function quarto.paths.pandoc() end

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -990,6 +990,9 @@ quarto = {
     tinytex_bin_dir = function()
       return param('quarto-environment', nil).paths.TinyTexBinDir
     end,
+    pandoc = function()
+      return param('quarto-environment', nil).paths.Pandoc
+    end,
   },
   json = json,
   base64 = base64,

--- a/tests/docs/smoke-all/2025/12/06/pandoc-path-api.lua
+++ b/tests/docs/smoke-all/2025/12/06/pandoc-path-api.lua
@@ -1,0 +1,7 @@
+function pandoc_path()
+  return quarto.paths.pandoc()
+end
+
+return {
+  ["pandoc"] = pandoc_path
+}

--- a/tests/docs/smoke-all/2025/12/06/pandoc-path-api.qmd
+++ b/tests/docs/smoke-all/2025/12/06/pandoc-path-api.qmd
@@ -1,0 +1,12 @@
+---
+format: html
+shortcodes:
+  - pandoc-path-api.lua
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - ["<p>The Pandoc path is .+.</p>"]
+---
+
+The Pandoc path is "{{< pandoc >}}".

--- a/tests/docs/smoke-all/2025/12/06/pandoc-path-api.qmd
+++ b/tests/docs/smoke-all/2025/12/06/pandoc-path-api.qmd
@@ -6,7 +6,7 @@ _quarto:
   tests:
     html:
       ensureFileRegexMatches:
-        - ["<p>The Pandoc path is .+.</p>"]
+        - ["<p>The Pandoc path is <code>.+pandoc</code>.</p>"]
 ---
 
-The Pandoc path is "{{< pandoc >}}".
+The Pandoc path is `{{< pandoc >}}`.


### PR DESCRIPTION
Expose the path to the Pandoc binary through a new Lua API function `quarto.paths.pandoc()`.

This is a follow up of #13762


