### PR TITLE
fix(shortcodes): use semicolon delimiter to avoid smart typography issue

### DIFF
--- a/src/resources/pandoc/datadir/lpegshortcode.lua
+++ b/src/resources/pandoc/datadir/lpegshortcode.lua
@@ -321,13 +321,13 @@ local function string_to_hex(str)
 end
 
 local md_shortcode_2_uuid         = "b58fc729-690b-4000-b19f-365a4093b2ff"
-local md_shortcode_2_uuid_pattern = "b58fc729%-690b%-4000%-b19f%-365a4093b2ff%-"
+local md_shortcode_2_uuid_pattern = "b58fc729%-690b%-4000%-b19f%-365a4093b2ff;"
 local function md_escaped_shortcode_2_fun(s)
   return table.concat({
     md_shortcode_2_uuid,
-    "-",
+    ";",
     string_to_hex("{{{<" .. s .. ">}}}"),
-    "-"
+    ";"
   })
 end
 
@@ -340,9 +340,9 @@ local function md_shortcode_2_fun(open, space, lst, close)
   raw = raw .. close
   return table.concat({
     md_shortcode_2_uuid,
-    "-",
+    ";",
     string_to_hex(raw),
-    "-"
+    ";"
   });
 end
 

--- a/src/resources/pandoc/datadir/readqmd.lua
+++ b/src/resources/pandoc/datadir/readqmd.lua
@@ -121,7 +121,7 @@ local function hex_to_string(hex)
 end
 
 local function readqmd(txt, opts)
-  local uuid_pattern = "b58fc729%-690b%-4000%-b19f%-365a4093b2ff%-([A-Fa-f0-9]+)%-"
+  local uuid_pattern = "b58fc729%-690b%-4000%-b19f%-365a4093b2ff;([A-Fa-f0-9]+);"
   local tags
   txt = md_fenced_div.attempt_to_fix_fenced_div(txt)
   txt, tags = escape_invalid_tags(txt)

--- a/tests/docs/shortcodes/.gitignore
+++ b/tests/docs/shortcodes/.gitignore
@@ -1,1 +1,3 @@
 /.quarto/
+
+**/*.quarto_ipynb

--- a/tests/docs/smoke-all/2026/01/19/13913.qmd
+++ b/tests/docs/smoke-all/2026/01/19/13913.qmd
@@ -1,0 +1,14 @@
+---
+title: Shortcode with trailing dash
+format: html
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - ['<p>Normal shortcode: [0-9]+\.[0-9]+\.[0-9]+</p>', '<p>Shortcode with trailing dash: [0-9]+\.[0-9]+\.[0-9]+-</p>']
+        - []
+---
+
+Normal shortcode: {{< version >}}
+
+Shortcode with trailing dash: {{< version >}}-

--- a/tests/docs/smoke-all/2026/01/19/13913.qmd
+++ b/tests/docs/smoke-all/2026/01/19/13913.qmd
@@ -1,14 +1,19 @@
 ---
-title: Shortcode with trailing dash
+title: Shortcode with trailing punctuation
 format: html
 _quarto:
   tests:
     html:
       ensureFileRegexMatches:
-        - ['<p>Normal shortcode: [0-9]+\.[0-9]+\.[0-9]+</p>', '<p>Shortcode with trailing dash: [0-9]+\.[0-9]+\.[0-9]+-</p>']
+        - 
+          - '<p>Normal shortcode: [0-9]+\.[0-9]+\.[0-9]+</p>'
+          - '<p>Shortcode with trailing dash: [0-9]+\.[0-9]+\.[0-9]+-</p>'
+          - '<p>Shortcode with trailing semicolon: [0-9]+\.[0-9]+\.[0-9]+;suffix</p>'
         - []
 ---
 
 Normal shortcode: {{< version >}}
 
 Shortcode with trailing dash: {{< version >}}-
+
+Shortcode with trailing semicolon: {{< version >}};suffix


### PR DESCRIPTION
Shortcodes followed by a trailing dash (e.g., `{{< version >}}-`) were being rendered as hex-encoded strings:

```
b58fc729-690b-4000-b19f-365a4093b2ff-7B7B3C2076657273696F6E203E7D7D–
```

## Root Cause

PR #13792 introduced a two-stage transformation that encodes shortcodes as `UUID-HEX-` to safely pass through Pandoc's markdown parser. When a user writes `{{< version >}}-`, the encoded form becomes `UUID-HEX--`. Pandoc's `+smart` extension converts `--` to an en-dash `–`, breaking the decode pattern match.

## Fix

Changed the delimiter from `-` to `;` in the UUID-HEX encoding format. Semicolons have no markdown meaning and are not affected by smart typography.

Fixes #13913