### PR TITLE
fix: code-tools show/hide all code buttons, and allow them to act on cells with `output: asis`

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -17,6 +17,7 @@ All changes included in 1.9:
 - ([#13633](https://github.com/quarto-dev/quarto-cli/issues/13633)): Fix detection and auto-installation of babel language packages from newer error format that doesn't explicitly mention `.ldf` filename.
 - ([#13694](https://github.com/quarto-dev/quarto-cli/issues/13694)): Fix `notebook-view.url` being ignored - external notebook links now properly use specified URLs instead of local preview files.
 - ([#13732](https://github.com/quarto-dev/quarto-cli/issues/13732)): Fix automatic font package installation for fonts with spaces in their names (e.g., "Noto Emoji", "DejaVu Sans"). Font file search patterns now match both with and without spaces.
+- ([#14120](https://github.com/quarto-dev/quarto-cli/pull/14120)): Fix code-tools show/hide all code buttons, and allow them to act on cells with `output: asis`
 
 ## Dependencies
 

--- a/src/resources/formats/html/templates/quarto-html-after-body.ejs
+++ b/src/resources/formats/html/templates/quarto-html-after-body.ejs
@@ -149,26 +149,9 @@
     }
     function toggleCodeHandler(show) {
       return function(e) {
-        const detailsSrc = window.document.querySelectorAll(".cell > details > .sourceCode");
-        for (let i=0; i<detailsSrc.length; i++) {
-          const details = detailsSrc[i].parentElement;
-          if (show) {
-            details.open = true;
-          } else {
-            details.removeAttribute("open");
-          }
-        }
-        const cellCodeDivs = window.document.querySelectorAll(".cell > .sourceCode");
-        const fromCls = show ? "hidden" : "unhidden";
-        const toCls = show ? "unhidden" : "hidden";
-        for (let i=0; i<cellCodeDivs.length; i++) {
-          const codeDiv = cellCodeDivs[i];
-          if (codeDiv.classList.contains(fromCls)) {
-            codeDiv.classList.remove(fromCls);
-            codeDiv.classList.add(toCls);
-          } 
-        }
-        return false;
+        document.querySelectorAll("details.code-fold").forEach((details) => {
+          details.toggleAttribute("open", show);
+        });
       }
     }
     const hideAllCode = window.document.getElementById("quarto-hide-all-code");


### PR DESCRIPTION
## Description

Originally this fix was to allow code cells with `output: asis` to open/close with the codetools menu buttons. But I rebased it onto main and found out that code-tools show/hide all code doesn't work at all. So I've fixed that too.

I'm also like 90% sure that the rest of the function was dead code, so I've removed it. If it at one point did something, it no longer works. Let me know if it was supposed to do something I can add it back.

This is one of the fixes mentioned in #13946 (I would still appreciate feedback on that discussion).

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [x] updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
