### PR TITLE
Fix CI: install rsvg-convert and verapdf when running all tests

### DIFF
--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Install rsvg-convert for SVG conversion tests
         # Only do it on linux runner, and only if we are running the relevant tests
-        if: runner.os == 'Linux' && (contains(inputs.buckets, 'render-pdf-svg-conversion') || contains(inputs.buckets, 'pdf-standard'))
+        if: runner.os == 'Linux' && (format('{0}', inputs.buckets) == '' || contains(inputs.buckets, 'render-pdf-svg-conversion') || contains(inputs.buckets, 'pdf-standard'))
         run: |
           sudo apt-get update -y
           sudo apt-get install -y librsvg2-bin
@@ -202,7 +202,7 @@ jobs:
           quarto install tinytex
 
       - name: Install veraPDF for PDF standard validation
-        if: runner.os == 'Linux' && contains(inputs.buckets, 'pdf-standard')
+        if: runner.os == 'Linux' && (format('{0}', inputs.buckets) == '' || contains(inputs.buckets, 'pdf-standard'))
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
`update-test-timing.yml` and daily `test-smokes.yml` schedule runs pass `buckets: ""` (run all tests), but `rsvg-convert` and `verapdf` were only installed when `inputs.buckets` contained specific bucket name strings like `render-pdf-svg-conversion` or `pdf-standard`. This caused 4 `pdf-standard/ua-*` tests to fail on every scheduled run since Jan 26, 2026.

## Root Cause

The conditional install steps used `contains(inputs.buckets, '...')` which is false when `buckets` is empty. Parallel smoke test runs pass because each bucket string contains the test file paths which match the condition.

Failing tests:
- `ua-missing-alt.qmd`, `ua-image-alt-text.qmd`, `ua-figure-missing-alt.qmd` — missing `rsvg-convert` for SVG-to-PDF conversion
- `ua-missing-title.qmd` — missing `verapdf` for PDF/UA validation warnings

## Fix

Add `format('{0}', inputs.buckets) == ''` to both install conditions, using the same pattern already used elsewhere in this workflow (lines 253, 262) to detect all-tests mode.

Fixes weekly `update-test-timing.yml` failures and daily schedule failures.