### PR TITLE
fix(R): detect x64 R on Windows ARM via exit codes

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -99,6 +99,7 @@ All changes included in 1.9:
 
 ## Other fixes and improvements
 
+- ([#8730](https://github.com/quarto-dev/quarto-cli/issues/8730)): Detect x64 R crashes on Windows ARM and provide helpful error message directing users to install native ARM64 R instead of showing generic "check your R installation" error.
 - ([#13402](https://github.com/quarto-dev/quarto-cli/issues/13402)): `nfpm` (<https://nfpm.goreleaser.com/>) is now used to create the `.deb` package, and new `.rpm` package. Both Linux packages are also now built for `x86_64` (`amd64`) and `aarch64` (`arm64`) architectures.
 - ([#13528](https://github.com/quarto-dev/quarto-cli/pull/13528)): Adds support for table specification using nested lists and the `list-table` class.
 - ([#13575](https://github.com/quarto-dev/quarto-cli/pull/13575)): Improve CPU architecture detection/reporting in macOS to allow quarto to run in virtualized environments such as OpenAI's `codex`.

--- a/src/core/knitr.ts
+++ b/src/core/knitr.ts
@@ -11,6 +11,7 @@ import { rBinaryPath, resourcePath } from "./resources.ts";
 import { readYamlFromString } from "./yaml.ts";
 import { coerce, satisfies } from "semver/mod.ts";
 import { debug } from "../deno_ral/log.ts";
+import { errorOnce } from "./log.ts";
 
 export interface KnitrCapabilities {
   versionMajor: number;
@@ -147,9 +148,10 @@ export async function knitrCapabilities(rBin: string | undefined) {
       return undefined;
     }
   } catch (e) {
-    // Rethrow x64-on-ARM errors - these have helpful messages
+    // Log x64-on-ARM errors once, then return undefined like other errors
     if (e instanceof WindowsArmX64RError) {
-      throw e;
+      errorOnce(e.message);
+      return undefined;
     }
     debug(
       `\n++ Error while running 'capabilities/knitr.R' ${

--- a/src/core/knitr.ts
+++ b/src/core/knitr.ts
@@ -132,11 +132,15 @@ export async function knitrCapabilities(rBin: string | undefined) {
 
       if (isX64RCrashOnArm) {
         throw new WindowsArmX64RError(
-          "x64 R detected on Windows ARM.\n\n" +
-            "x64 R runs under emulation and is not reliable for Quarto.\n" +
-            "Please install native ARM64 R. \n" +
-            "Read about R on 64-bit Windows ARM at https://blog.r-project.org/2024/04/23/r-on-64-bit-arm-windows/\n" +
-            "After installation, set QUARTO_R environment variable if the correct version is not correctly found.",
+          `R process crashed with known error code (${result.code}).\n\n` +
+            "This typically indicates x64 R running on Windows 11 ARM.\n" +
+            "x64 R runs under emulation and is not reliable for Quarto.\n\n" +
+            "To fix this issue:\n" +
+            "1. Check your R version with: Rscript -e \"R.version$platform\"\n" +
+            "2. If it shows 'x86_64-w64-mingw32', you need ARM64 R\n" +
+            "3. Install native ARM64 R: https://blog.r-project.org/2024/04/23/r-on-64-bit-arm-windows/\n" +
+            "4. If needed, set QUARTO_R environment variable to point to ARM64 Rscript\n\n" +
+            "More context on this issue: https://github.com/quarto-dev/quarto-cli/issues/8730",
         );
       }
 

--- a/src/core/knitr.ts
+++ b/src/core/knitr.ts
@@ -75,6 +75,30 @@ export class WindowsArmX64RError extends Error {
   }
 }
 
+// Check for x64 R crashes on ARM Windows
+// These specific error codes only occur when x64 R crashes on ARM Windows
+// See: https://github.com/quarto-dev/quarto-cli/issues/8730
+//      https://github.com/cderv/quarto-windows-arm
+function throwIfX64ROnArm(exitCode: number): void {
+  const isX64RCrashOnArm =
+    exitCode === -1073741569 ||  // STATUS_NOT_SUPPORTED (native ARM hardware)
+    exitCode === -1073741819;    // STATUS_ACCESS_VIOLATION (Windows ARM VM on Mac)
+
+  if (isX64RCrashOnArm) {
+    throw new WindowsArmX64RError(
+      `R process crashed with known error code (${exitCode}).\n\n` +
+        "This typically indicates x64 R running on Windows 11 ARM.\n" +
+        "x64 R runs under emulation and is not reliable for Quarto.\n\n" +
+        "To fix this issue:\n" +
+        "1. Check your R version with: Rscript -e \"R.version$platform\"\n" +
+        "2. If it shows 'x86_64-w64-mingw32', you need ARM64 R\n" +
+        "3. Install native ARM64 R: https://blog.r-project.org/2024/04/23/r-on-64-bit-arm-windows/\n" +
+        "4. If needed, set QUARTO_R environment variable to point to ARM64 Rscript\n\n" +
+        "More context on this issue: https://github.com/quarto-dev/quarto-cli/issues/8730",
+    );
+  }
+}
+
 export async function knitrCapabilities(rBin: string | undefined) {
   if (!rBin) return undefined;
   try {
@@ -123,27 +147,7 @@ export async function knitrCapabilities(rBin: string | undefined) {
         debug(`    with stderr from R:\n${result.stderr}`);
       }
 
-      // Check for x64 R crashes on ARM Windows
-      // These specific error codes only occur when x64 R crashes on ARM Windows
-      // See: https://github.com/quarto-dev/quarto-cli/issues/8730
-      //      https://github.com/cderv/quarto-windows-arm
-      const isX64RCrashOnArm =
-        result.code === -1073741569 ||  // STATUS_NOT_SUPPORTED (native ARM hardware)
-        result.code === -1073741819;    // STATUS_ACCESS_VIOLATION (Windows ARM VM on Mac)
-
-      if (isX64RCrashOnArm) {
-        throw new WindowsArmX64RError(
-          `R process crashed with known error code (${result.code}).\n\n` +
-            "This typically indicates x64 R running on Windows 11 ARM.\n" +
-            "x64 R runs under emulation and is not reliable for Quarto.\n\n" +
-            "To fix this issue:\n" +
-            "1. Check your R version with: Rscript -e \"R.version$platform\"\n" +
-            "2. If it shows 'x86_64-w64-mingw32', you need ARM64 R\n" +
-            "3. Install native ARM64 R: https://blog.r-project.org/2024/04/23/r-on-64-bit-arm-windows/\n" +
-            "4. If needed, set QUARTO_R environment variable to point to ARM64 Rscript\n\n" +
-            "More context on this issue: https://github.com/quarto-dev/quarto-cli/issues/8730",
-        );
-      }
+      throwIfX64ROnArm(result.code);
 
       return undefined;
     }

--- a/src/core/knitr.ts
+++ b/src/core/knitr.ts
@@ -124,6 +124,8 @@ export async function knitrCapabilities(rBin: string | undefined) {
 
       // Check for x64 R crashes on ARM Windows
       // These specific error codes only occur when x64 R crashes on ARM Windows
+      // See: https://github.com/quarto-dev/quarto-cli/issues/8730
+      //      https://github.com/cderv/quarto-windows-arm
       const isX64RCrashOnArm =
         result.code === -1073741569 ||  // STATUS_NOT_SUPPORTED (native ARM hardware)
         result.code === -1073741819;    // STATUS_ACCESS_VIOLATION (Windows ARM VM on Mac)


### PR DESCRIPTION
When x64 R crashes on Windows ARM, Quarto shows a generic "check your R installation" error instead of explaining the actual problem. This leaves users stuck with no clear path forward.

## Root Cause

x64 R running under emulation on Windows ARM crashes with specific exit codes when loading the rmarkdown package. The R script completes successfully and produces valid YAML output before crashing during process termination.

Two crash scenarios observed:
- **Native ARM hardware**: Exit code -1073741569 (STATUS_NOT_SUPPORTED)  
- **Windows ARM VM on Mac**: Exit code -1073741819 (STATUS_ACCESS_VIOLATION)

## Fix

Detect these specific exit codes and throw `WindowsArmX64RError` with a helpful message directing users to install native ARM64 R.

This approach is simpler than PR #13790's YAML parsing method - just 8 lines of error code checking vs 30+ lines of regex matching and YAML parsing.

## Implementation

`src/core/knitr.ts`:
- Added `WindowsArmX64RError` class for type-safe error handling
- Check for both exit codes when `knitrCapabilities()` fails on Windows ARM
- Rethrow error from catch block to preserve helpful message
- Error bubbles up through `quarto check` to display to user

## Testing

Requires Windows ARM hardware to test:
- With x64 R installed: Should show helpful error message
- With ARM64 R installed: Should work normally
- On x64 Windows: Should not trigger (not ARM)
- On macOS/Linux: Should not affect behavior

Closes #8730
Related: #13790