### PR TITLE
fix(license.lua): correct license metadata lua processing

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -103,3 +103,4 @@ All changes included in 1.9:
 - ([#13528](https://github.com/quarto-dev/quarto-cli/pull/13528)): Adds support for table specification using nested lists and the `list-table` class.
 - ([#13575](https://github.com/quarto-dev/quarto-cli/pull/13575)): Improve CPU architecture detection/reporting in macOS to allow quarto to run in virtualized environments such as OpenAI's `codex`.
 - ([#13656](https://github.com/quarto-dev/quarto-cli/issues/13656)): Fix R code cells with empty `lang: ""` option producing invalid markdown class attributes.
+- ([#13832](https://github.com/quarto-dev/quarto-cli/pull/13832)): Fix typo that prevented the `license.text` metadata from being set correctly when using an inline license. (author: @mcanouil)

--- a/src/resources/filters/modules/license.lua
+++ b/src/resources/filters/modules/license.lua
@@ -83,10 +83,14 @@ local function processLicense(el, meta)
     if ccLicense ~= nil then
       local license = licenses[ccLicense.base]
       if license ~= nil then
+        local licenseText = ''
+        if ccLicense.base and ccLicense.base ~= '' and ccLicense.version and ccLicense.version ~= '' then
+          licenseText = ccLicense.base:upper() .. ' ' .. ccLicense.version
+        end
         return {
           type = pandoc.Inlines(license.type),
           url = pandoc.Inlines(license.licenseUrl(meta.lang, ccLicense.version)),
-          text = pandoc.Inlines('')
+          text = pandoc.Inlines(licenseText)
         }
       end
     end

--- a/src/resources/filters/modules/license.lua
+++ b/src/resources/filters/modules/license.lua
@@ -159,7 +159,7 @@ local function processLicenseMeta(meta)
         end
         meta[constants.kLicense] = normalizedEls
       elseif pandoc.utils.type(licenseMeta) == "Inlines" then
-        meta[constants.kLicense] = {processLicense(licenseMeta, meta)}
+        meta[constants.kLicense] = processLicense(licenseMeta, meta)
       end
     end
 

--- a/tests/docs/smoke-all/2025/12/28/license-CC.qmd
+++ b/tests/docs/smoke-all/2025/12/28/license-CC.qmd
@@ -1,0 +1,12 @@
+---
+format: html
+license: "CC BY"
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - 
+          - "License: CC BY 4.0"
+---
+
+License: {{< meta license.text >}}

--- a/tests/docs/smoke-all/2025/12/28/license-CC0.qmd
+++ b/tests/docs/smoke-all/2025/12/28/license-CC0.qmd
@@ -1,0 +1,12 @@
+---
+format: html
+license: "CC0"
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - 
+          - "License: CC0"
+---
+
+License: {{< meta license.text >}}

--- a/tests/docs/smoke-all/2025/12/28/license-copyright-inline.qmd
+++ b/tests/docs/smoke-all/2025/12/28/license-copyright-inline.qmd
@@ -6,8 +6,9 @@ _quarto:
   tests:
     html:
       ensureFileRegexMatches:
-        - ['License: Whatever']
-        - ['Copyright: 2024 My Company']
+        - 
+          - "License: Whatever"
+          - "Copyright: 2024 My Company"
 ---
 
 License: {{< meta license.text >}}

--- a/tests/docs/smoke-all/2025/12/28/license-copyright-inline.qmd
+++ b/tests/docs/smoke-all/2025/12/28/license-copyright-inline.qmd
@@ -1,0 +1,15 @@
+---
+format: html
+license: "Whatever"
+copyright: "2024 My Company"
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - ['License: Whatever']
+        - ['Copyright: 2024 My Company']
+---
+
+License: {{< meta license.text >}}
+
+Copyright: {{< meta copyright.statement >}}


### PR DESCRIPTION
Correct the processing of license metadata to ensure proper handling of inline license elements.

The typo prevented from using `license.text` in template/partials/shortcodes when `license: "my license"` was used.

Note that version is not added to "text" for CC0 licenses because for some reason, the URL/parsing is created in TypeScript for this license.

```qmd
---
format: html
license: "Whatever"
---

{{< meta license.text >}}
```

```qmd
---
format: html
license: "CC BY"
---

{{< meta license.text >}}
```

```qmd
---
format: html
license: "CC0"
---

{{< meta license.text >}}
```