### PR TITLE
properly filter bundled extensions from engine list using normalized path

### DIFF
--- a/src/command/render/pandoc.ts
+++ b/src/command/render/pandoc.ts
@@ -435,7 +435,9 @@ export async function runPandoc(
       const filteredEngines = metadata.engines.filter((engine) => {
         const enginePath = typeof engine === "string" ? engine : engine.path;
         // Keep user engines, filter out bundled ones
-        return !enginePath?.includes("/src/resources/extension-subtrees/");
+        return !enginePath?.replace(/\\/g, "/").includes(
+          "resources/extension-subtrees/",
+        );
       });
 
       // Remove the engines key entirely if empty, otherwise assign filtered array
@@ -1314,9 +1316,9 @@ export async function runPandoc(
     const filteredEngines = pandocPassedMetadata.engines.filter((engine) => {
       const enginePath = typeof engine === "string" ? engine : engine.path;
       if (!enginePath) return true;
-
-      const normalizedPath = enginePath.replace(/\\/g, "/");
-      return !normalizedPath.includes("extension-subtrees/");
+      return !enginePath.replace(/\\/g, "/").includes(
+        "resources/extension-subtrees/",
+      );
     });
 
     if (filteredEngines.length === 0) {

--- a/tests/docs/smoke-all/2025/12/22/markdown-engine-no-extension-subtrees.qmd
+++ b/tests/docs/smoke-all/2025/12/22/markdown-engine-no-extension-subtrees.qmd
@@ -1,0 +1,13 @@
+---
+title: Basic doc
+format: html
+_quarto:
+  tests:
+    html:
+      printsMessage:
+        level: INFO
+        regex: 'resources[/\\]extension-subtrees[/\\]'
+        negate: true
+---
+
+It should be markdown engine.


### PR DESCRIPTION
* Filter normalized paths for printing
* Look for uniform `resources/extension-subtrees/` path
* Test

Fixes #13819