### PR TITLE
Update remaining GitHub Actions for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           echo ${{ steps.read-version.outputs.version_full }} > version.txt
 
-      - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5
+      - uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321
         if: ${{ inputs.publish-release }}
         id: version_commit
         with:
@@ -677,9 +677,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe
         with:
           tag_name: ${{needs.configure.outputs.tag_name}}
           target_commitish: ${{ needs.configure.outputs.version_commit }}

--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -217,7 +217,7 @@ jobs:
           quarto install chrome-headless-shell --no-prompt
 
       - name: Setup Julia
-        uses: julia-actions/setup-julia@v2
+        uses: julia-actions/setup-julia@a8c65a2a580b6a5cf30070e825e62f9fc0fee1d7
         id: setup-julia
         with:
           version: "1.12.5"


### PR DESCRIPTION
Follow-up to #14199 which updated official `actions/*` and several third-party actions.

Three actions were still on Node.js 20:

- `EndBug/add-and-commit`: v9.1.4 (node20) → v10.0.0 (node24)
- `softprops/action-gh-release`: v1-era SHA → v2.6.1 SHA (still node20, but current maintained version). Also removes deprecated `env: GITHUB_TOKEN` — v2 defaults `token` to `github.token`.
- `julia-actions/setup-julia`: `@v2` (node20) → pinned master SHA with node24 (julia-actions/setup-julia#374 merged but no release yet)

Two actions remain blocked upstream with no node24 release available: `softprops/action-gh-release` and `r-lib/actions/setup-r`. Tracked in #14201.

Closes #14201