### PR TITLE
fix: detect MiKTeX in `quarto check` on Windows

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -6,3 +6,9 @@ All changes included in 1.10:
 
 - ([#14261](https://github.com/quarto-dev/quarto-cli/issues/14261)): Fix theorem/example block titles containing inline code producing invalid Typst markup when syntax highlighting is applied.
 
+## Commands
+
+### `quarto check`
+
+- ([#14265](https://github.com/quarto-dev/quarto-cli/issues/14265)): Fix `quarto check` not detecting MiKTeX on Windows even when available in system PATH.
+

--- a/src/command/check/check.ts
+++ b/src/command/check/check.ts
@@ -414,8 +414,23 @@ async function checkInstall(conf: CheckConfiguration) {
       latexOutput.push(`${kIndent}Version: ${version}`);
       latexJson["version"] = version;
     } else {
-      latexOutput.push(`${kIndent}Tex:  (not detected)`);
-      latexJson["installed"] = false;
+      // Check for MiKTeX (uses initexmf instead of tlmgr)
+      const miktexDetection = await detectMiktex();
+      if (miktexDetection) {
+        latexOutput.push(`${kIndent}Using: MiKTeX`);
+        if (miktexDetection.path) {
+          latexOutput.push(`${kIndent}Path: ${miktexDetection.path}`);
+          latexJson["path"] = miktexDetection.path;
+        }
+        latexJson["source"] = "miktex";
+        if (miktexDetection.version) {
+          latexOutput.push(`${kIndent}Version: ${miktexDetection.version}`);
+          latexJson["version"] = miktexDetection.version;
+        }
+      } else {
+        latexOutput.push(`${kIndent}Tex:  (not detected)`);
+        latexJson["installed"] = false;
+      }
     }
   };
   if (conf.jsonResult) {
@@ -560,4 +575,51 @@ async function detectChromeForCheck(): Promise<ChromeCheckInfo> {
   }
 
   return result;
+}
+
+interface MiktexDetectionResult {
+  path?: string;
+  version?: string;
+}
+
+async function detectMiktex(): Promise<MiktexDetectionResult | undefined> {
+  try {
+    const initexmfPath = await which("initexmf");
+    if (!initexmfPath) {
+      return undefined;
+    }
+
+    const result: MiktexDetectionResult = {
+      path: dirname(initexmfPath),
+    };
+
+    // Get MiKTeX version via initexmf --version
+    try {
+      const versionResult = await execProcess({
+        cmd: "initexmf",
+        args: ["--version"],
+        stdout: "piped",
+        stderr: "piped",
+      });
+      if (versionResult.code === 0 && versionResult.stdout) {
+        // initexmf --version outputs lines like:
+        // MiKTeX Configuration Utility 4.12 (MiKTeX 24.1)
+        // The parenthesized version is the distribution version
+        const distVersionMatch = versionResult.stdout.match(
+          /\(MiKTeX\s+(\d[\d.]*)\)/i,
+        );
+        const versionMatch = distVersionMatch ||
+          versionResult.stdout.match(/MiKTeX\s+(\d[\d.]*)/i);
+        if (versionMatch) {
+          result.version = versionMatch[1];
+        }
+      }
+    } catch {
+      // Version detection is best-effort
+    }
+
+    return result;
+  } catch {
+    return undefined;
+  }
 }


### PR DESCRIPTION
## Summary

- Add MiKTeX detection as a fallback when TeX Live/TinyTeX are not found in `quarto check`
- Detect MiKTeX by locating `initexmf` in PATH and extracting version from its `--version` output
- Populate both human-readable output and JSON result with MiKTeX path, version, and source

Closes #14265

## Details

On Windows, `quarto check` reported `Tex: (not detected)` even when MiKTeX was installed, in PATH, and successfully used for PDF compilation. The existing LaTeX detection only checked for TeX Live (via `tlmgr`) and TinyTeX. MiKTeX uses `initexmf` as its configuration utility rather than `tlmgr`, so it was never found.

The fix adds a `detectMiktex()` function that:
1. Checks if `initexmf` is available via `which`
2. Extracts the installation path from `initexmf`'s location
3. Parses the MiKTeX distribution version from `initexmf --version` output (e.g., `MiKTeX 26.2`)

After the fix, users with MiKTeX will see:
```
Checking LaTeX...OK
  Using: MiKTeX
  Path: C:/Program Files/MiKTeX/miktex/bin/x64
  Version: 26.2
```

## Test plan

- [ ] Verify on Windows with MiKTeX installed: `quarto check` shows MiKTeX info
- [ ] Verify on Windows with TeX Live installed: behavior unchanged (TeX Live detected first)
- [ ] Verify on Windows with neither installed: still shows `(not detected)`
- [ ] Verify `quarto check --output check.json` includes `"source": "miktex"` in JSON output
- [ ] Verify existing CI tests pass (no behavioral change on Linux/macOS without MiKTeX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)