### PR TITLE
Fix intermittent smctl not found in signing workflow

### DIFF
--- a/.github/workflows/actions/sign-files/action.yml
+++ b/.github/workflows/actions/sign-files/action.yml
@@ -44,9 +44,43 @@ runs:
       run: |
         Write-Output "::group::Install smctl if needed"
         if (!(Get-Command smctl -ErrorAction SilentlyContinue)) {
-          curl -o smtools-windows-x64.msi "https://rstudio-buildtools.s3.amazonaws.com/posit-dev/smtools-windows-x64.msi"
-          msiexec /i smtools-windows-x64.msi /quiet /qn /log smtools-windows-x64.log
-          "C:/Program Files/DigiCert/DigiCert One Signing Manager Tools" | Out-File -FilePath $env:GITHUB_PATH -Append
+          # Download with retry (transient S3 failures cause silent install failures)
+          $maxRetries = 3
+          $downloaded = $false
+          for ($i = 1; $i -le $maxRetries; $i++) {
+            Write-Output "Downloading smtools MSI (attempt $i/$maxRetries)..."
+            curl -o smtools-windows-x64.msi "https://rstudio-buildtools.s3.amazonaws.com/posit-dev/smtools-windows-x64.msi"
+            if ($LASTEXITCODE -ne 0) {
+              Write-Output "::warning::curl failed with exit code $LASTEXITCODE"
+              continue
+            }
+            $fileSize = (Get-Item smtools-windows-x64.msi).Length
+            if ($fileSize -lt 1MB) {
+              Write-Output "::warning::Downloaded file is only $fileSize bytes, expected ~90MB"
+              continue
+            }
+            $downloaded = $true
+            Write-Output "Download successful ($fileSize bytes)"
+            break
+          }
+          if (-not $downloaded) {
+            Write-Output "::error title=Download Error::Failed to download smtools MSI after $maxRetries attempts"
+            exit 1
+          }
+          # Install synchronously (msiexec can return before install completes without -Wait)
+          $process = Start-Process msiexec -ArgumentList '/i', 'smtools-windows-x64.msi', '/quiet', '/qn', '/log', 'smtools-windows-x64.log' -Wait -PassThru
+          if ($process.ExitCode -ne 0) {
+            Write-Output "::error title=Install Error::msiexec failed with exit code $($process.ExitCode)"
+            Get-Content smtools-windows-x64.log -Tail 50
+            exit 1
+          }
+          # Verify smctl is actually on disk before declaring success
+          $smctlPath = "C:/Program Files/DigiCert/DigiCert One Signing Manager Tools"
+          if (!(Test-Path "$smctlPath/smctl.exe")) {
+            Write-Output "::error title=Install Error::smctl.exe not found at $smctlPath after install"
+            exit 1
+          }
+          $smctlPath | Out-File -FilePath $env:GITHUB_PATH -Append
           Write-Output "SMCTL installed and added on PATH"
         } else {
           Write-Output "SMCTL already installed and on PATH"


### PR DESCRIPTION
The `make-installer-win` job in `create-release.yml` intermittently fails at "Sync certificates" with `smctl` not recognized, despite the previous step reporting successful installation.

## Root Cause

The `Install SMCTL` step has no error handling. When the 90 MB MSI download from S3 silently fails (0 bytes received), `msiexec` runs on the empty file and exits with a non-zero code that PowerShell doesn't propagate. The script unconditionally prints "SMCTL installed and added on PATH" and the next step fails when `smctl.exe` doesn't exist on disk.

Evidence from failed runs ([#22838611306](https://github.com/quarto-dev/quarto-cli/actions/runs/22838611306), [#22635880163](https://github.com/quarto-dev/quarto-cli/actions/runs/22635880163)): curl shows 0 bytes downloaded while the successful run ([#22887281659](https://github.com/quarto-dev/quarto-cli/actions/runs/22887281659)) shows a normal 90.7 MB download.

## Fix

- Download retry loop (3 attempts) with file size validation
- Synchronous msiexec via `Start-Process -Wait` with exit code check
- Post-install verification that `smctl.exe` exists on disk
- Fail fast with clear error messages on any failure

## Test plan

- Trigger `create-release.yml` via `workflow_dispatch` with `publish-release=false` on this branch to exercise the signing path without publishing