### PR TITLE
add verapdf to configuration

### DIFF
--- a/configuration
+++ b/configuration
@@ -17,6 +17,7 @@ export PANDOC=3.8.3
 export DARTSASS=1.87.0
 export ESBUILD=0.25.10
 export TYPST=0.14.2
+export VERAPDF=1.28.2
 
 
 # NB: we can't put comments in the same line as export statements because it


### PR DESCRIPTION
Pin verapdf version for S3 bucket upload. This enables downloading verapdf from the quarto S3 bucket instead of verapdf.org.

It's still going to be an optional dependency installed via `quarto install verapdf`, so there is no additional configuration required.

@cscheid, once this is merged, please upload 
  https://software.verapdf.org/releases/1.28/verapdf-greenfield-1.28.2-installer.zip
to:
  s3://rstudio-buildtools/quarto/verapdf/1.28.2/verapdf-greenfield-1.28.2-installer.zip
