### PR TITLE
detect and warn about x64 R on Windows ARM

### DIFF
--- a/src/core/knitr.ts
+++ b/src/core/knitr.ts
@@ -82,7 +82,7 @@ function checkWindowsArmR(platform: string | undefined): void {
 
   const isX64R = platform.includes("x86_64") || platform.includes("i386");
 
-  if (isWindowsArm() && isX64R) {
+  if (isX64R && isWindowsArm()) {
     throw new WindowsArmX64RError(
       "x64 R detected on Windows ARM.\n\n" +
         "x64 R runs under emulation and is not reliable for Quarto.\n" +
@@ -131,7 +131,6 @@ export async function knitrCapabilities(rBin: string | undefined) {
         )
         : false;
 
-      checkWindowsArmR(caps.platform);
       return caps;
     } else {
       debug("\n++ Problem with results of knitr capabilities check.");

--- a/src/core/knitr.ts
+++ b/src/core/knitr.ts
@@ -12,6 +12,7 @@ import { readYamlFromString } from "./yaml.ts";
 import { coerce, satisfies } from "semver/mod.ts";
 import { debug } from "../deno_ral/log.ts";
 import { isWindows } from "../deno_ral/platform.ts";
+import { isWindowsArm } from "./windows.ts";
 
 export interface KnitrCapabilities {
   versionMajor: number;
@@ -79,10 +80,9 @@ export class WindowsArmX64RError extends Error {
 function checkWindowsArmR(platform: string | undefined): void {
   if (!platform) return;
 
-  const isWindowsArm = isWindows && Deno.build.arch === "aarch64";
   const isX64R = platform.includes("x86_64") || platform.includes("i386");
 
-  if (isWindowsArm && isX64R) {
+  if (isWindowsArm() && isX64R) {
     throw new WindowsArmX64RError(
       "x64 R detected on Windows ARM.\n\n" +
         "x64 R runs under emulation and is not reliable for Quarto.\n" +

--- a/src/core/windows.ts
+++ b/src/core/windows.ts
@@ -166,6 +166,17 @@ export async function safeWindowsExec(
 
 // Detect Windows ARM hardware using IsWow64Process2 API
 // Returns true if running on ARM64 hardware (even from x64 Deno under emulation)
+//
+// Background: Deno.build.arch reports the architecture Deno was compiled for,
+// not the actual hardware architecture. When x64 Deno runs on ARM64 under
+// WOW64 emulation, Deno.build.arch still reports "x86_64".
+//
+// Solution: Use Windows IsWow64Process2 API which returns the native machine
+// architecture regardless of emulation. This is a standard Windows API function
+// available since Windows 10 (kernel32.dll is always present on Windows).
+//
+// Reference: Validated approach from https://github.com/cderv/quarto-windows-arm
+// See: https://learn.microsoft.com/en-us/windows/win32/api/wow64apiset/nf-wow64apiset-iswow64process2
 export function isWindowsArm(): boolean {
   if (!isWindows) {
     return false;

--- a/src/resources/capabilities/knitr.R
+++ b/src/resources/capabilities/knitr.R
@@ -8,6 +8,7 @@ cat("libPaths:\n")
 for (lib in .libPaths()) {
   cat(paste0('  - ', shQuote(lib)), "\n")
 }
+cat("platform:", R.version[['platform']], "\n")
 cat("packages:\n")
 cat("  knitr: ")
 if (requireNamespace("knitr", quietly = TRUE)) {


### PR DESCRIPTION
When x64 R fails on Windows ARM, parse YAML output to detect the architecture mismatch and provide a specific error message with ARM64 R download links instead of the generic "check your R installation" message.

Also adds platform information to quarto check output with warning when x64 R is detected on ARM Windows.

This is draft PR because I need to check this work as expected in windows ARM runner
