### PR TITLE
Mapping for tagpdf-base.sty location in TeX Live package

### DIFF
--- a/src/command/render/latexmk/texlive.ts
+++ b/src/command/render/latexmk/texlive.ts
@@ -89,8 +89,16 @@ export async function findPackages(
     // Special cases for known packages where tlmgr file search doesn't work
     // https://github.com/rstudio/tinytex/blob/33cbe601ff671fae47c594250de1d22bbf293b27/R/latex.R#L470
     const knownPackages = ["fandol", "latex-lab", "colorprofiles"];
+    // Special cases where tlmgr --file search returns no results for a .sty file
+    // because the TeX Live package name differs from what the file search returns.
+    // tagpdf-base.sty is in the tagpdf-base package in TeX Live 2026.
+    const knownFileMappings: Record<string, string> = {
+      "tagpdf-base.sty": "tagpdf-base",
+    };
     if (knownPackages.includes(searchTerm)) {
       results.push(searchTerm);
+    } else if (knownFileMappings[searchTerm]) {
+      results.push(knownFileMappings[searchTerm]);
     } else {
       const result = await tlmgrCommand(
         "search",


### PR DESCRIPTION
## Description

A couple the smoke tests appears to be failing because they're not finding an expected style file.

```
      Rendering PDF
      running lualatex - 1
      This is LuaHBTeX, Version 1.24.0 (TeX Live 2026) 
       restricted system commands enabled.
      
      updating tlmgr
      
      updating existing packages
      finding package for tagpdf-base.sty
      
      compilation failed- no matching packages
      LaTeX Error: File `tagpdf-base.sty' not found.
      
      Type X to quit or <RETURN> to proceed,
      or enter new name. (Default extension: sty)
      
      Enter file name: 
      ! Emergency stop.
      <read *> 
         
      l.32 \input
               {pdfmanagement.ltx}
```

Closes https://github.com/quarto-dev/quarto-cli/issues/14317.

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [x] updated the appropriate changelog in the PR
- [x] ensured the present test suite passes and
- [x] added new tests.