### PR TITLE
fix: add root guard to dirname loops in extension discovery

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -1,3 +1,5 @@
 All changes included in 1.10:
 
+## Extensions
 
+- ([#14254](https://github.com/quarto-dev/quarto-cli/issues/14254)): Fix `quarto render` hanging when the input file is at the filesystem root. (author: @mcanouil)

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -563,7 +563,9 @@ export function inputExtensionDirs(input?: string, projectDir?: string) {
       if (extensionPath) {
         extensionDirectories.push(extensionPath);
       }
-      currentDir = dirname(currentDir);
+      const nextDir = dirname(currentDir);
+      if (nextDir === currentDir) break;
+      currentDir = nextDir;
     } while (isSubdir(projectDir, currentDir) || projectDir === currentDir);
     return extensionDirectories;
   } else if (input) {
@@ -878,7 +880,12 @@ async function readExtension(
             let projectDir = extensionDir, last;
             do {
               last = basename(projectDir);
-              projectDir = dirname(projectDir);
+              const nextDir = dirname(projectDir);
+              if (nextDir === projectDir) {
+                projectDir = "";
+                break;
+              }
+              projectDir = nextDir;
             } while (projectDir && last !== "_extensions");
             if (projectDir) {
               (object.project as Record<string, unknown>)[key] = relative(

--- a/tests/unit/extension-dirs.test.ts
+++ b/tests/unit/extension-dirs.test.ts
@@ -1,0 +1,26 @@
+/*
+* extension-dirs.test.ts
+*
+* Copyright (C) 2020-2026 Posit Software, PBC
+*
+*/
+
+import { unitTest } from "../test.ts";
+import { assert } from "testing/asserts";
+import { inputExtensionDirs } from "../../src/extension/extension.ts";
+
+// Test for issue #14254: inputExtensionDirs should not hang when
+// projectDir is the filesystem root.
+// deno-lint-ignore require-await
+unitTest("extension-dirs - no infinite loop at filesystem root", async () => {
+  const tempDir = Deno.makeTempDirSync({ prefix: "quarto-test-ext" });
+  const tempFile = `${tempDir}/test.qmd`;
+  Deno.writeTextFileSync(tempFile, "---\ntitle: test\n---\n");
+
+  // With projectDir = "/", the dirname loop must terminate at root.
+  // If the root guard is missing, this call hangs forever.
+  const dirs = inputExtensionDirs(tempFile, "/");
+  assert(Array.isArray(dirs), "inputExtensionDirs should return an array");
+
+  Deno.removeSync(tempDir, { recursive: true });
+});


### PR DESCRIPTION
Two directory-traversal loops in `src/extension/extension.ts` hang indefinitely when the input file is at the filesystem root (e.g. `/mermaid.qmd` in Docker containers with `WORKDIR /`), because `dirname("/")` returns `"/"`.

Add the same `nextDir === dir` root guard already used in `src/project/project-context.ts` to both loops: the extension directory walk in `inputExtensionDirs()` and the brand path resolution in `readExtension()`.

I only added test for one of the two loops without guardtrails, i.e. "extension" lookup.
For the brand lookup, it requires a more heavy setup as the internals is "private" thus requires a full Quarto project setup with extension, etc.
As the pattern is very similar, not sure it is worth it.


Closes #14254