### PR TITLE
Fix preview of single-file Julia documents

### DIFF
--- a/src/project/types/single-file/single-file.ts
+++ b/src/project/types/single-file/single-file.ts
@@ -35,6 +35,7 @@ import {
   mergeExtensionMetadata,
   resolveEngineExtensions,
 } from "../../project-context.ts";
+import { createExtensionContext } from "../../../extension/extension.ts";
 
 export async function singleFileProjectContext(
   source: string,
@@ -93,17 +94,19 @@ export async function singleFileProjectContext(
       result.diskCache.close();
     },
   };
+  // Always resolve engine extensions so bundled engines (e.g. Julia) are
+  // discovered even when called without renderOptions (e.g. from preview)
+  const extensionContext = renderOptions?.services.extension ||
+    createExtensionContext();
+  result.config = result.config || { project: {} };
+  result.config = await resolveEngineExtensions(
+    extensionContext,
+    result.config,
+    result.dir,
+  );
+
   if (renderOptions) {
-    result.config = {
-      project: {},
-    };
-    // First resolve engine extensions
-    result.config = await resolveEngineExtensions(
-      renderOptions.services.extension,
-      result.config,
-      result.dir,
-    );
-    // Then merge extension metadata
+    // Merge extension metadata (requires renderOptions for full services)
     await mergeExtensionMetadata(result, renderOptions);
 
     // Check if extensions contributed output-dir metadata

--- a/tests/unit/project/single-file-engine-resolution.test.ts
+++ b/tests/unit/project/single-file-engine-resolution.test.ts
@@ -1,0 +1,47 @@
+/*
+ * single-file-engine-resolution.test.ts
+ *
+ * Tests that singleFileProjectContext resolves engine extensions
+ * even without renderOptions (the preview code path).
+ * Related to issue #13983
+ *
+ * Copyright (C) 2026 Posit Software, PBC
+ */
+
+import { unitTest } from "../../test.ts";
+import { assert } from "testing/asserts";
+import { join } from "../../../src/deno_ral/path.ts";
+import { singleFileProjectContext } from "../../../src/project/types/single-file/single-file.ts";
+import { notebookContext } from "../../../src/render/notebook/notebook-context.ts";
+import { initYamlIntelligenceResourcesFromFilesystem } from "../../../src/core/schema/utils.ts";
+
+unitTest(
+  "singleFileProjectContext resolves engine extensions without renderOptions",
+  async () => {
+    await initYamlIntelligenceResourcesFromFilesystem();
+
+    const tmpDir = Deno.makeTempDirSync({ prefix: "quarto-test" });
+    const file = join(tmpDir, "test.qmd");
+    Deno.writeTextFileSync(
+      file,
+      "---\ntitle: test\nengine: julia\n---\n",
+    );
+
+    try {
+      const nbContext = notebookContext();
+      const project = await singleFileProjectContext(file, nbContext);
+
+      assert(
+        project.config !== undefined,
+        "config should be initialized even without renderOptions",
+      );
+      assert(
+        Array.isArray(project.config?.engines) &&
+          project.config.engines.length > 0,
+        "engine extensions should be resolved (bundled engines discovered)",
+      );
+    } finally {
+      Deno.removeSync(tmpDir, { recursive: true });
+    }
+  },
+);


### PR DESCRIPTION
Engine extensions (like the bundled Julia engine) were only loaded in singleFileProjectContext when renderOptions was provided. The preview command creates the project context before render services exist, so engine extensions were never discovered for single files. This caused Jupyter to win the language claim for Julia code blocks.

Now engine extensions are always resolved, using a fresh extension context as fallback when renderOptions is absent — matching the pattern used by projectContext.

Fixes #14208
