### PR TITLE
clarify deletion behavior of output-dir (closes #13896)

### DIFF
--- a/src/command/render/cmd.ts
+++ b/src/command/render/cmd.ts
@@ -37,7 +37,7 @@ export const renderCommand = new Command()
   )
   .option(
     "--output-dir",
-    "Write output to DIR (path is input/project relative)",
+    "Write output to DIR, which is first deleted (path is input/project relative)",
   )
   .option(
     "-M, --metadata",
@@ -89,7 +89,7 @@ export const renderCommand = new Command()
   )
   .option(
     "--no-clean",
-    "Do not clean project output-dir prior to render",
+    "Do not delete output-dir prior to render",
   )
   .option(
     "--debug",

--- a/src/resources/schema/project.yml
+++ b/src/resources/schema/project.yml
@@ -24,7 +24,11 @@
               - `project`: Use the root directory of the project.
         output-dir:
           path:
-            description: "Output directory"
+            description:
+              short: "Output directory"
+              long: >
+              The directory in which all outputs are placed. If a directory with this name
+              already exists, it will be deleted and replaced with a new directory.
         lib-dir:
           path:
             description: "HTML library (JS/CSS/etc.) directory"


### PR DESCRIPTION
This is a minor (typo-level) PR clarifying this potentially destructive side effect of `quarto render`, as discussed in #13896.

## Checklist

I have (if applicable):

- NA filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md). **this is typo-level, so IIUC I can skip this.** 
- [x] referenced the GitHub issue this PR closes
- NA updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- NA added new tests
- [x] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
