### PR TITLE
bug fix: HR vs YAML block parsing in breakQuartoMd

### DIFF
--- a/src/core/lib/break-quarto-md.ts
+++ b/src/core/lib/break-quarto-md.ts
@@ -168,11 +168,11 @@ export async function breakQuartoMd(
       return false;
     }
 
-    // if a yaml delimiter is surrounded by whitespace-only lines,
+    // if a yaml delimiter is followed by a whitespace-only line,
     // then it is actually an HR element; treat it as such.
+    // (YAML opening delimiters are followed by content like "key: value")
     if (
       skipHRs &&
-      index > 0 && srcLines[index - 1].substring.trim() === "" &&
       index < srcLines.length - 1 && srcLines[index + 1].substring.trim() === ""
     ) {
       return false;


### PR DESCRIPTION
I'm not sure if we should fix this, but I wanted to submit it for discussion.

There is a difference between how Pandoc and `breakQuartoMd` parse horizontal rules versus YAML blocks with

```
---
```

Pandoc "strongly recommends" that you put blank lines before and after an HR, but only checks for the latter.

OTOH `breakQuartoMd` only parses `---` as an HR if it is both preceded and followed by a blank line. Otherwise it might be starting a YAML block (if it finds the end of one).

This change tells `breakQuartoMd` to treat `---` as an HR if it followed by a blank line, like Pandoc. It no longer looks at line before.

## The Problem


The `quarto-marimo` `index.qmd` has a construction that looks like:


````markdown
---
title: marimo + quarto
format: html
---

# Heading
---

Some content here (including code blocks).

---

More content.
````

and now that it relies on `breakQuartoMd`, it loses some code blocks and fails.

I'm completely fine with telling them to add a newline, but thought I'd raise this fix for consideration.

## Blast radius

The function gets a lot of use, so it's little scary to change it

>   Components that depend on `breakQuartoMd`
> 
>   1. Project Code Cell Resolution - `projectResolveCodeCellsForFile` for understanding project structure
>   2. Markdown Include Expansion - `expandIncludes` for processing `{{< include >}}` directives
>   3. Language Cell Handling - `handleLanguageCells` for processing different language cells
>   4. Jupyter Notebook Conversion - `quartoMdToJupyter` for converting qmd to ipynb
>   5. OJS Resource Extraction - `extractResolvedResourceFilenamesFromQmd` for Observable JS
>   6. YAML Intelligence - `automationFromGoodParseMarkdown` for editor completions/validations


But the change does not affect the parsing of actual YAML block openings, since those would always have content in the next line.

