### PR TITLE
fix: pass correct directory to copyExtensions in template installatio…

### DIFF
--- a/src/command/use/commands/template.ts
+++ b/src/command/use/commands/template.ts
@@ -157,7 +157,7 @@ async function useTemplate(
         // Copy the extensions into a substaging directory
         // this will ensure that they are namespaced properly
         const subStagedDir = tempContext.createDir();
-        await copyExtensions(source, stagedDir, subStagedDir);
+        await copyExtensions(source, extDir, subStagedDir);
 
         // Now complete installation from this sub-staged directory
         await completeInstallation(subStagedDir, outputDirectory);


### PR DESCRIPTION
## Problem 
When running `quarto use template organization/template`, extensions included in the template fail to copy. An empty `_extensions` folder is created instead.

## Solution
Pass `extDir` instead of `stagedDir` to `copyExtensions()` on line 160 in `src/command/use/commands/template.ts`.

## Changes
- Fixed argument passed to `copyExtensions()` call in `useTemplate()` function

## Testing
The fix ensures that:
- Extensions found during initial staging are also found during the copy phase
- Template extensions are properly installed along with template files
- No empty `_extensions` folders are created