### PR TITLE
Fix stack trace shown for Typst compilation errors

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -68,6 +68,7 @@ All changes included in 1.9:
   - Two-column layout now uses `set page(columns:)` instead of `columns()` function, fixing compatibility with landscape sections.
   - Title block now properly spans both columns in multi-column layouts.
 - ([#13870](https://github.com/quarto-dev/quarto-cli/issues/13870)): Add support for `alt` attribute on cross-referenced equations for improved accessibility. (author: @mcanouil)
+- ([#13942](https://github.com/quarto-dev/quarto-cli/issues/13942)): Fix Typst compilation errors showing confusing internal stack traces. Users now see only the relevant Typst error message.
 - ([#13950](https://github.com/quarto-dev/quarto-cli/pull/13950)): Replace ctheorems with theorion package for theorem environments. Add `theorem-appearance` option to control styling: `simple` (default, classic LaTeX style), `fancy` (colored boxes with brand colors), `clouds` (rounded backgrounds), or `rainbow` (colored start border and colored title).
 - ([#13954](https://github.com/quarto-dev/quarto-cli/issues/13954)): Add support for Typst book projects via format extensions. Quarto now bundles the `orange-book` extension which provides a textbook-style format with chapter numbering, cross-references, and professional styling. Book projects with `format: typst` automatically use this extension.
 - ([#13978](https://github.com/quarto-dev/quarto-cli/pull/13978)): Keep term and description together in definition lists to avoid breaking across pages. (author: @mcanouil)

--- a/src/command/render/output-typst.ts
+++ b/src/command/render/output-typst.ts
@@ -29,6 +29,7 @@ import {
   kVariant,
 } from "../../config/constants.ts";
 import { error, warning } from "../../deno_ral/log.ts";
+import { ErrorEx } from "../../core/lib/error.ts";
 import { Format } from "../../config/types.ts";
 import { writeFileToStdout } from "../../core/console.ts";
 import { dirAndStem, expandPath } from "../../core/path.ts";
@@ -167,11 +168,10 @@ export function typstPdfOutputRecipe(
       typstOptions,
     );
     if (!result.success) {
-      // Log the error so test framework can detect it via shouldError
       if (result.stderr) {
         error(result.stderr);
       }
-      throw new Error("Typst compilation failed");
+      throw new ErrorEx("Error", "Typst compilation failed", false, false);
     }
 
     // Validate PDF against specified standards using verapdf (if available)

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -277,7 +277,11 @@ function resolveTestSpecs(
               verifyFns.push(verifyMap[key](outputFile.outputPath, ...value));
             }
           } else if (key === "printsMessage") {
-            verifyFns.push(verifyMap[key](value));
+            // Support both single object and array of printsMessage checks
+            const messages = Array.isArray(value) ? value : [value];
+            for (const msg of messages) {
+              verifyFns.push(verifyMap[key](msg));
+            }
           } else if (key === "ensureEpubFileRegexMatches") {
             // this ensure function is special because it takes an array of path + regex specifiers,
             // so we should never use the spread operator


### PR DESCRIPTION
## Summary

- When Typst compilation fails (e.g., PDF/UA compliance errors), show only the Typst error message without a confusing internal stack trace
- Uses `ErrorEx` with `printStack=false` for clean user-facing errors
- Also adds support for array of `printsMessage` checks in smoke tests (enabling tests for both presence AND absence of messages)

Fixes #13942

## Test plan

- [x] Tested in production build - error output now shows:
  ```
  ERROR: error: PDF/UA-1 error: missing alt text
      ...
  ERROR: Typst compilation failed
  ```
  Without the stack trace that was previously shown.

🤖 Generated with [Claude Code](https://claude.ai/code)