### PR TITLE
Fix multi-line subtitle escaping its CSS class in HTML output

### DIFF
--- a/tests/docs/smoke-all/2026/02/16/issue-13827-multiline.qmd
+++ b/tests/docs/smoke-all/2026/02/16/issue-13827-multiline.qmd
@@ -1,0 +1,24 @@
+---
+title: Test Title
+subtitle: |
+  First Part
+
+  Second Part
+format:
+  html: default
+  revealjs: default
+_quarto:
+  tests:
+    html:
+      ensureHtmlElementContents:
+        selectors: ['p.subtitle']
+        matches: ['First Part']
+    revealjs:
+      ensureHtmlElementContents:
+        selectors: ['p.subtitle']
+        matches: ['First Part']
+---
+
+## Test Content
+
+This tests that a multi-paragraph | scalar subtitle stays inside the subtitle class.

--- a/tests/docs/smoke-all/2026/02/16/issue-13827.qmd
+++ b/tests/docs/smoke-all/2026/02/16/issue-13827.qmd
@@ -1,0 +1,22 @@
+---
+title: Test Title
+subtitle: |
+  A Single Line Subtitle
+format:
+  html: default
+  revealjs: default
+_quarto:
+  tests:
+    html:
+      ensureHtmlElementContents:
+        selectors: ['p.subtitle']
+        matches: ['A Single Line Subtitle']
+    revealjs:
+      ensureHtmlElementContents:
+        selectors: ['p.subtitle']
+        matches: ['A Single Line Subtitle']
+---
+
+## Test Content
+
+This tests that a single-line | scalar subtitle stays inside the subtitle class.


### PR DESCRIPTION
When `subtitle` uses a YAML literal block scalar (`|`), the content escapes the `.subtitle` CSS class in HTML and RevealJS output. The `<p class="subtitle">` element ends up empty, with content rendered as sibling `<p>` tags outside the styled wrapper.

## Root Cause

1. YAML `|` values are parsed by Pandoc as `MetaBlocks` containing `Para` elements — even for single-line content, since `|` always appends a trailing newline
2. Title-block templates wrap `$subtitle$` in `<p class="subtitle">$subtitle$</p>`. When `$subtitle$` is `MetaBlocks`, Pandoc renders it as `<p>...</p>`, producing nested `<p>` tags — invalid HTML5
3. Any HTML5-compliant parser (browser or Quarto's deno-dom post-processing) auto-closes the outer `<p>` when it encounters the inner `<p>`, so content escapes the `.subtitle` class

Single-line values (no `|`) produce `MetaInlines` and render correctly since there's no `<p>` wrapping.

## Fix

A normalize filter converts `MetaBlocks` to `MetaInlines` for the `subtitle` field using the existing `quarto.utils.as_inlines()` API, which calls `pandoc.utils.blocks_to_inlines()` internally. The conversion is surgical — only `subtitle` is converted. Fields like `abstract` and `description` stay as blocks since they're placed in `<div>` containers where block-level content is valid.

For multi-paragraph `|` values, `blocks_to_inlines` joins paragraphs with `LineBreak` separators, rendering as `<br>` in HTML. This preserves the newline semantics of `|` (a folded scalar `>` would be used to collapse newlines).

The fix runs in `normalize.lua` for all output formats, though the nested `<p>` bug only manifests in formats whose templates wrap these fields in `<p>` elements.

Fixes #13827