### PR TITLE
Improve veraPDF Java version error message

### DIFF
--- a/src/tools/impl/verapdf.ts
+++ b/src/tools/impl/verapdf.ts
@@ -34,14 +34,15 @@ const kVersionFileName = "version";
 export const verapdfInstallable: InstallableTool = {
   name: "VeraPDF",
   prereqs: [{
-    check: async () => {
+    check: async (context) => {
       const javaVersion = await getJavaVersion();
+      context.props.javaVersion = javaVersion;
       return javaVersion !== undefined &&
         kSupportedJavaVersions.includes(javaVersion);
     },
     os: ["darwin", "linux", "windows"],
-    message: async () => {
-      const javaVersion = await getJavaVersion();
+    message: (context) => {
+      const javaVersion = context.props.javaVersion as number | undefined;
       const supportedVersions = kSupportedJavaVersions.join(", ");
       if (javaVersion === undefined) {
         return `Java is not installed. veraPDF requires Java ${supportedVersions}.`;

--- a/src/tools/impl/verapdf.ts
+++ b/src/tools/impl/verapdf.ts
@@ -40,8 +40,15 @@ export const verapdfInstallable: InstallableTool = {
         kSupportedJavaVersions.includes(javaVersion);
     },
     os: ["darwin", "linux", "windows"],
-    message:
-      `Java is not installed or version is not supported. veraPDF requires Java 8, 11, 17, or 21.`,
+    message: async () => {
+      const javaVersion = await getJavaVersion();
+      const supportedVersions = kSupportedJavaVersions.join(", ");
+      if (javaVersion === undefined) {
+        return `Java is not installed. veraPDF requires Java ${supportedVersions}.`;
+      } else {
+        return `Java ${javaVersion} is installed but not supported. veraPDF requires Java ${supportedVersions}.`;
+      }
+    },
   }],
   installed,
   installDir,

--- a/src/tools/impl/verapdf.ts
+++ b/src/tools/impl/verapdf.ts
@@ -29,6 +29,10 @@ const kDefaultVersion = "1.28.2";
 // Minimum Java version required
 const kMinJavaVersion = 8;
 
+// Highest Java LTS version officially supported by this veraPDF version.
+// Update this when bumping kDefaultVersion to a release that supports a newer LTS.
+const kMaxSupportedLtsVersion = 21;
+
 // The name of the file that we use to store the installed version
 const kVersionFileName = "version";
 
@@ -52,11 +56,20 @@ export const verapdfInstallable: InstallableTool = {
         return false;
       }
 
-      // Warn but allow installation for non-LTS Java versions
+      // Warn but allow installation for non-LTS or too-new LTS Java versions
       if (!isLtsJavaVersion(javaVersion)) {
+        const supportedVersions = Array.from(
+          { length: kMaxSupportedLtsVersion - 8 + 1 },
+          (_, i) => i + 8,
+        ).filter(isLtsJavaVersion).join(", ");
         warning(
           `Java ${javaVersion} is not a Long-Term Support (LTS) version. ` +
-            `veraPDF officially supports LTS versions (8, 11, 17, 21, 25, ...). ` +
+            `veraPDF ${kDefaultVersion} officially supports Java ${supportedVersions}. ` +
+            `Installation will proceed, but you may encounter issues.`,
+        );
+      } else if (javaVersion > kMaxSupportedLtsVersion) {
+        warning(
+          `Java ${javaVersion} is newer than veraPDF ${kDefaultVersion} officially supports. ` +
             `Installation will proceed, but you may encounter issues.`,
         );
       }

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -136,7 +136,10 @@ export async function installTool(name: string, updatePath?: boolean) {
           for (const prereq of platformPrereqs) {
             const met = await prereq.check(context);
             if (!met) {
-              context.error(prereq.message);
+              const message = typeof prereq.message === "function"
+                ? await prereq.message(context)
+                : prereq.message;
+              context.error(message);
               Deno.exit(1);
             }
           }

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -30,7 +30,7 @@ export interface InstallableTool {
 export interface InstallPreReq {
   check: (context: InstallContext) => Promise<boolean>;
   os: string[];
-  message: string;
+  message: string | ((context: InstallContext) => Promise<string>);
 }
 
 // Locally accessible Package information

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -30,7 +30,7 @@ export interface InstallableTool {
 export interface InstallPreReq {
   check: (context: InstallContext) => Promise<boolean>;
   os: string[];
-  message: string | ((context: InstallContext) => Promise<string>);
+  message: string | ((context: InstallContext) => string | Promise<string>);
 }
 
 // Locally accessible Package information


### PR DESCRIPTION
When installing veraPDF with an unsupported Java version, the error message was generic: "Java is not installed or version is not supported. veraPDF requires Java 8, 11, 17, or 21."

This made it unclear whether Java was missing or just the wrong version.

## Root Cause

The prereq check's error message was a static string, so it couldn't report the detected Java version.

## Fix

Made `InstallPreReq.message` support async functions in addition to static strings. The veraPDF prereq now:
- Detects the installed Java version
- Reports "Java is not installed" if Java is missing
- Reports "Java X is installed but not supported" with the actual version number
- Dynamically builds the supported versions list from `kSupportedJavaVersions`

## Results 

Now I got 

````
❯ quarto install verapdf
Installing verapdf
Java 25 is installed but not supported. veraPDF requires Java 8, 11, 17, 21.
````

However, there is still the question of why 25 is not supported, because manually I can install verapdf