### PR TITLE
fix(project): prevent output-dir: ./ from deleting project directory

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -11,6 +11,7 @@ All changes included in 1.9:
 - ([#13633](https://github.com/quarto-dev/quarto-cli/issues/13633)): Fix detection and auto-installation of babel language packages from newer error format that doesn't explicitly mention `.ldf` filename.
 - ([#13694](https://github.com/quarto-dev/quarto-cli/issues/13694)): Fix `notebook-view.url` being ignored - external notebook links now properly use specified URLs instead of local preview files.
 - ([#13732](https://github.com/quarto-dev/quarto-cli/issues/13732)): Fix automatic font package installation for fonts with spaces in their names (e.g., "Noto Emoji", "DejaVu Sans"). Font file search patterns now match both with and without spaces.
+- ([#13892](https://github.com/quarto-dev/quarto-cli/issues/13892)): Fix `output-dir: ./` deleting entire project directory. Path comparison now uses `resolve()` to correctly handle all current-directory variations (`.`, `./`, `.\`), and output directory cleanup uses `safeRemoveDirSync` for boundary protection.
 
 ## Dependencies
 

--- a/src/project/project-context.ts
+++ b/src/project/project-context.ts
@@ -10,6 +10,7 @@ import {
   isAbsolute,
   join,
   relative,
+  resolve,
   SEP,
 } from "../deno_ral/path.ts";
 
@@ -300,11 +301,17 @@ export async function projectContext(
           projectConfig.project[kProjectOutputDir] = type.outputDir;
         }
 
-        // if the output-dir is "." that's equivalent to no output dir so make that
-        // conversion now (this allows code downstream to just check for no output dir
-        // rather than that as well as ".")
-        if (projectConfig.project[kProjectOutputDir] === ".") {
-          delete projectConfig.project[kProjectOutputDir];
+        // if the output-dir resolves to the project directory, that's equivalent to
+        // no output dir so make that conversion now (this allows code downstream to
+        // just check for no output dir rather than checking for ".", "./", etc.)
+        // Fixes issue #13892: output-dir: ./ would delete the entire project
+        const outputDir = projectConfig.project[kProjectOutputDir];
+        if (outputDir) {
+          const resolvedOutputDir = resolve(dir, outputDir);
+          const resolvedDir = resolve(dir);
+          if (resolvedOutputDir === resolvedDir) {
+            delete projectConfig.project[kProjectOutputDir];
+          }
         }
 
         // if the output-dir is absolute then make it project dir relative

--- a/tests/docs/project/output-dir-dot/.gitignore
+++ b/tests/docs/project/output-dir-dot/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/tests/docs/project/output-dir-dot/_quarto.yml
+++ b/tests/docs/project/output-dir-dot/_quarto.yml
@@ -1,3 +1,3 @@
 project:
-  type: default
+  type: website
   output-dir: .

--- a/tests/docs/project/output-dir-dot/_quarto.yml
+++ b/tests/docs/project/output-dir-dot/_quarto.yml
@@ -1,0 +1,3 @@
+project:
+  type: default
+  output-dir: .

--- a/tests/docs/project/output-dir-dot/marker.txt
+++ b/tests/docs/project/output-dir-dot/marker.txt
@@ -1,0 +1,1 @@
+This file should NOT be deleted when rendering with output-dir: .

--- a/tests/docs/project/output-dir-dot/test.qmd
+++ b/tests/docs/project/output-dir-dot/test.qmd
@@ -1,0 +1,8 @@
+---
+title: "Output Dir Dot Test"
+format: html
+---
+
+# Test Document
+
+This document tests that `output-dir: .` works correctly.

--- a/tests/docs/project/output-dir-parent-ref/.gitignore
+++ b/tests/docs/project/output-dir-parent-ref/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/tests/docs/project/output-dir-parent-ref/_quarto.yml
+++ b/tests/docs/project/output-dir-parent-ref/_quarto.yml
@@ -1,0 +1,3 @@
+project:
+  type: website
+  output-dir: ../output-dir-parent-ref

--- a/tests/docs/project/output-dir-parent-ref/marker.txt
+++ b/tests/docs/project/output-dir-parent-ref/marker.txt
@@ -1,0 +1,2 @@
+This file should NOT be deleted when rendering with output-dir: ../output-dir-parent-ref
+This pattern references the project directory via parent traversal.

--- a/tests/docs/project/output-dir-parent-ref/test.qmd
+++ b/tests/docs/project/output-dir-parent-ref/test.qmd
@@ -1,0 +1,8 @@
+---
+title: "Output Dir Parent Ref Test"
+format: html
+---
+
+# Test Document
+
+This document tests that `output-dir: ../output-dir-parent-ref` (referencing the project directory via parent traversal) does not delete the project directory.

--- a/tests/docs/project/output-dir-safety/.gitignore
+++ b/tests/docs/project/output-dir-safety/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/tests/docs/project/output-dir-safety/_quarto.yml
+++ b/tests/docs/project/output-dir-safety/_quarto.yml
@@ -1,0 +1,3 @@
+project:
+  type: default
+  output-dir: ./

--- a/tests/docs/project/output-dir-safety/_quarto.yml
+++ b/tests/docs/project/output-dir-safety/_quarto.yml
@@ -1,3 +1,3 @@
 project:
-  type: default
+  type: website
   output-dir: ./

--- a/tests/docs/project/output-dir-safety/marker.txt
+++ b/tests/docs/project/output-dir-safety/marker.txt
@@ -1,0 +1,2 @@
+This file should NOT be deleted when rendering with output-dir: ./
+If this file is missing after render, the bug is present.

--- a/tests/docs/project/output-dir-safety/test.qmd
+++ b/tests/docs/project/output-dir-safety/test.qmd
@@ -1,0 +1,8 @@
+---
+title: "Output Dir Safety Test"
+format: html
+---
+
+# Test Document
+
+This document tests that `output-dir: ./` does not delete the project directory.

--- a/tests/docs/project/output-dir-subdir/.gitignore
+++ b/tests/docs/project/output-dir-subdir/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/tests/docs/project/output-dir-subdir/_quarto.yml
+++ b/tests/docs/project/output-dir-subdir/_quarto.yml
@@ -1,0 +1,3 @@
+project:
+  type: default
+  output-dir: _output

--- a/tests/docs/project/output-dir-subdir/marker.txt
+++ b/tests/docs/project/output-dir-subdir/marker.txt
@@ -1,0 +1,1 @@
+This file should NOT be deleted when rendering with output-dir: _output

--- a/tests/docs/project/output-dir-subdir/test.qmd
+++ b/tests/docs/project/output-dir-subdir/test.qmd
@@ -1,0 +1,8 @@
+---
+title: "Output Dir Subdir Test"
+format: html
+---
+
+# Test Document
+
+This document tests that `output-dir: _output` creates output in subdirectory.

--- a/tests/smoke/project/project-output-dir-safety.test.ts
+++ b/tests/smoke/project/project-output-dir-safety.test.ts
@@ -1,0 +1,64 @@
+/*
+ * project-output-dir-safety.test.ts
+ *
+ * Test for issue #13892: output-dir configurations should not delete project files
+ *
+ * Copyright (C) 2020-2025 Posit Software, PBC
+ */
+import { docs } from "../../utils.ts";
+
+import { join } from "../../../src/deno_ral/path.ts";
+import { existsSync } from "../../../src/deno_ral/fs.ts";
+import { testQuartoCmd } from "../../test.ts";
+import { fileExists, noErrors } from "../../verify.ts";
+
+// Helper to create output-dir safety tests
+function testOutputDirSafety(
+  name: string,
+  outputDir: string | null, // null means output is in project dir
+) {
+  const testDir = docs(`project/output-dir-${name}`);
+  const dir = join(Deno.cwd(), testDir);
+  const outputPath = outputDir ? join(dir, outputDir) : dir;
+
+  testQuartoCmd(
+    "render",
+    [testDir],
+    [
+      noErrors,
+      fileExists(join(dir, "marker.txt")),       // Project file must survive
+      fileExists(join(outputPath, "test.html")), // Output created correctly
+    ],
+    {
+      teardown: async () => {
+        // Clean up rendered output
+        if (outputDir) {
+          // Subdirectory case - remove the whole output dir
+          if (existsSync(outputPath)) {
+            await Deno.remove(outputPath, { recursive: true });
+          }
+        } else {
+          // In-place case - just remove the html file
+          const htmlFile = join(dir, "test.html");
+          if (existsSync(htmlFile)) {
+            await Deno.remove(htmlFile);
+          }
+        }
+        // Clean up .quarto directory
+        const quartoDir = join(dir, ".quarto");
+        if (existsSync(quartoDir)) {
+          await Deno.remove(quartoDir, { recursive: true });
+        }
+      },
+    },
+  );
+}
+
+// Test 1: output-dir: ./ (the bug case from #13892)
+testOutputDirSafety("safety", null);
+
+// Test 2: output-dir: . (without trailing slash)
+testOutputDirSafety("dot", null);
+
+// Test 3: output-dir: _output (normal subdirectory case)
+testOutputDirSafety("subdir", "_output");

--- a/tests/unit/path.test.ts
+++ b/tests/unit/path.test.ts
@@ -176,6 +176,16 @@ unitTest("path - output-dir equivalence with resolve()", async () => {
     );
   }
 
+  // Parent traversal back to project dir should also be equivalent
+  // e.g., project in "quarto-proj", output-dir: "../quarto-proj"
+  const dirName = testDir.split(/[/\\]/).pop()!;
+  const parentRef = `../${dirName}`;
+  const resolvedParentRef = resolve(testDir, parentRef);
+  assert(
+    resolvedParentRef === resolve(testDir),
+    `output-dir "${parentRef}" should resolve to project dir, got ${resolvedParentRef} vs ${resolve(testDir)}`,
+  );
+
   // Actual subdirectories should NOT be equivalent
   const subdir = "output";
   const resolvedSubdir = resolve(testDir, subdir);

--- a/tests/unit/path.test.ts
+++ b/tests/unit/path.test.ts
@@ -7,7 +7,8 @@
 
 import { unitTest } from "../test.ts";
 import { assert } from "testing/asserts";
-import { join } from "../../src/deno_ral/path.ts";
+import { join, resolve } from "../../src/deno_ral/path.ts";
+import { isWindows } from "../../src/deno_ral/platform.ts";
 import {
   dirAndStem,
   removeIfEmptyDir,
@@ -152,4 +153,36 @@ unitTest("path - resolvePathGlobs", async () => {
       `Invalid exclude result: ${globTest.name}`,
     );
   });
+});
+
+// Test for issue #13892: output-dir: ./ should resolve to same path as .
+// This validates the fix approach using resolve() for path comparison
+// deno-lint-ignore require-await
+unitTest("path - output-dir equivalence with resolve()", async () => {
+  const testDir = Deno.makeTempDirSync({ prefix: "quarto-outputdir-test" });
+
+  // All variations of "current directory" should resolve to the same path
+  // Note: ".\" is Windows-only (backslash separator)
+  const variations = [".", "./", "././", "./."];
+  if (isWindows) {
+    variations.push(".\\");
+  }
+  for (const variation of variations) {
+    const resolved = resolve(testDir, variation);
+    const resolvedDir = resolve(testDir);
+    assert(
+      resolved === resolvedDir,
+      `output-dir "${variation}" should resolve to project dir, got ${resolved} vs ${resolvedDir}`,
+    );
+  }
+
+  // Actual subdirectories should NOT be equivalent
+  const subdir = "output";
+  const resolvedSubdir = resolve(testDir, subdir);
+  assert(
+    resolvedSubdir !== resolve(testDir),
+    `output-dir "${subdir}" should NOT resolve to project dir`,
+  );
+
+  Deno.removeSync(testDir, { recursive: true });
 });


### PR DESCRIPTION
When `_quarto.yml` contains `output-dir: ./`, running `quarto render` would delete the entire project directory, leaving only an empty `.quarto/` directory.

## Root Cause

Two compounding issues in the output directory handling:

1. The special case in `project-context.ts:306-308` only checked for exact string `"."`:
```typescript
if (projectConfig.project[kProjectOutputDir] === ".") {
  delete projectConfig.project[kProjectOutputDir];
}
```
This missed `"./"` and other equivalent variations.

2. The deletion logic in `project.ts:287-291` used string comparison:
```typescript
if ((realOutputDir !== realProjectDir) &&
    realOutputDir.startsWith(realProjectDir)) {
  removeIfExists(realOutputDir);
}
```
After path normalization, `.` and `./` produce different strings (e.g., `C:\project` vs `C:\project\`), causing the safety check to incorrectly pass.

## Why `resolve()` instead of `normalize()`

We verified empirically that `normalize()` doesn't work for this case:
- `normalize("./")` → `.\` on Windows (keeps trailing separator)
- `normalize(".")` → `.`

But `resolve()` correctly handles all variations:
- `resolve(dir, ".")` and `resolve(dir, "./")` both → same absolute path
- `resolve(dir, "../dirname")` also correctly resolves to project dir when `dirname` matches
- This works consistently across platforms

## Fix Approach

1. Use `resolve()` for path comparison - handles all current-directory variations (`.`, `./`, `.\`, `././`, `../dirname`, etc.)

2. Replace `removeIfExists` with `safeRemoveDirSync` as defense in depth - this function uses proper `isSubdir` boundary checking and throws `UnsafeRemovalError` if someone attempts to delete the project directory

## Test Plan

Tests use `type: website` (which has `cleanOutputDir: true` by default) to properly trigger the bug.

| Scenario | Without Fix | With Fix |
|----------|-------------|----------|
| `output-dir: ./` | ❌ FAILED (attempts to delete project) | ✅ passed |
| `output-dir: .` | ✅ passed (old code handles exact ".") | ✅ passed |
| `output-dir: _output` | ✅ passed (normal subdirectory) | ✅ passed |
| `output-dir: ../dirname` | ❌ FAILED (parent traversal edge case) | ✅ passed |

Tests include:
- Unit test verifying `resolve()` behavior for path equivalence (platform-aware)
- Smoke tests for all scenarios above
- All tests verify marker files survive rendering

Fixes #13892