### PR TITLE
feat(html): section-collapse metadata

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -280,6 +280,8 @@ export const kCodeLines = "code-lines";
 export const kCodeToolsMenuCaption = "code-tools-menu-caption";
 export const kCodeToolsShowAllCode = "code-tools-show-all-code";
 export const kCodeToolsHideAllCode = "code-tools-hide-all-code";
+export const kCodeToolsShowAllSections = "code-tools-show-all-sections";
+export const kCodeToolsHideAllSections = "code-tools-hide-all-sections";
 export const kCodeToolsViewSource = "code-tools-view-source";
 export const kCodeToolsSourceCode = "code-tools-source-code";
 export const kSearchNoResultsText = "search-no-results-text";
@@ -410,6 +412,8 @@ export const kLanguageDefaultsKeys = [
   kCodeToolsMenuCaption,
   kCodeToolsShowAllCode,
   kCodeToolsHideAllCode,
+  kCodeToolsHideAllSections,
+  kCodeToolsShowAllSections,
   kCodeToolsViewSource,
   kCodeToolsSourceCode,
   kToolsShare,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -34,8 +34,10 @@ import {
   kCodeSummary,
   kCodeTools,
   kCodeToolsHideAllCode,
+  kCodeToolsHideAllSections,
   kCodeToolsMenuCaption,
   kCodeToolsShowAllCode,
+  kCodeToolsShowAllSections,
   kCodeToolsSourceCode,
   kCodeToolsViewSource,
   kColumns,
@@ -481,6 +483,7 @@ export interface FormatRender {
     source?: boolean;
     toggle?: boolean;
     caption?: string;
+    section?: boolean;
   };
   [kTblColwidths]?: "auto" | boolean | number[];
   [kShortcodes]?: string[];
@@ -680,6 +683,8 @@ export interface FormatLanguage {
   [kCodeToolsMenuCaption]?: string;
   [kCodeToolsShowAllCode]?: string;
   [kCodeToolsHideAllCode]?: string;
+  [kCodeToolsShowAllSections]?: string;
+  [kCodeToolsHideAllSections]?: string;
   [kCodeToolsViewSource]?: string;
   [kCodeToolsSourceCode]?: string;
   [kToolsDownload]?: string;

--- a/src/format/html/format-html-shared.ts
+++ b/src/format/html/format-html-shared.ts
@@ -58,6 +58,8 @@ export const kUtterances = "utterances";
 export const kGiscus = "giscus";
 export const kAxe = "axe";
 
+export const kSectionCollapse = "section-collapse";
+
 export const kGiscusRepoId = "repo-id";
 export const kGiscusCategoryId = "category-id";
 

--- a/src/format/html/format-html-types.ts
+++ b/src/format/html/format-html-types.ts
@@ -15,6 +15,7 @@ export interface HtmlFormatFeatureDefaults {
   figResponsive?: boolean;
   codeAnnotations?: boolean;
   hoverXrefs?: boolean;
+  sectionCollapse?: boolean | 'closed';
 }
 
 export interface HtmlFormatTippyOptions {

--- a/src/format/html/format-html.ts
+++ b/src/format/html/format-html.ts
@@ -87,6 +87,7 @@ import {
   kXrefsHover,
   quartoBaseLayer,
   quartoGlobalCssVariableRules,
+  kSectionCollapse,
 } from "./format-html-shared.ts";
 import {
   kSiteUrl,
@@ -327,6 +328,13 @@ export async function htmlFormatExtras(
     options.hoverFootnotes = format.metadata[kFootnotesHover] || false;
   }
 
+  if (featureDefaults.sectionCollapse) {
+    options.sectionCollapse = format.metadata[kSectionCollapse] !== false;
+  } else {
+    options.sectionCollapse = format.metadata[kSectionCollapse] || false;
+  }
+  options.sectionCollapseClosed = format.metadata[kSectionCollapse] === 'closed';
+
   // Books don't currently support hover xrefs (since the content to preview in the xref
   // is likely to be on another page and we don't want to do a full fetch of that page
   // to get the preview)
@@ -411,6 +419,14 @@ export async function htmlFormatExtras(
       name: "popper.min.js",
       path: formatResourcePath("html", join("popper", "popper.min.js")),
     });
+  }
+
+  // sectionCollapse if required
+  if (options.sectionCollapse) {
+    stylesheets.push({
+      name: "sectionCollapse.css",
+      path: formatResourcePath("html", "sectionCollapse.css"),
+    })
   }
 
   // tippy if required

--- a/src/resources/editor/tools/vs-code.mjs
+++ b/src/resources/editor/tools/vs-code.mjs
@@ -10344,6 +10344,8 @@ var require_yaml_intelligence_resources = __commonJS({
               "section-title-appendices": "string",
               "code-summary": "string",
               "code-tools-menu-caption": "string",
+              "code-tools-show-all-sections": "string",
+              "code-tools-hide-all-sections": "string",
               "code-tools-show-all-code": "string",
               "code-tools-hide-all-code": "string",
               "code-tools-view-source": "string",

--- a/src/resources/formats/html/sectionCollapse.css
+++ b/src/resources/formats/html/sectionCollapse.css
@@ -1,0 +1,22 @@
+.sc-carret {
+  font-family: "Courier New", Courier, monospace;
+  opacity: 0.7;
+  float: right;
+  cursor: pointer;
+  transform: rotate(-90deg);
+  transition: transform 0.15s ease;
+  user-select: none;
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  &.closed {
+    transform: rotate(0deg);
+  }
+}
+
+/* section:not(.cell-output):has(h1, h2, h3, h4, h5, h6 > div.sc-carret.closed) > :not(:first-child) */
+section:not(.cell-output):has(> :is(h1,h2,h3,h4,h5,h6) > div.sc-carret.closed)> :not(:first-child) {
+  display: none;
+}

--- a/src/resources/formats/html/templates/quarto-html-after-body.ejs
+++ b/src/resources/formats/html/templates/quarto-html-after-body.ejs
@@ -1,4 +1,4 @@
-<% if (darkMode !== undefined || tabby || anchors || copyCode || codeTools || tippy || hoverFootnotes || hoverCitations || linkExternalIcon || linkExternalNewwindow || hoverXrefs) { %> 
+<% if (darkMode !== undefined || tabby || anchors || copyCode || codeTools || tippy || hoverFootnotes || hoverCitations || linkExternalIcon || linkExternalNewwindow || hoverXrefs || sectionCollapse) { %> 
   <script id = "quarto-html-after-body" type="application/javascript">
   
   
@@ -678,7 +678,49 @@
     <% } %>
   
   });
-  
+
+  <% if (sectionCollapse) { %>
+
+  const onClickCollapse = (e) => {
+    e.target.classList.toggle('closed');
+  };
+  const sectionSelector = "section:not(.cell-output) > :is(h1, h2, h3, h4, h5, h6)";
+  document.querySelectorAll(sectionSelector).forEach(heading => {
+    const carret = document.createElement("div");
+    carret.innerHTML = "‹";
+    carret.classList.add("sc-carret");
+
+    <% if(sectionCollapseClosed) { %>
+    carret.classList.add("closed");
+    <% } %>
+
+    carret.addEventListener('click', onClickCollapse.bind(heading));
+    heading.appendChild(carret);
+  });
+
+  <% if (codeTools) { %>
+
+  const toggleSectionHandler = (show) => () => {
+    const els = document.querySelectorAll(sectionSelector + " .sc-carret");
+    if (show) {
+      els.forEach(e => e.classList.remove('closed'));
+    } else {
+      els.forEach(e => e.classList.add('closed'));
+    }
+  }
+
+  const hideAllSections = window.document.getElementById("quarto-hide-all-sections");
+  if (hideAllSections) {
+    hideAllSections.addEventListener("click", toggleSectionHandler(false));
+  }
+  const showAllSections = window.document.getElementById("quarto-show-all-sections");
+  if (showAllSections) {
+    showAllSections.addEventListener("click", toggleSectionHandler(true));
+  }
+
+  <% } %>
+
+  <% } %>
   </script>
   <% } %>
   

--- a/src/resources/language/_language.yml
+++ b/src/resources/language/_language.yml
@@ -46,6 +46,8 @@ code-summary: "Code"
 code-tools-menu-caption: "Code"
 code-tools-show-all-code: "Show All Code"
 code-tools-hide-all-code: "Hide All Code"
+code-tools-show-all-sections: "Expand Sections"
+code-tools-hide-all-sections: "Collapse Sections"
 code-tools-view-source: "View Source"
 code-tools-source-code: "Source Code"
 

--- a/src/resources/schema/definitions.yml
+++ b/src/resources/schema/definitions.yml
@@ -1377,6 +1377,8 @@
       section-title-appendices: string
       code-summary: string
       code-tools-menu-caption: string
+      code-tools-show-all-sections: string
+      code-tools-hide-all-sections: string
       code-tools-show-all-code: string
       code-tools-hide-all-code: string
       code-tools-view-source: string

--- a/src/resources/schema/document-code.yml
+++ b/src/resources/schema/document-code.yml
@@ -61,6 +61,7 @@
                 - string
             toggle: boolean
             caption: string
+            section: boolean
   default: false
   description:
     short: "Include a code tools menu (for hiding and showing code)."

--- a/src/resources/schema/document-options.yml
+++ b/src/resources/schema/document-options.yml
@@ -70,6 +70,14 @@
     formats: [$html-doc]
   description: Enables hover over a section title to see an anchor link.
 
+- name: section-collapse
+  schema:
+    enum: [true, false, "closed"]
+  default: false
+  tags:
+    formats: [$html-doc]
+  description: Add a button that collapses the content below a header
+
 - name: tabsets
   schema: boolean
   default: true

--- a/src/resources/schema/json-schemas.json
+++ b/src/resources/schema/json-schemas.json
@@ -1699,6 +1699,12 @@
           "code-tools-menu-caption": {
             "type": "string"
           },
+          "code-tools-show-all-sections": {
+            "type": "string"
+          },
+          "code-tools-hide-all-sections": {
+            "type": "string"
+          },
           "code-tools-show-all-code": {
             "type": "string"
           },

--- a/src/resources/types/schema-types.ts
+++ b/src/resources/types/schema-types.ts
@@ -682,6 +682,8 @@ export type FormatLanguage = {
   "code-tools-menu-caption"?: string;
   "code-tools-show-all-code"?: string;
   "code-tools-hide-all-code"?: string;
+  "code-tools-show-all-sections"?: string;
+  "code-tools-hide-all-sections"?: string;
   "code-tools-view-source"?: string;
   "code-tools-source-code"?: string;
   "search-no-results-text"?: string;


### PR DESCRIPTION
Collapse (hide) sections (delimited by headings) by clicking a chevron next to the heading. Expand/collapse all with an option in the codetools menu

## Description

New front-matter config for the HTML format `section-collapse`. Inspired by the old jupyter-contrib-nbextension: [Collapsible headings](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/collapsible_headings/readme.html) 

- when true: creates chevrons on the right of all headers, when clicked they "collapse" and hide all of their content
- when false: does nothing
- when `closed` start closed

Additionally:
- make the "code tools" menu multi-purpose. The name is displayed as "Tools" instead of "Code" when it's showing any non-code-related menu item
- Add `section` code-tools key which controls the addition of "expand/collapse all sections" buttons

Now that I'm opening the PR `section-fold` might make more sense, and we can change the behavior to mimic `code-fold` (true: closed, "show": open with option to fold). lmk if you prefer that.

<details>
<summary>screen shots</summary>

<img width="1036" height="550" alt="image" src="https://github.com/user-attachments/assets/402fe0ba-25e0-4ba1-9e09-6a56dfd8fe10" />

<img width="1046" height="872" alt="image" src="https://github.com/user-attachments/assets/7ed67bb0-7fcf-4364-86d4-54d728e13009" />

<img width="1047" height="452" alt="image" src="https://github.com/user-attachments/assets/bf346dd3-58c4-4a3e-b5c4-dc3833b525fe" />


</details>

part of #13946

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes (you guys don't like feature request issues, so I didn't make one)
- [ ] updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR (metadata documentation is autogenerated from yaml, right? I added descriptions in the yaml)
