### PR TITLE
Fix meta shortcode truncating multi-word values in raw HTML contexts

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -65,7 +65,9 @@ For external contributors (not core team):
 
 ## Regression Fixes
 
-**What qualifies:** Bugs introduced in recent versions (same major.minor)
+**What qualifies:** Bugs introduced in a previous major.minor version (e.g., a 1.8 feature that broke in 1.9)
+
+**Skip changelog entirely** when the regression was introduced by another change in the same version cycle. For example, if a 1.9 bug fix introduced a new bug also fixed in 1.9, the fix does not need a changelog entry — the original entry covers the feature area.
 
 **Placement:** Always at TOP of the file, before Dependencies
 

--- a/.claude/rules/testing/smoke-all-tests.md
+++ b/.claude/rules/testing/smoke-all-tests.md
@@ -63,6 +63,21 @@ _quarto:
         - ['\\begin\{figure\}']
 ```
 
+### Regex Match Array Format
+
+`ensureFileRegexMatches` (and variants like `ensureTypstFileRegexMatches`, `ensureLatexFileRegexMatches`) takes two arrays:
+
+```yaml
+ensureFileRegexMatches:
+  -                                   # First array: patterns that MUST match
+    - "pattern1"
+    - "pattern2"
+  -                                   # Second array (optional): patterns that must NOT match
+    - "forbidden-pattern"
+```
+
+Both patterns in the first array must be found. Any pattern in the second array causes failure if found.
+
 ### Message Verification
 
 Lua `warn()` appears as `level: INFO` on TypeScript side:

--- a/src/resources/filters/quarto-pre/shortcodes-handlers.lua
+++ b/src/resources/filters/quarto-pre/shortcodes-handlers.lua
@@ -267,8 +267,10 @@ function handleMeta(args, _kwargs, _meta, _raw_args, context)
       --
       -- differently to allow users to specify precisely the
       -- string they want to use.
-      if type(optionValue) == "table" and #optionValue > 0 and optionValue[1].t == "Str" then
+      if type(optionValue) == "table" and #optionValue == 1 and optionValue[1].t == "Str" then
         return optionValue[1].text
+      elseif pandoc.utils.type(optionValue) == "Inlines" then
+        return pandoc.utils.stringify(optionValue)
       else
         local blocks = pandoc.Blocks(optionValue)
         return pandoc.write(pandoc.Pandoc(blocks), "markdown")

--- a/tests/docs/smoke-all/2026/03/05/14159.qmd
+++ b/tests/docs/smoke-all/2026/03/05/14159.qmd
@@ -1,0 +1,20 @@
+---
+format: html
+my-value: Release Candidate
+include-after-body:
+  text: |
+    <script>window["test-include"] = '{{< meta my-value >}}';</script>
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        -
+          - "test-include.*Release Candidate"
+          - "test-rawblock.*Release Candidate"
+---
+
+Inline: {{< meta my-value >}}
+
+```{=html}
+<script>window["test-rawblock"] = '{{< meta my-value >}}';</script>
+```


### PR DESCRIPTION
When `{{< meta key >}}` appears in raw HTML contexts (include-after-body text blocks, raw HTML blocks), multi-word values are truncated to the first word. `"Release Candidate"` becomes `"Release"`.

## Root Cause

Shortcodes in raw text (RawBlock, CodeBlock, include text) are resolved by an lpeg parser that calls the handler with `context = "text"` and then stringifies the result (`customnodes/shortcodes.lua:247-248`). The `text` branch added by #14073 checked `#optionValue > 0` to handle single pandoc-native Str nodes, but this matched any non-empty Inlines list. For `[Str("Release"), Space, Str("Candidate")]`, only `optionValue[1].text` was returned.

## Fix

Narrow the guard to `#optionValue == 1` (exact single-Str match) and add an Inlines branch using `pandoc.utils.stringify()` which concatenates all inline elements. The Blocks path (`pandoc.write(markdown)`) is unchanged, preserving #14061 line-break behavior.

Fixes #14159