### PR TITLE
Fix gh-pages publish leaving stale worktrees on identity failure

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -123,6 +123,10 @@ All changes included in 1.9:
 
 - ([#13414](https://github.com/quarto-dev/quarto-cli/issues/13414)): Be more forgiving when Confluence server returns malformed JSON response. (author: @m1no)
 
+### `gh-pages`
+
+- ([#14046](https://github.com/quarto-dev/quarto-cli/issues/14046)): Fix `quarto publish gh-pages` leaving stale worktrees when `git commit` fails due to missing `user.name`/`user.email` configuration. Git identity is now validated before worktree creation, and worktree cleanup uses `--force` to handle modified/untracked files.
+
 ## Lua API
 
 - ([#13762](https://github.com/quarto-dev/quarto-cli/issues/13762)): Add `quarto.paths.typst()` to Quarto's Lua API to resolve Typst binary path in Lua filters and extensions consistently with Quarto itself. (author: @mcanouil)

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -87,6 +87,35 @@ export async function gitBranchExists(
   return Promise.resolve(undefined);
 }
 
+export async function gitUserIdentityConfigured(
+  dir: string,
+): Promise<boolean> {
+  const name = await execProcess({
+    cmd: "git",
+    args: ["config", "user.name"],
+    cwd: dir,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const email = await execProcess({
+    cmd: "git",
+    args: ["config", "user.email"],
+    cwd: dir,
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const hasName = (name.success && (name.stdout?.trim().length ?? 0) > 0) ||
+    (Deno.env.get("GIT_AUTHOR_NAME")?.trim().length ?? 0) > 0 ||
+    (Deno.env.get("GIT_COMMITTER_NAME")?.trim().length ?? 0) > 0;
+
+  const hasEmail = (email.success && (email.stdout?.trim().length ?? 0) > 0) ||
+    (Deno.env.get("GIT_AUTHOR_EMAIL")?.trim().length ?? 0) > 0 ||
+    (Deno.env.get("GIT_COMMITTER_EMAIL")?.trim().length ?? 0) > 0;
+
+  return hasName && hasEmail;
+}
+
 export async function gitCmdOutput(
   dir: string,
   args: string[],


### PR DESCRIPTION
When `git user.name` or `user.email` is not configured, `quarto publish gh-pages` creates a worktree, attempts a commit inside it, and fails. The worktree is left behind, and subsequent publish attempts also fail because the stale worktree still exists.

## Root Cause

The publish workflow creates a git worktree for the gh-pages branch, copies rendered output into it, then commits and pushes. If the commit fails (e.g., missing identity), the worktree cleanup in the `finally` block can also fail because the worktree contains modified/untracked files that `git worktree remove` (without `--force`) refuses to delete.

## Fix

Validate git user identity before creating the worktree, failing early with actionable guidance. The check covers `git config user.name`/`user.email` and `GIT_AUTHOR_*`/`GIT_COMMITTER_*` environment variables as fallback.

Additionally, both `git worktree remove` calls now use `--force` to handle dirty worktree state, making cleanup robust regardless of failure cause.

Fixes #14046