### PR TITLE
Fix non-deterministic tcolorbox option ordering in LaTeX output

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -82,6 +82,7 @@ All changes included in 1.9:
   - New `shorthands` variable for Babel language shortcuts control.
   - New `pdf-trailer-id` support for reproducible PDF builds.
   - New `cancel` package support for `\cancel` command in math.
+- ([#14017](https://github.com/quarto-dev/quarto-cli/issues/14017)]): `tColorOptions()` in .tex file will now always have options in alphabetical order. Previously, they were in random order leading to a different .tex intermediates for identical .qmd.
 
 ### `revealjs`
 

--- a/src/resources/filters/common/latex.lua
+++ b/src/resources/filters/common/latex.lua
@@ -6,7 +6,7 @@ function tColorOptions(options)
 
   local optionStr = ""
   local prepend = false
-  for k, v in pairs(options) do
+  for k, v in spairs(options) do
     if (prepend) then 
       optionStr = optionStr .. ', '
     end

--- a/tests/docs/smoke-all/2026/02/11/issue-14017.qmd
+++ b/tests/docs/smoke-all/2026/02/11/issue-14017.qmd
@@ -1,0 +1,18 @@
+---
+title: "Issue 14017"
+code-block-bg: true
+format:
+  pdf:
+    keep-tex: true
+_quarto:
+  tests:
+    pdf:
+      noErrors: default
+      ensureLatexFileRegexMatches:
+        - ['boxrule=0pt, breakable, enhanced, frame hidden, interior hidden, sharp corners']
+        - []
+---
+
+```r
+1 + 1
+```


### PR DESCRIPTION
When rendering the same `.qmd` to PDF multiple times, the `.tex` output differs between runs. The tcolorbox options in the `\Shaded` environment preamble appear in a different order each time (e.g. `frame hidden, interior hidden, breakable, sharp corners` vs `boxrule=0pt, sharp corners, breakable, enhanced, frame hidden, interior hidden`).

## Root Cause

`tColorOptions()` in `src/resources/filters/common/latex.lua` uses Lua's `pairs()` to iterate over the options table. `pairs()` does not guarantee iteration order, so the emitted option string varies between runs.

## Fix

Replace `pairs()` with `spairs()` (sorted pairs), which is already available globally from `src/resources/filters/common/table.lua`. This produces alphabetically sorted options, making the output deterministic.

Fixes #14017