### PR TITLE
feat(website): enhanced control over navbar and sidebar titles (#13477)

### DIFF
--- a/src/project/types/book/book-config.ts
+++ b/src/project/types/book/book-config.ts
@@ -191,7 +191,6 @@ export async function bookProjectConfig(
   // if we have a top-level 'contents' or 'appendix' fields fold into sidebar
   site[kSiteSidebar] = site[kSiteSidebar] || {};
   const siteSidebar = site[kSiteSidebar] as Metadata;
-  siteSidebar[kSiteTitle] = siteSidebar[kSiteTitle] || book?.[kSiteTitle];
   siteSidebar[kSidebarLogo] = siteSidebar[kSidebarLogo] || book?.[kSidebarLogo];
   siteSidebar[kSidebarLogoHref] = siteSidebar[kSidebarLogoHref] ||
     book?.[kSidebarLogoHref];

--- a/src/resources/projects/website/templates/navbrand.ejs
+++ b/src/resources/projects/website/templates/navbrand.ejs
@@ -1,6 +1,6 @@
-<% if (navbar.title || navbar.logo) { %>
+<% if (navbar.title || (navbar.logo && (navbar.logo.light || navbar.logo.dark))) { %>
   <div class="navbar-brand-container mx-auto">
-  <% if (navbar.logo) { %>
+  <% if (navbar.logo && (navbar.logo.light || navbar.logo.dark)) { %>
     <a href="<%- navbar['logo-href'] || '/index.html' %>" class="navbar-brand navbar-brand-logo">
     <% if (navbar.logo.light) { %>
     <img src="<%- navbar.logo.light.path %>" alt="<%- navbar.logo.light.alt || '' %>" class="navbar-logo light-content" />

--- a/src/resources/projects/website/templates/sidebar.ejs
+++ b/src/resources/projects/website/templates/sidebar.ejs
@@ -21,9 +21,9 @@
 
     let toolsLocation;
     // Under the title if that will be displayed
-    if (sidebar.title && !navbar) {
+    if (sidebar.title) {
       toolsLocation = "title";
-    } else if (sidebar.logo) {
+    } else if (sidebar.logo && (sidebar.logo.light || sidebar.logo.dark)) {
       toolsLocation = "logo";
     } else if (sidebar.search && sidebar.search !== "overlay") {
       toolsLocation = "search";
@@ -32,9 +32,9 @@
     }
   %>
     
-  <% if (sidebar.logo || (sidebar.title && !navbar)) { %>
-    <div class="pt-lg-2 mt-2 <%= alignCss %> sidebar-header<%= sidebar.logo && sidebar.title ? ' sidebar-header-stacked' : '' %>">
-    <% if (sidebar.logo) { %>
+  <% if ((sidebar.logo && (sidebar.logo.light || sidebar.logo.dark)) || sidebar.title) { %>
+    <div class="pt-lg-2 mt-2 <%= alignCss %> sidebar-header<%= (sidebar.logo && (sidebar.logo.light || sidebar.logo.dark)) && sidebar.title ? ' sidebar-header-stacked' : '' %>">
+    <% if (sidebar.logo && (sidebar.logo.light || sidebar.logo.dark)) { %>
       <a href="<%- sidebar['logo-href'] || '/index.html' %>" class="sidebar-logo-link">
       <% if (sidebar.logo.light) { %>
       <img src="<%- sidebar.logo.light.path %>" alt="<%- sidebar.logo.light.alt || '' %>" class="sidebar-logo light-content py-0 d-lg-inline d-none"/>
@@ -48,19 +48,15 @@
       <% partial('navtools.ejs', { align: 'start', tools: sidebar.tools, className: 'sidebar-tools-main', darkToggle: sidebar.darkToggle, search: sidebar.search, readerToggle: sidebar.readerToggle, language: language })%>
     <% } %> 
     
-    <% if (!navbar) { %>
     <% if (sidebar.title) { %>
     <div class="sidebar-title mb-0 py-0">
-      <% if (!navbar) { %>
       <a href="/">
       <%- sidebar.title %>
       </a> 
-      <% } %>  
       <% if (needsTools && toolsLocation === "title") { %>
         <% partial('navtools.ejs', { align: 'start', tools: sidebar.tools, className: 'sidebar-tools-main', darkToggle: sidebar.darkToggle, search: sidebar.search, readerToggle: sidebar.readerToggle, language: language })%>
       <% } %>  
     </div>
-    <% } %>
     <% } %>
       </div>
     <% } %>

--- a/src/resources/schema/definitions.yml
+++ b/src/resources/schema/definitions.yml
@@ -989,7 +989,7 @@
                   anyOf:
                     - string
                     - boolean
-                  description: "The navbar title. Uses the project title if none is specified."
+                  description: "The navbar title. Use a string for custom text, `true` (the default) to use the project title, or `false` to hide the title."
                 logo:
                   ref: logo-light-dark-specifier
                   description: "Specification of image that will be displayed to the left of the title."
@@ -1071,7 +1071,7 @@
                     anyOf:
                       - string
                       - boolean
-                    description: "The sidebar title. Uses the project title if none is specified."
+                    description: "The sidebar title. Use a string for custom text, `true` to use the project title, or `false` to hide the title. If unspecified, the title is shown if there is no navbar title and no sidebar logo (except for books, where a sidebar logo does not hide the title)."
                   logo:
                     ref: logo-light-dark-specifier
                     description: "Specification of image that will be displayed in the sidebar."

--- a/tests/docs/books/issue-13477/book-sidebar-logo/.gitignore
+++ b/tests/docs/books/issue-13477/book-sidebar-logo/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/tests/docs/books/issue-13477/book-sidebar-logo/_quarto.yml
+++ b/tests/docs/books/issue-13477/book-sidebar-logo/_quarto.yml
@@ -1,0 +1,9 @@
+project:
+  type: book
+  title: "My Book"
+
+book:
+  chapters:
+    - index.qmd
+  sidebar:
+    logo: logo.png

--- a/tests/docs/books/issue-13477/book-sidebar-logo/index.qmd
+++ b/tests/docs/books/issue-13477/book-sidebar-logo/index.qmd
@@ -1,0 +1,3 @@
+# Preface {.unnumbered}
+
+This is a book.

--- a/tests/docs/books/issue-13477/book-sidebar-logo/logo.png
+++ b/tests/docs/books/issue-13477/book-sidebar-logo/logo.png
@@ -1,0 +1,1 @@
+fake image content

--- a/tests/docs/websites/issue-13477/custom-titles/.gitignore
+++ b/tests/docs/websites/issue-13477/custom-titles/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/tests/docs/websites/issue-13477/custom-titles/_quarto.yml
+++ b/tests/docs/websites/issue-13477/custom-titles/_quarto.yml
@@ -1,0 +1,11 @@
+project:
+  type: website
+  title: "My Website"
+
+website:
+  navbar:
+    title: "Custom Nav"
+  sidebar:
+    title: "Custom Side"
+    contents:
+      - index.qmd

--- a/tests/docs/websites/issue-13477/custom-titles/index.qmd
+++ b/tests/docs/websites/issue-13477/custom-titles/index.qmd
@@ -1,0 +1,4 @@
+---
+title: "Home"
+---
+Hello

--- a/tests/docs/websites/issue-13477/navbar-false-sidebar-undefined/.gitignore
+++ b/tests/docs/websites/issue-13477/navbar-false-sidebar-undefined/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/tests/docs/websites/issue-13477/navbar-false-sidebar-undefined/_quarto.yml
+++ b/tests/docs/websites/issue-13477/navbar-false-sidebar-undefined/_quarto.yml
@@ -1,0 +1,10 @@
+project:
+  type: website
+  title: "My Website"
+
+website:
+  navbar:
+    title: false
+  sidebar:
+    contents:
+      - index.qmd

--- a/tests/docs/websites/issue-13477/navbar-false-sidebar-undefined/index.qmd
+++ b/tests/docs/websites/issue-13477/navbar-false-sidebar-undefined/index.qmd
@@ -1,0 +1,4 @@
+---
+title: "Home"
+---
+Hello

--- a/tests/docs/websites/issue-13477/navbar-true-sidebar-true/.gitignore
+++ b/tests/docs/websites/issue-13477/navbar-true-sidebar-true/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/tests/docs/websites/issue-13477/navbar-true-sidebar-true/_quarto.yml
+++ b/tests/docs/websites/issue-13477/navbar-true-sidebar-true/_quarto.yml
@@ -1,0 +1,11 @@
+project:
+  type: website
+  title: "My Website"
+
+website:
+  navbar:
+    title: true
+  sidebar:
+    title: true
+    contents:
+      - index.qmd

--- a/tests/docs/websites/issue-13477/navbar-true-sidebar-true/index.qmd
+++ b/tests/docs/websites/issue-13477/navbar-true-sidebar-true/index.qmd
@@ -1,0 +1,4 @@
+---
+title: "Home"
+---
+Hello

--- a/tests/docs/websites/issue-13477/no-titles/.gitignore
+++ b/tests/docs/websites/issue-13477/no-titles/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/tests/docs/websites/issue-13477/no-titles/_quarto.yml
+++ b/tests/docs/websites/issue-13477/no-titles/_quarto.yml
@@ -1,0 +1,11 @@
+project:
+  type: website
+  title: "My Website"
+
+website:
+  navbar:
+    title: false
+  sidebar:
+    title: false
+    contents:
+      - index.qmd

--- a/tests/docs/websites/issue-13477/no-titles/index.qmd
+++ b/tests/docs/websites/issue-13477/no-titles/index.qmd
@@ -1,0 +1,4 @@
+---
+title: "Home"
+---
+Hello

--- a/tests/smoke/website/issue-13477.test.ts
+++ b/tests/smoke/website/issue-13477.test.ts
@@ -1,0 +1,144 @@
+/*
+ * issue-13477.test.ts
+ *
+ * Verifies navbar and sidebar title control options.
+ *
+ * Copyright (C) 2020-2025 Posit Software, PBC
+ */
+
+import { docs } from "../../utils.ts";
+import { join } from "../../../src/deno_ral/path.ts";
+import { existsSync } from "../../../src/deno_ral/fs.ts";
+import { testQuartoCmd } from "../../test.ts";
+import { fileExists, noErrorsOrWarnings, ensureHtmlElementContents, ensureHtmlElements } from "../../verify.ts";
+
+// 1. navbar: false, sidebar: undefined -> should show in sidebar, not navbar
+const dir1 = docs("websites/issue-13477/navbar-false-sidebar-undefined");
+const outDir1 = join(Deno.cwd(), dir1, "_site");
+const index1 = join(outDir1, "index.html");
+
+testQuartoCmd(
+  "render",
+  [dir1],
+  [
+    noErrorsOrWarnings,
+    fileExists(index1),
+    ensureHtmlElementContents(index1, {
+      selectors: [".sidebar-title"],
+      matches: ["My Website"],
+    }),
+    ensureHtmlElements(index1, [], [".navbar-title"]),
+  ],
+  {
+    teardown: async () => {
+      if (existsSync(outDir1)) {
+        await Deno.remove(outDir1, { recursive: true });
+      }
+    },
+  },
+);
+
+// 2. navbar: true, sidebar: true -> should show in both
+const dir2 = docs("websites/issue-13477/navbar-true-sidebar-true");
+const outDir2 = join(Deno.cwd(), dir2, "_site");
+const index2 = join(outDir2, "index.html");
+
+testQuartoCmd(
+  "render",
+  [dir2],
+  [
+    noErrorsOrWarnings,
+    fileExists(index2),
+    ensureHtmlElementContents(index2, {
+      selectors: [".sidebar-title"],
+      matches: ["My Website"],
+    }),
+    ensureHtmlElementContents(index2, {
+      selectors: [".navbar-title"],
+      matches: ["My Website"],
+    }),
+  ],
+  {
+    teardown: async () => {
+      if (existsSync(outDir2)) {
+        await Deno.remove(outDir2, { recursive: true });
+      }
+    },
+  },
+);
+
+// 3. book: sidebar logo, sidebar title undefined -> should show in sidebar (book exception)
+const dir3 = "tests/docs/books/issue-13477/book-sidebar-logo";
+const outDir3 = join(Deno.cwd(), dir3, "_book");
+const index3 = join(outDir3, "index.html");
+
+testQuartoCmd(
+  "render",
+  [dir3],
+  [
+    noErrorsOrWarnings,
+    fileExists(index3),
+    ensureHtmlElementContents(index3, {
+      selectors: [".sidebar-title"],
+      matches: ["My Book"],
+    }),
+  ],
+  {
+    teardown: async () => {
+      if (existsSync(outDir3)) {
+        await Deno.remove(outDir3, { recursive: true });
+      }
+    },
+  },
+);
+
+// 4. custom titles
+const dir4 = docs("websites/issue-13477/custom-titles");
+const outDir4 = join(Deno.cwd(), dir4, "_site");
+const index4 = join(outDir4, "index.html");
+
+testQuartoCmd(
+  "render",
+  [dir4],
+  [
+    noErrorsOrWarnings,
+    fileExists(index4),
+    ensureHtmlElementContents(index4, {
+      selectors: [".navbar-title"],
+      matches: ["Custom Nav"],
+    }),
+    ensureHtmlElementContents(index4, {
+      selectors: [".sidebar-title"],
+      matches: ["Custom Side"],
+    }),
+  ],
+  {
+    teardown: async () => {
+      if (existsSync(outDir4)) {
+        await Deno.remove(outDir4, { recursive: true });
+      }
+    },
+  },
+);
+
+// 5. no titles
+const dir5 = docs("websites/issue-13477/no-titles");
+const outDir5 = join(Deno.cwd(), dir5, "_site");
+const index5 = join(outDir5, "index.html");
+
+testQuartoCmd(
+  "render",
+  [dir5],
+  [
+    noErrorsOrWarnings,
+    fileExists(index5),
+    ensureHtmlElements(index5, [], [".navbar-title", ".sidebar-title"]),
+  ],
+  {
+    teardown: async () => {
+      if (existsSync(outDir5)) {
+        await Deno.remove(outDir5, { recursive: true });
+      }
+    },
+  },
+);

--- a/tests/smoke/website/issue-13477.test.ts
+++ b/tests/smoke/website/issue-13477.test.ts
@@ -1,0 +1,144 @@
+/*
+ * issue-13477.test.ts
+ *
+ * Verifies navbar and sidebar title control options.
+ *
+ * Copyright (C) 2020-2025 Posit Software, PBC
+ */
+
+import { docs } from "../../utils.ts";
+import { join } from "../../../src/deno_ral/path.ts";
+import { existsSync } from "../../../src/deno_ral/fs.ts";
+import { testQuartoCmd } from "../../test.ts";
+import { fileExists, noErrorsOrWarnings, ensureHtmlElementContents, ensureHtmlElements } from "../../verify.ts";
+
+// 1. navbar: false, sidebar: undefined -> should show in sidebar, not navbar
+const dir1 = docs("websites/issue-13477/navbar-false-sidebar-undefined");
+const outDir1 = join(Deno.cwd(), dir1, "_site");
+const index1 = join(outDir1, "index.html");
+
+testQuartoCmd(
+  "render",
+  [dir1],
+  [
+    noErrorsOrWarnings,
+    fileExists(index1),
+    ensureHtmlElementContents(index1, {
+      selectors: [".sidebar-title"],
+      matches: ["My Website"],
+    }),
+    ensureHtmlElements(index1, [], [".navbar-title"]),
+  ],
+  {
+    teardown: async () => {
+      if (existsSync(outDir1)) {
+        await Deno.remove(outDir1, { recursive: true });
+      }
+    },
+  },
+);
+
+// 2. navbar: true, sidebar: true -> should show in both
+const dir2 = docs("websites/issue-13477/navbar-true-sidebar-true");
+const outDir2 = join(Deno.cwd(), dir2, "_site");
+const index2 = join(outDir2, "index.html");
+
+testQuartoCmd(
+  "render",
+  [dir2],
+  [
+    noErrorsOrWarnings,
+    fileExists(index2),
+    ensureHtmlElementContents(index2, {
+      selectors: [".sidebar-title"],
+      matches: ["My Website"],
+    }),
+    ensureHtmlElementContents(index2, {
+      selectors: [".navbar-title"],
+      matches: ["My Website"],
+    }),
+  ],
+  {
+    teardown: async () => {
+      if (existsSync(outDir2)) {
+        await Deno.remove(outDir2, { recursive: true });
+      }
+    },
+  },
+);
+
+// 3. book: sidebar logo, sidebar title undefined -> should show in sidebar (book exception)
+const dir3 = docs("books/issue-13477/book-sidebar-logo");
+const outDir3 = join(Deno.cwd(), dir3, "_book");
+const index3 = join(outDir3, "index.html");
+
+testQuartoCmd(
+  "render",
+  [dir3],
+  [
+    noErrorsOrWarnings,
+    fileExists(index3),
+    ensureHtmlElementContents(index3, {
+      selectors: [".sidebar-title"],
+      matches: ["My Book"],
+    }),
+  ],
+  {
+    teardown: async () => {
+      if (existsSync(outDir3)) {
+        await Deno.remove(outDir3, { recursive: true });
+      }
+    },
+  },
+);
+
+// 4. custom titles
+const dir4 = docs("websites/issue-13477/custom-titles");
+const outDir4 = join(Deno.cwd(), dir4, "_site");
+const index4 = join(outDir4, "index.html");
+
+testQuartoCmd(
+  "render",
+  [dir4],
+  [
+    noErrorsOrWarnings,
+    fileExists(index4),
+    ensureHtmlElementContents(index4, {
+      selectors: [".navbar-title"],
+      matches: ["Custom Nav"],
+    }),
+    ensureHtmlElementContents(index4, {
+      selectors: [".sidebar-title"],
+      matches: ["Custom Side"],
+    }),
+  ],
+  {
+    teardown: async () => {
+      if (existsSync(outDir4)) {
+        await Deno.remove(outDir4, { recursive: true });
+      }
+    },
+  },
+);
+
+// 5. no titles
+const dir5 = docs("websites/issue-13477/no-titles");
+const outDir5 = join(Deno.cwd(), dir5, "_site");
+const index5 = join(outDir5, "index.html");
+
+testQuartoCmd(
+  "render",
+  [dir5],
+  [
+    noErrorsOrWarnings,
+    fileExists(index5),
+    ensureHtmlElements(index5, [], [".navbar-title", ".sidebar-title"]),
+  ],
+  {
+    teardown: async () => {
+      if (existsSync(outDir5)) {
+        await Deno.remove(outDir5, { recursive: true });
+      }
+    },
+  },
+);


### PR DESCRIPTION
## Description

- Allow `navbar.title` and `sidebar.title` to be `boolean` or `string`.
- Fix bug where disabling navbar title erroneously hid sidebar title. #13477 
- Support custom titles for navbar and sidebar.
- Add smoke tests for title control options.
- Update schema documentation for titling options.

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog in the PR (Not yet. Waiting for positive feedback.)
- [x] ensured the present test suite passes 
- [x] added new tests 
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR (I'll work on this if I get positive feedback on this.)
