### PR TITLE
Fix remote fonts not recognised when using a brand extension

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -46,6 +46,7 @@ All changes included in 1.9:
 - ([#11929](https://github.com/quarto-dev/quarto-cli/issues/11929)): Import all `brand.typography.fonts` in CSS, whether or not fonts are referenced by typography elements.
 - ([#13413](https://github.com/quarto-dev/quarto-cli/issues/13413)): Fix uncentered play button in `video` shortcodes from cross-reference divs. (author: @bruvellu)
 - ([#13508](https://github.com/quarto-dev/quarto-cli/issues/13508)): Add `aria-label` support to `video` shortcode for improved accessibility.
+- ([#13685](https://github.com/quarto-dev/quarto-cli/issues/13685)): Fix remote font URLs in brand extensions being incorrectly joined with the extension path, resulting in broken font imports.
 - ([#13883](https://github.com/quarto-dev/quarto-cli/issues/13883)): Fix unequal top/bottom spacing in simple untitled callouts.
 
 ### `typst`

--- a/src/core/brand/brand.ts
+++ b/src/core/brand/brand.ts
@@ -32,6 +32,7 @@ import { InternalError } from "../lib/error.ts";
 import { dirname, join, relative, resolve } from "../../deno_ral/path.ts";
 import { warnOnce } from "../log.ts";
 import { isCssColorName } from "../css/color-names.ts";
+import { isExternalPath } from "../url.ts";
 import {
   LogoLightDarkSpecifierPathOptional,
   LogoOptionsPathOptional,
@@ -270,10 +271,6 @@ export class Brand {
     }
     return this.getLogoResource(entry);
   }
-}
-
-function isExternalPath(path: string) {
-  return /^\w+:/.test(path);
 }
 
 export type LightDarkBrand = {

--- a/src/core/sass/brand.ts
+++ b/src/core/sass/brand.ts
@@ -150,6 +150,8 @@ const googleFontImportString = (description: BrandFontGoogle) => {
   }:${styleString}wght@${weights}&display=${display}');`;
 };
 
+const isExternalPath = (path: string) => /^\w+:/.test(path);
+
 const fileFontImportString = (brand: Brand, description: BrandFontFile) => {
   const pathPrefix = relative(brand.projectDir, brand.brandDir);
   const parts = [];
@@ -162,9 +164,12 @@ const fileFontImportString = (brand: Brand, description: BrandFontFile) => {
       weight = file.weight;
       style = file.style;
     }
+    const fontUrl = isExternalPath(path)
+      ? path
+      : join(pathPrefix, path).replace(/\\/g, "/");
     parts.push(`@font-face {
     font-family: '${description.family}';
-    src: url('${join(pathPrefix, path).replace(/\\/g, "/")}');
+    src: url('${fontUrl}');
     font-weight: ${weight || "normal"};
     font-style: ${style || "normal"};
 }\n`);

--- a/src/core/sass/brand.ts
+++ b/src/core/sass/brand.ts
@@ -26,6 +26,7 @@ import { Brand } from "../brand/brand.ts";
 import { darkModeDefault } from "../../format/html/format-html-info.ts";
 import { kBrandMode } from "../../config/constants.ts";
 import { join, relative } from "../../deno_ral/path.ts";
+import { isExternalPath } from "../url.ts";
 
 const defaultColorNameMap: Record<string, string> = {
   "link-color": "link",
@@ -149,8 +150,6 @@ const googleFontImportString = (description: BrandFontGoogle) => {
     )
   }:${styleString}wght@${weights}&display=${display}');`;
 };
-
-const isExternalPath = (path: string) => /^\w+:/.test(path);
 
 const fileFontImportString = (brand: Brand, description: BrandFontFile) => {
   const pathPrefix = relative(brand.projectDir, brand.brandDir);

--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -1,14 +1,17 @@
 /*
-* url.ts
-*
-* Copyright (C) 2020-2022 Posit Software, PBC
-*
-*/
+ * url.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
 
 import { ensureTrailingSlash, pathWithForwardSlashes } from "./path.ts";
 
 export function isHttpUrl(url: string) {
   return /^https?:/i.test(url);
+}
+
+export function isExternalPath(path: string) {
+  return /^\w+:/.test(path);
 }
 
 export function joinUrl(baseUrl: string, path: string) {

--- a/src/project/types/website/website-navigation.ts
+++ b/src/project/types/website/website-navigation.ts
@@ -12,6 +12,7 @@ import { Document, Element } from "../../../core/deno-dom.ts";
 
 import { pathWithForwardSlashes, safeExistsSync } from "../../../core/path.ts";
 import { resourcePath } from "../../../core/resources.ts";
+import { isExternalPath } from "../../../core/url.ts";
 import { renderEjs } from "../../../core/ejs.ts";
 import { warnOnce } from "../../../core/log.ts";
 import { asHtmlId } from "../../../core/html.ts";
@@ -1538,10 +1539,6 @@ function navigationDependency(resource: string) {
     name: basename(resource),
     path: resourcePath(`projects/website/navigation/${resource}`),
   };
-}
-
-function isExternalPath(path: string) {
-  return /^\w+:/.test(path);
 }
 
 function resolveNavReferences(

--- a/src/project/types/website/website-utils.ts
+++ b/src/project/types/website/website-utils.ts
@@ -8,6 +8,7 @@ import { Document, Element } from "../../../core/deno-dom.ts";
 import { getDecodedAttribute } from "../../../core/html.ts";
 import { resolveInputTarget } from "../../project-index.ts";
 import { pathWithForwardSlashes, safeExistsSync } from "../../../core/path.ts";
+import { isExternalPath } from "../../../core/url.ts";
 import { projectOffset, projectOutputDir } from "../../project-shared.ts";
 import { engineValidExtensions } from "../../../execute/engine.ts";
 import { ProjectContext } from "../../types.ts";
@@ -118,8 +119,4 @@ export async function resolveProjectInputLinks(
       }
     }
   }
-}
-
-function isExternalPath(path: string) {
-  return /^\w+:/.test(path);
 }

--- a/tests/docs/smoke-all/brand/typography/remote-font-extension/.gitignore
+++ b/tests/docs/smoke-all/brand/typography/remote-font-extension/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/tests/docs/smoke-all/brand/typography/remote-font-extension/_extensions/my-brand/_extension.yml
+++ b/tests/docs/smoke-all/brand/typography/remote-font-extension/_extensions/my-brand/_extension.yml
@@ -1,0 +1,8 @@
+title: My Brand
+author: Quarto
+version: 1.0.0
+quarto-required: ">=99.9.0"
+contributes:
+  metadata:
+    project:
+      brand: mybrand.yml

--- a/tests/docs/smoke-all/brand/typography/remote-font-extension/_extensions/my-brand/mybrand.yml
+++ b/tests/docs/smoke-all/brand/typography/remote-font-extension/_extensions/my-brand/mybrand.yml
@@ -1,0 +1,8 @@
+typography:
+  fonts:
+    - family: Noto Sans
+      source: file
+      files:
+        - path: https://notofonts.github.io/latin-greek-cyrillic/fonts/NotoSans/unhinted/ttf/NotoSans-Regular.ttf
+  base:
+    family: Noto Sans

--- a/tests/docs/smoke-all/brand/typography/remote-font-extension/_quarto.yml
+++ b/tests/docs/smoke-all/brand/typography/remote-font-extension/_quarto.yml
@@ -1,0 +1,5 @@
+project:
+  type: default
+format:
+  html:
+    theme: brand

--- a/tests/docs/smoke-all/brand/typography/remote-font-extension/remote-font-extension.qmd
+++ b/tests/docs/smoke-all/brand/typography/remote-font-extension/remote-font-extension.qmd
@@ -1,0 +1,15 @@
+---
+title: Remote Font Extension Test
+_quarto:
+  tests:
+    html:
+      ensureCssRegexMatches:
+        - ['src:url\("https://notofonts\.github\.io/']
+        - ['_extensions/my-brand/https:']
+---
+
+# Remote Font Test
+
+This document tests that remote font URLs in brand extensions are handled correctly (issue #13685).
+
+{{< lipsum 1 >}}

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -18,6 +18,7 @@ import { breakQuartoMd } from "../../src/core/lib/break-quarto-md.ts";
 import { parse } from "../../src/core/yaml.ts";
 import { cleanoutput } from "./render/render.ts";
 import {
+  ensureCssRegexMatches,
   ensureEpubFileRegexMatches,
   ensureDocxRegexMatches,
   ensureDocxXpath,
@@ -183,6 +184,7 @@ function resolveTestSpecs(
   const result = [];
   // deno-lint-ignore no-explicit-any
   const verifyMap: Record<string, any> = {
+    ensureCssRegexMatches,
     ensureEpubFileRegexMatches,
     ensureHtmlElements,
     ensureHtmlElementContents,


### PR DESCRIPTION
## Summary

Fixes #13685

- Fix issue where remote font URLs in `brand.yml` are incorrectly treated as file paths when the brand file is in a subfolder (like an extension)
- Add `isExternalPath` helper to detect URLs (paths starting with a protocol like `https:`) and skip path joining for external font paths
- Add `ensureCssRegexMatches` test assertion for verifying CSS content in supporting files

## Test plan

- [x] Added smoke test that verifies:
  - CSS contains correct font URL (`src:url("https://notofonts.github.io/...`)
  - CSS does NOT contain broken path (`_extensions/my-brand/https:`)
- [x] Test passes locally

🤖 Generated with [Claude Code](https://claude.ai/code)