### PR TITLE
fix(typst): left-align cross-ref callouts

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -57,6 +57,7 @@ All changes included in 1.9:
 
 ### `typst`
 
+- ([#12803](https://github.com/quarto-dev/quarto-cli/issues/12803)): Fix callout text being centered instead of left-aligned when callout has a cross-reference ID prefix (e.g., `#tip-abc`).
 - ([#13249](https://github.com/quarto-dev/quarto-cli/pull/13249)): Update to Pandoc's Typst template following Pandoc 3.8.3 and Typst 0.14.2 support:
   - Code syntax highlighting now uses Skylighting by default.
   - New template variables `mathfont`, `codefont`, and `linestretch` for font and line spacing customization.

--- a/src/resources/formats/typst/pandoc/quarto/definitions.typ
+++ b/src/resources/formats/typst/pandoc/quarto/definitions.typ
@@ -163,9 +163,9 @@
         children.at(0) + new_title  // with icon: preserve icon block + new title
       }))
 
-  block_with_new_content(old_callout,
+  align(left, block_with_new_content(old_callout,
     block(below: 0pt, new_title_block) +
-    old_callout.body.children.at(1))
+    old_callout.body.children.at(1)))
 }
 
 // 2023-10-09: #fa-icon("fa-info") is not working, so we'll eval "#fa-info()" instead

--- a/src/resources/formats/typst/pandoc/quarto/definitions.typ
+++ b/src/resources/formats/typst/pandoc/quarto/definitions.typ
@@ -41,15 +41,14 @@
   )
 
 #let block_with_new_content(old_block, new_content) = {
-  let d = (:)
   let fields = old_block.fields()
-  fields.remove("body")
+  let _ = fields.remove("body")
   if fields.at("below", default: none) != none {
     // TODO: this is a hack because below is a "synthesized element"
     // according to the experts in the typst discord...
     fields.below = fields.below.abs
   }
-  return block.with(..fields)(new_content)
+  block.with(..fields)(new_content)
 }
 
 #let empty(v) = {

--- a/tests/docs/smoke-all/typst/callout-paragraph-alignment.qmd
+++ b/tests/docs/smoke-all/typst/callout-paragraph-alignment.qmd
@@ -1,0 +1,25 @@
+---
+title: "Callout Paragraph Alignment"
+format:
+  typst:
+    keep-typ: true
+_quarto:
+  tests:
+    typst:
+      ensurePdfTextPositions:
+        - # Paragraphs inside cross-referenced callout should be left-aligned
+          - subject: "ShortLine"
+            relation: leftAligned
+            object: "LongerParagraph with additional words"
+            tolerance: 2
+        - []
+      noErrors: default
+---
+
+::: {.callout-tip #tip-alignment}
+## Alignment Test
+
+ShortLine
+
+LongerParagraph with additional words filling out this line.
+:::


### PR DESCRIPTION
Corrects the text alignment issue in typst format's callouts when using a prefix. The text was previously centred, and this change ensures it is left-aligned as expected. Fixes #12803

This also fix the warning arising inside cross-reference callouts because the discarded element was not caught thus the explicit call to `return`.
