### PR TITLE
Activate tabs containing search matches

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -119,7 +119,7 @@ All changes included in 1.9:
 - ([#13932](https://github.com/quarto-dev/quarto-cli/pull/13932)): Add `llms-txt: true` option to generate LLM-friendly content for websites. Creates `.llms.md` markdown files alongside HTML pages and a root `llms.txt` index file following the [llms.txt](https://llmstxt.org/) specification.
 - ([#13951](https://github.com/quarto-dev/quarto-cli/issues/13951)): Fix `image-lazy-loading` not applying `loading="lazy"` attribute to auto-detected listing images.
 - ([#14003](https://github.com/quarto-dev/quarto-cli/pull/14003)): Add text fragments to search result links so browsers scroll to and highlight the matched text on the target page.
-- ([#14047](https://github.com/quarto-dev/quarto-cli/issues/14047)): Fix search highlights cleared before user can see them when landing on a page with `?q=` search parameter.
+- ([#9802](https://github.com/quarto-dev/quarto-cli/issues/9802), [#14047](https://github.com/quarto-dev/quarto-cli/issues/14047)): Fix search term highlighting disappearing on page scroll or layout events when navigating from search results. (author: @jtbayly, [#13442](https://github.com/quarto-dev/quarto-cli/pull/13442))
 
 ### `book`
 

--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -119,6 +119,7 @@ All changes included in 1.9:
 - ([#13932](https://github.com/quarto-dev/quarto-cli/pull/13932)): Add `llms-txt: true` option to generate LLM-friendly content for websites. Creates `.llms.md` markdown files alongside HTML pages and a root `llms.txt` index file following the [llms.txt](https://llmstxt.org/) specification.
 - ([#13951](https://github.com/quarto-dev/quarto-cli/issues/13951)): Fix `image-lazy-loading` not applying `loading="lazy"` attribute to auto-detected listing images.
 - ([#14003](https://github.com/quarto-dev/quarto-cli/pull/14003)): Add text fragments to search result links so browsers scroll to and highlight the matched text on the target page.
+- ([#14047](https://github.com/quarto-dev/quarto-cli/issues/14047)): Fix search highlights cleared before user can see them when landing on a page with `?q=` search parameter.
 
 ### `book`
 

--- a/src/resources/projects/website/search/quarto-search.js
+++ b/src/resources/projects/website/search/quarto-search.js
@@ -1129,8 +1129,8 @@ function activateTabsWithMatches(mainEl) {
   for (const mark of marks) {
     const pane = mark.closest(".tab-pane");
     if (!pane) continue;
-    const tabContent = pane.parentElement;
-    if (!tabContent || !tabContent.classList.contains("tab-content")) continue;
+    const tabContent = pane.closest(".tab-content");
+    if (!tabContent) continue;
 
     if (!tabsetMatches.has(tabContent)) {
       tabsetMatches.set(tabContent, { activeHasMatch: false, firstInactivePane: null });
@@ -1147,8 +1147,9 @@ function activateTabsWithMatches(mainEl) {
   for (const [, info] of tabsetMatches) {
     if (info.activeHasMatch || !info.firstInactivePane) continue;
 
+    const escapedId = CSS.escape(info.firstInactivePane.id);
     const tabButton = mainEl.querySelector(
-      `[data-bs-toggle="tab"][data-bs-target="#${info.firstInactivePane.id}"]`
+      `[data-bs-toggle="tab"][data-bs-target="#${escapedId}"]`
     );
     if (tabButton) {
       new bootstrap.Tab(tabButton).show();

--- a/src/resources/projects/website/search/quarto-search.js
+++ b/src/resources/projects/website/search/quarto-search.js
@@ -1178,7 +1178,7 @@ function activateTabsWithMatches(mainEl) {
       try {
         new bootstrap.Tab(tabButton).show();
       } catch (e) {
-        // Skip this tab if Bootstrap Tab API fails
+        console.debug("Failed to activate tab for search match:", e);
       }
     }
   }

--- a/src/resources/projects/website/search/quarto-search.js
+++ b/src/resources/projects/website/search/quarto-search.js
@@ -1175,7 +1175,11 @@ function activateTabsWithMatches(mainEl) {
       `[data-bs-toggle="tab"][data-bs-target="#${escapedId}"]`
     );
     if (tabButton) {
-      new bootstrap.Tab(tabButton).show();
+      try {
+        new bootstrap.Tab(tabButton).show();
+      } catch (e) {
+        // Skip this tab if Bootstrap Tab API fails
+      }
     }
   }
 }

--- a/src/resources/projects/website/search/quarto-search.js
+++ b/src/resources/projects/website/search/quarto-search.js
@@ -56,6 +56,9 @@ window.document.addEventListener("DOMContentLoaded", function (_event) {
     window.addEventListener("pageshow", function (event) {
       if (!event.persisted) {
         activateTabsWithMatches(mainEl);
+        // Let the browser settle layout after Bootstrap tab transitions
+        // before calculating scroll position.
+        requestAnimationFrame(() => scrollToFirstMatch(mainEl));
       }
     }, { once: true });
 
@@ -1192,6 +1195,29 @@ function ancestorCount(el, stopAt) {
     node = node.parentElement;
   }
   return count;
+}
+
+// After tab activation, scroll to the first visible search match so the user
+// sees the highlighted result without manually scrolling.
+// Only checks tab-pane visibility (not collapsed callouts, details/summary, etc.)
+// since this runs specifically after tab activation for search results.
+function scrollToFirstMatch(mainEl) {
+  const marks = mainEl.querySelectorAll("mark");
+  for (const mark of marks) {
+    let hidden = false;
+    let el = mark.parentElement;
+    while (el && el !== mainEl) {
+      if (el.classList.contains("tab-pane") && !el.classList.contains("active")) {
+        hidden = true;
+        break;
+      }
+      el = el.parentElement;
+    }
+    if (!hidden) {
+      mark.scrollIntoView({ block: "center" });
+      return;
+    }
+  }
 }
 
 // highlight matches

--- a/tests/docs/playwright/html/.gitignore
+++ b/tests/docs/playwright/html/.gitignore
@@ -1,2 +1,4 @@
 *_files/
 *.html
+/.quarto/
+**/*.quarto_ipynb

--- a/tests/docs/playwright/html/search-highlight/.gitignore
+++ b/tests/docs/playwright/html/search-highlight/.gitignore
@@ -1,0 +1,3 @@
+/.quarto/
+/_site/
+**/*.quarto_ipynb

--- a/tests/docs/playwright/html/search-highlight/_quarto.yml
+++ b/tests/docs/playwright/html/search-highlight/_quarto.yml
@@ -1,0 +1,11 @@
+project:
+  type: website
+
+website:
+  title: "Search Highlight Test"
+  navbar:
+    left:
+      - href: index.qmd
+        text: Home
+
+format: html

--- a/tests/docs/playwright/html/search-highlight/index.qmd
+++ b/tests/docs/playwright/html/search-highlight/index.qmd
@@ -1,0 +1,7 @@
+---
+title: "Search Highlight Test"
+---
+
+This page contains a special keyword that we use for testing search highlighting.
+
+The word special appears multiple times on this page to ensure search highlighting works correctly.

--- a/tests/docs/playwright/html/search-tabsets/.gitignore
+++ b/tests/docs/playwright/html/search-tabsets/.gitignore
@@ -1,0 +1,3 @@
+/.quarto/
+/_site/
+**/*.quarto_ipynb

--- a/tests/docs/playwright/html/search-tabsets/_quarto.yml
+++ b/tests/docs/playwright/html/search-tabsets/_quarto.yml
@@ -1,0 +1,9 @@
+project:
+  type: website
+website:
+  title: "Search Tab Test"
+  search: true
+  navbar:
+    left:
+      - href: index.qmd
+        text: Home

--- a/tests/docs/playwright/html/search-tabsets/_quarto.yml
+++ b/tests/docs/playwright/html/search-tabsets/_quarto.yml
@@ -7,3 +7,5 @@ website:
     left:
       - href: index.qmd
         text: Home
+
+format: html

--- a/tests/docs/playwright/html/search-tabsets/index.qmd
+++ b/tests/docs/playwright/html/search-tabsets/index.qmd
@@ -1,0 +1,49 @@
+---
+title: "Search Tab Test"
+---
+
+## Plain Section
+
+This section contains epsilon-no-tabs content outside of any tabset.
+
+## Ungrouped Tabset
+
+::: {.panel-tabset}
+
+### Tab Alpha
+
+This tab contains alpha-visible-content that is in the default active tab.
+
+### Tab Beta
+
+This tab contains beta-unique-search-term that is only in this inactive tab.
+
+:::
+
+## Both Tabs Match
+
+::: {.panel-tabset}
+
+### R
+
+This tab contains gamma-both-tabs content in the active R tab.
+
+### Python
+
+This tab also contains gamma-both-tabs content in the inactive Python tab.
+
+:::
+
+## Grouped Tabset
+
+::: {.panel-tabset group="language"}
+
+### R
+
+This tab contains delta-r-only-term that is only in the R tab.
+
+### Python
+
+This tab contains python-only-content in the Python tab.
+
+:::

--- a/tests/docs/playwright/html/search-tabsets/index.qmd
+++ b/tests/docs/playwright/html/search-tabsets/index.qmd
@@ -47,3 +47,43 @@ This tab contains delta-r-only-term that is only in the R tab.
 This tab contains python-only-content in the Python tab.
 
 :::
+
+## Second Grouped Tabset
+
+::: {.panel-tabset group="language"}
+
+### R
+
+This tab shows R content in the second grouped tabset.
+
+### Python
+
+This tab shows Python content in the second grouped tabset.
+
+:::
+
+## Nested Tabset
+
+::: {.panel-tabset}
+
+### Outer Tab A
+
+This is outer-tab-a-content in the default active outer tab.
+
+### Outer Tab B
+
+Content in outer tab B.
+
+::: {.panel-tabset}
+
+#### Inner Tab X
+
+This is inner-tab-x-content in the default active inner tab.
+
+#### Inner Tab Y
+
+This tab contains nested-inner-only-term that is only in this deeply nested inactive tab.
+
+:::
+
+:::

--- a/tests/integration/playwright/package.json
+++ b/tests/integration/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@playwright/test": "^1.28.1"
+    "@playwright/test": "^1.31.0"
   },
   "scripts": {}
 }

--- a/tests/integration/playwright/tests/html-search-highlight.spec.ts
+++ b/tests/integration/playwright/tests/html-search-highlight.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 
 const BASE = './html/search-highlight/_site/index.html';
 
-test('Search highlights not cleared by scroll events', async ({ page }) => {
+test('Search highlights persist after scrolling', async ({ page }) => {
   await page.goto(`${BASE}?q=special`);
   const marks = page.locator('mark');
 
@@ -10,19 +10,9 @@ test('Search highlights not cleared by scroll events', async ({ page }) => {
   const initialCount = await marks.count();
   expect(initialCount).toBeGreaterThanOrEqual(2);
 
-  // Dispatch layout events immediately (previously cleared marks via quarto-hrChanged)
-  await page.evaluate(() => {
-    window.dispatchEvent(new CustomEvent('quarto-hrChanged'));
-    window.dispatchEvent(new CustomEvent('quarto-sectionChanged'));
-  });
-  await expect(marks).toHaveCount(initialCount);
-
-  // Wait and dispatch again — marks should persist at any time
-  await page.waitForTimeout(1500);
-  await page.evaluate(() => {
-    window.dispatchEvent(new CustomEvent('quarto-hrChanged'));
-    window.dispatchEvent(new CustomEvent('quarto-sectionChanged'));
-  });
+  // Scroll the page — marks should not be cleared
+  await page.evaluate(() => window.scrollBy(0, 300));
+  await page.waitForTimeout(500);
   await expect(marks).toHaveCount(initialCount);
 });
 

--- a/tests/integration/playwright/tests/html-search-highlight.spec.ts
+++ b/tests/integration/playwright/tests/html-search-highlight.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "@playwright/test";
+
+test('Search highlights persist after page load', async ({ page }) => {
+  await page.goto('./html/search-highlight/_site/index.html?q=special');
+  const marks = page.locator('mark');
+
+  // Marks should exist after page load
+  await expect(marks.first()).toBeVisible({ timeout: 5000 });
+
+  // Simulate the layout-triggered quarto-hrChanged event that clears marks
+  // prematurely without the fix (#14047). With the fix, the listener is
+  // registered after a delay, so early events like this are ignored.
+  await page.evaluate(() => {
+    window.dispatchEvent(new CustomEvent('quarto-hrChanged'));
+  });
+
+  // Marks should still be visible after the simulated layout event
+  await expect(marks.first()).toBeVisible();
+  await expect(marks.first()).toContainText(/special/i);
+});
+
+test('Search highlights are cleared by scroll after delay', async ({ page }) => {
+  await page.goto('./html/search-highlight/_site/index.html?q=special');
+  const marks = page.locator('mark');
+
+  // Marks should exist after page load
+  await expect(marks.first()).toBeVisible({ timeout: 5000 });
+
+  // Wait for the delayed listener registration (1000ms in quarto-search.js)
+  await page.waitForTimeout(1500);
+
+  // Now quarto-hrChanged should clear marks (listener is registered)
+  await page.evaluate(() => {
+    window.dispatchEvent(new CustomEvent('quarto-hrChanged'));
+  });
+
+  await expect(marks).toHaveCount(0);
+});

--- a/tests/integration/playwright/tests/html-search-highlight.spec.ts
+++ b/tests/integration/playwright/tests/html-search-highlight.spec.ts
@@ -22,12 +22,12 @@ test('Search highlights cleared when query changes', async ({ page }) => {
 
   await expect(marks.first()).toBeVisible({ timeout: 5000 });
 
-  // Open the detached search overlay
-  await page.locator('.aa-DetachedSearchButton').click();
-  const input = page.locator('.aa-Input');
+  // Open the search overlay and type a different query
+  await page.locator('#quarto-search').getByRole('button').click();
+  const input = page.getByRole('searchbox');
   await expect(input).toBeVisible({ timeout: 2000 });
 
-  // Type a different query — triggers onStateChange which clears marks
+  // Typing a different query triggers onStateChange which clears marks
   await input.fill('different');
   await expect(page.locator('main mark')).toHaveCount(0, { timeout: 2000 });
 });

--- a/tests/integration/playwright/tests/html-search-tabsets.spec.ts
+++ b/tests/integration/playwright/tests/html-search-tabsets.spec.ts
@@ -2,18 +2,6 @@ import { test, expect, Page } from "@playwright/test";
 
 const BASE = './html/search-tabsets/_site/index.html';
 
-// Helper: wait for search tab activation (deferred to pageshow)
-// and return the active pane ID for a given tab-content index.
-async function getActiveTabId(page: Page, tabContentIndex: number): Promise<string> {
-  return page.evaluate((idx) => {
-    const tabContents = document.querySelectorAll('.tab-content');
-    const tc = tabContents[idx];
-    if (!tc) return 'not-found';
-    const active = tc.querySelector('.tab-pane.active');
-    return active?.id ?? 'none';
-  }, tabContentIndex);
-}
-
 // Helper: count marks visible (not inside an inactive tab pane)
 async function visibleMarkCount(page: Page): Promise<number> {
   return page.evaluate(() => {
@@ -37,9 +25,8 @@ test('Search activates inactive tab containing match', async ({ page }) => {
   const marks = page.locator('mark');
   await expect(marks.first()).toBeVisible({ timeout: 5000 });
 
-  // Tab Beta (tabset-1-2) should be active in the ungrouped tabset (index 0)
-  const activeId = await getActiveTabId(page, 0);
-  expect(activeId).toBe('tabset-1-2');
+  // Tab Beta should be active in the ungrouped tabset
+  await expect(page.getByRole('tab', { name: 'Tab Beta', exact: true })).toHaveClass(/active/);
 
   await expect(marks).toHaveCount(1);
   expect(await visibleMarkCount(page)).toBe(1);
@@ -51,9 +38,9 @@ test('Search keeps active tab when it already has a match', async ({ page }) => 
   const marks = page.locator('mark');
   await expect(marks.first()).toBeVisible({ timeout: 5000 });
 
-  // R tab (tabset-2-1) should stay active — it already has a match
-  const activeId = await getActiveTabId(page, 1);
-  expect(activeId).toBe('tabset-2-1');
+  // R tab should stay active — it already has a match
+  const section = page.locator('#both-tabs-match');
+  await expect(section.getByRole('tab', { name: 'R', exact: true })).toHaveClass(/active/);
 
   // 2 marks total (one in each tab), only 1 visible (in active tab)
   await expect(marks).toHaveCount(2);
@@ -67,8 +54,9 @@ test('Search highlights outside tabs without changing tab state', async ({ page 
   await expect(marks.first()).toBeVisible({ timeout: 5000 });
 
   // All tabs should remain at their defaults (first tab active)
-  expect(await getActiveTabId(page, 0)).toBe('tabset-1-1');
-  expect(await getActiveTabId(page, 1)).toBe('tabset-2-1');
+  await expect(page.getByRole('tab', { name: 'Tab Alpha', exact: true })).toHaveClass(/active/);
+  const bothSection = page.locator('#both-tabs-match');
+  await expect(bothSection.getByRole('tab', { name: 'R', exact: true })).toHaveClass(/active/);
 
   await expect(marks).toHaveCount(1);
   expect(await visibleMarkCount(page)).toBe(1);
@@ -80,10 +68,9 @@ test('Search activates both outer and inner tabs for nested match', async ({ pag
   const marks = page.locator('mark');
   await expect(marks.first()).toBeVisible({ timeout: 5000 });
 
-  // Outer Tab B (tabset-6-2) and Inner Tab Y (tabset-5-2) should both activate.
-  // Tabset indices: outer nested = 4, inner nested = 5
-  expect(await getActiveTabId(page, 4)).toBe('tabset-6-2');
-  expect(await getActiveTabId(page, 5)).toBe('tabset-5-2');
+  // Both outer and inner tabs should activate for the nested match
+  await expect(page.getByRole('tab', { name: 'Outer Tab B', exact: true })).toHaveClass(/active/);
+  await expect(page.getByRole('tab', { name: 'Inner Tab Y', exact: true })).toHaveClass(/active/);
 
   await expect(marks).toHaveCount(1);
   expect(await visibleMarkCount(page)).toBe(1);
@@ -105,12 +92,13 @@ test('Search activation overrides localStorage tab preference', async ({ page })
   const marks = page.locator('mark');
   await expect(marks.first()).toBeVisible({ timeout: 5000 });
 
-  // Python tab (tabset-3-2) should be active despite localStorage saying "R"
-  const activeId = await getActiveTabId(page, 2);
-  expect(activeId).toBe('tabset-3-2');
+  // Python tab should be active despite localStorage saying "R"
+  const groupedSection = page.locator('#grouped-tabset');
+  await expect(groupedSection.getByRole('tab', { name: 'Python', exact: true })).toHaveClass(/active/);
 
   // Second grouped tabset should remain on R (no search match there)
-  expect(await getActiveTabId(page, 3)).toBe('tabset-4-1');
+  const secondGrouped = page.locator('#second-grouped-tabset');
+  await expect(secondGrouped.getByRole('tab', { name: 'R', exact: true })).toHaveClass(/active/);
 
   await expect(marks).toHaveCount(1);
   expect(await visibleMarkCount(page)).toBe(1);

--- a/tests/integration/playwright/tests/html-search-tabsets.spec.ts
+++ b/tests/integration/playwright/tests/html-search-tabsets.spec.ts
@@ -103,3 +103,14 @@ test('Search activation overrides localStorage tab preference', async ({ page })
   await expect(marks).toHaveCount(1);
   expect(await visibleMarkCount(page)).toBe(1);
 });
+
+test('Search scrolls to first visible match', async ({ page }) => {
+  // Use small viewport so the nested tabset at the bottom is below the fold,
+  // ensuring the test actually exercises scrollIntoView (not trivially passing).
+  await page.setViewportSize({ width: 800, height: 400 });
+  await page.goto(`${BASE}?q=nested-inner-only-term`);
+
+  const mark = page.locator('mark').first();
+  await expect(mark).toBeVisible({ timeout: 5000 });
+  await expect(mark).toBeInViewport();
+});

--- a/tests/integration/playwright/tests/html-search-tabsets.spec.ts
+++ b/tests/integration/playwright/tests/html-search-tabsets.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from "@playwright/test";
+
+const BASE = './html/search-tabsets/_site/index.html';
+
+// Helper: wait for search tab activation (deferred to pageshow)
+// and return the active pane ID for a given tab-content index.
+async function getActiveTabId(page, tabContentIndex: number): Promise<string> {
+  return page.evaluate((idx) => {
+    const tabContents = document.querySelectorAll('.tab-content');
+    const tc = tabContents[idx];
+    if (!tc) return 'not-found';
+    const active = tc.querySelector('.tab-pane.active');
+    return active?.id ?? 'none';
+  }, tabContentIndex);
+}
+
+// Helper: count marks visible (not inside an inactive tab pane)
+async function visibleMarkCount(page): Promise<number> {
+  return page.evaluate(() => {
+    return Array.from(document.querySelectorAll('mark')).filter(m => {
+      let el: Element | null = m;
+      while (el) {
+        if (el.classList?.contains('tab-pane') && !el.classList.contains('active')) {
+          return false;
+        }
+        el = el.parentElement;
+      }
+      return true;
+    }).length;
+  });
+}
+
+test('Search activates inactive tab containing match', async ({ page }) => {
+  await page.goto(`${BASE}?q=beta-unique-search-term`);
+
+  // Mark should be visible (tab activation deferred to pageshow)
+  const marks = page.locator('mark');
+  await expect(marks.first()).toBeVisible({ timeout: 5000 });
+
+  // Tab Beta (tabset-1-2) should be active in the ungrouped tabset (index 0)
+  const activeId = await getActiveTabId(page, 0);
+  expect(activeId).toBe('tabset-1-2');
+
+  await expect(marks).toHaveCount(1);
+  expect(await visibleMarkCount(page)).toBe(1);
+});
+
+test('Search keeps active tab when it already has a match', async ({ page }) => {
+  await page.goto(`${BASE}?q=gamma-both-tabs`);
+
+  const marks = page.locator('mark');
+  await expect(marks.first()).toBeVisible({ timeout: 5000 });
+
+  // R tab (tabset-2-1) should stay active — it already has a match
+  const activeId = await getActiveTabId(page, 1);
+  expect(activeId).toBe('tabset-2-1');
+
+  // 2 marks total (one in each tab), only 1 visible (in active tab)
+  await expect(marks).toHaveCount(2);
+  expect(await visibleMarkCount(page)).toBe(1);
+});
+
+test('Search highlights outside tabs without changing tab state', async ({ page }) => {
+  await page.goto(`${BASE}?q=epsilon-no-tabs`);
+
+  const marks = page.locator('mark');
+  await expect(marks.first()).toBeVisible({ timeout: 5000 });
+
+  // All tabs should remain at their defaults (first tab active)
+  expect(await getActiveTabId(page, 0)).toBe('tabset-1-1');
+  expect(await getActiveTabId(page, 1)).toBe('tabset-2-1');
+
+  await expect(marks).toHaveCount(1);
+  expect(await visibleMarkCount(page)).toBe(1);
+});
+
+test('Search activates both outer and inner tabs for nested match', async ({ page }) => {
+  await page.goto(`${BASE}?q=nested-inner-only-term`);
+
+  const marks = page.locator('mark');
+  await expect(marks.first()).toBeVisible({ timeout: 5000 });
+
+  // Outer Tab B (tabset-6-2) and Inner Tab Y (tabset-5-2) should both activate.
+  // Tabset indices: outer nested = 4, inner nested = 5
+  expect(await getActiveTabId(page, 4)).toBe('tabset-6-2');
+  expect(await getActiveTabId(page, 5)).toBe('tabset-5-2');
+
+  await expect(marks).toHaveCount(1);
+  expect(await visibleMarkCount(page)).toBe(1);
+});
+
+test('Search activation overrides localStorage tab preference', async ({ page }) => {
+  // Pre-set localStorage to prefer "R" for the "language" group
+  await page.goto(`${BASE}`);
+  await page.evaluate(() => {
+    localStorage.setItem(
+      'quarto-persistent-tabsets-data',
+      JSON.stringify({ language: 'R' })
+    );
+  });
+
+  // Navigate with search query that matches only in the Python tab
+  await page.goto(`${BASE}?q=python-only-content`);
+
+  const marks = page.locator('mark');
+  await expect(marks.first()).toBeVisible({ timeout: 5000 });
+
+  // Python tab (tabset-3-2) should be active despite localStorage saying "R"
+  const activeId = await getActiveTabId(page, 2);
+  expect(activeId).toBe('tabset-3-2');
+
+  // Second grouped tabset should remain on R (no search match there)
+  expect(await getActiveTabId(page, 3)).toBe('tabset-4-1');
+
+  await expect(marks).toHaveCount(1);
+  expect(await visibleMarkCount(page)).toBe(1);
+});

--- a/tests/integration/playwright/tests/html-search-tabsets.spec.ts
+++ b/tests/integration/playwright/tests/html-search-tabsets.spec.ts
@@ -1,10 +1,10 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, Page } from "@playwright/test";
 
 const BASE = './html/search-tabsets/_site/index.html';
 
 // Helper: wait for search tab activation (deferred to pageshow)
 // and return the active pane ID for a given tab-content index.
-async function getActiveTabId(page, tabContentIndex: number): Promise<string> {
+async function getActiveTabId(page: Page, tabContentIndex: number): Promise<string> {
   return page.evaluate((idx) => {
     const tabContents = document.querySelectorAll('.tab-content');
     const tc = tabContents[idx];
@@ -15,7 +15,7 @@ async function getActiveTabId(page, tabContentIndex: number): Promise<string> {
 }
 
 // Helper: count marks visible (not inside an inactive tab pane)
-async function visibleMarkCount(page): Promise<number> {
+async function visibleMarkCount(page: Page): Promise<number> {
   return page.evaluate(() => {
     return Array.from(document.querySelectorAll('mark')).filter(m => {
       let el: Element | null = m;


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is to be merged AFTER #14049 which as a prerequisite fix 


> [!TIP]
> Demo website: https://cderv.github.io/quarto-search-highlight-demo/ 

When navigating to a page with `?q=term` in the URL, search matches inside inactive Bootstrap tabs are invisible because the matching tab is not activated. This builds on #14049 (mark-clearing fix) to also activate tabs that contain highlighted matches.

## How it works

After `highlight()` wraps matches in `<mark>` elements during DOMContentLoaded, a `pageshow` listener activates any tab panes containing marks. The pageshow timing is key — `tabsets.js` (loaded as an ES module) registers its own pageshow handler during module execution, which runs before DOMContentLoaded. By registering our handler during DOMContentLoaded, listener ordering guarantees we run *after* tabsets.js restores tab state from localStorage.

This means search activation wins over stored tab preferences, which is the intended UX — if you searched for something in the Python tab, you want to see the Python tab regardless of your stored language preference.

## Design decisions

- `bootstrap.Tab.show()` used instead of `.click()` to avoid triggering group sync in tabsets.js. Search activation is intentionally local to the tabset containing the match.
- Nested tabsets supported: walks ancestor `.tab-pane` elements, groups by `.tab-content`, activates outermost first.
- If the active tab already contains a match, no switch occurs (avoids unnecessary tab changes).
- `{once: true}` and `!event.persisted` guard on the pageshow listener for clean teardown.

## Test plan

- [x] Playwright tests (5 scenarios, all pass Chromium/Firefox/WebKit):
  1. Inactive tab activation
  2. Active-tab-has-match stays
  3. Outside-tabs no change
  4. Nested tabsets both activate
  5. Grouped + localStorage override
- [x] TDD verified: 3/5 tests fail against stock v1.9.20, all pass with this code
- [x] Chrome MCP timing experiments confirmed pageshow deferral approach

Fixes quarto-dev/quarto-cli#14047 (partial — tab activation aspect)