### PR TITLE
Fix crash with crossref div and conditional visibility

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -163,3 +163,4 @@ All changes included in 1.9:
 - ([#13890](https://github.com/quarto-dev/quarto-cli/issues/13890)): Fix render failure when using `embed-resources: true` with input path through a symlinked directory. The cleanup now resolves symlinks before comparing paths.
 - ([#13907](https://github.com/quarto-dev/quarto-cli/issues/13907)): Ignore AI assistant configuration files (`CLAUDE.md`, `AGENTS.md`) when scanning for project input files and in extension templates, similar to how `README.md` is handled.
 - ([#13935](https://github.com/quarto-dev/quarto-cli/issues/13935)): Fix `quarto install`, `quarto update`, and `quarto uninstall` interactive tool selection.
+- ([#13992](https://github.com/quarto-dev/quarto-cli/issues/13992)): Fix crash when rendering div with both cross-reference ID and conditional visibility to PDF.

--- a/src/resources/filters/customnodes/content-hidden.lua
+++ b/src/resources/filters/customnodes/content-hidden.lua
@@ -59,8 +59,16 @@ _quarto.ast.add_handler({
     local visible = is_visible(node)
     if visible then
       local el = node.node
-      clearHiddenVisibleAttributes(el)
-      return el.content
+      -- Handle case where slot content was transformed (e.g., Div → FloatRefTarget → Table)
+      if is_regular_node(el, "Div") then
+        -- Original behavior for Div: clear attributes and return inner content
+        clearHiddenVisibleAttributes(el)
+        return el.content
+      else
+        -- Slot was transformed to another type (Table, etc.)
+        -- Return the rendered element wrapped in Blocks
+        return pandoc.Blocks({el})
+      end
     else
       return {}
     end

--- a/src/resources/filters/customnodes/content-hidden.lua
+++ b/src/resources/filters/customnodes/content-hidden.lua
@@ -61,7 +61,9 @@ _quarto.ast.add_handler({
       local el = node.node
       -- Handle case where slot content was transformed (e.g., Div → FloatRefTarget → Table)
       if is_regular_node(el, "Div") then
-        -- Original behavior for Div: clear attributes and return inner content
+        -- Defensive: parse() already stripped visibility attrs (lines 46-47), so this is
+        -- typically a no-op. Kept as safety net in case future code adds attrs between
+        -- parse and render. See issue #13992 investigation for AST trace evidence.
         clearHiddenVisibleAttributes(el)
         return el.content
       else

--- a/tests/docs/smoke-all/2026/02/04/issue-13992-figure.qmd
+++ b/tests/docs/smoke-all/2026/02/04/issue-13992-figure.qmd
@@ -1,0 +1,31 @@
+---
+title: "Conditional visibility with figure (#13992)"
+keep-tex: true
+keep-typ: true
+_quarto:
+  tests:
+    pdf:
+      ensureLatexFileRegexMatches:
+        - ['Figure content visible', 'fig-cond', '\\begin{figure}', 'Figure~\\ref\{fig-cond\}']
+        - []
+    html:
+      ensureHtmlElements:
+        - []
+        - ['#fig-cond']
+      ensureFileRegexMatches:
+        - []
+        - ['Figure content visible']
+    typst:
+      ensureTypstFileRegexMatches:
+        - ['#figure', 'Figure content visible', '#ref\(<fig-cond>']
+        - []
+    native: default
+---
+
+See @fig-cond for conditional figure.
+
+::: {#fig-cond .content-visible unless-format="html"}
+![]({{< placeholder 300 >}})
+
+Figure content visible
+:::

--- a/tests/docs/smoke-all/2026/02/04/issue-13992-listing.qmd
+++ b/tests/docs/smoke-all/2026/02/04/issue-13992-listing.qmd
@@ -1,0 +1,32 @@
+---
+title: "Conditional visibility with listing (#13992)"
+keep-tex: true
+keep-typ: true
+_quarto:
+  tests:
+    pdf:
+      ensureLatexFileRegexMatches:
+        - ['Listing content visible', 'lst-cond', '\\begin{codelisting}', 'Listing~\\ref\{lst-cond\}']
+        - []
+    html:
+      ensureHtmlElements:
+        - []
+        - ['#lst-cond']
+      ensureFileRegexMatches:
+        - []
+        - ['Listing content visible']
+    typst:
+      ensureTypstFileRegexMatches:
+        - ['Listing content visible', '#ref\(<lst-cond>']
+        - []
+    native: default
+---
+
+See @lst-cond for conditional listing.
+
+::: {#lst-cond .content-visible unless-format="html"}
+```python
+# Listing content visible
+print("hello")
+```
+:::

--- a/tests/docs/smoke-all/2026/02/04/issue-13992-nested-callout.qmd
+++ b/tests/docs/smoke-all/2026/02/04/issue-13992-nested-callout.qmd
@@ -1,0 +1,30 @@
+---
+title: "Conditional visibility with nested callout (#13992)"
+keep-tex: true
+keep-typ: true
+_quarto:
+  tests:
+    pdf:
+      ensureLatexFileRegexMatches:
+        - ['Nested callout visible', 'tcolorbox', 'quarto-callout-note']
+        - []
+    html:
+      ensureHtmlElements:
+        - []
+        - ['div.callout']
+      ensureFileRegexMatches:
+        - []
+        - ['Nested callout visible']
+    typst:
+      ensureTypstFileRegexMatches:
+        - ['Nested callout visible', '#callout']
+        - []
+---
+
+This tests a callout nested inside a conditional visibility div.
+
+::: {.content-visible unless-format="html"}
+::: {.callout-note}
+Nested callout visible.
+:::
+:::

--- a/tests/docs/smoke-all/2026/02/04/issue-13992-nested-tabset.qmd
+++ b/tests/docs/smoke-all/2026/02/04/issue-13992-nested-tabset.qmd
@@ -1,0 +1,31 @@
+---
+title: "Conditional visibility with nested tabset (#13992)"
+keep-tex: true
+keep-typ: true
+_quarto:
+  tests:
+    pdf:
+      ensureLatexFileRegexMatches:
+        - []
+        - ['Nested tabset visible', 'Tab A']
+    html:
+      ensureHtmlElements:
+        - ['div.panel-tabset']
+        - []
+      ensureFileRegexMatches:
+        - ['Nested tabset visible', 'Tab A']
+        - []
+    typst:
+      ensureTypstFileRegexMatches:
+        - []
+        - ['Nested tabset visible', 'Tab A']
+---
+
+This tests a tabset nested inside a conditional visibility div.
+
+::: {.content-visible when-format="html"}
+::: {.panel-tabset}
+### Tab A
+Nested tabset visible. 
+:::
+:::

--- a/tests/docs/smoke-all/2026/02/04/issue-13992-plain.qmd
+++ b/tests/docs/smoke-all/2026/02/04/issue-13992-plain.qmd
@@ -1,0 +1,25 @@
+---
+title: "Conditional visibility with plain div (#13992)"
+keep-tex: true
+keep-typ: true
+_quarto:
+  tests:
+    pdf:
+      ensureLatexFileRegexMatches:
+        - ['Plain div content visible']
+        - []
+    html:
+      ensureFileRegexMatches:
+        - []
+        - ['Plain div content visible']
+    typst:
+      ensureTypstFileRegexMatches:
+        - ['Plain div content visible']
+        - []
+---
+
+This tests the baseline case of a plain div with `.content-visible`.
+
+::: {.content-visible unless-format="html"}
+Plain div content visible.
+:::

--- a/tests/docs/smoke-all/2026/02/04/issue-13992-proof.qmd
+++ b/tests/docs/smoke-all/2026/02/04/issue-13992-proof.qmd
@@ -1,0 +1,25 @@
+---
+title: "Conditional visibility with proof (#13992)"
+keep-tex: true
+keep-typ: true
+_quarto:
+  tests:
+    pdf:
+      ensureLatexFileRegexMatches:
+        - ['Proof content visible', '\\begin{proof}', '\\end{proof}']
+        - []
+    html:
+      ensureFileRegexMatches:
+        - []
+        - ['Proof content visible']
+    typst:
+      ensureTypstFileRegexMatches:
+        - ['#emph\[Proof\]\. Proof content visible']
+        - []
+---
+
+This tests a proof div with `.proof` class and `.content-visible`.
+
+::: {.proof .content-visible unless-format="html"}
+Proof content visible.
+:::

--- a/tests/docs/smoke-all/2026/02/04/issue-13992-table.qmd
+++ b/tests/docs/smoke-all/2026/02/04/issue-13992-table.qmd
@@ -19,6 +19,7 @@ _quarto:
       ensureTypstFileRegexMatches:
         - ['#ref\(<tbl-mytypes>', 'Type 1', 'Type 2', 'Item 1', 'Item 2']
         - []
+    native: default
 ---
 
 This tests that a table div with both a cross-reference ID and conditional visibility renders correctly.

--- a/tests/docs/smoke-all/2026/02/04/issue-13992-theorem.qmd
+++ b/tests/docs/smoke-all/2026/02/04/issue-13992-theorem.qmd
@@ -1,0 +1,30 @@
+---
+title: "Conditional visibility with theorem (#13992)"
+keep-tex: true
+keep-typ: true
+_quarto:
+  tests:
+    pdf:
+      ensureLatexFileRegexMatches:
+        - ['Theorem content visible', 'thm-cond', '\\begin\{theorem\}']
+        - []
+    html:
+      ensureHtmlElements:
+        - []
+        - ['#thm-cond']
+      ensureFileRegexMatches:
+        - []
+        - ['Theorem content visible']
+    typst:
+      ensureTypstFileRegexMatches:
+        - ['Theorem content visible', '#ref\(<thm-cond>', '#theorem']
+        - []
+---
+
+See @thm-cond for conditional theorem.
+
+::: {#thm-cond .content-visible unless-format="html"}
+## Test Theorem
+
+Theorem content visible.
+:::

--- a/tests/docs/smoke-all/2026/02/04/issue-13992.qmd
+++ b/tests/docs/smoke-all/2026/02/04/issue-13992.qmd
@@ -1,0 +1,38 @@
+---
+title: "Crossref table with conditional visibility (#13992)"
+keep-tex: true
+keep-typ: true
+_quarto:
+  tests:
+    pdf:
+      ensureLatexFileRegexMatches:
+        - ['Type 1', 'Type 2', 'Item 1', 'Item 2', 'tbl-mytypes']
+        - []
+    html:
+      ensureHtmlElements:
+        - []
+        - ['#tbl-mytypes', 'table']
+      ensureFileRegexMatches:
+        - []
+        - ['Type 1', 'Type 2', 'Item 1', 'Item 2']
+    typst:
+      ensureTypstFileRegexMatches:
+        - ['#ref\(<tbl-mytypes>', 'Type 1', 'Type 2', 'Item 1', 'Item 2']
+        - []
+---
+
+This tests that a table div with both a cross-reference ID and conditional visibility renders correctly.
+
+See @tbl-mytypes for the table.
+
+::: {#tbl-mytypes .content-visible unless-format="html"}
+
+| Type 1 | Type 2 |
+| ------ | ------ |
+| Item 1 | Item 2 |
+
+: Test table caption
+
+:::
+
+The table above should appear in PDF and Typst but not HTML.


### PR DESCRIPTION
So I have looked into #13992  with the help of Claude Code, and tested different scenarios. I believe this could fix #13992 

--------

## Summary

Rendering fails with `attempt to index a nil value` when a div has both:
- A cross-reference ID (`#tbl-`, `#fig-`, `#lst-`)
- Conditional visibility class (`.content-visible` / `.content-hidden`)

## Root Cause

The `content-hidden.lua` render function assumes `node.node` is always a Div and calls `el.content`. However, `parsefiguredivs.lua` transforms crossref divs into `FloatRefTarget` custom nodes, which then render to Table/Figure/etc. When the slot content is no longer a Div, calling `.content` crashes.

## Fix

Check if the slot is still a regular Div before accessing `.content`. For transformed elements, return them wrapped in `pandoc.Blocks()`.

```lua
if is_regular_node(el, "Div") then
  clearHiddenVisibleAttributes(el)
  return el.content
else
  return pandoc.Blocks({el})
end
```

## Test Coverage

Added 8 test files covering various scenarios:
- Table, Figure, Listing (FloatRefTarget transformations)
- Plain div baseline (no transformation)
- Nested callout and tabset content

Fixes #13992