### PR TITLE
Update release checklist for prerelease-callout shortcode

### DIFF
--- a/dev-docs/checklist-make-a-new-quarto-release.md
+++ b/dev-docs/checklist-make-a-new-quarto-release.md
@@ -28,7 +28,7 @@
       - [ ] Ensure the download links on https://quarto.org/docs/get-started/ and https://quarto.org/docs/download/ point to the stable and prerelease versions respectively
   - In the `prerelease` branch:
     - [ ] update the highlights files
-      - [ ] create `docs/prerelease/1.5/{_highlights, index, _pre-release-feature}.qmd` files based on the ones from the previous release
+      - [ ] create `docs/prerelease/1.5/{_highlights, index}.qmd` files based on the ones from the previous release
       - [ ] change `docs/prerelease/_highlights.qmd` so its include points to the new version-specific `_highlights.qmd` file (here, 1.5)
       - [ ] change `docs/prerelease/_highlights-release.qmd` so its include points to the new version-specific `_highlights.qmd` file (here, 1.4)
     - [ ] add the stable version to the older downloads list by editing /docs/download/\_download-older.yml
@@ -36,7 +36,7 @@
   - [ ] push the changes to `prerelease` branch, ensure they build correctly
   - [ ] Merge the `prerelease` branch into `main`, push to `main`
     - [ ] ensure the build completes successfully
-    - [ ] verify `_quarto.yml` `version` on `main` reflects the released version (e.g. `'1.4'`) — needed for `prerelease-docs-url` shortcode to resolve blog links to quarto.org
+    - [ ] verify `_quarto.yml` `version` on `main` reflects the released version (e.g. `'1.4'`) — needed for `prerelease` shortcodes to resolve blog links and pre-release callouts
   - [ ] Merge `main` into `prerelease`, push to `prerelease`
     - [ ] ensure the build completes successfully
   - [ ] Create new tag on `main` with stable release version number (here, `v1.4`) to mark when the new main site version went live


### PR DESCRIPTION
quarto-dev/quarto-web#1961 replaces per-version `_pre-release-feature.qmd` include files with an automatic `prerelease-callout` shortcode. This updates the release checklist to match:

- Remove `_pre-release-feature` from the list of files to create per release
- Update shortcode reference from old `prerelease-docs-url` extension name to `prerelease`