### PR TITLE
Update font in cosmo.scss

### DIFF
--- a/src/resources/formats/html/bootstrap/themes/cosmo.scss
+++ b/src/resources/formats/html/bootstrap/themes/cosmo.scss
@@ -52,7 +52,7 @@ $body-color:    $gray-800 !default;
 // Fonts
 
 // stylelint-disable-next-line value-keyword-case
-$font-family-sans-serif:    "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
+$font-family-sans-serif:    "Source Sans 3", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
 $headings-font-weight:      400 !default;
 
 // Navbar
@@ -75,7 +75,7 @@ $progress-height:               .5rem !default;
 
 // Variables
 
-$web-font-path: "https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400;700&display=swap" !default;
+$web-font-path: "https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&display=swap" !default;
 @if $web-font-path {
   @import url($web-font-path);
 }


### PR DESCRIPTION
## Description

Source Sans Pro is now known as Source Sans 3. But the real reason I make this change is to include the italic: as it stands, a default-settings Quarto document has rather ugly-looking automatically-generated italic letters (slanted versions of the upright).

The bottom line in this screenshot shows the new, proper italic glyphs for _a_ and _g_:

<img width="1500" height="424" alt="image" src="https://github.com/user-attachments/assets/93b3f55e-7dc1-4da9-9072-8d63287f3b1a" />

## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
