### PR TITLE
Fix tab activation regression in search highlighting

### DIFF
--- a/src/resources/projects/website/search/quarto-search.js
+++ b/src/resources/projects/website/search/quarto-search.js
@@ -1260,16 +1260,10 @@ function openAllTabsetsContainingEl(el) {
 
 function scrollToFirstVisibleMatch(mainEl) {
   for (const mark of mainEl.querySelectorAll("mark")) {
-    let hidden = false;
-    let el = mark.parentElement;
-    while (el && el !== mainEl) {
-      if (el.classList.contains("tab-pane") && !el.classList.contains("active")) {
-        hidden = true;
-        break;
-      }
-      el = el.parentElement;
-    }
-    if (!hidden) {
+    const isMarkVisible = matchAncestors(mark, '.tab-pane').every(markTabPane =>
+      markTabPane.classList.contains("active")
+    )
+    if (isMarkVisible) {
       mark.scrollIntoView({ behavior: "smooth", block: "center" });
       return;
     }


### PR DESCRIPTION
> [!IMPORTANT]
> This PR targets the `feature/robust-search-highlighting` branch (#14080), not `main`. It is intended to be merged into #14080 before that PR merges into `main`.

## Context

PR #14080 replaced `activateTabsWithMatches()` (from #14053) with `openAllTabsetsContainingEl()`, which is a much cleaner approach — 9 lines vs 65 — but dropped two behaviors that the playwright tests in `html-search-tabsets.spec.ts` verify.

## What regressed

1. **"Keep active tab" logic** — when multiple panes in the same tabset contain a match, the old code kept the already-active tab. The new code unconditionally activated each pane, so the last match processed won.

2. **Pageshow timing** — tab activation ran during `DOMContentLoaded`, but `tabsets.js` restores tab state from localStorage on `pageshow` (which fires after). So localStorage overwrote search activation.

## Fix

Adapt `openAllTabsetsContainingEl` (not replace it) with minimal changes:

- Before activating a pane, check if the same tabset's active pane already has a `<mark>` — skip if so
- Move tab activation from inside `highlight()` to a `pageshow` handler, so it runs after `tabsets.js`
- Add `scrollToFirstVisibleMatch` that skips marks inside inactive tab panes
- Fix `for (leaf of leafNodes)` → `for (const leaf of leafNodes)` (implicit global)

The adapted function stays at 9 lines (vs the 65-line `activateTabsWithMatches` it replaced). `highlight()` is simplified to marking-only.

## Test

All 6 tests × 3 browsers pass locally:

```
Running 18 tests using 11 workers
  18 passed (16.3s)
```
