### PR TITLE
Add `a11y` to schema groups

### DIFF
--- a/src/resources/schema/groups.yml
+++ b/src/resources/schema/groups.yml
@@ -92,6 +92,8 @@ document:
     title: "Language"
   comments:
     title: "Comments"
+  a11y:
+    title: "Accessibility"
   includes:
     title: "Includes"
   metadata:


### PR DESCRIPTION
Adds `a11y` to `groups.yml` so options from `document-a11y.yml` appear on format reference pages on `quarto-web`.
