### PR TITLE
Fix meta shortcode not preserving line breaks in values (#14061)

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -3,6 +3,7 @@ All changes included in 1.9:
 ## Shortcodes
 
 - ([#13342](https://github.com/quarto-dev/quarto-cli/issues/13342)): Ensure that the `contents` shortcode works inside metadata.
+- ([#14061](https://github.com/quarto-dev/quarto-cli/issues/14061)): Fix `meta` shortcode not preserving line breaks in values. The shortcode now respects its usage context (block, inline, or text) and preserves paragraph breaks in block and code block contexts.
 
 ## Regression fixes
 

--- a/tests/docs/smoke-all/2026/02/20/14061.qmd
+++ b/tests/docs/smoke-all/2026/02/20/14061.qmd
@@ -1,0 +1,22 @@
+---
+format: html
+key: |
+  Something with a line break
+
+  I want to preserve.
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        -
+          - "Something with a line break"
+          - "I want to preserve"
+        -
+          - "line break I want"
+---
+
+``` yaml
+{{< meta key >}}
+```
+
+{{< meta key >}}


### PR DESCRIPTION
The meta shortcode handler previously used processValue() for all contexts, which collapses multi-line metadata into inline content. Now handleMeta() dispatches based on context: block context returns Blocks directly via processValueInBlockContext(), inline context preserves the existing behavior, and text context (e.g. inside code blocks) writes blocks back as markdown to preserve structure.

Closes #14061.