### PR TITLE
Fix preview crash on re-render (BadResource error)

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -127,6 +127,10 @@ All changes included in 1.9:
 
 - ([#4426](https://github.com/quarto-dev/quarto-cli/issues/4426)): New `quarto install verapdf` command installs [veraPDF](https://verapdf.org/) for PDF/A and PDF/UA validation. When verapdf is available, PDFs created with the `pdf-standard` option are automatically validated for compliance. Also supports `quarto uninstall verapdf`, `quarto update verapdf`, and `quarto tools`.
 
+### `preview`
+
+- ([#13804](https://github.com/quarto-dev/quarto-cli/pull/13804)): Fix intermittent preview crashes during re-renders by properly managing project context lifecycle. Resolves issues with missing temporary directories and `quarto_ipynb` files when editing notebooks and qmd files together.
+
 ## Extensions
 
 - Metadata and brand extensions now work without a `_quarto.yml` project. (Engine extensions do too.) A temporary default project is created in memory.

--- a/src/command/preview/preview.ts
+++ b/src/command/preview/preview.ts
@@ -429,8 +429,8 @@ export async function renderForPreview(
   // fileInformationCache contains file content that needs to be refreshed.
   // TODO(#13955): Consider adding a dedicated invalidateForFile() method on ProjectContext
   if (project?.fileInformationCache) {
-    debug(`[renderForPreview] Invalidating file information cache for ${file}`);
-    project.fileInformationCache.delete(file);
+    const normalizedFile = normalizePath(file);
+    project.fileInformationCache.delete(normalizedFile);
   }
 
   // render

--- a/src/command/preview/preview.ts
+++ b/src/command/preview/preview.ts
@@ -424,6 +424,17 @@ export async function renderForPreview(
   pandocArgs: string[],
   project?: ProjectContext,
 ): Promise<RenderForPreviewResult> {
+  // Invalidate file cache for the file being rendered so changes are picked up.
+  // The project context persists across re-renders in preview mode, but the
+  // fileInformationCache contains file content that needs to be refreshed.
+  // TODO(#13955): Consider adding a dedicated invalidateForFile() method on ProjectContext
+  if (project?.fileInformationCache) {
+    const normalizedFile = normalizePath(file);
+    if (project.fileInformationCache.has(normalizedFile)) {
+      project.fileInformationCache.delete(normalizedFile);
+    }
+  }
+
   // render
   const renderResult = await render(file, {
     services,

--- a/src/command/preview/preview.ts
+++ b/src/command/preview/preview.ts
@@ -429,8 +429,7 @@ export async function renderForPreview(
   // fileInformationCache contains file content that needs to be refreshed.
   // TODO(#13955): Consider adding a dedicated invalidateForFile() method on ProjectContext
   if (project?.fileInformationCache) {
-    const normalizedFile = normalizePath(file);
-    project.fileInformationCache.delete(normalizedFile);
+    project.fileInformationCache.delete(file);
   }
 
   // render

--- a/src/command/preview/preview.ts
+++ b/src/command/preview/preview.ts
@@ -4,7 +4,7 @@
  * Copyright (C) 2020-2022 Posit Software, PBC
  */
 
-import { info, warning } from "../../deno_ral/log.ts";
+import { debug, info, warning } from "../../deno_ral/log.ts";
 import {
   basename,
   dirname,
@@ -429,10 +429,8 @@ export async function renderForPreview(
   // fileInformationCache contains file content that needs to be refreshed.
   // TODO(#13955): Consider adding a dedicated invalidateForFile() method on ProjectContext
   if (project?.fileInformationCache) {
-    const normalizedFile = normalizePath(file);
-    if (project.fileInformationCache.has(normalizedFile)) {
-      project.fileInformationCache.delete(normalizedFile);
-    }
+    debug(`[renderForPreview] Invalidating file information cache for ${file}`);
+    project.fileInformationCache.delete(file);
   }
 
   // render

--- a/src/command/preview/preview.ts
+++ b/src/command/preview/preview.ts
@@ -485,8 +485,6 @@ export async function renderForPreview(
     [],
   ));
 
-  renderResult.context.cleanup();
-
   return {
     file,
     format: renderResult.files[0].format,

--- a/src/core/sass/cache.ts
+++ b/src/core/sass/cache.ts
@@ -147,10 +147,9 @@ class SassCache implements Cloneable<SassCache> {
     const registerCleanup = temp ? temp.onCleanup : onCleanup;
     const cachePath = this.path;
     registerCleanup(() => {
-      log.debug(`SassCache cleanup EXECUTING for ${cachePath}`);
+      log.debug(`SassCache cleanup executing for ${cachePath}`);
       try {
         this.kv.close();
-        log.debug(`SassCache KV closed for ${cachePath}`);
         if (temp) safeRemoveIfExists(this.path);
       } catch (error) {
         log.info(
@@ -158,7 +157,6 @@ class SassCache implements Cloneable<SassCache> {
         );
       }
     });
-    log.debug(`SassCache cleanup REGISTERED for ${cachePath}`);
   }
 }
 
@@ -203,7 +201,7 @@ export async function sassCache(
   temp: TempContext | undefined,
 ): Promise<SassCache> {
   if (!_sassCache[path]) {
-    log.debug(`Creating NEW SassCache at ${path}`);
+    log.debug(`Creating SassCache at ${path}`);
     ensureDirSync(path);
     const kvFile = join(path, "sass.kv");
     const kv = await Deno.openKv(kvFile);
@@ -211,8 +209,6 @@ export async function sassCache(
     _sassCache[path] = new SassCache(kv, path);
     // register cleanup for this cache
     _sassCache[path].cleanup(temp);
-  } else {
-    log.debug(`Found EXISTING SassCache entry for ${path} (may be stale if KV was closed)`);
   }
   log.debug(`Returning SassCache at ${path}`);
   const result = _sassCache[path];

--- a/src/execute/jupyter/jupyter.ts
+++ b/src/execute/jupyter/jupyter.ts
@@ -8,6 +8,7 @@ import { basename, dirname, join, relative } from "../../deno_ral/path.ts";
 import { satisfies } from "semver/mod.ts";
 
 import { existsSync } from "../../deno_ral/fs.ts";
+import { normalizePath } from "../../core/path.ts";
 
 import { error, info } from "../../deno_ral/log.ts";
 
@@ -865,7 +866,8 @@ function cleanupNotebook(
 ) {
   // Make notebook non-transient when keep-ipynb is set
   const data = target.data as JupyterTargetData;
-  const cached = project.fileInformationCache.get(target.source);
+  const normalizedSource = normalizePath(target.source);
+  const cached = project.fileInformationCache.get(normalizedSource);
   if (cached && data.transient && format.execute[kKeepIpynb]) {
     if (cached.target && cached.target.data) {
       (cached.target.data as JupyterTargetData).transient = false;

--- a/src/execute/jupyter/jupyter.ts
+++ b/src/execute/jupyter/jupyter.ts
@@ -8,7 +8,6 @@ import { basename, dirname, join, relative } from "../../deno_ral/path.ts";
 import { satisfies } from "semver/mod.ts";
 
 import { existsSync } from "../../deno_ral/fs.ts";
-import { normalizePath } from "../../core/path.ts";
 
 import { error, info } from "../../deno_ral/log.ts";
 
@@ -866,8 +865,7 @@ function cleanupNotebook(
 ) {
   // Make notebook non-transient when keep-ipynb is set
   const data = target.data as JupyterTargetData;
-  const normalizedSource = normalizePath(target.source);
-  const cached = project.fileInformationCache.get(normalizedSource);
+  const cached = project.fileInformationCache.get(target.source);
   if (cached && data.transient && format.execute[kKeepIpynb]) {
     if (cached.target && cached.target.data) {
       (cached.target.data as JupyterTargetData).transient = false;

--- a/src/inspect/inspect.ts
+++ b/src/inspect/inspect.ts
@@ -125,7 +125,6 @@ const populateFileInformation = async (
   fileInformation: Record<string, InspectedFile>,
   file: string,
 ) => {
-  const normalizedFile = normalizePath(file);
   const engine = await fileExecutionEngine(file, undefined, context);
   const src = await context.resolveFullMarkdownForFile(engine, file);
   if (engine) {
@@ -140,9 +139,9 @@ const populateFileInformation = async (
   }
   await projectResolveCodeCellsForFile(context, engine, file);
   await projectFileMetadata(context, file);
-  const cacheEntry = context.fileInformationCache.get(normalizedFile);
+  const cacheEntry = context.fileInformationCache.get(file);
   // Output key: project-relative for portability
-  const outputKey = relative(context.dir, normalizedFile);
+  const outputKey = relative(context.dir, normalizePath(file));
   fileInformation[outputKey] = {
     includeMap: cacheEntry?.includeMap ?? [],
     codeCells: cacheEntry?.codeCells ?? [],
@@ -219,8 +218,7 @@ const inspectDocumentConfig = async (path: string) => {
     await context.resolveFullMarkdownForFile(engine, path);
     await projectResolveCodeCellsForFile(context, engine, path);
     await projectFileMetadata(context, path);
-    const normalizedPath = normalizePath(path);
-    const fileInformation = context.fileInformationCache.get(normalizedPath);
+    const fileInformation = context.fileInformationCache.get(path);
 
     // data to write
     const config: InspectedDocumentConfig = {

--- a/src/project/project-shared.ts
+++ b/src/project/project-shared.ts
@@ -505,18 +505,17 @@ export const ensureFileInformationCache = (
   project: ProjectContext,
   file: string,
 ) => {
-  const normalizedFile = normalizePath(file);
   if (!project.fileInformationCache) {
-    project.fileInformationCache = new Map();
+    project.fileInformationCache = new FileInformationCacheMap();
   }
   assert(
     project.fileInformationCache instanceof Map,
     JSON.stringify(project.fileInformationCache),
   );
-  if (!project.fileInformationCache.has(normalizedFile)) {
-    project.fileInformationCache.set(normalizedFile, {} as FileInformation);
+  if (!project.fileInformationCache.has(file)) {
+    project.fileInformationCache.set(file, {} as FileInformation);
   }
-  return project.fileInformationCache.get(normalizedFile)!;
+  return project.fileInformationCache.get(file)!;
 };
 
 export async function projectResolveBrand(
@@ -657,8 +656,25 @@ export async function projectResolveBrand(
 }
 
 // Create a class that extends Map and implements Cloneable
+// All operations normalize keys for cross-platform consistency
 export class FileInformationCacheMap extends Map<string, FileInformation>
   implements Cloneable<Map<string, FileInformation>> {
+  override get(key: string): FileInformation | undefined {
+    return super.get(normalizePath(key));
+  }
+
+  override has(key: string): boolean {
+    return super.has(normalizePath(key));
+  }
+
+  override set(key: string, value: FileInformation): this {
+    return super.set(normalizePath(key), value);
+  }
+
+  override delete(key: string): boolean {
+    return super.delete(normalizePath(key));
+  }
+
   clone(): Map<string, FileInformation> {
     // Return the same instance (reference) instead of creating a clone
     return this;

--- a/src/project/project-shared.ts
+++ b/src/project/project-shared.ts
@@ -655,8 +655,10 @@ export async function projectResolveBrand(
   }
 }
 
-// Create a class that extends Map and implements Cloneable
-// All operations normalize keys for cross-platform consistency
+// A Map that normalizes path keys for cross-platform consistency.
+// All path operations normalize keys (forward slashes, lowercase on Windows).
+// Implements Cloneable but shares state intentionally - in preview mode,
+// the project context is reused across renders and cache state must persist.
 export class FileInformationCacheMap extends Map<string, FileInformation>
   implements Cloneable<Map<string, FileInformation>> {
   override get(key: string): FileInformation | undefined {
@@ -675,8 +677,14 @@ export class FileInformationCacheMap extends Map<string, FileInformation>
     return super.delete(normalizePath(key));
   }
 
+  // Note: Iterator methods (keys(), entries(), forEach(), [Symbol.iterator])
+  // return normalized keys as stored. Code iterating over the cache sees
+  // normalized paths, which is consistent with how keys are stored.
+
+  // Returns this instance (shared reference) rather than a copy.
+  // This is intentional: in preview mode, project context is cloned for
+  // each render but the cache must be shared so invalidations persist.
   clone(): Map<string, FileInformation> {
-    // Return the same instance (reference) instead of creating a clone
     return this;
   }
 }

--- a/src/project/project-shared.ts
+++ b/src/project/project-shared.ts
@@ -505,6 +505,7 @@ export const ensureFileInformationCache = (
   project: ProjectContext,
   file: string,
 ) => {
+  const normalizedFile = normalizePath(file);
   if (!project.fileInformationCache) {
     project.fileInformationCache = new Map();
   }
@@ -512,10 +513,10 @@ export const ensureFileInformationCache = (
     project.fileInformationCache instanceof Map,
     JSON.stringify(project.fileInformationCache),
   );
-  if (!project.fileInformationCache.has(file)) {
-    project.fileInformationCache.set(file, {} as FileInformation);
+  if (!project.fileInformationCache.has(normalizedFile)) {
+    project.fileInformationCache.set(normalizedFile, {} as FileInformation);
   }
-  return project.fileInformationCache.get(file)!;
+  return project.fileInformationCache.get(normalizedFile)!;
 };
 
 export async function projectResolveBrand(

--- a/src/project/types/single-file/single-file.ts
+++ b/src/project/types/single-file/single-file.ts
@@ -45,10 +45,12 @@ export async function singleFileProjectContext(
   const temp = globalTempContext();
   const projectCacheBaseDir = temp.createDir();
 
+  const normalizedDir = normalizePath(dirname(source));
+
   const result: ProjectContext = {
     clone: () => result,
     resolveBrand: (fileName?: string) => projectResolveBrand(result, fileName),
-    dir: normalizePath(dirname(source)),
+    dir: normalizedDir,
     engines: [],
     files: {
       input: [],

--- a/tests/docs/smoke-all/2025/05/21/keep_ipynb_project/.gitignore
+++ b/tests/docs/smoke-all/2025/05/21/keep_ipynb_project/.gitignore
@@ -1,1 +1,3 @@
 /.quarto/
+
+**/*.quarto_ipynb

--- a/tests/unit/project/file-information-cache.test.ts
+++ b/tests/unit/project/file-information-cache.test.ts
@@ -4,7 +4,7 @@
  * Tests for fileInformationCache path normalization
  * Related to issue #13955
  *
- * Copyright (C) 2020-2022 Posit Software, PBC
+ * Copyright (C) 2026 Posit Software, PBC
  */
 
 import { unitTest } from "../../test.ts";

--- a/tests/unit/project/file-information-cache.test.ts
+++ b/tests/unit/project/file-information-cache.test.ts
@@ -10,7 +10,10 @@
 import { unitTest } from "../../test.ts";
 import { assert } from "testing/asserts";
 import { join } from "../../../src/deno_ral/path.ts";
-import { ensureFileInformationCache } from "../../../src/project/project-shared.ts";
+import {
+  ensureFileInformationCache,
+  FileInformationCacheMap,
+} from "../../../src/project/project-shared.ts";
 import { createMockProjectContext } from "./utils.ts";
 
 // deno-lint-ignore require-await
@@ -83,6 +86,24 @@ unitTest(
     assert(
       entry1 === entry2,
       "Should return same cache entry object",
+    );
+  },
+);
+
+// deno-lint-ignore require-await
+unitTest(
+  "ensureFileInformationCache - creates FileInformationCacheMap when cache is missing",
+  async () => {
+    const project = createMockProjectContext();
+    // Simulate minimal ProjectContext without cache (as in command-utils.ts)
+    // deno-lint-ignore no-explicit-any
+    (project as any).fileInformationCache = undefined;
+
+    ensureFileInformationCache(project, join(project.dir, "doc.qmd"));
+
+    assert(
+      project.fileInformationCache instanceof FileInformationCacheMap,
+      "Should create FileInformationCacheMap, not plain Map",
     );
   },
 );

--- a/tests/unit/project/file-information-cache.test.ts
+++ b/tests/unit/project/file-information-cache.test.ts
@@ -1,0 +1,88 @@
+/*
+ * file-information-cache.test.ts
+ *
+ * Tests for fileInformationCache path normalization
+ * Related to issue #13955
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
+
+import { unitTest } from "../../test.ts";
+import { assert } from "testing/asserts";
+import { join } from "../../../src/deno_ral/path.ts";
+import { ensureFileInformationCache } from "../../../src/project/project-shared.ts";
+import { createMockProjectContext } from "./utils.ts";
+
+// deno-lint-ignore require-await
+unitTest(
+  "fileInformationCache - same path returns same entry",
+  async () => {
+    const project = createMockProjectContext();
+
+    // Use cross-platform absolute path (backslashes on Windows, forward on Linux)
+    const path1 = join(project.dir, "doc.qmd");
+    const path2 = join(project.dir, "doc.qmd");
+
+    const entry1 = ensureFileInformationCache(project, path1);
+    const entry2 = ensureFileInformationCache(project, path2);
+
+    assert(
+      entry1 === entry2,
+      "Same path should return same cache entry",
+    );
+    assert(
+      project.fileInformationCache.size === 1,
+      "Should have exactly one cache entry",
+    );
+  },
+);
+
+// deno-lint-ignore require-await
+unitTest(
+  "fileInformationCache - different paths create different entries",
+  async () => {
+    const project = createMockProjectContext();
+
+    const path1 = join(project.dir, "doc1.qmd");
+    const path2 = join(project.dir, "doc2.qmd");
+
+    const entry1 = ensureFileInformationCache(project, path1);
+    const entry2 = ensureFileInformationCache(project, path2);
+
+    assert(
+      entry1 !== entry2,
+      "Different paths should return different cache entries",
+    );
+    assert(
+      project.fileInformationCache.size === 2,
+      "Should have two cache entries for different paths",
+    );
+  },
+);
+
+// deno-lint-ignore require-await
+unitTest(
+  "fileInformationCache - cache entry persists across calls",
+  async () => {
+    const project = createMockProjectContext();
+
+    const path = join(project.dir, "doc.qmd");
+
+    // First call creates entry
+    const entry1 = ensureFileInformationCache(project, path);
+    // Modify the entry
+    entry1.metadata = { title: "Test" };
+
+    // Second call should return same entry with our modification
+    const entry2 = ensureFileInformationCache(project, path);
+
+    assert(
+      entry2.metadata?.title === "Test",
+      "Cache entry should persist modifications",
+    );
+    assert(
+      entry1 === entry2,
+      "Should return same cache entry object",
+    );
+  },
+);

--- a/tests/unit/project/utils.ts
+++ b/tests/unit/project/utils.ts
@@ -1,0 +1,43 @@
+/*
+ * utils.ts
+ *
+ * Test utilities for project-related unit tests
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
+
+import { ProjectContext } from "../../../src/project/types.ts";
+
+/**
+ * Create a minimal mock ProjectContext for testing.
+ * Only provides the essential properties needed for cache-related tests.
+ *
+ * @param dir - The project directory (defaults to a temp directory)
+ * @returns A mock ProjectContext suitable for unit testing
+ */
+export function createMockProjectContext(
+  dir?: string,
+): ProjectContext {
+  const projectDir = dir ?? Deno.makeTempDirSync({ prefix: "quarto-test" });
+
+  return {
+    dir: projectDir,
+    engines: [],
+    files: { input: [] },
+    notebookContext: {} as ProjectContext["notebookContext"],
+    fileInformationCache: new Map(),
+    resolveBrand: () => Promise.resolve(undefined),
+    resolveFullMarkdownForFile: () => Promise.resolve({} as never),
+    fileExecutionEngineAndTarget: () => Promise.resolve({} as never),
+    fileMetadata: () => Promise.resolve({}),
+    environment: () => Promise.resolve({} as never),
+    renderFormats: () => Promise.resolve({}),
+    clone: function () {
+      return this;
+    },
+    isSingleFile: false,
+    diskCache: {} as ProjectContext["diskCache"],
+    temp: {} as ProjectContext["temp"],
+    cleanup: () => {},
+  } as ProjectContext;
+}

--- a/tests/unit/project/utils.ts
+++ b/tests/unit/project/utils.ts
@@ -3,7 +3,7 @@
  *
  * Test utilities for project-related unit tests
  *
- * Copyright (C) 2020-2022 Posit Software, PBC
+ * Copyright (C) 2026 Posit Software, PBC
  */
 
 import { ProjectContext } from "../../../src/project/types.ts";


### PR DESCRIPTION
When re-rendering a file during `quarto preview` in a project, the preview crashes with `BadResource: Bad resource ID` from the Sass cache Deno.Kv operations.

## Root Cause

This is a regression from #13804 which changed how `ProjectContext` is managed during preview. That PR made the project context persist across re-renders (instead of being recreated each time), but `renderForPreview()` still called `renderResult.context.cleanup()` after each render.

The cleanup closes shared resources like the SassCache Deno.Kv handle. On subsequent re-renders, the code returns the cached `SassCache` instance whose KV handle was already closed, causing the `BadResource` error when calling `kv.get()`.

## Fix

1. Remove the `cleanup()` call from `renderForPreview()` - the project context is owned by `preview()` and should only be cleaned up when preview exits via `onCleanup()`

2. Invalidate the `fileInformationCache` entry for the rendered file before each render - since `cleanup()` previously cleared all caches (including `fileInformationCache`), removing the call means stale file content would be reused. The cache entry for the specific file being rendered is now deleted so changes are picked up.

Fixes #13955