### PR TITLE
Fix shortcodes not resolving inside math expressions

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -19,4 +19,5 @@ All changes included in 1.10:
 ## Other fixes and improvements
 
 - ([#6651](https://github.com/quarto-dev/quarto-cli/issues/6651)): Fix dart-sass compilation failing in enterprise environments where `.bat` files are blocked by group policy.
+- ([#14255](https://github.com/quarto-dev/quarto-cli/issues/14255)): Fix shortcodes inside inline and display math expressions not being resolved.
 

--- a/src/resources/filters/customnodes/shortcodes.lua
+++ b/src/resources/filters/customnodes/shortcodes.lua
@@ -325,6 +325,10 @@ function shortcodes_filter()
       doc = _quarto.ast.walk(doc, {
         Shortcode = inline_handler,
         RawInline = code_handler,
+        Math = function(el)
+          el.text = apply_code_shortcode(el.text)
+          return el
+        end,
         Image = function(el)
           el = attr_handler(el)
           el.src = apply_code_shortcode(el.src)

--- a/src/resources/pandoc/datadir/readqmd.lua
+++ b/src/resources/pandoc/datadir/readqmd.lua
@@ -192,6 +192,7 @@ local function readqmd(txt, opts)
     Code = unshortcode_text,
     RawInline = unshortcode_text,
     RawBlock = unshortcode_text,
+    Math = unshortcode_text,
     Header = filter_attrs,
     Span = filter_attrs,
     Div = filter_attrs,

--- a/tests/docs/smoke-all/shortcodes/shortcode-math.qmd
+++ b/tests/docs/smoke-all/shortcodes/shortcode-math.qmd
@@ -1,0 +1,17 @@
+---
+title: Shortcode in Math
+format: html
+five: 5
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - ['5 \+ 5']
+        - ['b58fc729|7B7B3C']
+---
+
+Inline: $5 + {{< meta five >}}$
+
+Display: $$5 + {{< meta five >}}$$
+
+Plain: {{< meta five >}}


### PR DESCRIPTION
When using shortcodes inside inline or display math (e.g., `$5 + {{< meta five >}}$`), the output contains hex-encoded UUID placeholders instead of the resolved shortcode value.

## Root Cause

The two-stage shortcode encoding (introduced for Pandoc 3.7+ compatibility) converts shortcodes to UUID-guarded hex strings before `pandoc.read()`, then restores them afterward. The restoration walker in `readqmd.lua` and the shortcode resolution filter in `shortcodes.lua` both handle `Code`, `RawInline`, `RawBlock`, and `Str` nodes — but neither handles `Math` nodes. Since Pandoc parses `$5 + UUID;HEX;$` into a `Math` node with the placeholder in its `.text` field, the shortcode is never restored or resolved.

## Fix

Add `Math` node handlers to both pipeline stages:

1. `readqmd.lua`: restore hex-encoded shortcode text back to `{{< ... >}}` syntax (reuses existing `unshortcode_text`)
2. `shortcodes.lua`: resolve shortcodes to their values inside math text (reuses existing `apply_code_shortcode`)

Both inline (`$...$`) and display (`$$...$$`) math are covered by the single `Math` handler, since Pandoc uses one node type with a `mathtype` discriminator.

Fixes #14255