### PR TITLE
Fix profile image's top padding in compact view (#14211)

### DIFF
--- a/src/resources/projects/website/about/about.scss
+++ b/src/resources/projects/website/about/about.scss
@@ -172,7 +172,7 @@ div.quarto-about-trestles {
 
   @include media-breakpoint-down(lg) {
     flex-direction: column;
-    padding-top: 0em !important;
+    padding-top: 3em !important;
   }
 
   .about-entity {
@@ -224,6 +224,7 @@ div.quarto-about-trestles {
 // Marquee
 div.quarto-about-marquee {
   padding-bottom: 1em;
+  padding-top: 14px !important;
 
   .about-contents {
     display: flex;
@@ -260,6 +261,7 @@ div.quarto-about-broadside {
   display: flex;
   flex-direction: column;
   padding-bottom: 1em;
+  padding-top: 14px !important;
 
   .about-main {
     display: flex !important;

--- a/src/resources/projects/website/about/about.scss
+++ b/src/resources/projects/website/about/about.scss
@@ -224,7 +224,7 @@ div.quarto-about-trestles {
 // Marquee
 div.quarto-about-marquee {
   padding-bottom: 1em;
-  padding-top: 14px !important;
+  padding-top: $content-padding-top !important;
 
   .about-contents {
     display: flex;
@@ -261,7 +261,7 @@ div.quarto-about-broadside {
   display: flex;
   flex-direction: column;
   padding-bottom: 1em;
-  padding-top: 14px !important;
+  padding-top: $content-padding-top !important;
 
   .about-main {
     display: flex !important;


### PR DESCRIPTION
Fixes #14211 - Add top padding to the profile image on a website's about page in compact view (trestles, marquee, broadside)

## Description

I modify three lines in the `src/resources/projects/website/about/about.scss` file, all related to the profile image's top padding in compact view.

**LINE 175:**
- In the `trestles` template, I set the top padding to 3em to match the top padding value in non-compact view from here:
https://github.com/quarto-dev/quarto-cli/blob/e6268254359e532cb781dd7f792c4e81f2c25483/src/resources/projects/website/about/about.scss#L170

- I am not sure why it was previously explicitly set to 0, but found no issues changing it to 3em

**LINES 227 & 264:**
- In the `marquee` and `broadside` templates, I set the top padding to 14px, which comes from a default content padding value (which is used in non-compact view) from this line
https://github.com/quarto-dev/quarto-cli/blob/e6268254359e532cb781dd7f792c4e81f2c25483/src/resources/projects/website/navigation/quarto-nav.scss#L37

## Verification

1. Create a new website project: `quarto create project blog test title`
2. (Optional) In `_quarto.yml`, change the theme from `cosmo` to `cerulean` for better visibility
3. In `about.qmd`, choose one of `trestles`, `marquee`, or `broadside` templates
4. Run `quarto preview about.qmd` in the created project's root directory
5. Make the browser window narrower to enter compact view (or open the website on your phone)


## Checklist

I have (if applicable):

- [ ] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
