### PR TITLE
fix(typst): prevent breaking inside definition items

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -56,6 +56,7 @@ All changes included in 1.9:
 - ([#13870](https://github.com/quarto-dev/quarto-cli/issues/13870)): Add support for `alt` attribute on cross-referenced equations for improved accessibility. (author: @mcanouil)
 - ([#13950](https://github.com/quarto-dev/quarto-cli/pull/13950)): Replace ctheorems with theorion package for theorem environments. Add `theorem-appearance` option to control styling: `simple` (default, classic LaTeX style), `fancy` (colored boxes with brand colors), `clouds` (rounded backgrounds), or `rainbow` (colored start border and colored title).
 - ([#13954](https://github.com/quarto-dev/quarto-cli/issues/13954)): Add support for Typst book projects via format extensions. Quarto now bundles the `orange-book` extension which provides a textbook-style format with chapter numbering, cross-references, and professional styling. Book projects with `format: typst` automatically use this extension.
+- ([#13978])(https://github.com/quarto-dev/quarto-cli/pull/13978)): Keep term and description together in definition lists to avoid breaking across pages. (author: @mcanouil)
 
 ### `pdf`
 

--- a/src/resources/formats/typst/pandoc/quarto/definitions.typ
+++ b/src/resources/formats/typst/pandoc/quarto/definitions.typ
@@ -28,6 +28,9 @@
   it
 }
 
+// Prevent breaking inside definition items, i.e., keep term and description together.
+#show terms.item: set block(breakable: false)
+
 // Some quarto-specific definitions.
 
 #show raw.where(block: true): set block(

--- a/tests/docs/smoke-all/typst/definition-item-no-break.qmd
+++ b/tests/docs/smoke-all/typst/definition-item-no-break.qmd
@@ -1,0 +1,24 @@
+---
+title: "Definition Item No Break Test"
+format: typst
+_quarto:
+  tests:
+    typst:
+      ensurePdfTextPositions:
+        - # Term and description must be on the same page (fails if on different pages)
+          - subject: "Generate HTML"
+            relation: below
+            object: "Multi-format"
+        - # Description should be indented (NOT left-aligned with term)
+          - subject: "Generate HTML"
+            relation: leftAligned
+            object: "Multi-format"
+      noErrors: default
+---
+
+## Introduction
+
+{{< lipsum 4 >}}
+
+Multi-format
+: Generate HTML, PDF, Word, ePub, and more from one source.


### PR DESCRIPTION
Ensure terms and their descriptions remain together by preventing breaks within definition items.

The rule needs to be separate from the content rule, because here we play on the implicit block generated by Typst.

As this is a visual change, there are no tests, but I believe non breaking term/definition is a sensible default.

<table>
<tr><th>Code</th><th>Before</th><th>After</th></tr>
<tr><td>

````qmd
---
title: "Quarto Playground"
format: typst
keep-typ: true
---

## Introduction

{{< lipsum 4 >}}

Multi-format output
: Generate HTML, PDF, Word, ePub, and more from one source.
````

</td><td>

<img width="545" height="351" alt="Two-page document showing Quarto Playground title page with Lorem Ipsum text with at the bottom Multi-format output followed on the facing page with definition in centered box" src="https://github.com/user-attachments/assets/bb113f0a-ad62-461f-a66e-39adfb98f229" />

</td>

</td><td>

<img width="547" height="350" alt="Two-page document showing Quarto Playground title page with Lorem Ipsum text and facing page with Multi-format output definition in centered box" src="https://github.com/user-attachments/assets/e1be6ba1-91dd-4ce7-869a-2ff9cf0c7dc1" />

</td></tr>
</table>