### PR TITLE
Warn when cell-renderings has duplicate names

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -47,6 +47,7 @@ All changes included in 1.9:
 - ([#13413](https://github.com/quarto-dev/quarto-cli/issues/13413)): Fix uncentered play button in `video` shortcodes from cross-reference divs. (author: @bruvellu)
 - ([#13508](https://github.com/quarto-dev/quarto-cli/issues/13508)): Add `aria-label` support to `video` shortcode for improved accessibility.
 - ([#13883](https://github.com/quarto-dev/quarto-cli/issues/13883)): Fix unequal top/bottom spacing in simple untitled callouts.
+- ([#13900](https://github.com/quarto-dev/quarto-cli/issues/13900)): Warn when `renderings` cell option contains duplicate names. Previously, duplicate names like `[dark, light, dark, light]` would silently use only the last output for each name.
 
 ### `typst`
 

--- a/src/resources/filters/quarto-post/cell-renderings.lua
+++ b/src/resources/filters/quarto-post/cell-renderings.lua
@@ -38,7 +38,12 @@ function choose_cell_renderings()
       end
     
       local outputs = {}
+      local seen = {}
       for i, r in ipairs(renderings) do
+        if seen[r] then
+          quarto.log.warning("duplicate rendering name '" .. r .. "' in renderings; only the last cell output with each name will be used")
+        end
+        seen[r] = true
         outputs[r] = cods[i]
       end
       local lightDiv = outputs['light']

--- a/tests/docs/smoke-all/2026/01/16/13900.qmd
+++ b/tests/docs/smoke-all/2026/01/16/13900.qmd
@@ -1,0 +1,21 @@
+---
+title: "Test duplicate rendering names warning"
+format: html
+execute:
+  echo: false
+_quarto:
+  tests:
+    html:
+      printsMessage:
+        level: INFO
+        regex: "duplicate rendering name 'dark' in renderings"
+---
+
+```{r}
+#| renderings: [dark, light, dark, light]
+
+plot(1, main = "Plot 1 (dark)")
+plot(2, main = "Plot 2 (light)")
+plot(3, main = "Plot 3 (dark)")
+plot(4, main = "Plot 4 (light)")
+```


### PR DESCRIPTION
## Summary
- Adds a warning when `renderings` attribute contains duplicate names (e.g., `[dark, light, dark, light]`)
- Previously, duplicate names were silently dropped with only the last cell output for each name being used
- Users now get a clear warning explaining which outputs will be discarded

Fixes #13900

## Test plan
- [ ] Verify warning is produced when using duplicate rendering names
- [ ] Run smoke-all test: `./run-fast-tests.sh docs/smoke-all/2026/01/16/13900.qmd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)