### PR TITLE
Fix env var restoration on error path to prevent test pollution

### DIFF
--- a/src/quarto.ts
+++ b/src/quarto.ts
@@ -196,13 +196,6 @@ export async function quarto(
 
   try {
     await promise;
-    for (const [key, value] of Object.entries(oldEnv)) {
-      if (value === undefined) {
-        Deno.env.delete(key);
-      } else {
-        Deno.env.set(key, value);
-      }
-    }
     if (commandFailed()) {
       exitWithCleanup(1);
     }
@@ -212,6 +205,14 @@ export async function quarto(
       exitWithCleanup(1);
     } else {
       throw e;
+    }
+  } finally {
+    for (const [key, value] of Object.entries(oldEnv)) {
+      if (value === undefined) {
+        Deno.env.delete(key);
+      } else {
+        Deno.env.set(key, value);
+      }
     }
   }
 }


### PR DESCRIPTION
When tests pass environment variables via `TestContext.env`, the `quarto()` function sets them globally with `Deno.env.set()` and restores the original values after execution. However, the restore code only runs on the success path — if `await promise` throws (e.g. a `CommandError` from a failed render, or Deno's exit sanitizer intercepting a `Deno.exit()` call inside the command), execution jumps to the `catch` block and the env vars are never restored.

In the sequential test runner (`deno test` with all files in one process), this means env vars from a failing test leak to all subsequent tests.

## Fix

Move the env restoration into a `finally` block so it runs on both success and error paths.

## Context

Discovered while reviewing #14241, which adds a test that sets `QUARTO_PDF_STANDARD` via `TestContext.env`. Same class of env pollution as #14218, though #14218 is a separate issue where `crossref.ts` sets env vars directly without any cleanup mechanism.

Related: #12621 (broader `Deno.env` cleanup effort)