### PR TITLE
Add missing Open Graph tags

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -23,6 +23,6 @@ All changes included in 1.10:
 
 ## Other fixes and improvements
 
+- Fix website Open Graph metadata for posts to include the missing `og:type` and `og:url` tags.
 - ([#6651](https://github.com/quarto-dev/quarto-cli/issues/6651)): Fix dart-sass compilation failing in enterprise environments where `.bat` files are blocked by group policy.
 - ([#14255](https://github.com/quarto-dev/quarto-cli/issues/14255)): Fix shortcodes inside inline and display math expressions not being resolved.
-

--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -23,6 +23,6 @@ All changes included in 1.10:
 
 ## Other fixes and improvements
 
-- Fix website Open Graph metadata for posts to include the missing `og:type` and `og:url` tags.
+- ([#14306](https://github.com/quarto-dev/quarto-cli/issues/14306)): Fix website Open Graph metadata for posts to include the missing `og:type` and `og:url` tags.
 - ([#6651](https://github.com/quarto-dev/quarto-cli/issues/6651)): Fix dart-sass compilation failing in enterprise environments where `.bat` files are blocked by group policy.
 - ([#14255](https://github.com/quarto-dev/quarto-cli/issues/14255)): Fix shortcodes inside inline and display math expressions not being resolved.

--- a/src/project/types/website/website-meta.ts
+++ b/src/project/types/website/website-meta.ts
@@ -8,6 +8,10 @@ import { Document, Element } from "../../../core/deno-dom.ts";
 import { dirname, join, relative } from "../../../deno_ral/path.ts";
 import {
   kAbstract,
+  kAuthor,
+  kAuthors,
+  kDate,
+  kDateModified,
   kDescription,
   kNumberSections,
   kSubtitle,
@@ -49,9 +53,12 @@ import { imageSize } from "../../../core/image.ts";
 import { writeMetaTag } from "../../../format/html/format-html-shared.ts";
 import { joinUrl } from "../../../core/url.ts";
 import { truncateText } from "../../../core/text.ts";
+import { synthesizeCitationUrl } from "../../../quarto-core/attribution/document.ts";
 import { websiteImage } from "./website-config.ts";
 
 const kCard = "card";
+const kType = "type";
+const kUrl = "url";
 
 interface SocialMetadataProvider {
   key: string;
@@ -117,6 +124,17 @@ export function metadataHtmlPostProcessor(
         }
 
         return value;
+      },
+      resolveDefaults: (finalMetadata: Metadata) => {
+        if (finalMetadata[kType] === undefined) {
+          finalMetadata[kType] = openGraphType(format);
+        }
+        if (finalMetadata[kUrl] === undefined) {
+          const url = openGraphUrl(source, project, format);
+          if (url) {
+            finalMetadata[kUrl] = url;
+          }
+        }
       },
     };
 
@@ -261,6 +279,8 @@ function opengraphMetadata(
       kImageWidth,
       kLocale,
       kSiteName,
+      kType,
+      kUrl,
     ].forEach((key) => {
       if (openGraph[key] !== undefined) {
         metadata[key] = openGraph[key];
@@ -343,6 +363,28 @@ function resolveImageMetadata(
 
     return inputRelImg as string;
   }
+}
+
+function openGraphType(format: Format) {
+  return format.metadata[kDate] !== undefined ||
+      format.metadata[kDateModified] !== undefined ||
+      format.metadata[kAuthor] !== undefined ||
+      format.metadata[kAuthors] !== undefined
+    ? "article"
+    : "website";
+}
+
+function openGraphUrl(
+  source: string,
+  project: ProjectContext,
+  format: Format,
+) {
+  return synthesizeCitationUrl(
+    source,
+    format.metadata,
+    format.pandoc["output-file"],
+    relative(dirname(source), project.dir),
+  );
 }
 
 function mergedSiteAndDocumentData(

--- a/src/resources/types/schema-types.ts
+++ b/src/resources/types/schema-types.ts
@@ -331,6 +331,8 @@ export type OpenGraphConfig = {
 provided in the `open-graph` metadata, Quarto will use the website or
 book `title` by default. */;
   locale?: string; /* Locale of open graph metadata */
+  type?: string; /* Content to use for the `og:type` tag */
+  url?: string; /* Content to use for the `og:url` tag */
 } & SocialMetadata;
 
 export type PageFooter = {

--- a/src/resources/types/zod/schema-types.ts
+++ b/src/resources/types/zod/schema-types.ts
@@ -269,6 +269,8 @@ export const ZodOpenGraphConfig = z.object({
   "image-height": z.number(),
   locale: z.string(),
   "site-name": z.string(),
+  type: z.string(),
+  url: z.string(),
 }).strict().partial();
 
 export const ZodPageFooter = z.object({

--- a/tests/docs/smoke-all/2026/04/02/og-type-url/_quarto.yml
+++ b/tests/docs/smoke-all/2026/04/02/og-type-url/_quarto.yml
@@ -1,0 +1,9 @@
+project:
+  type: website
+
+website:
+  title: "Open Graph Type URL"
+  site-url: https://example.com
+  open-graph: true
+
+format: html

--- a/tests/docs/smoke-all/2026/04/02/og-type-url/index.qmd
+++ b/tests/docs/smoke-all/2026/04/02/og-type-url/index.qmd
@@ -1,0 +1,5 @@
+---
+title: "Home"
+---
+
+Home page.

--- a/tests/docs/smoke-all/2026/04/02/og-type-url/posts/a-test-post/index.qmd
+++ b/tests/docs/smoke-all/2026/04/02/og-type-url/posts/a-test-post/index.qmd
@@ -1,0 +1,17 @@
+---
+title: "A Test Post"
+description: "A test post for Open Graph metadata."
+date: "2026-04-02"
+author: "Quarto Tester"
+_quarto:
+  render-project: true
+  tests:
+    html:
+      ensureFileRegexMatches:
+        -
+          - '<meta property="og:type" content="article">'
+          - '<meta property="og:url" content="https://example.com/posts/a-test-post/">'
+        - []
+---
+
+This is a test post.

--- a/tests/docs/smoke-all/2026/04/02/og-type-url/posts/override-og/index.qmd
+++ b/tests/docs/smoke-all/2026/04/02/og-type-url/posts/override-og/index.qmd
@@ -1,0 +1,21 @@
+---
+title: "Override Open Graph"
+description: "A test post for Open Graph metadata overrides."
+date: "2026-04-02"
+author: "Quarto Tester"
+website:
+  open-graph:
+    type: website
+    url: https://www.example.com/
+_quarto:
+  render-project: true
+  tests:
+    html:
+      ensureFileRegexMatches:
+        -
+          - '<meta property="og:type" content="website">'
+          - '<meta property="og:url" content="https://www.example.com/">'
+        - []
+---
+
+This is a test post with overridden Open Graph metadata.


### PR DESCRIPTION
## Description

At present Quarto inserts a number of Open Graph tags into blog posts.

There are, however, a couple of important tags missing:

- `og:type` and
- `og:url`.

I have implemented the changes required to insert those tags and also provided suitable tests. Very happy to revise as required. Thank you for your consideration.

Closes https://github.com/quarto-dev/quarto-cli/issues/14306.

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [x] updated the appropriate changelog in the PR
- [x] ensured the present test suite passes and
- [x] added new tests.
