### PR TITLE
build, macos - Add typst-gather to signed artifacts

### DIFF
--- a/package/src/macos/installer.ts
+++ b/package/src/macos/installer.ts
@@ -107,6 +107,16 @@ export async function makeInstallerMac(config: Configuration) {
       signWithEntitlements.push(join(config.directoryInfo.pkgWorking.bin, "tools", arch, "pandoc"));
       signWithEntitlements.push(join(config.directoryInfo.pkgWorking.bin, "tools", arch, "typst"));
 
+      const typstGatherPath = join(
+        config.directoryInfo.pkgWorking.bin,
+        "tools",
+        arch,
+        "typst-gather",
+      );
+      if (existsSync(typstGatherPath)) {
+        signWithEntitlements.push(typstGatherPath);
+      }
+
       const denoDomPath = join(
         config.directoryInfo.pkgWorking.bin,
         "tools",


### PR DESCRIPTION
New binary we ship is missing from list of binary to sign in Mac. So this could explain the CI failure in our create release workflow. 

````
  {"0":"xcrun","1":"stapler","2":"staple","3":"/Users/runner/work/quarto-cli/quarto-cli/package/out/quarto-1.9.18-macos.pkg"}
  Starting xcrun
  Finished xcrun
  Status 65
ERROR: 
ERROR: Command xcrun,stapler,staple,/Users/runner/work/quarto-cli/quarto-cli/package/out/quarto-1.9.18-macos.pkg failed.
````

Let's see ! 