### PR TITLE
use npm: prefix for acorn-class-fields in import map

### DIFF
--- a/src/import_map.json
+++ b/src/import_map.json
@@ -42,7 +42,7 @@
     "moment-guess": "https://cdn.skypack.dev/moment-guess@1.2.4",
     "ansi_up": "https://cdn.skypack.dev/ansi_up@v6.0.2",
     "lodash/": "npm:/lodash@4.17.21/",
-    "acorn-class-fields": "https://cdn.skypack.dev/acorn-class-fields@1.0.0",
+    "acorn-class-fields": "npm:/acorn-class-fields@1.0.0",
     "acorn/acorn": "https://cdn.skypack.dev/acorn@8.4.0",
     "acorn/walk": "https://cdn.skypack.dev/acorn-walk@8.2.0",
     "binary-search-bounds": "https://cdn.skypack.dev/binary-search-bounds@2.0.5",


### PR DESCRIPTION
Skypack CDN is failing with error 500 for acorn-class-fields:

```
❯ curl https://cdn.skypack.dev/acorn-class-fields@1.0.0
A server error has occurred

FUNCTION_INVOCATION_FAILED

cle1::pglvj-1768811217533-04fc98231f31
```

Same fix as #13850 for lodash.

Fixes failing CI: https://github.com/quarto-dev/quarto-cli/actions/runs/21131746275/job/60764260398