### PR TITLE
Fix spurious blank page in Typst when using raw set page rule

### DIFF
--- a/src/resources/formats/typst/pandoc/quarto/typst-template.typ
+++ b/src/resources/formats/typst/pandoc/quarto/typst-template.typ
@@ -61,61 +61,64 @@
     }
    }
 
-  place(
-    top,
-    float: true,
-    scope: "parent",
-    clearance: 4mm,
-    block(below: 1em, width: 100%)[
+  let has-title-block = title != none or (authors != none and authors != ()) or date != none or abstract != none
+  if has-title-block {
+    place(
+      top,
+      float: true,
+      scope: "parent",
+      clearance: 4mm,
+      block(below: 1em, width: 100%)[
 
-      #if title != none {
-        align(center, block(inset: 2em)[
-          #set par(leading: heading-line-height) if heading-line-height != none
-          #set text(font: heading-family) if heading-family != none
-          #set text(weight: heading-weight)
-          #set text(style: heading-style) if heading-style != "normal"
-          #set text(fill: heading-color) if heading-color != black
+        #if title != none {
+          align(center, block(inset: 2em)[
+            #set par(leading: heading-line-height) if heading-line-height != none
+            #set text(font: heading-family) if heading-family != none
+            #set text(weight: heading-weight)
+            #set text(style: heading-style) if heading-style != "normal"
+            #set text(fill: heading-color) if heading-color != black
 
-          #text(size: title-size)[#title #if thanks != none {
-            footnote(thanks, numbering: "*")
-            counter(footnote).update(n => n - 1)
-          }]
-          #(if subtitle != none {
-            parbreak()
-            text(size: subtitle-size)[#subtitle]
-          })
-        ])
-      }
+            #text(size: title-size)[#title #if thanks != none {
+              footnote(thanks, numbering: "*")
+              counter(footnote).update(n => n - 1)
+            }]
+            #(if subtitle != none {
+              parbreak()
+              text(size: subtitle-size)[#subtitle]
+            })
+          ])
+        }
 
-      #if authors != none and authors != () {
-        let count = authors.len()
-        let ncols = calc.min(count, 3)
-        grid(
-          columns: (1fr,) * ncols,
-          row-gutter: 1.5em,
-          ..authors.map(author =>
-              align(center)[
-                #author.name \
-                #author.affiliation \
-                #author.email
-              ]
+        #if authors != none and authors != () {
+          let count = authors.len()
+          let ncols = calc.min(count, 3)
+          grid(
+            columns: (1fr,) * ncols,
+            row-gutter: 1.5em,
+            ..authors.map(author =>
+                align(center)[
+                  #author.name \
+                  #author.affiliation \
+                  #author.email
+                ]
+            )
           )
-        )
-      }
+        }
 
-      #if date != none {
-        align(center)[#block(inset: 1em)[
-          #date
-        ]]
-      }
+        #if date != none {
+          align(center)[#block(inset: 1em)[
+            #date
+          ]]
+        }
 
-      #if abstract != none {
-        block(inset: 2em)[
-        #text(weight: "semibold")[#abstract-title] #h(1em) #abstract
-        ]
-      }
-    ]
-  )
+        #if abstract != none {
+          block(inset: 2em)[
+          #text(weight: "semibold")[#abstract-title] #h(1em) #abstract
+          ]
+        }
+      ]
+    )
+  }
 
   if toc {
     let title = if toc_title == none {

--- a/tests/docs/smoke-all/typst/raw-set-page-no-extra-page.qmd
+++ b/tests/docs/smoke-all/typst/raw-set-page-no-extra-page.qmd
@@ -1,0 +1,28 @@
+---
+format:
+  typst:
+    keep-typ: true
+_quarto:
+  tests:
+    typst:
+      ensurePdfTextPositions:
+        - # Body text should be on page 1 (no spurious blank page before it)
+          - subject: "BODY_CONTENT_START"
+            relation: above
+            object:
+              role: "Page"
+              page: 1
+              edge: bottom
+        - []
+      noErrors: default
+---
+
+```{=typst}
+#set page(footer: none)
+```
+
+BODY_CONTENT_START
+
+| a | b |
+|---|---|
+| 1 | 2 |


### PR DESCRIPTION
Unfortunately it means changing the indentation on most of the template yet again, but we have `git diff -w`

## Summary

- Skip the empty `place(top, float: true, ...)` title block in the Typst `article()` template when there is no title, authors, date, or abstract
- The unconditional empty block counted as content, so a subsequent raw `#set page(...)` in the document body triggered a page break in Typst, producing a spurious blank first page

Fixes #14217

## Test plan

- [x] New test `tests/docs/smoke-all/typst/raw-set-page-no-extra-page.qmd` asserts body content is on page 1
- [x] Verified test fails without the fix (body on page 2), passes with the fix (body on page 1)
- [x] Existing Typst tests pass (columns, callouts, title blocks)