### PR TITLE
fix: theorem/example block titles with inline code produce invalid Typst markup

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -1,3 +1,8 @@
 All changes included in 1.10:
 
+## Formats
+
+### `typst`
+
+- ([#14261](https://github.com/quarto-dev/quarto-cli/issues/14261)): Fix theorem/example block titles containing inline code producing invalid Typst markup when syntax highlighting is applied.
 

--- a/src/resources/filters/customnodes/theorem.lua
+++ b/src/resources/filters/customnodes/theorem.lua
@@ -259,9 +259,9 @@ end, function(thm)
     ensure_typst_theorems(type)
     local preamble = pandoc.Plain({pandoc.RawInline("typst", "#" .. theorem_type.env .. "(")})
     if name and #name > 0 then
-      preamble.content:insert(pandoc.RawInline("typst", 'title: "'))
+      preamble.content:insert(pandoc.RawInline("typst", 'title: ['))
       tappend(preamble.content, name)
-      preamble.content:insert(pandoc.RawInline("typst", '"'))
+      preamble.content:insert(pandoc.RawInline("typst", ']'))
     end
     preamble.content:insert(pandoc.RawInline("typst", ")["))
     local callthm = make_scaffold(pandoc.Div, preamble)

--- a/tests/docs/smoke-all/crossrefs/theorem/algorithm.qmd
+++ b/tests/docs/smoke-all/crossrefs/theorem/algorithm.qmd
@@ -22,7 +22,7 @@ _quarto:
         -
           - "#ref\\(<alg-gcd>, supplement: \\[alg.\\]\\)"
           - "#ref\\(<alg-gcd>, supplement: \\[Alg.\\]\\)"
-          - "#algorithm\\(title: \"Euclid\"\\)"
+          - "#algorithm\\(title: \\[Euclid\\]\\)"
         - []
     markdown:
       ensureFileRegexMatches:

--- a/tests/docs/smoke-all/crossrefs/theorem/lemma-1.qmd
+++ b/tests/docs/smoke-all/crossrefs/theorem/lemma-1.qmd
@@ -20,7 +20,7 @@ _quarto:
       ensureTypstFileRegexMatches:
         -
           - "#ref\\(<lem-line>, supplement: \\[Lemma\\]\\)"
-          - "#lemma\\(title: \"Line\"\\)"
+          - "#lemma\\(title: \\[Line\\]\\)"
         - []
     markdown:
       ensureFileRegexMatches:

--- a/tests/docs/smoke-all/crossrefs/theorem/theorem-1.qmd
+++ b/tests/docs/smoke-all/crossrefs/theorem/theorem-1.qmd
@@ -21,7 +21,7 @@ _quarto:
       ensureTypstFileRegexMatches:
         -
           - "#ref\\(<thm-line>, supplement: \\[Theorem\\]\\)"
-          - "#theorem\\(title: \"Line\"\\)"
+          - "#theorem\\(title: \\[Line\\]\\)"
           - "#import \"@preview/theorion:0\\.4\\.1\": make-frame"
           - "simple-theorem-render"
         -

--- a/tests/docs/smoke-all/typst/theorem/theorem-inline-code-title.qmd
+++ b/tests/docs/smoke-all/typst/theorem/theorem-inline-code-title.qmd
@@ -1,0 +1,37 @@
+---
+format:
+  typst:
+    keep-typ: true
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+        -
+          - "title: \\["
+        -
+          - "\\(title: \""
+---
+
+# Theorem Test - Inline Code in Title
+
+::: {#exm-devtools}
+
+## `devtools`
+
+A useful package for R developers.
+
+```r
+install.packages("devtools")
+```
+
+:::
+
+::: {#thm-bayes}
+
+## `P(A|B)` = Bayes' Rule
+
+If $P(B) > 0$, then $P(A|B) = \frac{P(B|A)P(A)}{P(B)}$.
+
+:::
+
+See @exm-devtools and @thm-bayes.


### PR DESCRIPTION
## Summary

- Inline code in theorem/example block titles (e.g. `` ## `devtools` ``) gets syntax-highlighted into Typst expressions like `#NormalTok("devtools")`, but these were being placed inside string literals (`title: "..."`) in the generated Typst, producing invalid markup
- Fix: use content brackets (`title: [...]`) instead of string quotes, matching how callouts already handle their titles
- Add test with an example block (`#exm-`) and theorem block (`#thm-`) both using inline code in titles

## Test plan

- [x] New smoke test `tests/docs/smoke-all/typst/theorem/theorem-inline-code-title.qmd` confirms `(title: [` is used and `(title: "` is not
- [x] All existing theorem appearance tests (`theorem-simple`, `theorem-fancy`, `theorem-clouds`, `theorem-rainbow`) still pass

Fixes #14261