### PR TITLE
QUARTO_PDF_STANDARD

### DIFF
--- a/src/command/render/output-tex.ts
+++ b/src/command/render/output-tex.ts
@@ -18,6 +18,7 @@ import {
   kPdfStandard,
   kPdfStandardApplied,
   kTargetFormat,
+  pdfStandardEnv,
 } from "../../config/constants.ts";
 import { Format } from "../../config/types.ts";
 import { asArray } from "../../core/array.ts";
@@ -90,7 +91,8 @@ export function texToPdfOutputRecipe(
     const pdfStandards = asArray(
       pandocOptions.format.metadata?.[kPdfStandardApplied] ??
         format.render?.[kPdfStandard] ??
-        format.metadata?.[kPdfStandard],
+        format.metadata?.[kPdfStandard] ??
+        pdfStandardEnv(),
     ) as string[];
     if (pdfStandards.length > 0) {
       await validatePdfStandards(pdfOutput, pdfStandards, {

--- a/src/command/render/output-typst.ts
+++ b/src/command/render/output-typst.ts
@@ -34,6 +34,7 @@ import {
   kOutputFile,
   kPdfStandard,
   kVariant,
+  pdfStandardEnv,
 } from "../../config/constants.ts";
 import { error, warning } from "../../deno_ral/log.ts";
 import { ErrorEx } from "../../core/lib/error.ts";
@@ -158,7 +159,8 @@ export function typstPdfOutputRecipe(
       ),
       pdfStandard: normalizePdfStandardForTypst(
         asArray(
-          format.render?.[kPdfStandard] ?? format.metadata?.[kPdfStandard],
+          format.render?.[kPdfStandard] ?? format.metadata?.[kPdfStandard] ??
+            pdfStandardEnv(),
         ),
       ),
     };
@@ -185,7 +187,8 @@ export function typstPdfOutputRecipe(
 
     // Validate PDF against specified standards using verapdf (if available)
     const pdfStandards = asArray(
-      format.render?.[kPdfStandard] ?? format.metadata?.[kPdfStandard],
+      format.render?.[kPdfStandard] ?? format.metadata?.[kPdfStandard] ??
+        pdfStandardEnv(),
     ) as string[];
     if (pdfStandards.length > 0) {
       await validatePdfStandards(pdfOutput, pdfStandards, {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -88,6 +88,15 @@ export const kKeepTex = "keep-tex";
 export const kKeepTyp = "keep-typ";
 export const kPdfStandard = "pdf-standard";
 export const kPdfStandardApplied = "pdf-standard-applied";
+
+/** Read QUARTO_PDF_STANDARD env var as a fallback for pdf-standard option. */
+export function pdfStandardEnv(): string[] | undefined {
+  const val = Deno.env.get("QUARTO_PDF_STANDARD");
+  if (val) {
+    return val.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+  }
+  return undefined;
+}
 export const kKeepIpynb = "keep-ipynb";
 export const kKeepSource = "keep-source";
 export const kVariant = "variant";

--- a/src/format/pdf/format-pdf.ts
+++ b/src/format/pdf/format-pdf.ts
@@ -38,6 +38,7 @@ import {
   kTblCapLoc,
   kTopLevelDivision,
   kWarning,
+  pdfStandardEnv,
 } from "../../config/constants.ts";
 import { warning } from "../../deno_ral/log.ts";
 import { asArray } from "../../core/array.ts";
@@ -326,7 +327,8 @@ function createPdfFormat(
 
         // Handle pdf-standard option for PDF/A, PDF/UA, PDF/X conformance
         const pdfStandard = asArray(
-          format.render?.[kPdfStandard] ?? format.metadata?.[kPdfStandard],
+          format.render?.[kPdfStandard] ?? format.metadata?.[kPdfStandard] ??
+            pdfStandardEnv(),
         );
         if (pdfStandard.length > 0) {
           const { version, standards, needsTagging } =

--- a/tests/docs/render/pdf-standard-env.qmd
+++ b/tests/docs/render/pdf-standard-env.qmd
@@ -1,0 +1,10 @@
+---
+title: PDF Standard from Environment Variable
+lang: en
+format:
+  pdf:
+    keep-tex: true
+---
+
+This document does not set `pdf-standard` in its YAML.
+It should only get PDF standard settings from the `QUARTO_PDF_STANDARD` environment variable.

--- a/tests/smoke/render/render-pdf-standard-env.test.ts
+++ b/tests/smoke/render/render-pdf-standard-env.test.ts
@@ -1,0 +1,30 @@
+/*
+ * render-pdf-standard-env.test.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ *
+ * Tests that QUARTO_PDF_STANDARD environment variable is used as a fallback
+ * when no pdf-standard is set in the document YAML.
+ */
+
+import { docs, outputForInput } from "../../utils.ts";
+import { ensureLatexFileRegexMatches } from "../../verify.ts";
+import { testRender } from "./render.ts";
+
+const input = docs("render/pdf-standard-env.qmd");
+const output = outputForInput(input, "pdf");
+
+// Test that QUARTO_PDF_STANDARD env var applies ua-2 even though
+// the document has no pdf-standard in its YAML
+testRender(input, "pdf", true, [
+  ensureLatexFileRegexMatches(
+    output.outputPath,
+    [/\\DocumentMetadata\{/, /pdfstandard=\{ua-2\}/, /tagging=on/],
+    [],
+    input,
+  ),
+], {
+  env: {
+    QUARTO_PDF_STANDARD: "ua-2",
+  },
+});


### PR DESCRIPTION
Not important to get this into the release, but I'd like to get it out of the way.

- Extract the `QUARTO_PDF_STANDARD` environment variable implementation
- In order to close the a11y experiment #14097

With the environment variable, we can run that experiment again in the future.

## Summary

- Add `QUARTO_PDF_STANDARD` environment variable as a fallback when no `pdf-standard` is set in document YAML
- Comma-separated values, e.g. `QUARTO_PDF_STANDARD=ua-2` or `QUARTO_PDF_STANDARD=a-2b,ua-1`
- Applied in LaTeX, Typst, and PDF format resolution (`output-tex.ts`, `output-typst.ts`, `format-pdf.ts`)
- Extracted from #14097

## Test plan

- [x] Smoke test verifies env var produces `\DocumentMetadata` with correct `pdfstandard` in LaTeX output
- [x] Test fails without the feature code, passes with it
- [x] Typechecks clean