### PR TITLE
fix(extension): `quarto use template` failed correctly copy extensions when scoped in organisation/owner name

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -117,6 +117,10 @@ All changes included in 1.9:
 
 ## Commands
 
+### `use template`
+
+- ([#14008](https://github.com/quarto-dev/quarto-cli/issues/14008)): Fix `quarto use template` failing to install extensions from GitHub organisation repositories (e.g., `quarto-journals/acm`). (author: @mcanouil)
+
 ### `use brand`
 
 - ([#13828](https://github.com/quarto-dev/quarto-cli/pull/13828)): New `quarto use brand` command copies and synchronizes the `_brand/` directory from a repo, directory, or ZIP file. See [the prerelease documentation](https://prerelease.quarto.org/docs/authoring/brand.html#quarto-use-brand) for details.

--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -119,7 +119,7 @@ All changes included in 1.9:
 
 ### `use template`
 
-- ([#14008](https://github.com/quarto-dev/quarto-cli/issues/14008)): Fix `quarto use template` failing to install extensions from GitHub organisation repositories (e.g., `quarto-journals/acm`). (author: @mcanouil)
+- ([#14008](https://github.com/quarto-dev/quarto-cli/issues/14008)): Fix `quarto use template` failing to install extensions from GitHub organisation repositories when the extension was scoped with the organisation (e.g., `quarto-journals/acm`). (author: @mcanouil)
 
 ### `use brand`
 

--- a/src/command/use/commands/template.ts
+++ b/src/command/use/commands/template.ts
@@ -157,7 +157,7 @@ async function useTemplate(
         // Copy the extensions into a substaging directory
         // this will ensure that they are namespaced properly
         const subStagedDir = tempContext.createDir();
-        await copyExtensions(source, stagedDir, subStagedDir);
+        await copyExtensions(source, extDir, subStagedDir);
 
         // Now complete installation from this sub-staged directory
         await completeInstallation(subStagedDir, outputDirectory);

--- a/tests/smoke/use/template.test.ts
+++ b/tests/smoke/use/template.test.ts
@@ -1,35 +1,37 @@
 import { testQuartoCmd } from "../../test.ts";
-import { directoryContainsOnlyAllowedPaths, fileExists, folderExists, noErrorsOrWarnings, printsMessage } from "../../verify.ts";
+import { directoryContainsOnlyAllowedPaths, fileExists, noErrorsOrWarnings, printsMessage } from "../../verify.ts";
 import { join } from "../../../src/deno_ral/path.ts";
 import { ensureDirSync } from "../../../src/deno_ral/fs.ts";
 
 const tempDir = Deno.makeTempDirSync();
 
-const templateFolder = "article";
-const workingDir = join(tempDir, templateFolder);
-const extensionsDir = join(workingDir, "_extensions");
-ensureDirSync(workingDir);
-testQuartoCmd(
-  "use",
-  ["template", "quarto-journals/jasa", "--no-prompt"],
-  [noErrorsOrWarnings, fileExists(`${templateFolder}.qmd`), folderExists(extensionsDir)],
-  {
-    setup: () => {
-      return Promise.resolve();
-    },
-    cwd: () => {
-      return workingDir;
-    },
-    teardown: () => {
-      try {
-       Deno.removeSync(workingDir, {recursive: true});
-      } catch {
+for (const ext of ["jasa", "acm"]) {
+  const templateFolder = `${ext}-article`;
+  const workingDir = join(tempDir, templateFolder);
+  const extensionYml = join(workingDir, "_extensions", "quarto-journals", ext, "_extension.yml");
+  ensureDirSync(workingDir);
+  testQuartoCmd(
+    "use",
+    ["template", `quarto-journals/${ext}`, "--no-prompt"],
+    [noErrorsOrWarnings, fileExists(`${templateFolder}.qmd`), fileExists(extensionYml)],
+    {
+      setup: () => {
+        return Promise.resolve();
+      },
+      cwd: () => {
+        return workingDir;
+      },
+      teardown: () => {
+        try {
+         Deno.removeSync(workingDir, {recursive: true});
+        } catch {
 
+        }
+         return Promise.resolve();
       }
-       return Promise.resolve();
     }
-  }
-)
+  )
+}
 
 const nonEmptyTemplateFolder = "notempty";
 const nonEmptyFileName = `${nonEmptyTemplateFolder}.qmd`;
@@ -52,7 +54,7 @@ testQuartoCmd(
       try {
        Deno.removeSync(nonEmptyWorkingDir, {recursive: true});
       } catch {
-        
+
       }
        return Promise.resolve();
     }


### PR DESCRIPTION
The `quarto use template` command previously created an empty `_extensions` folder and failed to copy the necessary extension's resource (e.g., `quarto-journals/acm`) because of two things:

- the path provided to `copyExtensions` was not the one leading to `_extensions/`
- the acm extension lives in `_extensions/quarto-journals/acm/`, not in `_extensions/acm/`.

Update the `quarto use template` test to properly test that the extension (the manifest to be accurate) is properly copied for both "jasa" (correct/expected structure) and "acm".

Fixes #14008

