### PR TITLE
Fix `quarto preview subdir/file.qmd` crashing with doubled path

### DIFF
--- a/src/command/render/render.ts
+++ b/src/command/render/render.ts
@@ -385,8 +385,24 @@ export async function renderPandoc(
           ));
       }
 
-      // if there is a project context then return paths relative to the project
-      const projectPath = (path: string) => {
+      // Compute the project-relative path for the input source file.
+      // Uses normalizePath to handle both relative and absolute source paths.
+      const projectRelativeInput = (sourcePath: string) => {
+        if (context.project) {
+          return relative(
+            normalizePath(context.project.dir),
+            normalizePath(sourcePath),
+          );
+        }
+        return sourcePath;
+      };
+
+      // Resolve an output file path to a project-relative path.
+      // Output paths (like "page.html") are relative to the source file's
+      // directory, so we join with dirname(target.source) before computing
+      // the project-relative result. Absolute output paths pass through
+      // normalizePath directly.
+      const projectOutputPath = (path: string) => {
         if (context.project) {
           if (isAbsolute(path)) {
             return relative(
@@ -411,7 +427,7 @@ export async function renderPandoc(
 
       const result: RenderedFile = {
         isTransient: recipe.isOutputTransient,
-        input: projectPath(context.target.source),
+        input: projectRelativeInput(context.target.source),
         markdown: executeResult.markdown,
         format,
         supporting: supporting
@@ -421,7 +437,7 @@ export async function renderPandoc(
           : undefined,
         file: recipe.isOutputTransient
           ? finalOutput!
-          : projectPath(finalOutput!),
+          : projectOutputPath(finalOutput!),
         resourceFiles: {
           globs: pandocResult.resources,
           files,

--- a/tests/unit/project/file-information-cache.test.ts
+++ b/tests/unit/project/file-information-cache.test.ts
@@ -9,7 +9,7 @@
 
 import { unitTest } from "../../test.ts";
 import { assert } from "testing/asserts";
-import { join } from "../../../src/deno_ral/path.ts";
+import { join, relative } from "../../../src/deno_ral/path.ts";
 import {
   ensureFileInformationCache,
   FileInformationCacheMap,
@@ -104,6 +104,29 @@ unitTest(
     assert(
       project.fileInformationCache instanceof FileInformationCacheMap,
       "Should create FileInformationCacheMap, not plain Map",
+    );
+  },
+);
+
+// deno-lint-ignore require-await
+unitTest(
+  "fileInformationCache - relative and absolute paths share same entry",
+  async () => {
+    const project = createMockProjectContext();
+
+    const absolutePath = join(project.dir, "subdir", "page.qmd");
+    const relativePath = relative(Deno.cwd(), absolutePath);
+
+    const entry1 = ensureFileInformationCache(project, relativePath);
+    const entry2 = ensureFileInformationCache(project, absolutePath);
+
+    assert(
+      entry1 === entry2,
+      "Relative and absolute paths to same file should share a cache entry",
+    );
+    assert(
+      project.fileInformationCache.size === 1,
+      "Should have exactly one cache entry",
     );
   },
 );


### PR DESCRIPTION
`quarto preview subdir/page.qmd` in a website project crashes with `readfile subdir\subdir\page.qmd` — a doubled path. `quarto render` works fine.

## Root Cause

Preview makes two render calls: `renderFormats` (receives the original relative path) then `renderProject` (normalizes to absolute). The first call creates a cached `ExecutionTarget` with `source: "subdir/page.qmd"`. The second gets a cache hit with the stale relative source.

`projectPath()` was designed for output filenames — it resolves relative paths via `join(dirname(target.source), path)`.
https://github.com/quarto-dev/quarto-cli/blob/0f97e0540fbb1c28dd9d0215095e7bcca937d531/src/command/render/render.ts#L389-L405

But then, `context.target.source` itself is passed through this function.
https://github.com/quarto-dev/quarto-cli/blob/0f97e0540fbb1c28dd9d0215095e7bcca937d531/src/command/render/render.ts#L414

When `target.source` was relative, `dirname + join` doubled the subdirectory:

```
join(dirname("subdir/page.qmd"), "subdir/page.qmd") → "subdir/subdir/page.qmd"
```

`projectPath(finalOutput!)` is used correctly though — output filenames like `page.html` do need the `dirname + join` resolution.
https://github.com/quarto-dev/quarto-cli/blob/0f97e0540fbb1c28dd9d0215095e7bcca937d531/src/command/render/render.ts#L424

## Fix

Split `projectPath` into two functions with distinct responsibilities:

- `projectRelativeInput(sourcePath)` — for the source file path. Uses `normalizePath` directly, which handles both relative and absolute paths, because our `normalizePath` function does make path absolute if not.
- `projectOutputPath(path)` — for output filenames (like `page.html`). Preserves the existing `dirname + join` logic since output names are relative to the source directory.

## Bisect

Last good: v1.9.17. First bad: v1.9.18 (77633b39a).

## Related

Follow up on preview fixes that introduced this

- https://github.com/quarto-dev/quarto-cli/pull/13967 (for issue https://github.com/quarto-dev/quarto-cli/issues/13955)

which was a regression of broader quarto preview behavior change

- https://github.com/quarto-dev/quarto-cli/pull/13804

Also, in a way related to this observation we've done since new single project context is out

- https://github.com/quarto-dev/quarto-cli/pull/12401