### PR TITLE
[backport] Fix Windows paths with accented characters breaking dart-sass

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -1,3 +1,13 @@
+# v1.10 backports
+
+## In this release
+
+- ([#14267](https://github.com/quarto-dev/quarto-cli/issues/14267)): Fix Windows paths with accented characters (e.g., `C:\Users\Sébastien\`) breaking dart-sass compilation.
+
+## In previous releases
+
+# v1.9 changes
+
 All changes included in 1.9:
 
 ## Shortcodes

--- a/src/core/windows.ts
+++ b/src/core/windows.ts
@@ -156,7 +156,7 @@ export async function safeWindowsExec(
   try {
     Deno.writeTextFileSync(
       tempFile,
-      ["@echo off", [program, ...args].join(" ")].join("\n"),
+      ["@echo off", "chcp 65001 >nul", [program, ...args].join(" ")].join("\r\n"),
     );
     return await fnExec(["cmd", "/c", tempFile]);
   } finally {

--- a/tests/unit/windows-exec.test.ts
+++ b/tests/unit/windows-exec.test.ts
@@ -155,3 +155,58 @@ echo ARG: %~1
   },
   { ignore: !isWindows },
 );
+
+// Test that safeWindowsExec handles accented/Unicode characters in paths (issue #14267)
+// The bug: safeWindowsExec writes .bat as UTF-8 but cmd.exe reads using OEM code page
+// (e.g., CP850), garbling multi-byte chars like é (0xC3 0xA9 → two CP850 chars).
+unitTest(
+  "safeWindowsExec - handles accented characters in paths (issue #14267)",
+  async () => {
+    const tempDir = Deno.makeTempDirSync({ prefix: "quarto-test" });
+
+    try {
+      // Create directory with accented characters (simulates C:\Users\Sébastien\)
+      const accentedDir = join(tempDir, "Sébastien", "project");
+      Deno.mkdirSync(accentedDir, { recursive: true });
+
+      // Create a test file at the accented path
+      const testFile = join(accentedDir, "test.txt");
+      Deno.writeTextFileSync(testFile, "accented path works");
+
+      // Create batch file that reads the accented-path file
+      const batFile = join(tempDir, "read-file.bat");
+      Deno.writeTextFileSync(
+        batFile,
+        `@echo off
+type %1
+`,
+      );
+
+      const quoted = requireQuoting([batFile, testFile]);
+
+      const result = await safeWindowsExec(
+        quoted.args[0],
+        quoted.args.slice(1),
+        (cmd) =>
+          execProcess({
+            cmd: cmd[0],
+            args: cmd.slice(1),
+            stdout: "piped",
+            stderr: "piped",
+          }),
+      );
+
+      assert(
+        result.success,
+        `Should execute successfully with accented path. stderr: ${result.stderr}`,
+      );
+      assert(
+        result.stdout?.includes("accented path works"),
+        `Should read file at accented path. Got: ${result.stdout}`,
+      );
+    } finally {
+      Deno.removeSync(tempDir, { recursive: true });
+    }
+  },
+  { ignore: !isWindows },
+);


### PR DESCRIPTION
> [!IMPORTANT]
> Backport from #14273

On Windows, `safeWindowsExec` writes temp `.bat` files as UTF-8 but `cmd.exe` reads them using OEM code page (CP850), garbling accented characters in paths (e.g., `C:\Users\Sébastien\`).

Adds `chcp 65001 >nul` to switch `cmd.exe` to UTF-8 before the command line is parsed. Uses CRLF line endings for correct batch parsing.

The full fix on main (#14273) also bypasses `sass.bat` entirely by calling `dart.exe` directly — that larger change is not backported here.

Fixes #14267