### PR TITLE
[backport] Fix quarto inspect standalone file project emission for RStudio

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -5,6 +5,7 @@
 - ([#14267](https://github.com/quarto-dev/quarto-cli/issues/14267)): Fix Windows paths with accented characters (e.g., `C:\Users\Sébastien\`) breaking dart-sass compilation.
 - ([#14281](https://github.com/quarto-dev/quarto-cli/issues/14281)): Fix transient `.quarto_ipynb` files accumulating during `quarto preview` with Jupyter engine.
 - ([#14298](https://github.com/quarto-dev/quarto-cli/issues/14298)): Fix `quarto preview` browse URL including output filename (e.g., `hello.html`) for single-file documents, breaking Posit Workbench proxied server access.
+- ([rstudio/rstudio#17333](https://github.com/rstudio/rstudio/issues/17333)): Fix `quarto inspect` on standalone files emitting project metadata that breaks RStudio's publishing wizard.
 
 ## In previous releases
 

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -14,7 +14,15 @@ export function isWSL() {
   return !!Deno.env.get("WSL_DISTRO_NAME");
 }
 
+// Test override for isRStudio — avoids Deno.env.set() race conditions
+// in parallel tests. See quarto-dev/quarto-cli#14218 and PR #12621.
+let _isRStudioOverride: boolean | undefined;
+export function _setIsRStudioForTest(value: boolean | undefined) {
+  _isRStudioOverride = value;
+}
+
 export function isRStudio() {
+  if (_isRStudioOverride !== undefined) return _isRStudioOverride;
   return !!Deno.env.get("RSTUDIO");
 }
 

--- a/src/inspect/inspect.ts
+++ b/src/inspect/inspect.ts
@@ -49,6 +49,7 @@ import {
 import { validateDocumentFromSource } from "../core/schema/validate-document.ts";
 import { error } from "../deno_ral/log.ts";
 import { ProjectContext } from "../project/types.ts";
+import { isRStudio } from "../core/platform.ts";
 
 export function isProjectConfig(
   config: InspectedConfig,
@@ -238,7 +239,9 @@ const inspectDocumentConfig = async (path: string) => {
     };
 
     // if there is a project then add it
-    if (context?.config) {
+    // Suppress project for standalone files in RStudio: current releases
+    // assume project.dir implies _quarto.yml exists (rstudio/rstudio#17333)
+    if (context?.config && !(context.isSingleFile && isRStudio())) {
       config.project = await inspectProjectConfig(context);
     }
     return config;

--- a/tests/docs/inspect/standalone-hello.qmd
+++ b/tests/docs/inspect/standalone-hello.qmd
@@ -1,0 +1,6 @@
+---
+title: Hello
+format: html
+---
+
+Hello world.

--- a/tests/smoke/inspect/inspect-standalone-rstudio.test.ts
+++ b/tests/smoke/inspect/inspect-standalone-rstudio.test.ts
@@ -1,0 +1,78 @@
+/*
+* inspect-standalone-rstudio.test.ts
+*
+* Copyright (C) 2020-2026 Posit Software, PBC
+*
+*/
+
+import { existsSync } from "../../../src/deno_ral/fs.ts";
+import { _setIsRStudioForTest } from "../../../src/core/platform.ts";
+import {
+  ExecuteOutput,
+  testQuartoCmd,
+} from "../../test.ts";
+import { assert, assertEquals } from "testing/asserts";
+
+// Test: standalone file inspect with RStudio override should NOT emit project.
+// Uses _setIsRStudioForTest to avoid Deno.env.set() race conditions in
+// parallel tests (see #14218, PR #12621).
+(() => {
+  const input = "docs/inspect/standalone-hello.qmd";
+  const output = "docs/inspect/standalone-hello.json";
+  testQuartoCmd(
+    "inspect",
+    [input, output],
+    [
+      {
+        name: "inspect-standalone-no-project-in-rstudio",
+        verify: async (_outputs: ExecuteOutput[]) => {
+          assert(existsSync(output));
+          const json = JSON.parse(Deno.readTextFileSync(output));
+          assertEquals(json.project, undefined,
+            "Standalone file inspect should not emit 'project' when in RStudio");
+        }
+      }
+    ],
+    {
+      setup: async () => {
+        _setIsRStudioForTest(true);
+      },
+      teardown: async () => {
+        _setIsRStudioForTest(undefined);
+        if (existsSync(output)) {
+          Deno.removeSync(output);
+        }
+      }
+    },
+  );
+})();
+
+// Test: standalone file inspect WITHOUT RStudio should still emit project
+(() => {
+  const input = "docs/inspect/standalone-hello.qmd";
+  const output = "docs/inspect/standalone-hello-nors.json";
+  testQuartoCmd(
+    "inspect",
+    [input, output],
+    [
+      {
+        name: "inspect-standalone-has-project-outside-rstudio",
+        verify: async (_outputs: ExecuteOutput[]) => {
+          assert(existsSync(output));
+          const json = JSON.parse(Deno.readTextFileSync(output));
+          assert(json.project !== undefined,
+            "Standalone file inspect should emit 'project' when not in RStudio");
+          assert(json.project.dir !== undefined,
+            "project.dir should be set");
+        }
+      }
+    ],
+    {
+      teardown: async () => {
+        if (existsSync(output)) {
+          Deno.removeSync(output);
+        }
+      }
+    },
+  );
+})();


### PR DESCRIPTION
> [!IMPORTANT]
> Backport from #14307

Fix RStudio publishing wizard crash when publishing standalone Quarto documents with Quarto >= 1.9.35. Gate `project` emission in `inspectDocumentConfig` on `!(isSingleFile && isRStudio())` so current RStudio releases continue to work.

## Test Plan

- [x] Both new inspect tests pass on v1.9 worktree
- [x] Existing inspect tests unaffected

Ref: rstudio/rstudio#17333