### PR TITLE
Fix caption used as fallback alt text in PDF/UA

### DIFF
--- a/src/command/render/latexmk/parse-error.ts
+++ b/src/command/render/latexmk/parse-error.ts
@@ -125,8 +125,10 @@ export function findPdfAccessibilityWarnings(
 
   // Match: Package tagpdf Warning: Alternative text for graphic is missing.
   //        (tagpdf)                Using 'filename' instead.
+  // Note: tagpdf wraps long filenames across multiple (tagpdf) continuation
+  // lines, so we allow optional line breaks with (tagpdf) prefixes.
   const altTextRegex =
-    /Package tagpdf Warning: Alternative text for graphic is missing\.\s*\n\(tagpdf\)\s*Using ['`]([^'`]+)['`] instead\./g;
+    /Package tagpdf Warning: Alternative text for graphic is missing\.\s*\n\(tagpdf\)\s*Using ['`]([^'`]+)['`]\s*(?:\n\(tagpdf\)\s*)?instead\./g;
   let match;
   while ((match = altTextRegex.exec(logText)) !== null) {
     result.missingAltText.push(match[1]);

--- a/src/command/render/latexmk/pdf.ts
+++ b/src/command/render/latexmk/pdf.ts
@@ -204,7 +204,7 @@ async function initialCompileLatex(
       if (accessibilityWarnings.missingAltText.length > 0) {
         const fileList = accessibilityWarnings.missingAltText.join(", ");
         warning(
-          `PDF accessibility: Missing alt text for image(s): ${fileList}. Add alt text using ![alt text](image.png) syntax for PDF/UA compliance.\n`,
+          `PDF accessibility: Missing alt text for image(s): ${fileList}. Add alt text using fig-alt in YAML or {fig-alt="description"} on the image for PDF/UA compliance.\n`,
         );
       }
       if (accessibilityWarnings.missingLanguage) {

--- a/src/resources/filters/customnodes/floatreftarget.lua
+++ b/src/resources/filters/customnodes/floatreftarget.lua
@@ -978,6 +978,22 @@ end, function(float)
   local kind = "quarto-float-" .. ref
   local supplement = titleString(ref, info.name)
 
+  -- For figures: mark images so typst.lua won't use caption-as-alt fallback
+  -- when caption IS the visible figure caption (not an explicit alt override).
+  -- In Pandoc 3, {alt="text"} replaces image.caption with the alt value,
+  -- so image.caption != float.caption means an explicit alt was provided.
+  if ref == "fig" then
+    local float_caption_text = pandoc.utils.stringify(float.caption_long or {})
+    float.content = _quarto.ast.walk(float.content, {
+      Image = function(img)
+        if pandoc.utils.stringify(img.caption) == float_caption_text then
+          img.attributes["_quarto_no_caption_alt"] = "true"
+        end
+        return img
+      end
+    })
+  end
+
   -- Inject show rule to left-align listing figures (only once per document)
   -- This overrides any template centering for listing-kind figures
   -- https://github.com/quarto-dev/quarto-cli/issues/9724

--- a/src/resources/filters/layout/latex.lua
+++ b/src/resources/filters/layout/latex.lua
@@ -332,10 +332,6 @@ function latexCell(cell, vAlign, endOfRow, endOfTable)
     -- see if it's a captioned figure
     if image and #image.caption > 0 then
       caption = image.caption:clone()
-      -- preserve caption as alt attribute for PDF accessibility before clearing
-      if not image.attributes["alt"] then
-        image.attributes["alt"] = pandoc.utils.stringify(image.caption)
-      end
       tclear(image.caption)
     elseif tbl then
       caption = pandoc.utils.blocks_to_inlines(tbl.caption.long)
@@ -384,10 +380,6 @@ function latexCell(cell, vAlign, endOfRow, endOfTable)
     if image and #image.caption > 0 then
       local caption = image.caption:clone()
       markupLatexCaption(cell, caption)
-      -- preserve caption as alt attribute for PDF accessibility before clearing
-      if not image.attributes["alt"] then
-        image.attributes["alt"] = pandoc.utils.stringify(image.caption)
-      end
       tclear(image.caption)
       content:insert(pandoc.RawBlock("latex", "\\raisebox{-\\height}{"))
       content:insert(pandoc.Para(image))
@@ -669,10 +661,6 @@ function latexImageFigure(image)
 
     -- make a copy of the caption and clear it
     local caption = image.caption:clone()
-    -- preserve caption as alt attribute for PDF accessibility before clearing
-    if #image.caption > 0 and not image.attributes["alt"] then
-      image.attributes["alt"] = pandoc.utils.stringify(image.caption)
-    end
     tclear(image.caption)
     
     -- get align

--- a/src/resources/filters/layout/pandoc3_figure.lua
+++ b/src/resources/filters/layout/pandoc3_figure.lua
@@ -146,6 +146,13 @@ function render_pandoc3_figure()
       for k, v in pairs(figure.attributes) do
         image.attributes[k] = v
       end
+      -- Convert fig-alt to alt for LaTeX \includegraphics[alt=...]
+      if image.attributes[kFigAlt] then
+        if not image.attributes["alt"] then
+          image.attributes["alt"] = image.attributes[kFigAlt]
+        end
+        image.attributes[kFigAlt] = nil
+      end
       if subfig then
         image.attributes['quarto-caption-env'] = 'subcaption'
       end
@@ -170,6 +177,26 @@ function render_pandoc3_figure()
     return {
       traverse = "topdown",
       Figure = function(figure)
+        -- For figure images: prevent caption-as-alt fallback when caption IS the
+        -- visible figure caption (not an explicit alt override via {alt="..."}).
+        -- In Pandoc 3, {alt="text"} replaces image.caption with the alt value,
+        -- so image.caption != figure.caption means an explicit alt was provided.
+        -- Also propagate fig-alt from figure to image for accessibility.
+        local figure_caption_text = pandoc.utils.stringify(figure.caption.long)
+        local fig_alt = figure.attributes[kFigAlt]
+        for _, block in ipairs(figure.content) do
+          if block.t == "Plain" or block.t == "Para" then
+            for _, inline in ipairs(block.content) do
+              if inline.t == "Image" then
+                if fig_alt then
+                  inline.attributes[kFigAlt] = fig_alt
+                elseif pandoc.utils.stringify(inline.caption) == figure_caption_text then
+                  inline.attributes["_quarto_no_caption_alt"] = "true"
+                end
+              end
+            end
+          end
+        end
         return make_typst_figure({
           content = figure.content[1],
           caption = figure.caption.long[1],

--- a/src/resources/filters/quarto-post/typst.lua
+++ b/src/resources/filters/quarto-post/typst.lua
@@ -232,7 +232,11 @@ function render_typst_fixups()
       if alt_text then
         image.attributes[kFigAlt] = nil
       end
-      if (alt_text == nil or alt_text == "") and #image.caption > 0 then
+      -- Use caption as alt only for inline images (not figures)
+      -- Figure images are marked with _quarto_no_caption_alt by layout filters
+      local no_caption_alt = image.attributes["_quarto_no_caption_alt"]
+      image.attributes["_quarto_no_caption_alt"] = nil
+      if (alt_text == nil or alt_text == "") and #image.caption > 0 and not no_caption_alt then
         alt_text = pandoc.utils.stringify(image.caption)
       end
 

--- a/tests/docs/smoke-all/pdf-standard/caption-not-alt-ua.qmd
+++ b/tests/docs/smoke-all/pdf-standard/caption-not-alt-ua.qmd
@@ -1,0 +1,32 @@
+---
+title: "Caption should not be used as fallback alt text"
+lang: en
+format:
+  pdf:
+    pdf-standard: ua-2
+    keep-tex: true
+  typst:
+    pdf-standard: ua-1
+    keep-typ: true
+_quarto:
+  tests:
+    run:
+      # verapdf validation not available on Windows CI
+      not_os: windows
+    pdf:
+      noErrors: default
+      ensureLatexFileRegexMatches:
+        - ['\\DocumentMetadata\{', 'pdfstandard=\{ua-2\}', 'tagging=on']
+        - # Caption must NOT appear as alt text on \includegraphics
+          ['includegraphics\[.*alt=']
+    typst:
+      # Typst's own PDF/UA enforcement errors on missing alt
+      shouldError: default
+---
+
+# Caption is not alt text
+
+A figure with a caption but no explicit `fig-alt`.
+The caption should NOT be copied into alt text.
+
+![This is a caption, not alt text](penrose.svg)

--- a/tests/docs/smoke-all/pdf-standard/caption-not-alt-ua.qmd
+++ b/tests/docs/smoke-all/pdf-standard/caption-not-alt-ua.qmd
@@ -19,6 +19,11 @@ _quarto:
         - ['\\DocumentMetadata\{', 'pdfstandard=\{ua-2\}', 'tagging=on']
         - # Caption must NOT appear as alt text on \includegraphics
           ['includegraphics\[.*alt=']
+      printsMessage:
+        # tagpdf warns about missing alt text and falls back to filename;
+        # Quarto surfaces this as a user-facing warning
+        level: WARN
+        regex: "PDF accessibility:.*Missing alt text"
     typst:
       # Typst's own PDF/UA enforcement errors on missing alt
       shouldError: default
@@ -29,4 +34,8 @@ _quarto:
 A figure with a caption but no explicit `fig-alt`.
 The caption should NOT be copied into alt text.
 
-![This is a caption, not alt text](penrose.svg)
+Uses a cross-ref label to go through FloatRefTarget, which produces
+valid UA-2 structure. See `ua2-unlabeled-figure-caption.qmd` for the
+known structural issue with unlabeled captioned figures.
+
+![This is a caption, not alt text](penrose.svg){#fig-test}

--- a/tests/docs/smoke-all/pdf-standard/tc8-fig-alt.svg
+++ b/tests/docs/smoke-all/pdf-standard/tc8-fig-alt.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <!-- Simplified Penrose-style kite and dart pattern -->
+  <defs>
+    <polygon id="kite" points="50,0 95,35 50,100 5,35" fill="#4a90d9" stroke="#1a365d" stroke-width="1"/>
+    <polygon id="dart" points="50,0 80,50 50,35 20,50" fill="#f0c040" stroke="#8b6914" stroke-width="1"/>
+  </defs>
+  <g transform="translate(0,0) scale(0.5)">
+    <use href="#kite" transform="translate(0,0)"/>
+    <use href="#dart" transform="translate(50,0) rotate(36,50,50)"/>
+    <use href="#kite" transform="translate(100,0) rotate(72,50,50)"/>
+  </g>
+  <g transform="translate(25,50) scale(0.5)">
+    <use href="#dart" transform="translate(0,0) rotate(-36,50,50)"/>
+    <use href="#kite" transform="translate(50,0)"/>
+  </g>
+</svg>

--- a/tests/docs/smoke-all/pdf-standard/typst-image-alt-text.qmd
+++ b/tests/docs/smoke-all/pdf-standard/typst-image-alt-text.qmd
@@ -9,7 +9,6 @@ _quarto:
       noErrors: default
       ensureTypstFileRegexMatches:
         - # Patterns that MUST be found - alt text in image() calls
-          - 'image\("tc1-figure\.svg",\s*alt:\s*"TC1 figure caption as alt'
           - 'image\("tc2-inline\.svg",\s*alt:\s*"TC2 inline image'
           - 'image\("tc3-explicit\.svg",\s*alt:\s*"TC3 explicit alt attribute'
           - 'image\("tc4-dimensions\.svg",\s*alt:\s*"TC4 with dimensions",\s*height:\s*1in,\s*width:\s*1in'
@@ -17,7 +16,11 @@ _quarto:
           - 'image\("tc6-backslash\.svg",\s*alt:\s*"TC6 backslash C:\\\\path'
           # TC7 should have the image but without alt parameter
           - 'image\("tc7-no-alt\.svg"\)'
+          # TC8: Explicit fig-alt should produce alt text
+          - 'image\("tc8-fig-alt\.svg",\s*alt:\s*"TC8 explicit fig-alt'
         - # Patterns that must NOT be found
+          # TC1 figure caption should NOT be used as alt text
+          - 'tc1-figure\.svg.*alt:.*TC1 figure caption'
           # TC7 with no caption/alt should NOT have alt parameter
           - 'tc7-no-alt\.svg.*alt:'
 ---
@@ -55,3 +58,7 @@ Here is ![TC4 with dimensions](tc4-dimensions.svg){width=1in height=1in} inline.
 This image has no caption and no alt attribute.
 
 ![](tc7-no-alt.svg)
+
+## TC8: Explicit fig-alt on a figure
+
+![TC8 visible caption](tc8-fig-alt.svg){fig-alt="TC8 explicit fig-alt description"}

--- a/tests/docs/smoke-all/pdf-standard/ua-image-alt-text.qmd
+++ b/tests/docs/smoke-all/pdf-standard/ua-image-alt-text.qmd
@@ -32,4 +32,4 @@ _quarto:
 
 This image has alt text which should be passed through for PDF/UA compliance.
 
-![Test image description](penrose.svg)
+![Test image description](penrose.svg){fig-alt="A Penrose tiling pattern"}

--- a/tests/docs/smoke-all/pdf-standard/ua2-unlabeled-figure-caption.qmd
+++ b/tests/docs/smoke-all/pdf-standard/ua2-unlabeled-figure-caption.qmd
@@ -1,0 +1,47 @@
+---
+title: "UA-2: unlabeled figure caption produces invalid structure"
+lang: en
+format:
+  pdf:
+    pdf-standard: ua-2
+    keep-tex: true
+_quarto:
+  tests:
+    run:
+      # verapdf validation not available on Windows CI
+      not_os: windows
+    pdf:
+      noErrors: default
+      ensureLatexFileRegexMatches:
+        - ['\\DocumentMetadata\{', 'pdfstandard=\{ua-2\}', 'tagging=on']
+        - []
+      printsMessage:
+        # Known issue: unlabeled captioned figures go through pandoc3_figure.lua
+        # which produces a bare \begin{figure}[H] environment. LaTeX's tagpdf
+        # places <Caption> as a sibling of <Figure> under <Document> instead of
+        # nesting them inside a grouping element. This violates UA-2 which
+        # requires <Caption> to be a child of <Figure>, <Table>, or <Formula>.
+        #
+        # Labeled figures ({#fig-label}) go through FloatRefTarget, which wraps
+        # the figure in a \Div that provides the grouping context tagpdf needs.
+        #
+        # Structure produced (invalid):
+        #   /Document
+        #     /Caption    <- should be inside a grouping element
+        #     /Figure     <- sibling instead of parent
+        #
+        # Expected (valid, as produced by labeled figures):
+        #   /Document
+        #     /Div
+        #       /Caption  <- properly nested
+        #       /Figure
+        level: WARN
+        regex: "PDF validation failed for ua-2"
+---
+
+# Known LaTeX tagging limitation
+
+An unlabeled captioned figure produces invalid UA-2 structure because
+tagpdf does not nest `<Caption>` inside a grouping element.
+
+![This is a caption on an unlabeled figure](penrose.svg)


### PR DESCRIPTION
## Summary

Removes the anti-pattern where figure captions are copied into image alt text for PDF/UA compliance. Captions describe a figure's significance in context; alt text describes what the image looks like. Using one as the other is an accessibility anti-pattern that merely silences validators without helping screen reader users.

This was introduced in the Jan 2026 PDF/UA work (commits `a867c3c24` and `ba75b374f`) to satisfy PDF/UA validators, which require every `<Figure>` structure element to have an `/Alt` string.

Fixes #14107

## What changed

**LaTeX** (`latex.lua`): Removed 3 caption-as-alt blocks that copied `image.caption` into `image.attributes["alt"]` before clearing the caption for separate rendering.

**Typst** (`pandoc3_figure.lua`, `floatreftarget.lua`, `typst.lua`): Used a marker attribute (`_quarto_no_caption_alt`) to prevent the caption-as-alt fallback for figure images, while preserving it for inline images where `image.caption` IS the standard markdown alt text (`![alt text](img.svg)` in running text).

The distinction matters because of how Pandoc 3 represents alt text in its AST.

## Pandoc 3 AST analysis

In Pandoc 3, `{alt="text"}` on an image does **not** set `image.attributes["alt"]` — it **replaces** `image.caption` with the alt value. The `![visible caption]` text moves to `figure.caption.long`, while `image.caption` becomes the alt text. This means `image.caption` serves double duty:

- **Inline images**: `image.caption` IS the alt text (the `![...]` content is alt by the HTML spec)
- **Figure images**: `image.caption` is a copy of the visible caption (unless overridden by `{alt="..."}`)

To distinguish these cases, we compare `image.caption` to the figure's visible caption (`figure.caption.long` or `float.caption_long`). If they match, no explicit alt was provided — we set `_quarto_no_caption_alt` to suppress the fallback. If they differ, `{alt="..."}` was used and `image.caption` IS the explicit alt text.

This is the same heuristic Pandoc's own Markdown writer uses (confirmed via [Pandoc source](https://github.com/jgm/pandoc/blob/main/src/Text/Pandoc/Writers/Markdown.hs) — it compares image alt to figure caption to decide whether to emit `{alt="..."}`). Pandoc itself acknowledges the ambiguity: the AST cannot distinguish "caption that happens to match alt" from "no explicit alt provided." The recommended workaround is Quarto's `fig-alt` attribute, which flows through a separate, unambiguous path.

## How `fig-alt` vs `alt` work

- **`{alt="text"}`**: Pandoc replaces `image.caption`, no separate attribute. Works but ambiguous when caption and alt are intentionally identical.
- **`{fig-alt="text"}`**: Quarto stores as `image.attributes["fig-alt"]`, propagated explicitly to `\includegraphics[alt=...]` (LaTeX) or `image(alt: "...")` (Typst). Always unambiguous. This is the recommended approach.

## Test plan

- `caption-not-alt-ua.qmd` — verifies caption is NOT copied to `\includegraphics[alt=]` and that Quarto warns about missing alt text
- `typst-image-alt-text.qmd` — TC1 moved to must-not-match; TC8 added for `fig-alt`
- `ua-image-alt-text.qmd` — now uses explicit `fig-alt` 
- All 39 pdf-standard tests pass