### PR TITLE
Add text fragments to quarto-search.js items

### DIFF
--- a/src/resources/projects/website/search/quarto-search.js
+++ b/src/resources/projects/website/search/quarto-search.js
@@ -356,6 +356,22 @@ window.document.addEventListener("DOMContentLoaded", function (_event) {
             },
 
             item({ item, createElement }) {
+              // process items to include text fragments as they are rendered
+              if (item.text && item.href && !item.href.includes(':~:text=')) {
+                // e.g. `item.text` for a search "def fiz": "bla bla bla<mark class='search-match'>def fiz</mark> bla bla"
+                const fullMatches = item.text.matchAll(/<mark class='search-match'>(.*?)<\/mark>/g)
+                // extract capture group with the search match
+                // result e.g. ["def fiz"]
+                const searchMatches = [...fullMatches].map(match => match[1])
+                if (searchMatches[0]) {
+                  if (item.href.includes('#')) {
+                    item.href += ':~:text=' + encodeURIComponent(searchMatches[0])
+                  } else {
+                    item.href += '#:~:text=' + encodeURIComponent(searchMatches[0])
+                  }
+                }
+              }
+              
               return renderItem(
                 item,
                 createElement,


### PR DESCRIPTION
## Description

Adds text fragments to items in search. Example video:

https://github.com/user-attachments/assets/835dec4f-9b58-47c4-aa92-37732d39e195

I have attempted to write this code quite defensively so that it will not break things. Its not quite the ideal place for this code since this piece of code can be called multiple time for a single item, but it gets the job done.

Text fragments are [well supported](https://caniuse.com/?search=text+fragments) and apparently browsers will fall back to id linking if the text fragment is not supported or found (worked in my testing in chrome and safari and firefox on Desktop MacOS Tahoe, e.g. https://en.wikipedia.org/wiki/Dog#Domestication:~:text=blablabla).