### PR TITLE
Fix `tbl-column: margin` for Typst output

### DIFF
--- a/src/core/handlers/base.ts
+++ b/src/core/handlers/base.ts
@@ -862,10 +862,10 @@ export function getDivAttributes(
     classes.push(`tbl-cap-location-${options?.[kTblCapLoc]}`);
   }
   if (typeof options?.[kCellFigColumn] === "string") {
-    classes.push(`fig-caption-${options?.[kCellFigColumn]}`);
+    classes.push(`fig-column-${options?.[kCellFigColumn]}`);
   }
   if (typeof options?.[kCellTblColumn] === "string") {
-    classes.push(`fig-caption-${options?.[kCellTblColumn]}`);
+    classes.push(`tbl-column-${options?.[kCellTblColumn]}`);
   }
   return { attrs, classes };
 }

--- a/src/resources/filters/layout/columns-preprocess.lua
+++ b/src/resources/filters/layout/columns-preprocess.lua
@@ -7,6 +7,11 @@ function columns_preprocess()
       if float.parent_id ~= nil then
         return nil
       end
+      -- Apply scoped column classes from document-level options (e.g. fig-column, tbl-column)
+      -- This ensures the column class reaches the float directly, rather than relying
+      -- on the Div propagation chain which can fail for some float types
+      local ref = ref_type_from_float(float)
+      resolveElementForScopedColumns(float, ref)
       -- Check for margin figure placement (.column-margin or .aside class)
       if hasMarginColumn(float) then
         noteHasColumns()

--- a/tests/docs/smoke-all/typst/margin-layout/fig-column-margin.qmd
+++ b/tests/docs/smoke-all/typst/margin-layout/fig-column-margin.qmd
@@ -1,0 +1,52 @@
+---
+title: "Fig-Column Margin Test"
+papersize: us-letter
+fig-column: margin
+format:
+  html: default
+  typst:
+    keep-typ: true
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+        # Figure should use notefigure for margin placement
+        - ['#notefigure\(', 'kind: "quarto-float-fig"']
+        - []
+      ensurePdfRegexMatches:
+        - ['Table 1', 'TBL-BODY-CAP', 'TBL-BODY-MARKER']
+        - []
+      ensurePdfTextPositions:
+        - # Table stays in body, not pushed to margin
+          - subject: "TBL-BODY-MARKER"
+            relation: below
+            object: "BODY-TEXT-MARKER"
+        - # Table should NOT be right of body text (not in margin)
+          - subject: "TBL-BODY-MARKER"
+            relation: rightOf
+            object: "BODY-TEXT-MARKER"
+      noErrors: default
+---
+
+BODY-TEXT-MARKER: This tests the document-level `fig-column: margin` option. Figures should go to the margin; tables should stay in the body.
+
+```{r}
+#| label: fig-fc-test
+#| fig-cap: "FIG-COL-MARGIN-CAP"
+#| echo: false
+library(ggplot2)
+ggplot(mtcars, aes(x = wt, y = mpg)) +
+  geom_point() +
+  theme_minimal()
+```
+
+```{r}
+#| label: tbl-fc-test
+#| tbl-cap: "TBL-BODY-CAP"
+#| echo: false
+knitr::kable(
+  data.frame(Item = c("TBL-BODY-MARKER", "Row2"), Value = c(10, 20))
+)
+```
+
+The figure should be in the margin and the table in the body.

--- a/tests/docs/smoke-all/typst/margin-layout/tbl-column-margin.qmd
+++ b/tests/docs/smoke-all/typst/margin-layout/tbl-column-margin.qmd
@@ -1,0 +1,49 @@
+---
+title: "Tbl-Column Margin Test"
+papersize: us-letter
+tbl-column: margin
+format:
+  html: default
+  typst:
+    keep-typ: true
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+        # Table should use notefigure for margin placement
+        - ['#notefigure\(', 'kind: "quarto-float-tbl"']
+        - []
+      ensurePdfRegexMatches:
+        - ['Table 1', 'TblColMarginCap', 'Alpha']
+        - []
+      ensurePdfTextPositions:
+        - # Table text should be in the margin, right of body text
+          - subject: "Alpha"
+            relation: rightOf
+            object: "BODYTEXT"
+        - []
+      noErrors: default
+---
+
+BODYTEXT: This tests the document-level `tbl-column: margin` option. Tables should go to the margin; figures should stay in the body.
+
+```{r}
+#| label: fig-tc-test
+#| fig-cap: "FigBodyCap"
+#| echo: false
+library(ggplot2)
+ggplot(mtcars, aes(x = wt, y = mpg)) +
+  geom_point() +
+  theme_minimal()
+```
+
+```{r}
+#| label: tbl-tc-test
+#| tbl-cap: "TblColMarginCap"
+#| echo: false
+knitr::kable(
+  data.frame(Item = c("Alpha", "Beta"), Value = c(10, 20))
+)
+```
+
+The table should be in the margin and the figure in the body.


### PR DESCRIPTION
## Summary

Closes #13929.

- Apply scoped column classes (`fig-column`, `tbl-column`) directly to FloatRefTargets in `columns-preprocess.lua`, bypassing the Div propagation chain which silently failed for tables
- Fix copy-paste bug in `base.ts` where `fig-caption-` prefix was used instead of `fig-column-`/`tbl-column-` (affects OJS/generic engine path)
- Add smoke tests for both `tbl-column: margin` and `fig-column: margin` document-level options

## Test plan

- [x] `tbl-column-margin.qmd` — verifies tables go to margin (`#notefigure()` in .typ, spatial position in PDF)
- [x] `fig-column-margin.qmd` — verifies figures go to margin, tables stay in body
- [x] 12 existing margin-layout regression tests pass (margin-table, margin-figure, margin-caption, column-widths)