### PR TITLE
fix(book): add missing support for configurable link target and rel attributes in the book project configuration

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -58,6 +58,10 @@ All changes included in 1.9:
 - ([#13570](https://github.com/quarto-dev/quarto-cli/pull/13570)): Replace Twitter with Bluesky in default blog template and documentation examples. New blog projects now include Bluesky social links instead of Twitter.
 - ([#13716](https://github.com/quarto-dev/quarto-cli/issues/13716)): Fix draft pages showing blank during preview when pre-render scripts are configured.
 
+### `book`
+
+- ([#13769](https://github.com/quarto-dev/quarto-cli/issues/13769)): Apply `repo-link-target` and `repo-link-rel` options to tools in book sidebar for consistent link attribute handling with website projects. (author: @mcanouil)
+
 ### `manuscript`
 
 - ([#10031](https://github.com/quarto-dev/quarto-cli/issues/10031)): Fix manuscript rendering prompting for GitHub credentials when origin points to private repository. Auto-detection of manuscript URL now fails gracefully with a warning instead of blocking renders.

--- a/src/project/types/book/book-config.ts
+++ b/src/project/types/book/book-config.ts
@@ -82,6 +82,7 @@ import {
 import {
   repoUrlIcon,
   websiteConfigActions,
+  websiteConfigString,
   websiteProjectConfig,
 } from "../website/website-config.ts";
 
@@ -229,11 +230,25 @@ export async function bookProjectConfig(
   if (site[kSiteRepoUrl]) {
     const repoUrl = siteRepoUrl(site);
     const icon = repoUrlIcon(repoUrl);
-    tools.push({
+    const tool = {
       text: language[kCodeToolsSourceCode] || "Source Code",
       icon,
       href: repoUrl,
-    });
+    } as Record<string, unknown>;
+
+    // Apply repo-link-target if configured
+    const linkTarget = websiteConfigString(kSiteRepoLinkTarget, config);
+    if (linkTarget) {
+      tool.target = linkTarget;
+    }
+
+    // Apply repo-link-rel if configured
+    const linkRel = websiteConfigString(kSiteRepoLinkRel, config);
+    if (linkRel) {
+      tool.rel = linkRel;
+    }
+
+    tools.push(tool);
   }
   tools.push(...(downloadTools(projectDir, config, language) || []));
   tools.push(...(sharingTools(config, language) || []));

--- a/tests/docs/smoke-all/2025/12/10/13769/_quarto.yml
+++ b/tests/docs/smoke-all/2025/12/10/13769/_quarto.yml
@@ -1,0 +1,20 @@
+project:
+  type: book
+
+book:
+  title: "issue13769"
+  author: "Norah Jones"
+  date: "12/10/2025"
+  repo-url: "https://github.com/quarto-dev/quarto-cli"
+  repo-link-target: "_blank"
+  repo-link-rel: "noreferrer"
+  repo-actions: none
+  chapters:
+    - index.qmd
+
+
+format:
+  html:
+    theme:
+      - cosmo
+      - brand

--- a/tests/docs/smoke-all/2025/12/10/13769/index.qmd
+++ b/tests/docs/smoke-all/2025/12/10/13769/index.qmd
@@ -1,0 +1,15 @@
+---
+format: html
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ['rel="noreferrer"']
+        - ['target="_blank"']
+---
+
+# Preface
+
+This is a Quarto book.
+
+To learn more about Quarto books visit <https://quarto.org/docs/books>.

--- a/tests/docs/smoke-all/2025/12/10/13769/index.qmd
+++ b/tests/docs/smoke-all/2025/12/10/13769/index.qmd
@@ -1,11 +1,9 @@
 ---
-format: html
 _quarto:
   tests:
     html:
       ensureHtmlElements:
-        - ['rel="noreferrer"']
-        - ['target="_blank"']
+        - ['a[rel="noreferrer"][target="_blank"][href="https://github.com/quarto-dev/quarto-cli"][class~="quarto-navigation-tool"]']
 ---
 
 # Preface


### PR DESCRIPTION
The update adds support for the `repo-link-target` and `repo-link-rel` attributes in the book project configuration.

The logic is similar to what was done for website/repo-actions:

- https://github.com/quarto-dev/quarto-cli/blob/9311ca873881e38c4cecddaf4fefb014fdc235f4/src/project/types/website/website-navigation.ts#L753-L785

Fixes #13769

