### PR TITLE
fix: remove dead add_typst_font_path Lua API

### DIFF
--- a/src/resources/pandoc/datadir/init.lua
+++ b/src/resources/pandoc/datadir/init.lua
@@ -914,11 +914,6 @@ quarto = {
       writeToDependencyFile(dependency("usepackage", {package = package, options = options }))
     end,
 
-    -- could be add_metadata(namespace, {stuff})
-    add_typst_font_path = function(path)
-      writeToDependencyFile(dependency("typst-font-path", {path = path}))
-    end,
-
     add_format_resource = function(path)
       writeToDependencyFile(dependency("format-resources", { file = resolvePathExt(path)}))
     end,


### PR DESCRIPTION
## Summary

- Removes the dead `quarto.doc.add_typst_font_path()` Lua API from `init.lua`
- The TypeScript-side handler for `"typst-font-path"` dependencies was removed in 7bac8f0f when Typst font handling moved from Lua to TypeScript, but the Lua API declaration was missed
- No functionality is affected — this was unreachable dead code

Closes #13521