### PR TITLE
use npm: prefix in import map for lodash 

### DIFF
--- a/src/command/render/cleanup.ts
+++ b/src/command/render/cleanup.ts
@@ -13,7 +13,6 @@ import {
   normalizePath,
   removeIfEmptyDir,
   removeIfExists,
-  safeRemoveSync,
 } from "../../core/path.ts";
 import { figuresDir, inputFilesDir } from "../../core/render.ts";
 
@@ -90,7 +89,7 @@ export function renderCleanup(
     }
 
     // clean supporting
-    ld.uniq(supporting).forEach((path) => {
+    ld.uniq(supporting).forEach((path: string) => {
       if (existsSync(path)) {
         safeRemoveDirSync(path, project.dir);
       }

--- a/src/command/render/project.ts
+++ b/src/command/render/project.ts
@@ -599,7 +599,7 @@ export async function renderProject(
     // as an example case)
     const uniqOps = ld.uniqBy(fileOperations, (op: FileOperation) => {
       return op.key;
-    });
+    }) as FileOperation[];
 
     const sortedOperations = uniqOps.sort((a, b) => {
       if (a.src === b.src) {

--- a/src/core/jupyter/venv.ts
+++ b/src/core/jupyter/venv.ts
@@ -35,10 +35,10 @@ export async function jupyterCreateVenv(dir: string, packages?: string[]) {
       kEnvDir,
       isWindows ? "Scripts\\pip.exe" : "bin/pip3",
     );
-    packages = ld.uniq(["jupyter"].concat(packages || []));
+    const pkgList = ld.uniq(["jupyter"].concat(packages || [])) as string[];
     const installResult = await execProcess({
       cmd: pip3,
-      args: ["install", ...packages],
+      args: ["install", ...pkgList],
       cwd: dir,
     });
     if (!installResult.success) {
@@ -55,10 +55,10 @@ export async function jupyterCreateCondaenv(dir: string, packages?: string[]) {
   const conda = await which("conda");
   if (conda) {
     info(`Using conda at ${conda}`);
-    packages = ld.uniq(["jupyter"].concat(packages || []));
+    const pkgList = ld.uniq(["jupyter"].concat(packages || [])) as string[];
     const installResult = await execProcess({
       cmd: "conda",
-      args: ["create", "--yes", "--prefix", "env", ...packages],
+      args: ["create", "--yes", "--prefix", "env", ...pkgList],
       cwd: dir,
     });
     if (!installResult.success) {

--- a/src/format/html/format-html-notebook-preview.ts
+++ b/src/format/html/format-html-notebook-preview.ts
@@ -14,7 +14,13 @@ import { Format, NotebookPreviewDescriptor } from "../../config/types.ts";
 
 import { RenderServices } from "../../command/render/types.ts";
 
-import { basename, dirname, isAbsolute, join, relative } from "../../deno_ral/path.ts";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+} from "../../deno_ral/path.ts";
 import { pathWithForwardSlashes } from "../../core/path.ts";
 import { ProjectContext } from "../../project/types.ts";
 import { projectIsBook } from "../../project/project-shared.ts";
@@ -102,7 +108,7 @@ export const notebookPreviewer = (
       .metadata[kNotebookPreviewOptions] as NotebookPreviewOptions;
 
     const notebookPaths = previewQueue.map((work) => (work.nbPath));
-    const uniquePaths = ld.uniq(notebookPaths);
+    const uniquePaths = ld.uniq(notebookPaths) as string[];
     const toRenderPaths = uniquePaths.filter((nbPath) => {
       return services.notebook.get(nbPath, project) === undefined;
     });
@@ -252,7 +258,8 @@ export const notebookPreviewer = (
         // to form links to this notebook
         const nbPreview = {
           title: resolvedTitle,
-          href: descriptor?.url || relative(inputDir, renderedNotebook[kHtmlPreview].hrefPath),
+          href: descriptor?.url ||
+            relative(inputDir, renderedNotebook[kHtmlPreview].hrefPath),
           supporting,
           resources,
           order: work.order,

--- a/src/format/html/format-html-notebook.ts
+++ b/src/format/html/format-html-notebook.ts
@@ -254,7 +254,7 @@ export async function emplaceNotebookPreviews(
         (nbPath: { href: string; title?: string }) => {
           return nbPath.href;
         },
-      ).forEach((nbPath) => {
+      ).forEach((nbPath: NotebookPreview) => {
         const li = doc.createElement("li");
 
         const link = doc.createElement("a");

--- a/src/import_map.json
+++ b/src/import_map.json
@@ -15,7 +15,7 @@
     "uuid/": "jsr:/@std/uuid@1.0.6/",
     "https://deno.land/std@0.91.0/path/mod.ts": "jsr:/@std/path@1.0.8",
     "https://deno.land/std@0.91.0/path/": "jsr:/@std/path@1.0.8/",
-    
+
     "testing/": "jsr:/@std/testing@0.224.0/",
     "flags": "jsr:/@std/flags@0.224.0",
     "datetime/": "jsr:/@std/datetime@0.225.4/",
@@ -41,7 +41,7 @@
     "dayjs/": "https://cdn.skypack.dev/dayjs@1.8.21/",
     "moment-guess": "https://cdn.skypack.dev/moment-guess@1.2.4",
     "ansi_up": "https://cdn.skypack.dev/ansi_up@v6.0.2",
-    "lodash/": "https://cdn.skypack.dev/lodash@4.17.21/",
+    "lodash/": "npm:/lodash@4.17.21/",
     "acorn-class-fields": "https://cdn.skypack.dev/acorn-class-fields@1.0.0",
     "acorn/acorn": "https://cdn.skypack.dev/acorn@8.4.0",
     "acorn/walk": "https://cdn.skypack.dev/acorn-walk@8.2.0",

--- a/src/project/types/book/book-bibliography.ts
+++ b/src/project/types/book/book-bibliography.ts
@@ -269,7 +269,7 @@ export async function generateBibliography(
   // make the aggregated bibliography
   const yaml: Metadata = {
     [kBibliography]: biblioPaths.map(pathWithForwardSlashes),
-    [kNoCite]: ld.uniq(citeIds).map((id) => "@" + id).join(", "),
+    [kNoCite]: ld.uniq(citeIds).map((id: string) => "@" + id).join(", "),
   };
   if (csl) {
     yaml[kCsl] = isAbsolute(csl)

--- a/src/project/types/manuscript/manuscript-meca.ts
+++ b/src/project/types/manuscript/manuscript-meca.ts
@@ -264,7 +264,7 @@ export const createMecaBundle = async (
     const manuscriptResources: MecaItem[] = [];
     const manuscriptZipFiles: string[] = [];
     if (jatsArticle.supporting) {
-      ld.uniq(jatsArticle.supporting).forEach((file) => {
+      ld.uniq(jatsArticle.supporting).forEach((file: string) => {
         const relPath = isAbsolute(file) ? relative(outputDir, file) : file;
         const absPath = isAbsolute(file) ? file : join(outputDir, file);
         const workingPath = toWorkingDir(absPath, relPath, false);

--- a/src/project/types/website/listing/website-listing.ts
+++ b/src/project/types/website/listing/website-listing.ts
@@ -110,7 +110,7 @@ export function listingSupplementalFiles(
         return !inputs.find((inp) => {
           return inp.path === file;
         }) && existsSync(file);
-      }));
+      })) as string[];
 
       const onRenderComplete = async (
         project: ProjectContext,

--- a/src/project/types/website/website-navigation.ts
+++ b/src/project/types/website/website-navigation.ts
@@ -1204,7 +1204,7 @@ function nextAndPrevious(
       (sidebarItem: SidebarItem) => {
         return sidebarItem.href || Math.random().toString();
       },
-    );
+    ) as SidebarItem[];
 
     const index = sidebarItemsUniq.findIndex((item) => item.href === href);
     const nextPage = index > -1 && index < sidebarItemsUniq.length - 1 &&


### PR DESCRIPTION
as skypack CDN is failing with error 500

````
❯ curl https://cdn.skypack.dev/lodash@4.17.21/shuffle.js
A server error has occurred

FUNCTION_INVOCATION_FAILED

sfo1::fvwp6-1767640949044-b60f29d6cb65
````

It seems to be the way to do it now https://docs.deno.com/runtime/fundamentals/node/ 

and we do it for ZOD

````
    "zod": "npm:/zod@3.24.4",
```` 

