### PR TITLE
quarto api: quarto.system.pandoc(), breakQuartoMd cell regex

### DIFF
--- a/llm-docs/README.md
+++ b/llm-docs/README.md
@@ -1,0 +1,4 @@
+# LLM documentation for Quarto
+
+This directory contains documents providing context and instructions for LLMs
+to execute tasks in the `quarto-cli` codebase.

--- a/packages/quarto-types/dist/index.d.ts
+++ b/packages/quarto-types/dist/index.d.ts
@@ -837,9 +837,12 @@ export interface QuartoAPI {
 		 * @param src - Markdown string or MappedString
 		 * @param validate - Whether to validate cells (default: false)
 		 * @param lenient - Whether to use lenient parsing (default: false)
+		 * @param startCodeCellRegex - Optional custom regex for detecting code cell starts.
+		 *        Must have capture group 1 for backticks and group 2 for language.
+		 *        Default matches `{language}` syntax.
 		 * @returns Promise resolving to chunks with cells
 		 */
-		breakQuartoMd: (src: string | MappedString, validate?: boolean, lenient?: boolean) => Promise<QuartoMdChunks>;
+		breakQuartoMd: (src: string | MappedString, validate?: boolean, lenient?: boolean, startCodeCellRegex?: RegExp) => Promise<QuartoMdChunks>;
 	};
 	/**
 	 * MappedString utilities for source location tracking
@@ -1300,6 +1303,17 @@ export interface QuartoAPI {
 		 * @returns Promise resolving to render result with success status
 		 */
 		checkRender: (options: CheckRenderOptions) => Promise<CheckRenderResult>;
+		/**
+		 * Execute pandoc with the given arguments
+		 *
+		 * Runs the bundled pandoc binary (or QUARTO_PANDOC override) with
+		 * the specified arguments. Path to pandoc is automatically resolved.
+		 *
+		 * @param args - Command line arguments to pass to pandoc
+		 * @param stdin - Optional stdin content to pipe to pandoc
+		 * @returns Promise resolving to process result with stdout/stderr
+		 */
+		pandoc: (args: string[], stdin?: string) => Promise<ProcessResult>;
 	};
 	/**
 	 * Text processing utilities

--- a/packages/quarto-types/src/quarto-api.ts
+++ b/packages/quarto-types/src/quarto-api.ts
@@ -72,12 +72,16 @@ export interface QuartoAPI {
      * @param src - Markdown string or MappedString
      * @param validate - Whether to validate cells (default: false)
      * @param lenient - Whether to use lenient parsing (default: false)
+     * @param startCodeCellRegex - Optional custom regex for detecting code cell starts.
+     *        Must have capture group 1 for backticks and group 2 for language.
+     *        Default matches `{language}` syntax.
      * @returns Promise resolving to chunks with cells
      */
     breakQuartoMd: (
       src: string | MappedString,
       validate?: boolean,
       lenient?: boolean,
+      startCodeCellRegex?: RegExp,
     ) => Promise<QuartoMdChunks>;
   };
 
@@ -637,6 +641,18 @@ export interface QuartoAPI {
      * @returns Promise resolving to render result with success status
      */
     checkRender: (options: CheckRenderOptions) => Promise<CheckRenderResult>;
+
+    /**
+     * Execute pandoc with the given arguments
+     *
+     * Runs the bundled pandoc binary (or QUARTO_PANDOC override) with
+     * the specified arguments. Path to pandoc is automatically resolved.
+     *
+     * @param args - Command line arguments to pass to pandoc
+     * @param stdin - Optional stdin content to pipe to pandoc
+     * @returns Promise resolving to process result with stdout/stderr
+     */
+    pandoc: (args: string[], stdin?: string) => Promise<ProcessResult>;
   };
 
   /**

--- a/src/core/api/system.ts
+++ b/src/core/api/system.ts
@@ -11,6 +11,7 @@ import { runExternalPreviewServer } from "../../preview/preview-server.ts";
 import { onCleanup } from "../cleanup.ts";
 import { globalTempContext } from "../temp.ts";
 import { checkRender } from "../../command/check/check-render.ts";
+import { pandocBinaryPath } from "../resources.ts";
 
 // Register system namespace
 globalRegistry.register("system", (): SystemNamespace => {
@@ -22,5 +23,16 @@ globalRegistry.register("system", (): SystemNamespace => {
     onCleanup,
     tempContext: globalTempContext,
     checkRender,
+    pandoc: (args: string[], stdin?: string) => {
+      return execProcess(
+        {
+          cmd: pandocBinaryPath(),
+          args,
+          stdout: "piped",
+          stderr: "piped",
+        },
+        stdin,
+      );
+    },
   };
 });

--- a/src/core/api/types.ts
+++ b/src/core/api/types.ts
@@ -42,6 +42,7 @@ export interface MarkdownRegexNamespace {
     src: string | MappedString,
     validate?: boolean,
     lenient?: boolean,
+    startCodeCellRegex?: RegExp,
   ) => Promise<QuartoMdChunks>;
 }
 
@@ -179,6 +180,7 @@ export interface SystemNamespace {
     language: string;
     services: RenderServiceWithLifetime;
   }) => Promise<{ success: boolean; error?: Error }>;
+  pandoc: (args: string[], stdin?: string) => Promise<ProcessResult>;
 }
 
 /**

--- a/src/core/lib/break-quarto-md.ts
+++ b/src/core/lib/break-quarto-md.ts
@@ -29,6 +29,7 @@ export async function breakQuartoMd(
   src: EitherString,
   validate = false,
   lenient = false,
+  startCodeCellRegex?: RegExp,
 ) {
   if (typeof src === "string") {
     src = asMappedString(src);
@@ -42,7 +43,7 @@ export async function breakQuartoMd(
 
   // regexes
   const yamlRegEx = /^---\s*$/;
-  const startCodeCellRegEx = new RegExp(
+  const startCodeCellRegEx = startCodeCellRegex ?? new RegExp(
     "^\\s*(```+)\\s*\\{([=A-Za-z]+)( *[ ,].*)?\\}\\s*$",
   );
   const startCodeRegEx = /^```/;

--- a/src/core/lib/break-quarto-md.ts
+++ b/src/core/lib/break-quarto-md.ts
@@ -43,7 +43,7 @@ export async function breakQuartoMd(
 
   // regexes
   const yamlRegEx = /^---\s*$/;
-  const startCodeCellRegEx = startCodeCellRegex ?? new RegExp(
+  const startCodeCellRegEx = startCodeCellRegex || new RegExp(
     "^\\s*(```+)\\s*\\{([=A-Za-z]+)( *[ ,].*)?\\}\\s*$",
   );
   const startCodeRegEx = /^```/;


### PR DESCRIPTION
* pandoc execution wrapper `quarto.system.pandoc()`
* add optional `startCodeCellRegex` param to `breakQuartoMd`
* `llm-docs`: update quarto api and add `README.md`
