### PR TITLE
Fix false citeproc warning from @ in book metadata URLs

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -131,6 +131,7 @@ All changes included in 1.9:
 
 ### `book`
 
+- ([#12136](https://github.com/quarto-dev/quarto-cli/issues/12136)): Fix false `citeproc: citation not found` warnings when book metadata URLs contain `@` (e.g., Mastodon links). The `@` in URL strings is now escaped before passing to Pandoc, preventing misinterpretation as citation references.
 - ([#13769](https://github.com/quarto-dev/quarto-cli/issues/13769)): Apply `repo-link-target` and `repo-link-rel` options to tools in book sidebar for consistent link attribute handling with website projects. (author: @mcanouil)
 
 ### `manuscript`

--- a/src/command/render/pandoc.ts
+++ b/src/command/render/pandoc.ts
@@ -27,6 +27,7 @@ import { Document } from "../../core/deno-dom.ts";
 import { execProcess } from "../../core/process.ts";
 import { dirAndStem, normalizePath } from "../../core/path.ts";
 import { mergeConfigs } from "../../core/config.ts";
+import { isExternalPath } from "../../core/url.ts";
 
 import {
   Format,
@@ -1844,7 +1845,7 @@ function resolveTextHighlightStyle(
 // deno-lint-ignore no-explicit-any
 function escapeAtInMetadata(value: any): any {
   if (typeof value === "string") {
-    return value.replaceAll("@", "&#64;");
+    return isExternalPath(value) ? value.replaceAll("@", "&#64;") : value;
   }
   if (Array.isArray(value)) {
     return value.map(escapeAtInMetadata);

--- a/src/command/render/pandoc.ts
+++ b/src/command/render/pandoc.ts
@@ -1339,6 +1339,13 @@ export async function runPandoc(
     }
   }
 
+  // Escape @ in book metadata to prevent false citeproc warnings (#12136).
+  // Book metadata can't be deleted like website/about because {{< meta book.* >}}
+  // shortcodes depend on it. Pandoc resolves &#64; back to @ in the AST.
+  if (pandocPassedMetadata.book) {
+    pandocPassedMetadata.book = escapeAtInMetadata(pandocPassedMetadata.book);
+  }
+
   Deno.writeTextFileSync(
     metadataTemp,
     stringify(pandocPassedMetadata, {
@@ -1832,4 +1839,22 @@ function resolveTextHighlightStyle(
       break;
   }
   return extras;
+}
+
+// deno-lint-ignore no-explicit-any
+function escapeAtInMetadata(value: any): any {
+  if (typeof value === "string") {
+    return value.replaceAll("@", "&#64;");
+  }
+  if (Array.isArray(value)) {
+    return value.map(escapeAtInMetadata);
+  }
+  if (value !== null && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      result[k] = escapeAtInMetadata(v);
+    }
+    return result;
+  }
+  return value;
 }

--- a/tests/docs/smoke-all/2026/02/24/issue-12136/.gitignore
+++ b/tests/docs/smoke-all/2026/02/24/issue-12136/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/tests/docs/smoke-all/2026/02/24/issue-12136/_quarto.yml
+++ b/tests/docs/smoke-all/2026/02/24/issue-12136/_quarto.yml
@@ -1,0 +1,16 @@
+project:
+  type: book
+
+book:
+  title: "Test Issue 12136"
+  navbar:
+    right:
+      - icon: mastodon
+        href: https://mastodon.online/@testuser
+  chapters:
+    - index.qmd
+
+bibliography: references.bib
+
+format:
+  html: default

--- a/tests/docs/smoke-all/2026/02/24/issue-12136/index.qmd
+++ b/tests/docs/smoke-all/2026/02/24/issue-12136/index.qmd
@@ -1,0 +1,14 @@
+---
+title: "Test"
+_quarto:
+  tests:
+    html:
+      printsMessage:
+        level: INFO
+        regex: 'Citeproc: citation'
+        negate: true
+---
+
+# Test {.unnumbered}
+
+No false citeproc warnings from @ in book navbar URLs.

--- a/tests/docs/smoke-all/2026/02/24/issue-12136/index.qmd
+++ b/tests/docs/smoke-all/2026/02/24/issue-12136/index.qmd
@@ -7,6 +7,9 @@ _quarto:
         level: INFO
         regex: 'Citeproc: citation'
         negate: true
+      ensureHtmlElements:
+        - ['a.nav-link[href="https://mastodon.online/@testuser"]']
+        - []
 ---
 
 # Test {.unnumbered}

--- a/tests/docs/smoke-all/2026/02/24/issue-12136/references.bib
+++ b/tests/docs/smoke-all/2026/02/24/issue-12136/references.bib
@@ -1,0 +1,5 @@
+@misc{example,
+  author = {Test Author},
+  title = {Example},
+  year = {2024}
+}

--- a/tests/docs/smoke-all/book/htmlbook/.gitignore
+++ b/tests/docs/smoke-all/book/htmlbook/.gitignore
@@ -1,1 +1,3 @@
 /.quarto/
+
+**/*.quarto_ipynb

--- a/tests/docs/smoke-all/book/page-footer/.gitignore
+++ b/tests/docs/smoke-all/book/page-footer/.gitignore
@@ -1,2 +1,3 @@
 /.quarto/
 /_book/
+**/*.quarto_ipynb

--- a/tests/docs/smoke-all/book/simple/.gitignore
+++ b/tests/docs/smoke-all/book/simple/.gitignore
@@ -1,1 +1,3 @@
 /.quarto/
+
+**/*.quarto_ipynb


### PR DESCRIPTION
When a book project has URLs containing `@` in navbar config (e.g., `href: https://mastodon.online/@user`) and a bibliography, Pandoc emits false `[WARNING] Citeproc: citation not found` warnings. Pandoc parses YAML metadata strings as Markdown, so `@user` is interpreted as a citation reference.

## Root Cause

Website metadata is deleted before passing to Pandoc (`pandoc.ts:1319`), avoiding the issue. Book metadata cannot be deleted because `{{< meta book.* >}}` shortcodes depend on it being in the Pandoc AST.

## Fix

Escape `@` to `&#64;` in URL strings within `book` metadata before writing the Pandoc metadata file. Pandoc resolves the HTML entity back to `@` in the AST, so templates and shortcodes see the original character.

The escaping is scoped to URL strings only (using `isExternalPath()`, which matches strings starting with a protocol scheme like `http:`, `https:`, `mailto:`). Non-URL metadata strings are left untouched, preserving intentional citations like `@smith2024` in book description fields.

Fixes #12136