### PR TITLE
Use quarto.org URL for veraPDF download

### DIFF
--- a/src/tools/impl/verapdf.ts
+++ b/src/tools/impl/verapdf.ts
@@ -123,9 +123,8 @@ async function latestRelease(): Promise<RemotePackageInfo> {
   // Use pinned version from configuration or default
   const version = Deno.env.get("VERAPDF") || kDefaultVersion;
   const filename = `verapdf-greenfield-${version}-installer.zip`;
-  // Use quarto.org redirect (points to S3 bucket)
-  const downloadUrl =
-    `${kDownloadBaseUrl}/verapdf/verapdf-greenfield-installer.zip`;
+  // Use quarto.org redirect with version in path (points to S3 bucket)
+  const downloadUrl = `${kDownloadBaseUrl}/verapdf/${version}/${filename}`;
 
   return {
     url: downloadUrl,

--- a/src/tools/impl/verapdf.ts
+++ b/src/tools/impl/verapdf.ts
@@ -21,8 +21,8 @@ import {
 import { createToolSymlink, removeToolSymlink } from "../tools.ts";
 import { isWindows } from "../../deno_ral/platform.ts";
 
-// S3 bucket for veraPDF downloads
-const kBucketBaseUrl = "https://s3.amazonaws.com/rstudio-buildtools/quarto";
+// Download base URL (quarto.org redirects to S3 bucket)
+const kDownloadBaseUrl = "https://quarto.org/download";
 const kDefaultVersion = "1.28.2";
 
 // Supported Java versions for veraPDF
@@ -123,7 +123,9 @@ async function latestRelease(): Promise<RemotePackageInfo> {
   // Use pinned version from configuration or default
   const version = Deno.env.get("VERAPDF") || kDefaultVersion;
   const filename = `verapdf-greenfield-${version}-installer.zip`;
-  const downloadUrl = `${kBucketBaseUrl}/verapdf/${version}/${filename}`;
+  // Use quarto.org redirect (points to S3 bucket)
+  const downloadUrl =
+    `${kDownloadBaseUrl}/verapdf/verapdf-greenfield-installer.zip`;
 
   return {
     url: downloadUrl,


### PR DESCRIPTION
Changes the veraPDF download URL to use a quarto.org redirect instead of the direct S3 bucket URL.

## Change

New URL: `https://quarto.org/download/verapdf/verapdf-greenfield-installer.zip`


## Why

- Cleaner, shorter URL for users
- Central version management via the redirect
- Consistent URL pattern with other Quarto downloads

## Dependency

Requires quarto-dev/quarto-web#1867 to be deployed first (adds the redirect to quarto.org).

The tests won't pass until it is merged.