### PR TITLE
Manage projectcontext objects correctly on preview

### DIFF
--- a/package/scripts/common/quarto
+++ b/package/scripts/common/quarto
@@ -187,9 +187,9 @@ QUARTO_DENO_OPTIONS="--unstable-ffi --unstable-kv --no-config --no-lock ${QUARTO
 
 # --enable-experimental-regexp-engine is required for /regex/l, https://github.com/quarto-dev/quarto-cli/issues/9737
 if [ "$QUARTO_DENO_V8_OPTIONS" != "" ]; then
-  QUARTO_DENO_V8_OPTIONS="--enable-experimental-regexp-engine,--max-old-space-size=8192,--max-heap-size=8192,${QUARTO_DENO_V8_OPTIONS}"
+  QUARTO_DENO_V8_OPTIONS="--enable-experimental-regexp-engine,--max-old-space-size=8192,--max-heap-size=8192,--stack-trace-limit=100,${QUARTO_DENO_V8_OPTIONS}"
 else
-  QUARTO_DENO_V8_OPTIONS="--enable-experimental-regexp-engine,--max-old-space-size=8192,--max-heap-size=8192"
+  QUARTO_DENO_V8_OPTIONS="--enable-experimental-regexp-engine,--max-old-space-size=8192,--max-heap-size=8192,--stack-trace-limit=100"
 fi
 
 if [ "$QUARTO_DENO_EXTRA_OPTIONS" == "" ]; then

--- a/package/scripts/windows/quarto.cmd
+++ b/package/scripts/windows/quarto.cmd
@@ -142,8 +142,11 @@ IF DEFINED QUARTO_DENO_V8_OPTIONS (
 	IF "!QUARTO_DENO_V8_OPTIONS!"=="!QUARTO_DENO_V8_OPTIONS:--max-heap-size=!" (
 		SET "QUARTO_DENO_V8_OPTIONS=--max-heap-size=8192,!QUARTO_DENO_V8_OPTIONS!"
 	)
+	IF "!QUARTO_DENO_V8_OPTIONS!"=="!QUARTO_DENO_V8_OPTIONS:--stack-trace-limit=!" (
+		SET "QUARTO_DENO_V8_OPTIONS=--stack-trace-limit=100,!QUARTO_DENO_V8_OPTIONS!"
+	)
 ) ELSE (
-  SET "QUARTO_DENO_V8_OPTIONS=--enable-experimental-regexp-engine,--max-old-space-size=8192,--max-heap-size=8192"
+  SET "QUARTO_DENO_V8_OPTIONS=--enable-experimental-regexp-engine,--max-old-space-size=8192,--max-heap-size=8192,--stack-trace-limit=100"
 )
 
 REM Prepend v8-flags for deno run if necessary

--- a/src/command/preview/cmd.ts
+++ b/src/command/preview/cmd.ts
@@ -292,7 +292,7 @@ export const previewCommand = new Command()
           services.cleanup();
         }
       })();
-      const format = await previewFormat(file, flags.to, formats, project);
+      const format = await previewFormat(file, project, flags.to, formats);
 
       // see if this is server: shiny document and if it is then forward to previewShiny
       if (isHtmlOutput(parseFormatString(format).baseFormat)) {
@@ -314,6 +314,7 @@ export const previewCommand = new Command()
               format,
               pandocArgs: args,
               watchInputs: options.watchInputs!,
+              project,
             });
             exitWithCleanup(result.code);
             throw new Error(); // unreachable

--- a/src/command/preview/preview-shiny.ts
+++ b/src/command/preview/preview-shiny.ts
@@ -33,18 +33,16 @@ import {
 } from "../../core/http.ts";
 import { findOpenPort } from "../../core/port.ts";
 import { handleHttpRequests } from "../../core/http-server.ts";
-import { kLocalhost } from "../../core/port-consts.ts";
 import { normalizePath } from "../../core/path.ts";
 import { previewMonitorResources } from "../../core/quarto.ts";
 import { renderServices } from "../render/render-services.ts";
 import { RenderFlags } from "../render/types.ts";
 import { notebookContext } from "../../render/notebook/notebook-context.ts";
-import { isIpynbOutput } from "../../config/format.ts";
 
 export interface PreviewShinyOptions extends RunOptions {
   pandocArgs: string[];
   watchInputs: boolean;
-  project?: ProjectContext;
+  project: ProjectContext;
 }
 
 export async function previewShiny(options: PreviewShinyOptions) {
@@ -128,8 +126,8 @@ function runPreviewControlService(
     return normalizePath(options.input) === normalizePath(prevReq.path) &&
       await previewRenderRequestIsCompatible(
         prevReq,
-        options.format,
         options.project,
+        options.format,
       );
   };
 

--- a/src/command/preview/preview.ts
+++ b/src/command/preview/preview.ts
@@ -85,7 +85,7 @@ import {
 import { isJupyterNotebook } from "../../core/jupyter/jupyter.ts";
 import { watchForFileChanges } from "../../core/watch.ts";
 import { previewMonitorResources } from "../../core/quarto.ts";
-import { exitWithCleanup } from "../../core/cleanup.ts";
+import { exitWithCleanup, onCleanup } from "../../core/cleanup.ts";
 import {
   extensionFilesFromDirs,
   inputExtensionDirs,
@@ -151,11 +151,15 @@ export async function preview(
 ) {
   const nbContext = notebookContext();
   // see if this is project file
-  const project = await projectContext(file, nbContext);
+  const project = (await projectContext(file, nbContext)) ||
+    (await singleFileProjectContext(file, nbContext));
+  onCleanup(() => {
+    project.cleanup();
+  });
 
   // determine the target format if there isn't one in the command line args
   // (current we force the use of an html or pdf based format)
-  const format = await previewFormat(file, flags.to, undefined, project);
+  const format = await previewFormat(file, project, flags.to, undefined);
   setPreviewFormat(format, flags, pandocArgs);
 
   // render for preview (create function we can pass to watcher then call it)
@@ -224,6 +228,7 @@ export async function preview(
       options.port!,
       reloader,
       changeHandler.render,
+      project,
     )
     : project
     ? projectHtmlFileRequestHandler(
@@ -241,6 +246,7 @@ export async function preview(
       result.format,
       reloader,
       changeHandler.render,
+      project,
     );
 
   // open browser if this is a browseable format
@@ -340,17 +346,17 @@ export function previewRenderRequest(
 
 export async function previewRenderRequestIsCompatible(
   request: PreviewRenderRequest,
+  project: ProjectContext,
   format?: string,
-  project?: ProjectContext,
 ) {
   if (request.version === 1) {
     return true; // rstudio manages its own request compatibility state
   } else {
     const reqFormat = await previewFormat(
       request.path,
+      project,
       request.format,
       undefined,
-      project,
     );
     return reqFormat === format;
   }
@@ -359,20 +365,20 @@ export async function previewRenderRequestIsCompatible(
 // determine the format to preview
 export async function previewFormat(
   file: string,
+  project: ProjectContext,
   format?: string,
   formats?: Record<string, Format>,
-  project?: ProjectContext,
 ) {
   if (format) {
     return format;
   }
-  const nbContext = notebookContext();
-  project = project || (await singleFileProjectContext(file, nbContext));
+  // const nbContext = notebookContext();
+  // project = project || (await singleFileProjectContext(file, nbContext));
   formats = formats ||
     await withRenderServices(
-      nbContext,
+      project.notebookContext,
       (services: RenderServices) =>
-        renderFormats(file, services, "all", project!),
+        renderFormats(file, services, "all", project),
     );
   format = Object.keys(formats)[0] || "html";
   return format;
@@ -418,7 +424,6 @@ export async function renderForPreview(
   pandocArgs: string[],
   project?: ProjectContext,
 ): Promise<RenderForPreviewResult> {
-
   // render
   const renderResult = await render(file, {
     services,
@@ -426,7 +431,7 @@ export async function renderForPreview(
     pandocArgs: pandocArgs,
     previewServer: true,
     setProjectDir: project !== undefined,
-  });
+  }, project);
   if (renderResult.error) {
     throw renderResult.error;
   }
@@ -689,6 +694,7 @@ function htmlFileRequestHandler(
   format: Format,
   reloader: HttpDevServer,
   renderHandler: (to?: string) => Promise<RenderForPreviewResult | undefined>,
+  context: ProjectContext,
 ) {
   return httpFileRequestHandler(
     htmlFileRequestHandlerOptions(
@@ -699,6 +705,7 @@ function htmlFileRequestHandler(
       format,
       reloader,
       renderHandler,
+      context,
     ),
   );
 }
@@ -711,7 +718,7 @@ function htmlFileRequestHandlerOptions(
   format: Format,
   devserver: HttpDevServer,
   renderHandler: (to?: string) => Promise<RenderForPreviewResult | undefined>,
-  project?: ProjectContext,
+  project: ProjectContext,
 ): HttpFileRequestOptions {
   // if we an alternate format on the fly we need to do a full re-render
   // to get the correct state back. this flag will be set whenever
@@ -742,7 +749,7 @@ function htmlFileRequestHandlerOptions(
           prevReq &&
           existsSync(prevReq.path) &&
           normalizePath(prevReq.path) === normalizePath(inputFile) &&
-          await previewRenderRequestIsCompatible(prevReq, flags.to)
+          await previewRenderRequestIsCompatible(prevReq, project, flags.to)
         ) {
           // don't wait for the promise so the
           // caller gets an immediate reply
@@ -853,6 +860,7 @@ function pdfFileRequestHandler(
   port: number,
   reloader: HttpDevServer,
   renderHandler: () => Promise<RenderForPreviewResult | undefined>,
+  project: ProjectContext,
 ) {
   // start w/ the html handler (as we still need it's http reload injection)
   const pdfOptions = htmlFileRequestHandlerOptions(
@@ -863,6 +871,7 @@ function pdfFileRequestHandler(
     format,
     reloader,
     renderHandler,
+    project,
   );
 
   // pdf customizations

--- a/src/command/render/render-shared.ts
+++ b/src/command/render/render-shared.ts
@@ -47,9 +47,7 @@ export async function render(
   const nbContext = pContext?.notebookContext || notebookContext();
 
   // determine target context/files
-  // let context = await projectContext(path, nbContext, options);
-  let context = pContext || (await projectContext(path, nbContext, options)) ||
-    (await singleFileProjectContext(path, nbContext, options));
+  let context = pContext || (await projectContext(path, nbContext, options));
 
   // Create a synthetic project when --output-dir is used without a project file
   // This creates a temporary .quarto directory to manage the render, which must
@@ -60,6 +58,11 @@ export async function render(
     // forceClean signals this is a synthetic project that needs full cleanup
     // including removing the .quarto scratch directory after rendering (#13625)
     options.forceClean = options.flags.clean !== false;
+  }
+
+  // Fall back to single file context if we still don't have a context
+  if (!context) {
+    context = await singleFileProjectContext(path, nbContext, options);
   }
 
   // set env var if requested

--- a/src/command/serve/cmd.ts
+++ b/src/command/serve/cmd.ts
@@ -75,7 +75,7 @@ export const serveCommand = new Command()
       (services: RenderServices) =>
         renderFormats(input, services, undefined, context),
     );
-    const format = await previewFormat(input, undefined, formats, context);
+    const format = await previewFormat(input, context, undefined, formats);
 
     const result = await serve({
       input,

--- a/src/execute/jupyter/jupyter.ts
+++ b/src/execute/jupyter/jupyter.ts
@@ -317,7 +317,23 @@ title: "Title"
           // of additional changes to our file handling code (without changes,
           // our output files would be called $FILE.quarto.html, which
           // is not what we want). So for now, we'll use .quarto_ipynb
-          const notebook = join(fileDir, fileStem + ".quarto_ipynb");
+          let counter: number | undefined = undefined;
+          let notebook = join(
+            fileDir,
+            `${fileStem}.quarto_ipynb${counter ? "_" + String(counter) : ""}`,
+          );
+
+          while (existsSync(notebook)) {
+            if (!counter) {
+              counter = 1;
+            } else {
+              ++counter;
+            }
+            notebook = join(
+              fileDir,
+              `${fileStem}.quarto_ipynb${counter ? "_" + String(counter) : ""}`,
+            );
+          }
           const target = {
             source: file,
             input: notebook,

--- a/src/project/project-context.ts
+++ b/src/project/project-context.ts
@@ -107,7 +107,6 @@ import { createProjectCache } from "../core/cache/cache.ts";
 import { createTempContext } from "../core/temp.ts";
 
 import { onCleanup } from "../core/cleanup.ts";
-import { once } from "../core/once.ts";
 import { Zod } from "../resources/types/zod/schema-types.ts";
 import { ExternalEngine } from "../resources/types/schema-types.ts";
 
@@ -374,11 +373,11 @@ export async function projectContext(
           previewServer: renderOptions?.previewServer,
           diskCache: await createProjectCache(join(dir, ".quarto")),
           temp,
-          cleanup: once(() => {
+          cleanup: () => {
             cleanupFileInformationCache(result);
             result.diskCache.close();
             temp.cleanup();
-          }),
+          },
         };
 
         // see if the project [kProjectType] wants to filter the project config
@@ -466,11 +465,11 @@ export async function projectContext(
           previewServer: renderOptions?.previewServer,
           diskCache: await createProjectCache(join(dir, ".quarto")),
           temp,
-          cleanup: once(() => {
+          cleanup: () => {
             cleanupFileInformationCache(result);
             result.diskCache.close();
             temp.cleanup();
-          }),
+          },
         };
         const { files, engines } = await projectInputFiles(
           result,
@@ -546,11 +545,11 @@ export async function projectContext(
             previewServer: renderOptions?.previewServer,
             diskCache: await createProjectCache(join(temp.baseDir, ".quarto")),
             temp,
-            cleanup: once(() => {
+            cleanup: () => {
               cleanupFileInformationCache(context);
               context.diskCache.close();
               temp.cleanup();
-            }),
+            },
           };
           if (Deno.statSync(path).isDirectory) {
             const { files, engines } = await projectInputFiles(context);

--- a/src/project/serve/serve.ts
+++ b/src/project/serve/serve.ts
@@ -810,7 +810,7 @@ function previewControlChannelRequestHandler(
       );
       if (
         prevReq &&
-        (await previewRenderRequestIsCompatible(prevReq, flags.to, project))
+        (await previewRenderRequestIsCompatible(prevReq, project, flags.to))
       ) {
         if (isProjectInputFile(prevReq.path, project!)) {
           const services = renderServices(notebookContext());

--- a/src/project/types/single-file/single-file.ts
+++ b/src/project/types/single-file/single-file.ts
@@ -86,10 +86,10 @@ export async function singleFileProjectContext(
     isSingleFile: true,
     diskCache: await createProjectCache(projectCacheBaseDir),
     temp,
-    cleanup: once(() => {
+    cleanup: () => {
       cleanupFileInformationCache(result);
       result.diskCache.close();
-    }),
+    },
   };
   if (renderOptions) {
     result.config = {

--- a/src/resources/filters/quarto-post/foldcode.lua
+++ b/src/resources/filters/quarto-post/foldcode.lua
@@ -106,7 +106,6 @@ function fold_code_and_lift_codeblocks()
           })
           if need_to_move_dl then
             assert(prev_annotated_code_block_scaffold)
-            print(prev_annotated_code_block_scaffold)
             prev_annotated_code_block_scaffold.content:insert(div)
             return {}
           end

--- a/src/resources/filters/quarto-post/typst.lua
+++ b/src/resources/filters/quarto-post/typst.lua
@@ -73,7 +73,6 @@ function render_typst()
         m["toc-indent"] = option("toc-indent")
         if m["number-depth"] then
           number_depth = tonumber(pandoc.utils.stringify(m["number-depth"]))
-          print(number_depth)
         end
         return m
       end

--- a/src/resources/filters/quarto-pre/shiny.lua
+++ b/src/resources/filters/quarto-pre/shiny.lua
@@ -112,7 +112,6 @@ function server_shiny()
     end,
 
     Pandoc = function(doc)
-      print(quarto.doc.output_file)
       codeCells["html_file"] = pandoc.path.split_extension(
         pandoc.path.filename(quarto.doc.output_file)
       ) .. ".html"

--- a/src/resources/filters/quarto-pre/shiny.lua
+++ b/src/resources/filters/quarto-pre/shiny.lua
@@ -112,6 +112,7 @@ function server_shiny()
     end,
 
     Pandoc = function(doc)
+      print(quarto.doc.output_file)
       codeCells["html_file"] = pandoc.path.split_extension(
         pandoc.path.filename(quarto.doc.output_file)
       ) .. ".html"
@@ -123,7 +124,7 @@ function server_shiny()
       end
 
       -- Write the code cells to a temporary file.
-      codeCellsOutfile = pandoc.path.split_extension(quarto.doc.output_file) .. "-cells.tmp.json"
+      local codeCellsOutfile = pandoc.path.split_extension(quarto.doc.output_file) .. "-cells.tmp.json"
       local file = io.open(codeCellsOutfile, "w")
       if file == nil then
         error("Error opening file: " .. codeCellsOutfile .. " for writing.")
@@ -132,7 +133,7 @@ function server_shiny()
       file:close()
 
       -- Convert the json file to app.py by calling `shiny convert-cells`.
-      appOutfile = pandoc.path.join({
+      local appOutfile = pandoc.path.join({
         pandoc.path.directory(quarto.doc.output_file),
         "app.py"
       });

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -645,16 +645,9 @@ local function inputFile()
       return source
    else
       local projectDir = projectDirectory()
-      if projectDir then
-         return pandoc.path.join({projectDir, source})
-      else
-         -- outside of a project, quarto already changes 
-         -- pwd to the file's directory prior to calling pandoc,
-         -- so we should just use the filename
-         -- https://github.com/quarto-dev/quarto-cli/issues/7424
-         local path_parts = pandoc.path.split(source)
-         return pandoc.path.join({pandoc.system.get_working_directory(), path_parts[#path_parts]})
-      end   
+      -- we now always have a projectDir, even in single-file settings
+      assert(projectDir)
+      return pandoc.path.join({projectDir, source})
    end
 end
 

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -645,9 +645,16 @@ local function inputFile()
       return source
    else
       local projectDir = projectDirectory()
-      -- we now always have a projectDir, even in single-file settings
-      assert(projectDir)
-      return pandoc.path.join({projectDir, source})
+      if projectDir then
+         return pandoc.path.join({projectDir, source})
+      else
+         -- outside of a project, quarto already changes 
+         -- pwd to the file's directory prior to calling pandoc,
+         -- so we should just use the filename
+         -- https://github.com/quarto-dev/quarto-cli/issues/7424
+         local path_parts = pandoc.path.split(source)
+         return pandoc.path.join({pandoc.system.get_working_directory(), path_parts[#path_parts]})
+      end   
    end
 end
 
@@ -655,6 +662,10 @@ local function outputFile()
    local projectOutDir = projectOutputDirectory()
    if projectOutDir then
       local projectDir = projectDirectory()
+      print("---")
+      print(projectDir)
+      print(pandoc.path.directory(inputFile()))
+      print("---")
       if projectDir then
          local input = pandoc.path.directory(inputFile())
          local relativeDir = pandoc.path.make_relative(input, projectDir)

--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -662,10 +662,6 @@ local function outputFile()
    local projectOutDir = projectOutputDirectory()
    if projectOutDir then
       local projectDir = projectDirectory()
-      print("---")
-      print(projectDir)
-      print(pandoc.path.directory(inputFile()))
-      print("---")
       if projectDir then
          local input = pandoc.path.directory(inputFile())
          local relativeDir = pandoc.path.make_relative(input, projectDir)

--- a/tests/docs/playwright/embed-resources/issue-11860/.gitignore
+++ b/tests/docs/playwright/embed-resources/issue-11860/.gitignore
@@ -1,2 +1,4 @@
 inner
 /.quarto/
+
+**/*.quarto_ipynb

--- a/tests/integration/playwright/tests/html-embed-resources-es6-modules.spec.ts
+++ b/tests/integration/playwright/tests/html-embed-resources-es6-modules.spec.ts
@@ -1,5 +1,11 @@
 import { expect, Page, test } from "@playwright/test";
 
+// To run this test standalone, first render the fixture with --output-dir:
+//   quarto render tests/docs/playwright/embed-resources/issue-11860/main.qmd --output-dir=inner
+// Then run:
+//   npx playwright test tests/html-embed-resources-es6-modules.spec.ts
+//
+// The full test suite (integration/playwright-tests.test.ts) handles rendering automatically.
 test("es6 modules to be bundled correctly in documents with embed-resources=true", async ({ page }) => {
   const messages: string[] = [];
   page.on('response', (response) => {


### PR DESCRIPTION
This should close a few of our `quarto preview` intermittent issues whose symptom is a missing `quarto_ipynb` file.

See, eg, #12992.