### PR TITLE
Add breaking change of new pandoc in release note

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -15,6 +15,7 @@ All changes included in 1.9:
 ## Dependencies
 
 - Update `pandoc` to 3.8.3
+  - ([#13925](https://github.com/quarto-dev/quarto-cli/issues/13925)): Pandoc 3.8.3 introduces `^[text]^` as inline footnote syntax. This conflicts with superscript containing a Span at the start (e.g., `^[text]{.class}^`) since the `^[` sequence now triggers footnote parsing. A workaround is to insert a zero-width space or other invisible character between `^` and `[`.
 - Update `typst` to 0.14.2
 - Update `esbuild` to 0.25.10
 - Update `deno` to 2.4.5


### PR DESCRIPTION
Relates to https://github.com/quarto-dev/quarto-cli/issues/13925 and https://github.com/jgm/pandoc/issues/11409

This is adding a bullet in release note about this pandoc breaking change. 

We don't usually do breaking change, and it is not ours, so I did not do it as a new `## Breaking` section, but put it under the dependency itself. 

Not sure about that though. 

@cwickham what is your thought on that ?

This aimed to be in the doc. 
