### PR TITLE
Fix interactive tool selection in quarto install/update/uninstall

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -127,6 +127,7 @@ All changes included in 1.9:
 
 ## Other fixes and improvements
 
+- Fix `quarto install`, `quarto update`, and `quarto uninstall` interactive tool selection (same issue as [#9765](https://github.com/quarto-dev/quarto-cli/pull/9765)).
 - ([#8730](https://github.com/quarto-dev/quarto-cli/issues/8730)): Detect x64 R crashes on Windows ARM and provide helpful error message directing users to install native ARM64 R instead of showing generic "check your R installation" error.
 - ([#13402](https://github.com/quarto-dev/quarto-cli/issues/13402)): `nfpm` (<https://nfpm.goreleaser.com/>) is now used to create the `.deb` package, and new `.rpm` package. Both Linux packages are also now built for `x86_64` (`amd64`) and `aarch64` (`arm64`) architectures.
 - ([#13528](https://github.com/quarto-dev/quarto-cli/pull/13528)): Adds support for table specification using nested lists and the `list-table` class.

--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -127,7 +127,6 @@ All changes included in 1.9:
 
 ## Other fixes and improvements
 
-- Fix `quarto install`, `quarto update`, and `quarto uninstall` interactive tool selection (same issue as [#9765](https://github.com/quarto-dev/quarto-cli/pull/9765)).
 - ([#8730](https://github.com/quarto-dev/quarto-cli/issues/8730)): Detect x64 R crashes on Windows ARM and provide helpful error message directing users to install native ARM64 R instead of showing generic "check your R installation" error.
 - ([#13402](https://github.com/quarto-dev/quarto-cli/issues/13402)): `nfpm` (<https://nfpm.goreleaser.com/>) is now used to create the `.deb` package, and new `.rpm` package. Both Linux packages are also now built for `x86_64` (`amd64`) and `aarch64` (`arm64`) architectures.
 - ([#13528](https://github.com/quarto-dev/quarto-cli/pull/13528)): Adds support for table specification using nested lists and the `list-table` class.
@@ -137,3 +136,4 @@ All changes included in 1.9:
 - ([#13856](https://github.com/quarto-dev/quarto-cli/issues/13856)): Add code annotation support for Typst and Observable.js code blocks. (author: @mcanouil)
 - ([#13890](https://github.com/quarto-dev/quarto-cli/issues/13890)): Fix render failure when using `embed-resources: true` with input path through a symlinked directory. The cleanup now resolves symlinks before comparing paths.
 - ([#13907](https://github.com/quarto-dev/quarto-cli/issues/13907)): Ignore AI assistant configuration files (`CLAUDE.md`, `AGENTS.md`) when scanning for project input files and in extension templates, similar to how `README.md` is handled.
+- ([#13935](https://github.com/quarto-dev/quarto-cli/issues/13935)): Fix `quarto install`, `quarto update`, and `quarto uninstall` interactive tool selection.

--- a/src/tools/tools-console.ts
+++ b/src/tools/tools-console.ts
@@ -4,7 +4,7 @@
  * Copyright (C) 2021-2022 Posit Software, PBC
  */
 import * as colors from "fmt/colors";
-import { Confirm, Select } from "cliffy/prompt/mod.ts";
+import { Confirm, prompt, Select } from "cliffy/prompt/mod.ts";
 import { Table } from "cliffy/table/mod.ts";
 import { info, warning } from "../deno_ral/log.ts";
 
@@ -237,7 +237,8 @@ export async function selectTool(
     }
   };
 
-  const toolTarget: string = (await Select.prompt({
+  const result = await prompt([{
+    name: "tool",
     message: `Select a tool to ${action}`,
     options: toolsInfo.map((toolInfo) => {
       return {
@@ -248,6 +249,7 @@ export async function selectTool(
           : !toolInfo.installed,
       };
     }),
-  })).value;
-  return toolTarget;
+    type: Select,
+  }]);
+  return result.tool;
 }


### PR DESCRIPTION
When running `quarto install`, `quarto update`, or `quarto uninstall` without arguments, the interactive tool selector shows the list but the selection always returns `undefined`.

## Root Cause

Same issue as #9765 - Cliffy's `Select.prompt()` returns the selected value directly, but the code incorrectly accesses `.value` on the result.

## Fix

Use the `prompt()` array syntax with a named field, same pattern as #9765.