### PR TITLE
simplify typst-gather build

### DIFF
--- a/.github/workflows/actions/quarto-dev/action.yml
+++ b/.github/workflows/actions/quarto-dev/action.yml
@@ -12,11 +12,6 @@ runs:
         restore-keys: |
           ${{ runner.os }}-deno_std-2-
 
-    - name: Install Rust for typst-gather
-      uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: stable
-
     - name: Cache Cargo dependencies
       uses: actions/cache@v4
       with:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -133,11 +133,6 @@ jobs:
         if: ${{ inputs.publish-release }}
         uses: ./.github/workflows/actions/prevent-rerun
 
-      - name: Install Rust for typst-gather
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-
       - name: Configure
         run: |
           ./configure.sh
@@ -266,11 +261,6 @@ jobs:
         if: ${{ inputs.publish-release }}
         uses: ./.github/workflows/actions/prevent-rerun
 
-      - name: Install Rust for typst-gather
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-
       - name: Configure
         run: |
           ./configure.sh
@@ -369,11 +359,6 @@ jobs:
       - name: Prevent Re-run
         if: ${{ inputs.publish-release }}
         uses: ./.github/workflows/actions/prevent-rerun
-
-      - name: Install Rust for typst-gather and launcher
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
 
       - name: Configure
         run: |
@@ -502,11 +487,6 @@ jobs:
       - name: Prevent Re-run
         if: ${{ inputs.publish-release }}
         uses: ./.github/workflows/actions/prevent-rerun
-
-      - name: Install Rust for typst-gather
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
 
       - name: Configure
         run: |

--- a/configure.cmd
+++ b/configure.cmd
@@ -89,9 +89,10 @@ IF EXIST !QUARTO_BIN_PATH!\quarto.cmd (
 ECHO NOTE: To use quarto please use quarto.cmd (located in this folder) or add the following path to your PATH
 ECHO !QUARTO_BIN_PATH!
 
-REM Build typst-gather
+REM Build typst-gather and install to tools directory
 ECHO Building typst-gather...
 cargo build --release --manifest-path package\typst-gather\Cargo.toml
+COPY package\typst-gather\target\release\typst-gather.exe "!QUARTO_BIN_PATH!\tools\x86_64\"
 
 endlocal & set QUARTO_BIN_DEV=%QUARTO_BIN_PATH%
 

--- a/configure.cmd
+++ b/configure.cmd
@@ -89,15 +89,9 @@ IF EXIST !QUARTO_BIN_PATH!\quarto.cmd (
 ECHO NOTE: To use quarto please use quarto.cmd (located in this folder) or add the following path to your PATH
 ECHO !QUARTO_BIN_PATH!
 
-REM Build typst-gather if cargo is available
-where cargo >nul 2>nul
-if %ERRORLEVEL% EQU 0 (
-  ECHO Building typst-gather...
-  cargo build --release --manifest-path package\typst-gather\Cargo.toml
-) else (
-  ECHO Note: Rust/cargo not found, skipping typst-gather build
-  ECHO Install Rust to use 'quarto call typst-gather'
-)
+REM Build typst-gather
+ECHO Building typst-gather...
+cargo build --release --manifest-path package\typst-gather\Cargo.toml
 
 endlocal & set QUARTO_BIN_DEV=%QUARTO_BIN_PATH%
 

--- a/configure.sh
+++ b/configure.sh
@@ -103,6 +103,7 @@ else
 	quarto --version
 fi
 
-# Build typst-gather
+# Build typst-gather and install to tools directory
 echo "Building typst-gather..."
 cargo build --release --manifest-path package/typst-gather/Cargo.toml
+cp package/typst-gather/target/release/typst-gather "$QUARTO_BIN_PATH/tools/$DENO_ARCH_DIR/"

--- a/configure.sh
+++ b/configure.sh
@@ -103,11 +103,6 @@ else
 	quarto --version
 fi
 
-# Build typst-gather if cargo is available
-if command -v cargo &> /dev/null; then
-  echo "Building typst-gather..."
-  cargo build --release --manifest-path package/typst-gather/Cargo.toml
-else
-  echo "Note: Rust/cargo not found, skipping typst-gather build"
-  echo "Install Rust to use 'quarto call typst-gather'"
-fi
+# Build typst-gather
+echo "Building typst-gather..."
+cargo build --release --manifest-path package/typst-gather/Cargo.toml

--- a/package/src/common/prepare-dist.ts
+++ b/package/src/common/prepare-dist.ts
@@ -100,7 +100,7 @@ export async function prepareDist(
     }
   }
 
-  // Stage typst-gather binary if it exists (built by configure.sh)
+  // Stage typst-gather binary (built by configure.sh)
   // Only stage if the build machine architecture matches the target architecture
   // (cross-compilation is not currently supported)
   const buildArch = Deno.build.arch === "aarch64" ? "aarch64" : "x86_64";
@@ -111,15 +111,17 @@ export async function prepareDist(
       "package/typst-gather/target/release",
       typstGatherBinaryName,
     );
-    if (existsSync(typstGatherSrc)) {
-      info("\nStaging typst-gather binary");
-      const typstGatherDest = join(targetDir, config.arch, typstGatherBinaryName);
-      ensureDirSync(join(targetDir, config.arch));
-      copySync(typstGatherSrc, typstGatherDest, { overwrite: true });
-      info(`Copied ${typstGatherSrc} to ${typstGatherDest}`);
-    } else {
-      info("\nNote: typst-gather binary not found, skipping staging");
+    if (!existsSync(typstGatherSrc)) {
+      throw new Error(
+        `typst-gather binary not found at ${typstGatherSrc}\n` +
+          "Run ./configure.sh to build it.",
+      );
     }
+    info("\nStaging typst-gather binary");
+    const typstGatherDest = join(targetDir, config.arch, typstGatherBinaryName);
+    ensureDirSync(join(targetDir, config.arch));
+    copySync(typstGatherSrc, typstGatherDest, { overwrite: true });
+    info(`Copied ${typstGatherSrc} to ${typstGatherDest}`);
   } else {
     info(`\nNote: Skipping typst-gather staging (build arch ${buildArch} != target arch ${config.arch})`);
   }

--- a/src/command/call/typst-gather/cmd.ts
+++ b/src/command/call/typst-gather/cmd.ts
@@ -452,36 +452,15 @@ export const typstGatherCommand = new Command()
         Deno.exit(1);
       }
 
-      // Find typst-gather binary
-      // First try architecture-specific path, then fall back to PATH
-      let typstGatherBinary: string;
+      // Find typst-gather binary in standard tools location
       const binaryName = isWindows ? "typst-gather.exe" : "typst-gather";
-
-      const archPath = architectureToolsPath(binaryName);
-      if (existsSync(archPath)) {
-        typstGatherBinary = archPath;
-      } else {
-        // Try to find in PATH or use development location
-        const quartoRoot = Deno.env.get("QUARTO_ROOT");
-        if (quartoRoot) {
-          const devPath = join(
-            quartoRoot,
-            "package/typst-gather/target/release",
-            binaryName,
-          );
-          if (existsSync(devPath)) {
-            typstGatherBinary = devPath;
-          } else {
-            console.error(
-              `typst-gather binary not found.\n` +
-                `Build it with: cd package/typst-gather && cargo build --release`,
-            );
-            Deno.exit(1);
-          }
-        } else {
-          console.error("typst-gather binary not found.");
-          Deno.exit(1);
-        }
+      const typstGatherBinary = architectureToolsPath(binaryName);
+      if (!existsSync(typstGatherBinary)) {
+        console.error(
+          `typst-gather binary not found.\n` +
+            `Run ./configure.sh to build and install it.`,
+        );
+        Deno.exit(1);
       }
 
       // Determine config file to use

--- a/src/command/dev-call/typst-gather/cmd.ts
+++ b/src/command/dev-call/typst-gather/cmd.ts
@@ -5,9 +5,11 @@
  */
 
 import { Command } from "cliffy/command/mod.ts";
+import { existsSync } from "../../../deno_ral/fs.ts";
 import { error, info } from "../../../deno_ral/log.ts";
 import { join } from "../../../deno_ral/path.ts";
 import { isWindows } from "../../../deno_ral/platform.ts";
+import { architectureToolsPath } from "../../../core/resources.ts";
 
 export const typstGatherCommand = new Command()
   .name("typst-gather")
@@ -33,21 +35,13 @@ export const typstGatherCommand = new Command()
       "src/command/dev-call/typst-gather/typst-gather.toml",
     );
 
-    // Path to the typst-gather binary
+    // Find typst-gather binary in standard tools location
     const binaryName = isWindows ? "typst-gather.exe" : "typst-gather";
-    const typstGatherBinary = join(
-      quartoRoot,
-      "package/typst-gather/target/release",
-      binaryName,
-    );
-
-    // Check if binary exists
-    try {
-      await Deno.stat(typstGatherBinary);
-    } catch {
+    const typstGatherBinary = architectureToolsPath(binaryName);
+    if (!existsSync(typstGatherBinary)) {
       error(
-        `typst-gather binary not found at ${typstGatherBinary}\n` +
-          "Build it with: cd package/typst-gather && cargo build --release",
+        `typst-gather binary not found.\n` +
+          "Run ./configure.sh to build and install it.",
       );
       Deno.exit(1);
     }

--- a/tests/docs/smoke-all/pdf-standard/pdfversion-numeric.qmd
+++ b/tests/docs/smoke-all/pdf-standard/pdfversion-numeric.qmd
@@ -1,7 +1,7 @@
 ---
 title: "PDF version (numeric YAML)"
 lang: en
-pdf-standard: 2.0
+pdf-standard: "2.0"
 keep-tex: true
 keep-typ: true
 _quarto:


### PR DESCRIPTION
Stable Rust is the default on GH runners, so we don't need any workflow steps. 

(Including for the Windows launcher; we can build that on stable instead of pinned as discussed.)

Also:
* configure will fail if `typst-gather` fails to build.
* `typst-gather` binary gets copied to the usual `bin` directory and run/dist from there.