### PR TITLE
Add q param to algolia search, fix search term highlighting across html nodes

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -121,8 +121,8 @@ All changes included in 1.9:
 - ([#13910](https://github.com/quarto-dev/quarto-cli/issues/13910)): Add support for `logo: false` to disable sidebar and navbar logos when using `_brand.yml`. Works in website projects (`sidebar.logo: false`, `navbar.logo: false`) and book projects (`book.sidebar.logo: false`, `book.navbar.logo: false`).
 - ([#13932](https://github.com/quarto-dev/quarto-cli/pull/13932)): Add `llms-txt: true` option to generate LLM-friendly content for websites. Creates `.llms.md` markdown files alongside HTML pages and a root `llms.txt` index file following the [llms.txt](https://llmstxt.org/) specification.
 - ([#13951](https://github.com/quarto-dev/quarto-cli/issues/13951)): Fix `image-lazy-loading` not applying `loading="lazy"` attribute to auto-detected listing images.
-- ([#14003](https://github.com/quarto-dev/quarto-cli/pull/14003)): Add text fragments to search result links so browsers scroll to and highlight the matched text on the target page.
 - ([#9802](https://github.com/quarto-dev/quarto-cli/issues/9802), [#14047](https://github.com/quarto-dev/quarto-cli/issues/14047)): Fix search term highlighting disappearing on page scroll or layout events when navigating from search results. (author: @jtbayly, [#13442](https://github.com/quarto-dev/quarto-cli/pull/13442))
+- ([#14080](https://github.com/quarto-dev/quarto-cli/pull/14080)): Algolia search results now highlight matching terms on the target page. Search term highlighting also works when matches span across formatted text (e.g., inline code, syntax highlighting).
 
 ### `book`
 

--- a/src/resources/projects/website/search/quarto-search.js
+++ b/src/resources/projects/website/search/quarto-search.js
@@ -1260,16 +1260,10 @@ function openAllTabsetsContainingEl(el) {
 
 function scrollToFirstVisibleMatch(mainEl) {
   for (const mark of mainEl.querySelectorAll("mark")) {
-    let hidden = false;
-    let el = mark.parentElement;
-    while (el && el !== mainEl) {
-      if (el.classList.contains("tab-pane") && !el.classList.contains("active")) {
-        hidden = true;
-        break;
-      }
-      el = el.parentElement;
-    }
-    if (!hidden) {
+    const isMarkVisible = matchAncestors(mark, '.tab-pane').every(markTabPane =>
+      markTabPane.classList.contains("active")
+    )
+    if (isMarkVisible) {
       mark.scrollIntoView({ behavior: "smooth", block: "center" });
       return;
     }

--- a/src/resources/projects/website/search/quarto-search.js
+++ b/src/resources/projects/website/search/quarto-search.js
@@ -177,8 +177,8 @@ window.document.addEventListener("DOMContentLoaded", function (_event) {
                     title: isExpanded
                       ? language["search-hide-matches-text"]
                       : remainingCount === 1
-                      ? `${remainingCount} ${language["search-more-match-text"]}`
-                      : `${remainingCount} ${language["search-more-matches-text"]}`,
+                        ? `${remainingCount} ${language["search-more-match-text"]}`
+                        : `${remainingCount} ${language["search-more-matches-text"]}`,
                     type: kItemTypeMore,
                     href: kItemTypeMoreHref,
                   });
@@ -296,9 +296,8 @@ window.document.addEventListener("DOMContentLoaded", function (_event) {
               return createElement(
                 "div",
                 {
-                  class: `quarto-search-no-results${
-                    hasQuery ? "" : " no-query"
-                  }`,
+                  class: `quarto-search-no-results${hasQuery ? "" : " no-query"
+                    }`,
                 },
                 language["search-no-results-text"]
               );
@@ -1113,8 +1112,26 @@ function getLeafNodes(root) {
   traverse(root);
   return leaves;
 }
+/** create and return `<mark>${txt}</mark>` */
+const markEl = txt => {
+  const el = document.createElement("mark");
+  el.appendChild(document.createTextNode(txt));
+  return el
+}
+/** get all ancestors of an element matching the given css selector */
+const matchAncestors = (el, selector) => {
+  let ancestors = [];
+  while (el) {
+    if (el.matches?.(selector)) ancestors.push(el);
+    el = el.parentNode;
+  }
+  return ancestors;
+};
 
 const isWhitespace = s => s.trim().length === 0
+// =================
+// MATCHING CODE
+// =================
 const initMatch = () => ({
   i: 0,
   lohisByNode: new Map()
@@ -1185,12 +1202,6 @@ function searchMatches(inSearch, el) {
   return matches
 }
 
-/** create and return `<mark>${txt}</mark>` */
-const markEl = txt => {
-  const el = document.createElement("mark");
-  el.appendChild(document.createTextNode(txt));
-  return el
-}
 /** 
  * e.g. `markMatches(myTextNode, [[0,5],[12,15]])` would wrap the
  * character sequences in myTextNode from 0-5 and 12-15 in marks.
@@ -1220,16 +1231,7 @@ function markMatches(node, lohis) {
   return parent
 }
 
-/** get all ancestors of an element matching the given css selector */
-const matchAncestors = (el, selector) => {
-  let ancestors = [];
-  while (el) {
-    if (el.matches?.(selector)) ancestors.push(el);
-    el = el.parentNode;
-  }
-  return ancestors;
-};
-const openAllTabsetsContainingEl = el => {
+function openAllTabsetsContainingEl(el) {
   for (const tab of matchAncestors(el, '.tab-pane')) {
     const tabButton = document.querySelector(`[data-bs-target="#${tab.id}"]`);
     if (tabButton) new bootstrap.Tab(tabButton).show();


### PR DESCRIPTION
## Examples
I highlighted and copied some text on various pages that spans decorated and undecorated text, then pasted it into algolia search, and these are the successful matches:

<img width="414" height="251" alt="image" src="https://github.com/user-attachments/assets/44699526-3530-41ff-a996-a880d2c35e59" />
---
<img width="678" height="63" alt="image" src="https://github.com/user-attachments/assets/cd0df1e4-f7fa-4070-99ad-5b14bfcf3801" />
---
<img width="728" height="279" alt="image" src="https://github.com/user-attachments/assets/9c127676-31ec-49d8-a0b5-d9de4cd667a4" />
---

## Description
This PR 
1. replaces text fragments (from PR https://github.com/quarto-dev/quarto-cli/pull/14003) in algolia search urls with a `q={search term}` param, enabling multiple match highlighting
1. replaces the previous method of highlighting search terms in the page which only worked when the search term was fully contained within a single node. The previous method worked great for matches in paragraphs that did not have any decoration, but did not work for matches that contained both decorated and undecorated text, and did not work well for code cells with syntax highlighting.

I referenced @cderv's PR https://github.com/quarto-dev/quarto-cli/pull/14053 while finishing this PR. Building off of that, I found a method for opening containing tabsets that requires significantly less code. See `openAllTabsetsContainingEl`