### PR TITLE
Fix dark highlighting themes missing base text color

### DIFF
--- a/src/format/html/format-html-scss.ts
+++ b/src/format/html/format-html-scss.ts
@@ -314,7 +314,13 @@ export function resolveTextHighlightingLayer(
           true,
         );
       }
+    }
 
+    // Inject a text color regardless of adaptive status. Adaptive themes
+    // handle their own bg, but when separate light/dark themes are paired
+    // (e.g. kate + zenburn), the dark theme still needs its text-color
+    // emitted as $code-block-color so Bootstrap rules can apply it.
+    if (themeDescriptor) {
       const textColor = themeDescriptor.json["text-color"] as string;
       if (textColor) {
         layer.defaults = layer.defaults + "\n" + outputVariable(

--- a/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
@@ -863,6 +863,14 @@ div.sourceCode {
   div.sourceCode pre.sourceCode {
     color: $code-block-color;
   }
+  // Themes that omit "Normal" from text-styles (e.g. zenburn, espresso)
+  // don't generate a span-level color rule in the syntax highlighting CSS.
+  // When layered with a light theme that does, the light theme's near-black
+  // span color persists in dark mode. This ensures a base span color is set.
+  pre > code.sourceCode > span,
+  code.sourceCode > span {
+    color: $code-block-color;
+  }
 }
 
 pre.sourceCode {


### PR DESCRIPTION
## Summary

Fixes #14099

Dark syntax highlighting themes like **zenburn** and **espresso** don't set a base text color when paired with a light theme. Unhighlighted code tokens inherit the light theme's near-black color, making them invisible against the dark background.

### Root cause

Two issues:

1. **`$code-block-color` never emitted for paired themes** (`format-html-scss.ts`): The `text-color` extraction from the theme JSON was gated by `!themeDescriptor.isAdaptive`. When users specify separate light/dark themes (`highlight-style: {light: kate, dark: zenburn}`), `isAdaptiveTheme()` returns `true` because the config object has both `light` and `dark` keys — even though neither kate nor zenburn is actually an adaptive theme. So `$code-block-color` was never set as an SCSS variable.

2. **No span-level color rule** (`_bootstrap-rules.scss`): Even with `$code-block-color` set, it was only applied to container elements (`div.sourceCode`, `div.sourceCode pre.sourceCode`). The light theme's syntax highlighting CSS generates `code.sourceCode > span { color: #1f1c1b; }` which has higher specificity than container inheritance.

### Fix

1. **`format-html-scss.ts`**: Move the `text-color` → `$code-block-color` extraction outside the `!isAdaptive` guard. Adaptive themes handle their own background-color, but text-color still needs to propagate for Bootstrap rules to use.

2. **`_bootstrap-rules.scss`**: Add span-level selectors (`pre > code.sourceCode > span`, `code.sourceCode > span`) alongside the existing container-level `$code-block-color` rules. This follows the same pattern as the existing background-color handling.

### Affected themes

7 built-in themes missing `"Normal"` in `text-styles`: espresso, haddock, monochrome, none, pygments, tango, zenburn. Also covers user-created custom themes with the same structure.

### Verified

Built quarto from source and tested:
- `{light: kate, dark: zenburn}` → dark CSS now includes `code.sourceCode > span { color: #ccc; }`
- `{light: kate, dark: espresso}` → dark CSS now includes `code.sourceCode > span { color: #bdae9d; }`
- Light mode unchanged (kate's rules still present, no regressions)

cc @mcanouil — this follows the `_bootstrap-rules.scss` pattern you suggested, plus fixes an upstream gating issue where `$code-block-color` was never emitted for paired (non-adaptive) themes.