### PR TITLE
Add typst-gather 0.2.2 binary dependency

### DIFF
--- a/configuration
+++ b/configuration
@@ -17,6 +17,7 @@ export PANDOC=3.8.3
 export DARTSASS=1.87.0
 export ESBUILD=0.25.10
 export TYPST=0.14.2
+export TYPST_GATHER=0.2.2
 export VERAPDF=1.28.2
 
 

--- a/package/src/common/dependencies/dependencies.ts
+++ b/package/src/common/dependencies/dependencies.ts
@@ -15,6 +15,7 @@ import { esBuild } from "./esbuild.ts";
 import { pandoc } from "./pandoc.ts";
 import { archiveUrl } from "../archive-binary-dependencies.ts";
 import { typst } from "./typst.ts";
+import { typstGather } from "./typst-gather.ts";
 import { verapdf } from "./verapdf.ts";
 
 // The list of binary dependencies for Quarto
@@ -24,6 +25,7 @@ export const kDependencies = [
   dartSass(version("DARTSASS")),
   esBuild(version("ESBUILD")),
   typst(version("TYPST")),
+  typstGather(version("TYPST_GATHER")),
   verapdf(version("VERAPDF")),
 ];
 

--- a/package/src/common/dependencies/typst-gather.ts
+++ b/package/src/common/dependencies/typst-gather.ts
@@ -1,0 +1,58 @@
+
+import { join, dirname } from "../../../../src/deno_ral/path.ts"
+import { ensureDirSync, existsSync } from "../../../../src/deno_ral/fs.ts"
+
+import { Configuration } from "../config.ts";
+import { Dependency } from "./dependencies.ts";
+import { which } from "../../../../src/core/path.ts";
+import { unTar } from "../../util/tar.ts";
+
+export function typstGather(version: string): Dependency {
+  const typstGatherRelease = (filename: string) => {
+    return {
+      filename,
+      url: `https://github.com/quarto-dev/typst-gather/releases/download/v${version}/${filename}`,
+      configure: async (config: Configuration, path: string) => {
+        const file = config.os === "windows" ? "typst-gather.exe" : "typst-gather";
+        const vendor = Deno.env.get("QUARTO_VENDOR_BINARIES");
+        if (vendor === undefined || vendor === "true") {
+          const dir = dirname(path);
+          const targetDir = join(dir, config.arch);
+          ensureDirSync(targetDir);
+
+          // expand
+          await unTar(path);
+
+          // move the binary and cleanup
+          const extractedPath = join(dir, file);
+          Deno.renameSync(extractedPath, join(targetDir, file));
+        } else {
+          // verify that the binary is on PATH, but otherwise don't do anything
+          if (which(file) === undefined) {
+            throw new Error(
+              `${file} is not on PATH. Please install it and add it to PATH.`,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    name: "typst-gather",
+    bucket: "typst-gather",
+    version,
+    archiveOnly: true,
+    architectureDependencies: {
+      "x86_64": {
+        "windows": typstGatherRelease("typst-gather-x86_64-pc-windows-msvc.zip"),
+        "linux": typstGatherRelease("typst-gather-x86_64-unknown-linux-gnu.tar.gz"),
+        "darwin": typstGatherRelease("typst-gather-x86_64-apple-darwin.tar.gz"),
+      },
+      "aarch64": {
+        "linux": typstGatherRelease("typst-gather-aarch64-unknown-linux-gnu.tar.gz"),
+        "darwin": typstGatherRelease("typst-gather-aarch64-apple-darwin.tar.gz"),
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds [typst-gather](https://github.com/quarto-dev/typst-gather) v0.2.2 as a downloaded binary dependency, following the same pattern as Pandoc, Typst, esbuild, and other binary deps
- Pre-built binaries are fetched from GitHub releases for all 5 supported platform/arch combos (x86_64 + aarch64, Linux/macOS/Windows)
- This is a dependency-only prerequisite for #13983 (selective typst package staging)

## Files changed

- `configuration` — add `TYPST_GATHER=0.2.2`
- `package/src/common/dependencies/typst-gather.ts` — new dependency definition
- `package/src/common/dependencies/dependencies.ts` — register in dependency list

## Test plan

- [ ] Verify `./configure.sh` downloads the binary to `package/dist/bin/tools/<arch>/typst-gather`
- [ ] Verify `typst-gather --version` reports `0.2.2`
- [ ] Verify CI passes on all platforms