### PR TITLE
[backport] Add arm64 Linux support for chrome-headless-shell and deprecate chromium installer

### DIFF
--- a/.github/workflows/test-ff-matrix.yml
+++ b/.github/workflows/test-ff-matrix.yml
@@ -20,6 +20,7 @@ on:
       - ".github/workflows/stale-needs-repro.yml"
       - ".github/workflows/test-bundle.yml"
       - ".github/workflows/test-smokes-parallel.yml"
+      - ".github/workflows/test-install.yml"
       - ".github/workflows/test-quarto-latexmk.yml"
       - ".github/workflows/update-test-timing.yml"
   pull_request:
@@ -31,6 +32,7 @@ on:
       - ".github/workflows/performance-check.yml"
       - ".github/workflows/stale-needs-repro.yml"
       - ".github/workflows/test-bundle.yml"
+      - ".github/workflows/test-install.yml"
       - ".github/workflows/test-smokes-parallel.yml"
       - ".github/workflows/test-quarto-latexmk.yml"
       - ".github/workflows/update-test-timing.yml"

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -1,0 +1,53 @@
+# Integration test for `quarto install` on platforms not covered by smoke tests.
+# Smoke tests (test-smokes.yml) cover x86_64 Linux and Windows.
+# This workflow fills the gap for arm64 Linux and macOS.
+name: Test Tool Install
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - "v1.*"
+    paths:
+      - "src/tools/**"
+      - ".github/workflows/test-install.yml"
+  pull_request:
+    paths:
+      - "src/tools/**"
+      - ".github/workflows/test-install.yml"
+  schedule:
+    # Weekly Monday 9am UTC — detect upstream CDN/API breakage
+    - cron: "0 9 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  test-install:
+    name: Install tools (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04-arm, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v6
+
+      - uses: ./.github/workflows/actions/quarto-dev
+
+      - name: Install TinyTeX
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          quarto install tinytex
+
+      - name: Install Chrome Headless Shell
+        # arm64 Linux support requires #14334. Remove this condition once merged.
+        if: runner.arch != 'ARM64'
+        run: |
+          quarto install chrome-headless-shell --no-prompt
+
+      - name: Verify tools with quarto check
+        run: |
+          quarto check install

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -76,12 +76,15 @@ jobs:
         id: install-chromium
         shell: bash
         run: |
-          output=$(quarto install chromium --no-prompt 2>&1) || true
+          set +e
+          output=$(quarto install chromium --no-prompt 2>&1)
+          exit_code=$?
+          set -e
           echo "$output"
-          if echo "$output" | grep -q "deprecated"; then
+          if echo "$output" | grep -Fq "is deprecated"; then
             echo "deprecation-warning=true" >> "$GITHUB_OUTPUT"
           fi
-          if echo "$output" | grep -q "Installation successful"; then
+          if [ "$exit_code" -eq 0 ]; then
             echo "chromium-installed=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -96,9 +99,11 @@ jobs:
         id: update-chromium
         shell: bash
         run: |
-          output=$(quarto update chromium --no-prompt 2>&1) || true
+          set +e
+          output=$(quarto update chromium --no-prompt 2>&1)
+          set -e
           echo "$output"
-          if echo "$output" | grep -q "deprecated"; then
+          if echo "$output" | grep -Fq "is deprecated"; then
             echo "deprecation-warning=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -113,9 +118,9 @@ jobs:
         if: steps.install-chromium.outputs.chromium-installed == 'true'
         shell: bash
         run: |
-          output=$(quarto check install 2>&1) || true
+          output=$(quarto check install 2>&1)
           echo "$output"
-          if ! echo "$output" | grep -q "outdated"; then
+          if ! echo "$output" | grep -Fq "Chromium is outdated"; then
             echo "::error::Outdated Chromium warning missing from quarto check"
             exit 1
           fi

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -63,58 +63,42 @@ jobs:
 
       - uses: ./.github/workflows/actions/quarto-dev
 
-      - name: Verify chromium install shows deprecation warning (Unix)
-        if: runner.os != 'Windows'
+      - name: Make quarto available in bash (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
         run: |
-          quarto install chromium --no-prompt 2>&1 | tee /tmp/chromium-output.txt || true
-          if grep -q "deprecated" /tmp/chromium-output.txt; then
-            echo "Deprecation warning found"
-          else
-            echo "Deprecation warning missing"
-            cat /tmp/chromium-output.txt
-            exit 1
+          quarto_cmd=$(command -v quarto.cmd)
+          dir=$(dirname "$quarto_cmd")
+          printf '#!/bin/bash\nexec "%s" "$@"\n' "$quarto_cmd" > "$dir/quarto"
+          chmod +x "$dir/quarto"
+
+      - name: Install chromium and capture result
+        id: install-chromium
+        shell: bash
+        run: |
+          output=$(quarto install chromium --no-prompt 2>&1) || true
+          echo "$output"
+          if echo "$output" | grep -q "deprecated"; then
+            echo "deprecation-warning=true" >> "$GITHUB_OUTPUT"
+          fi
+          if echo "$output" | grep -q "Installation successful"; then
+            echo "chromium-installed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Verify chromium install shows deprecation warning (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
+      - name: Assert deprecation warning was shown
+        if: steps.install-chromium.outputs.deprecation-warning != 'true'
+        shell: bash
         run: |
-          $output = quarto install chromium --no-prompt 2>&1 | Out-String
-          Write-Host $output
-          if ($output -match "deprecated") {
-            Write-Host "Deprecation warning found"
-          } else {
-            Write-Host "Deprecation warning missing"
-            exit 1
-          }
+          echo "::error::Deprecation warning missing from quarto install chromium output"
+          exit 1
 
-      - name: Verify quarto check warns about outdated Chromium (Unix)
-        if: runner.os != 'Windows'
+      - name: Verify quarto check warns about outdated Chromium
+        if: steps.install-chromium.outputs.chromium-installed == 'true'
+        shell: bash
         run: |
-          # Only assert if chromium was actually installed (fails on arm64)
-          if grep -q "Installation successful" /tmp/chromium-output.txt; then
-            quarto check install 2>&1 | tee /tmp/check-output.txt || true
-            if grep -q "outdated" /tmp/check-output.txt; then
-              echo "Outdated Chromium warning found in quarto check"
-            else
-              echo "Outdated Chromium warning missing from quarto check"
-              cat /tmp/check-output.txt
-              exit 1
-            fi
-          else
-            echo "Chromium install did not succeed on this platform, skipping check"
+          output=$(quarto check install 2>&1) || true
+          echo "$output"
+          if ! echo "$output" | grep -q "outdated"; then
+            echo "::error::Outdated Chromium warning missing from quarto check"
+            exit 1
           fi
-
-      - name: Verify quarto check warns about outdated Chromium (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          # Chromium installs via Puppeteer on Windows, so should always be present
-          $output = quarto check install 2>&1 | Out-String
-          Write-Host $output
-          if ($output -match "outdated") {
-            Write-Host "Outdated Chromium warning found in quarto check"
-          } else {
-            Write-Host "Outdated Chromium warning missing from quarto check"
-            exit 1
-          }

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -43,11 +43,34 @@ jobs:
           quarto install tinytex
 
       - name: Install Chrome Headless Shell
-        # arm64 Linux support requires #14334. Remove this condition once merged.
-        if: runner.arch != 'ARM64'
         run: |
           quarto install chrome-headless-shell --no-prompt
 
       - name: Verify tools with quarto check
         run: |
           quarto check install
+
+  test-chromium-deprecation:
+    name: Chromium deprecation warning (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v6
+
+      - uses: ./.github/workflows/actions/quarto-dev
+
+      - name: Verify chromium install shows deprecation warning
+        shell: bash
+        run: |
+          quarto install chromium --no-prompt 2>&1 | tee /tmp/chromium-output.txt || true
+          if grep -q "deprecated" /tmp/chromium-output.txt; then
+            echo "✓ Deprecation warning found"
+          else
+            echo "✗ Deprecation warning missing"
+            cat /tmp/chromium-output.txt
+            exit 1
+          fi

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -85,11 +85,28 @@ jobs:
             echo "chromium-installed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Assert deprecation warning was shown
+      - name: Assert install deprecation warning was shown
         if: steps.install-chromium.outputs.deprecation-warning != 'true'
         shell: bash
         run: |
           echo "::error::Deprecation warning missing from quarto install chromium output"
+          exit 1
+
+      - name: Update chromium and capture result
+        id: update-chromium
+        shell: bash
+        run: |
+          output=$(quarto update chromium --no-prompt 2>&1) || true
+          echo "$output"
+          if echo "$output" | grep -q "deprecated"; then
+            echo "deprecation-warning=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Assert update deprecation warning was shown
+        if: steps.update-chromium.outputs.deprecation-warning != 'true'
+        shell: bash
+        run: |
+          echo "::error::Deprecation warning missing from quarto update chromium output"
           exit 1
 
       - name: Verify quarto check warns about outdated Chromium

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -89,11 +89,13 @@ jobs:
           fi
 
       - name: Assert install deprecation warning was shown
-        if: steps.install-chromium.outputs.deprecation-warning != 'true'
         shell: bash
         run: |
-          echo "::error::Deprecation warning missing from quarto install chromium output"
-          exit 1
+          if [ "${{ steps.install-chromium.outputs.deprecation-warning }}" != "true" ]; then
+            echo "::error::Deprecation warning missing from quarto install chromium output"
+            exit 1
+          fi
+          echo "Install deprecation warning found"
 
       - name: Update chromium and capture result
         id: update-chromium
@@ -108,19 +110,25 @@ jobs:
           fi
 
       - name: Assert update deprecation warning was shown
-        if: steps.update-chromium.outputs.deprecation-warning != 'true'
         shell: bash
         run: |
-          echo "::error::Deprecation warning missing from quarto update chromium output"
-          exit 1
+          if [ "${{ steps.update-chromium.outputs.deprecation-warning }}" != "true" ]; then
+            echo "::error::Deprecation warning missing from quarto update chromium output"
+            exit 1
+          fi
+          echo "Update deprecation warning found"
 
       - name: Verify quarto check warns about outdated Chromium
-        if: steps.install-chromium.outputs.chromium-installed == 'true'
         shell: bash
         run: |
+          if [ "${{ steps.install-chromium.outputs.chromium-installed }}" != "true" ]; then
+            echo "Chromium install did not succeed on this platform, skipping check"
+            exit 0
+          fi
           output=$(quarto check install 2>&1)
           echo "$output"
           if ! echo "$output" | grep -Fq "Chromium is outdated"; then
             echo "::error::Outdated Chromium warning missing from quarto check"
             exit 1
           fi
+          echo "Outdated Chromium warning found in quarto check"

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -63,31 +63,27 @@ jobs:
 
       - uses: ./.github/workflows/actions/quarto-dev
 
-      - name: Verify chromium install shows deprecation warning
-        shell: bash
+      - name: Verify chromium install shows deprecation warning (Unix)
+        if: runner.os != 'Windows'
         run: |
           quarto install chromium --no-prompt 2>&1 | tee /tmp/chromium-output.txt || true
           if grep -q "deprecated" /tmp/chromium-output.txt; then
-            echo "✓ Deprecation warning found"
+            echo "Deprecation warning found"
           else
-            echo "✗ Deprecation warning missing"
+            echo "Deprecation warning missing"
             cat /tmp/chromium-output.txt
             exit 1
           fi
 
-      - name: Verify quarto check warns about outdated Chromium
-        shell: bash
+      - name: Verify chromium install shows deprecation warning (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
         run: |
-          # Only check if chromium was actually installed (may fail on arm64)
-          quarto check install 2>&1 | tee /tmp/check-output.txt || true
-          if grep -q "Installation successful" /tmp/chromium-output.txt; then
-            if grep -q "outdated" /tmp/check-output.txt; then
-              echo "✓ Outdated Chromium warning found in quarto check"
-            else
-              echo "✗ Outdated Chromium warning missing from quarto check"
-              cat /tmp/check-output.txt
-              exit 1
-            fi
-          else
-            echo "⊘ Chromium install did not succeed on this platform, skipping check"
-          fi
+          $output = quarto install chromium --no-prompt 2>&1 | Out-String
+          Write-Host $output
+          if ($output -match "deprecated") {
+            Write-Host "Deprecation warning found"
+          } else {
+            Write-Host "Deprecation warning missing"
+            exit 1
+          }

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -74,3 +74,20 @@ jobs:
             cat /tmp/chromium-output.txt
             exit 1
           fi
+
+      - name: Verify quarto check warns about outdated Chromium
+        shell: bash
+        run: |
+          # Only check if chromium was actually installed (may fail on arm64)
+          quarto check install 2>&1 | tee /tmp/check-output.txt || true
+          if grep -q "Installation successful" /tmp/chromium-output.txt; then
+            if grep -q "outdated" /tmp/check-output.txt; then
+              echo "✓ Outdated Chromium warning found in quarto check"
+            else
+              echo "✗ Outdated Chromium warning missing from quarto check"
+              cat /tmp/check-output.txt
+              exit 1
+            fi
+          else
+            echo "⊘ Chromium install did not succeed on this platform, skipping check"
+          fi

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -87,3 +87,34 @@ jobs:
             Write-Host "Deprecation warning missing"
             exit 1
           }
+
+      - name: Verify quarto check warns about outdated Chromium (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          # Only assert if chromium was actually installed (fails on arm64)
+          if grep -q "Installation successful" /tmp/chromium-output.txt; then
+            quarto check install 2>&1 | tee /tmp/check-output.txt || true
+            if grep -q "outdated" /tmp/check-output.txt; then
+              echo "Outdated Chromium warning found in quarto check"
+            else
+              echo "Outdated Chromium warning missing from quarto check"
+              cat /tmp/check-output.txt
+              exit 1
+            fi
+          else
+            echo "Chromium install did not succeed on this platform, skipping check"
+          fi
+
+      - name: Verify quarto check warns about outdated Chromium (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          # Chromium installs via Puppeteer on Windows, so should always be present
+          $output = quarto check install 2>&1 | Out-String
+          Write-Host $output
+          if ($output -match "outdated") {
+            Write-Host "Outdated Chromium warning found in quarto check"
+          } else {
+            Write-Host "Outdated Chromium warning missing from quarto check"
+            exit 1
+          }

--- a/.github/workflows/test-smokes-parallel.yml
+++ b/.github/workflows/test-smokes-parallel.yml
@@ -29,6 +29,7 @@ on:
       - ".github/workflows/stale-needs-repro.yml"
       - ".github/workflows/test-bundle.yml"
       - ".github/workflows/test-ff-matrix.yml"
+      - ".github/workflows/test-install.yml"
       - ".github/workflows/test-quarto-latexmk.yml"
       - ".github/workflows/update-test-timing.yml"
   push:

--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -6,6 +6,7 @@
 - ([#14281](https://github.com/quarto-dev/quarto-cli/issues/14281)): Fix transient `.quarto_ipynb` files accumulating during `quarto preview` with Jupyter engine.
 - ([#14298](https://github.com/quarto-dev/quarto-cli/issues/14298)): Fix `quarto preview` browse URL including output filename (e.g., `hello.html`) for single-file documents, breaking Posit Workbench proxied server access.
 - ([rstudio/rstudio#17333](https://github.com/rstudio/rstudio/issues/17333)): Fix `quarto inspect` on standalone files emitting project metadata that breaks RStudio's publishing wizard.
+- ([#14334](https://github.com/quarto-dev/quarto-cli/pull/14334)): Add arm64 Linux support for `quarto install chrome-headless-shell` using Playwright CDN as download source. `quarto install chromium` now shows a deprecation warning — use `chrome-headless-shell` instead, which always installs the latest stable Chrome (the legacy `chromium` installer pins an outdated Puppeteer revision that cannot receive security updates).
 
 ## In previous releases
 

--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -6,7 +6,7 @@
 - ([#14281](https://github.com/quarto-dev/quarto-cli/issues/14281)): Fix transient `.quarto_ipynb` files accumulating during `quarto preview` with Jupyter engine.
 - ([#14298](https://github.com/quarto-dev/quarto-cli/issues/14298)): Fix `quarto preview` browse URL including output filename (e.g., `hello.html`) for single-file documents, breaking Posit Workbench proxied server access.
 - ([rstudio/rstudio#17333](https://github.com/rstudio/rstudio/issues/17333)): Fix `quarto inspect` on standalone files emitting project metadata that breaks RStudio's publishing wizard.
-- ([#14334](https://github.com/quarto-dev/quarto-cli/pull/14334), [#9710](https://github.com/quarto-dev/quarto-cli/issues/9710)): Add arm64 Linux support for `quarto install chrome-headless-shell` using Playwright CDN as download source. `quarto install chromium` now shows a deprecation warning — use `chrome-headless-shell` instead, which always installs the latest stable Chrome (the legacy `chromium` installer pins an outdated Puppeteer revision that cannot receive security updates).
+- ([#14334](https://github.com/quarto-dev/quarto-cli/pull/14334), [#9710](https://github.com/quarto-dev/quarto-cli/issues/9710)): Add arm64 Linux support for `quarto install chrome-headless-shell` using Playwright CDN as download source. `quarto install chromium` and `quarto update chromium` now show a deprecation warning — use `chrome-headless-shell` instead, which always installs the latest stable Chrome (the legacy `chromium` installer pins an outdated Puppeteer revision that cannot receive security updates). `quarto check install` also warns when legacy Chromium is detected.
 
 ## In previous releases
 

--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -6,7 +6,7 @@
 - ([#14281](https://github.com/quarto-dev/quarto-cli/issues/14281)): Fix transient `.quarto_ipynb` files accumulating during `quarto preview` with Jupyter engine.
 - ([#14298](https://github.com/quarto-dev/quarto-cli/issues/14298)): Fix `quarto preview` browse URL including output filename (e.g., `hello.html`) for single-file documents, breaking Posit Workbench proxied server access.
 - ([rstudio/rstudio#17333](https://github.com/rstudio/rstudio/issues/17333)): Fix `quarto inspect` on standalone files emitting project metadata that breaks RStudio's publishing wizard.
-- ([#14334](https://github.com/quarto-dev/quarto-cli/pull/14334)): Add arm64 Linux support for `quarto install chrome-headless-shell` using Playwright CDN as download source. `quarto install chromium` now shows a deprecation warning — use `chrome-headless-shell` instead, which always installs the latest stable Chrome (the legacy `chromium` installer pins an outdated Puppeteer revision that cannot receive security updates).
+- ([#14334](https://github.com/quarto-dev/quarto-cli/pull/14334), [#9710](https://github.com/quarto-dev/quarto-cli/issues/9710)): Add arm64 Linux support for `quarto install chrome-headless-shell` using Playwright CDN as download source. `quarto install chromium` now shows a deprecation warning — use `chrome-headless-shell` instead, which always installs the latest stable Chrome (the legacy `chromium` installer pins an outdated Puppeteer revision that cannot receive security updates).
 
 ## In previous releases
 

--- a/src/command/check/check.ts
+++ b/src/command/check/check.ts
@@ -364,6 +364,11 @@ async function checkInstall(conf: CheckConfiguration) {
       toolsJson[tool.name] = {
         version,
       };
+      if (tool.name === "Chromium") {
+        toolsOutput.push(
+          `${kIndent}      (Chromium is outdated. Run "quarto uninstall chromium" then "quarto install chrome-headless-shell")`,
+        );
+      }
     }
     for (const tool of tools.notInstalled) {
       toolsOutput.push(`${kIndent}${tool.name}: (not installed)`);

--- a/src/tools/impl/chrome-for-testing.ts
+++ b/src/tools/impl/chrome-for-testing.ts
@@ -18,6 +18,7 @@ import { InstallContext } from "../types.ts";
 /** CfT platform identifiers matching the Google Chrome for Testing API. */
 export type CftPlatform =
   | "linux64"
+  | "linux-arm64"
   | "mac-arm64"
   | "mac-x64"
   | "win32"
@@ -37,6 +38,7 @@ export interface PlatformInfo {
 export function detectCftPlatform(): PlatformInfo {
   const platformMap: Record<string, CftPlatform> = {
     "linux-x86_64": "linux64",
+    "linux-aarch64": "linux-arm64",
     "darwin-aarch64": "mac-arm64",
     "darwin-x86_64": "mac-x64",
     "windows-x86_64": "win64",
@@ -47,14 +49,8 @@ export function detectCftPlatform(): PlatformInfo {
   const platform = platformMap[key];
 
   if (!platform) {
-    if (os === "linux" && arch === "aarch64") {
-      throw new Error(
-        "linux-arm64 is not supported by Chrome for Testing. " +
-          "Use 'quarto install chromium' for arm64 support.",
-      );
-    }
     throw new Error(
-      `Unsupported platform for Chrome for Testing: ${os} ${arch}`,
+      `Unsupported platform for chrome-headless-shell: ${os} ${arch}`,
     );
   }
 
@@ -120,6 +116,79 @@ export async function fetchLatestCftRelease(): Promise<CftStableRelease> {
     version: stable.version,
     downloads: stable.downloads,
   };
+}
+
+/** Parsed entry from Playwright's browsers.json for chromium-headless-shell. */
+export interface PlaywrightBrowserEntry {
+  revision: string;
+  browserVersion: string;
+}
+
+const kPlaywrightBrowsersJsonUrl =
+  "https://raw.githubusercontent.com/microsoft/playwright/main/packages/playwright-core/browsers.json";
+
+/** Check if the current platform requires Playwright CDN (arm64 Linux). */
+export function isPlaywrightCdnPlatform(info?: PlatformInfo): boolean {
+  const p = info ?? detectCftPlatform();
+  return p.platform === "linux-arm64";
+}
+
+/**
+ * Fetch Playwright's browsers.json and extract the chromium-headless-shell entry.
+ * Used as the version/revision source for arm64 Linux where CfT has no builds.
+ */
+export async function fetchPlaywrightBrowsersJson(): Promise<PlaywrightBrowserEntry> {
+  let response: Response;
+  const fallbackHint = "\nIf this persists, install a system Chrome/Chromium instead " +
+    "(Quarto will detect it automatically).";
+  try {
+    response = await fetch(kPlaywrightBrowsersJsonUrl);
+  } catch (e) {
+    throw new Error(
+      `Failed to fetch Playwright browsers.json: ${
+        e instanceof Error ? e.message : String(e)
+      }${fallbackHint}`,
+    );
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Playwright browsers.json returned ${response.status}: ${response.statusText}${fallbackHint}`,
+    );
+  }
+
+  // deno-lint-ignore no-explicit-any
+  let data: any;
+  try {
+    data = await response.json();
+  } catch {
+    throw new Error("Playwright browsers.json returned invalid JSON");
+  }
+
+  const browsers = data?.browsers;
+  if (!Array.isArray(browsers)) {
+    throw new Error("Playwright browsers.json missing 'browsers' array");
+  }
+
+  // deno-lint-ignore no-explicit-any
+  const entry = browsers.find((b: any) => b.name === "chromium-headless-shell");
+  if (!entry || !entry.revision || !entry.browserVersion) {
+    throw new Error(
+      "Playwright browsers.json has no 'chromium-headless-shell' entry with revision and browserVersion",
+    );
+  }
+
+  return {
+    revision: entry.revision,
+    browserVersion: entry.browserVersion,
+  };
+}
+
+/**
+ * Construct the Playwright CDN download URL for chrome-headless-shell on linux arm64.
+ */
+export function playwrightCdnDownloadUrl(revision: string): string {
+  return `https://cdn.playwright.dev/builds/chromium/${revision}/chromium-headless-shell-linux-arm64.zip`;
 }
 
 /**

--- a/src/tools/impl/chrome-for-testing.ts
+++ b/src/tools/impl/chrome-for-testing.ts
@@ -33,7 +33,7 @@ export interface PlatformInfo {
 
 /**
  * Map os + arch to a CfT platform string.
- * Throws on unsupported platforms (e.g., linux aarch64 — to be handled by Playwright CDN).
+ * Throws on unsupported platforms.
  */
 export function detectCftPlatform(): PlatformInfo {
   const platformMap: Record<string, CftPlatform> = {

--- a/src/tools/impl/chrome-headless-shell.ts
+++ b/src/tools/impl/chrome-headless-shell.ts
@@ -20,7 +20,10 @@ import {
   detectCftPlatform,
   downloadAndExtractCft,
   fetchLatestCftRelease,
+  fetchPlaywrightBrowsersJson,
   findCftExecutable,
+  isPlaywrightCdnPlatform,
+  playwrightCdnDownloadUrl,
 } from "./chrome-for-testing.ts";
 
 const kVersionFileName = "version";
@@ -33,6 +36,18 @@ export function chromeHeadlessShellInstallDir(): string {
 }
 
 /**
+ * The executable name for chrome-headless-shell on the current platform.
+ * CfT builds use "chrome-headless-shell", Playwright arm64 builds use "headless_shell".
+ */
+export function chromeHeadlessShellBinaryName(): string {
+  try {
+    return isPlaywrightCdnPlatform() ? "headless_shell" : "chrome-headless-shell";
+  } catch {
+    return "chrome-headless-shell";
+  }
+}
+
+/**
  * Find the chrome-headless-shell executable in the install directory.
  * Returns the absolute path if installed, undefined otherwise.
  */
@@ -41,7 +56,7 @@ export function chromeHeadlessShellExecutablePath(): string | undefined {
   if (!existsSync(dir)) {
     return undefined;
   }
-  return findCftExecutable(dir, "chrome-headless-shell");
+  return findCftExecutable(dir, chromeHeadlessShellBinaryName());
 }
 
 /** Record the installed version as a plain text file. */
@@ -62,7 +77,7 @@ export function readInstalledVersion(dir: string): string | undefined {
 /** Check if chrome-headless-shell is installed in the given directory. */
 export function isInstalled(dir: string): boolean {
   return existsSync(join(dir, kVersionFileName)) &&
-    findCftExecutable(dir, "chrome-headless-shell") !== undefined;
+    findCftExecutable(dir, chromeHeadlessShellBinaryName()) !== undefined;
 }
 
 // -- InstallableTool methods --
@@ -84,8 +99,22 @@ async function installedVersion(): Promise<string | undefined> {
 }
 
 async function latestRelease(): Promise<RemotePackageInfo> {
+  const platformInfo = detectCftPlatform();
+
+  if (isPlaywrightCdnPlatform(platformInfo)) {
+    // arm64 Linux: use Playwright CDN
+    const entry = await fetchPlaywrightBrowsersJson();
+    const url = playwrightCdnDownloadUrl(entry.revision);
+    return {
+      url,
+      version: entry.browserVersion,
+      assets: [{ name: "chrome-headless-shell", url }],
+    };
+  }
+
+  // All other platforms: use CfT API
   const release = await fetchLatestCftRelease();
-  const { platform } = detectCftPlatform();
+  const { platform } = platformInfo;
 
   const downloads = release.downloads["chrome-headless-shell"];
   if (!downloads) {
@@ -110,13 +139,15 @@ async function preparePackage(ctx: InstallContext): Promise<PackageInfo> {
   const release = await latestRelease();
   const workingDir = Deno.makeTempDirSync({ prefix: "quarto-chrome-hs-" });
 
+  const binaryName = chromeHeadlessShellBinaryName();
+
   try {
     await downloadAndExtractCft(
       "Chrome Headless Shell",
       release.url,
       workingDir,
       ctx,
-      "chrome-headless-shell",
+      binaryName,
     );
   } catch (e) {
     safeRemoveSync(workingDir, { recursive: true });

--- a/src/tools/tools-console.ts
+++ b/src/tools/tools-console.ts
@@ -149,6 +149,14 @@ export async function updateOrInstallTool(
   prompt?: boolean,
   updatePath?: boolean,
 ) {
+  // Deprecation warning for chromium
+  if (tool.toLowerCase() === "chromium" && action === "update") {
+    warning(
+      '"quarto update chromium" is deprecated and will be removed in Quarto 1.10. ' +
+        'Use "quarto install chrome-headless-shell" instead.',
+    );
+  }
+
   const summary = await toolSummary(tool);
 
   if (action === "update") {

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -92,6 +92,12 @@ export async function printToolInfo(name: string) {
 }
 
 export function checkToolRequirement(name: string) {
+  if (name.toLowerCase() === "chromium") {
+    warning(
+      '"quarto install chromium" is deprecated and will be removed in Quarto 1.10. ' +
+        'Use "quarto install chrome-headless-shell" instead.',
+    );
+  }
   if (name.toLowerCase() === "chromium" && isWSL()) {
     // TODO: Change to a quarto-web url page ?
     const troubleshootUrl =
@@ -108,12 +114,6 @@ export function checkToolRequirement(name: string) {
     );
     return true;
   } else {
-    if (name.toLowerCase() === "chromium") {
-      warning(
-        '"quarto install chromium" is deprecated and will be removed in Quarto 1.10. ' +
-          'Use "quarto install chrome-headless-shell" instead.',
-      );
-    }
     return true;
   }
 }

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -108,6 +108,12 @@ export function checkToolRequirement(name: string) {
     );
     return true;
   } else {
+    if (name.toLowerCase() === "chromium") {
+      warning(
+        '"quarto install chromium" is deprecated and will be removed in Quarto 1.10. ' +
+          'Use "quarto install chrome-headless-shell" instead.',
+      );
+    }
     return true;
   }
 }

--- a/tests/unit/tools/chrome-for-testing.test.ts
+++ b/tests/unit/tools/chrome-for-testing.test.ts
@@ -22,7 +22,7 @@ import {
 // Step 1: detectCftPlatform()
 unitTest("detectCftPlatform - returns valid CftPlatform for current system", async () => {
   const result = detectCftPlatform();
-  const validPlatforms = ["linux64", "mac-arm64", "mac-x64", "win32", "win64"];
+  const validPlatforms = ["linux64", "linux-arm64", "mac-arm64", "mac-x64", "win32", "win64"];
   assert(
     validPlatforms.includes(result.platform),
     `Expected one of ${validPlatforms.join(", ")}, got: ${result.platform}`,
@@ -172,3 +172,67 @@ unitTest(
     ignore: runningInCI(),
   },
 );
+
+// -- Playwright CDN tests (arm64 Linux support) --
+
+import {
+  isPlaywrightCdnPlatform,
+  playwrightCdnDownloadUrl,
+  fetchPlaywrightBrowsersJson,
+} from "../../../src/tools/impl/chrome-for-testing.ts";
+
+// isPlaywrightCdnPlatform — pure logic, runs everywhere
+unitTest("isPlaywrightCdnPlatform - returns false on non-arm64 platform", async () => {
+  if (os === "linux" && arch === "aarch64") return; // Skip on actual arm64
+  const result = isPlaywrightCdnPlatform();
+  assertEquals(result, false);
+});
+
+// playwrightCdnDownloadUrl — pure function, no HTTP
+unitTest("playwrightCdnDownloadUrl - constructs correct arm64 URL", async () => {
+  const url = playwrightCdnDownloadUrl("1219");
+  assert(
+    url.startsWith("https://cdn.playwright.dev/"),
+    `URL should start with cdn.playwright.dev, got: ${url}`,
+  );
+  assert(
+    url.includes("/builds/chromium/1219/"),
+    `URL should contain revision path, got: ${url}`,
+  );
+  assert(
+    url.endsWith("chromium-headless-shell-linux-arm64.zip"),
+    `URL should end with arm64 zip name, got: ${url}`,
+  );
+});
+
+// fetchPlaywrightBrowsersJson — external HTTP, skip on CI
+unitTest("fetchPlaywrightBrowsersJson - returns chromium-headless-shell entry", async () => {
+  const entry = await fetchPlaywrightBrowsersJson();
+  assert(entry.revision, "revision should be non-empty");
+  assert(
+    /^\d+$/.test(entry.revision),
+    `revision should be numeric, got: ${entry.revision}`,
+  );
+  assert(entry.browserVersion, "browserVersion should be non-empty");
+  assert(
+    /^\d+\.\d+\.\d+\.\d+$/.test(entry.browserVersion),
+    `browserVersion format wrong: ${entry.browserVersion}`,
+  );
+}, { ignore: runningInCI() });
+
+// findCftExecutable with Playwright arm64 layout (chrome-linux/headless_shell)
+unitTest("findCftExecutable - finds binary in Playwright arm64 layout", async () => {
+  if (isWindows) return; // arm64 layout is Linux-only, no .exe
+  const tempDir = Deno.makeTempDirSync();
+  try {
+    const subdir = join(tempDir, "chrome-linux");
+    Deno.mkdirSync(subdir);
+    Deno.writeTextFileSync(join(subdir, "headless_shell"), "fake binary");
+
+    const found = findCftExecutable(tempDir, "headless_shell");
+    assert(found !== undefined, "should find headless_shell in chrome-linux/");
+    assert(found!.endsWith("headless_shell"), `should end with headless_shell, got: ${found}`);
+  } finally {
+    safeRemoveSync(tempDir, { recursive: true });
+  }
+});

--- a/tests/unit/tools/chrome-headless-shell.test.ts
+++ b/tests/unit/tools/chrome-headless-shell.test.ts
@@ -8,12 +8,13 @@ import { unitTest } from "../../test.ts";
 import { assert, assertEquals } from "testing/asserts";
 import { join } from "../../../src/deno_ral/path.ts";
 import { existsSync, safeRemoveSync } from "../../../src/deno_ral/fs.ts";
-import { isWindows } from "../../../src/deno_ral/platform.ts";
+import { arch, isWindows, os } from "../../../src/deno_ral/platform.ts";
 import { runningInCI } from "../../../src/core/ci-info.ts";
 import { InstallContext } from "../../../src/tools/types.ts";
 import { detectCftPlatform, findCftExecutable } from "../../../src/tools/impl/chrome-for-testing.ts";
 import { installableTool, installableTools } from "../../../src/tools/tools.ts";
 import {
+  chromeHeadlessShellBinaryName,
   chromeHeadlessShellInstallable,
   chromeHeadlessShellInstallDir,
   chromeHeadlessShellExecutablePath,
@@ -256,4 +257,11 @@ unitTest("tool registry - installableTool looks up chrome-headless-shell", async
   const tool = installableTool("chrome-headless-shell");
   assert(tool !== undefined, "installableTool should find chrome-headless-shell");
   assertEquals(tool.name, "Chrome Headless Shell");
+});
+
+// -- arm64 support --
+
+unitTest("chromeHeadlessShellBinaryName - returns chrome-headless-shell on non-arm64", async () => {
+  if (os === "linux" && arch === "aarch64") return; // Skip on actual arm64
+  assertEquals(chromeHeadlessShellBinaryName(), "chrome-headless-shell");
 });

--- a/tests/unit/tools/chrome-headless-shell.test.ts
+++ b/tests/unit/tools/chrome-headless-shell.test.ts
@@ -11,7 +11,7 @@ import { existsSync, safeRemoveSync } from "../../../src/deno_ral/fs.ts";
 import { arch, isWindows, os } from "../../../src/deno_ral/platform.ts";
 import { runningInCI } from "../../../src/core/ci-info.ts";
 import { InstallContext } from "../../../src/tools/types.ts";
-import { detectCftPlatform, findCftExecutable } from "../../../src/tools/impl/chrome-for-testing.ts";
+import { detectCftPlatform, findCftExecutable, isPlaywrightCdnPlatform } from "../../../src/tools/impl/chrome-for-testing.ts";
 import { installableTool, installableTools } from "../../../src/tools/tools.ts";
 import {
   chromeHeadlessShellBinaryName,
@@ -93,10 +93,13 @@ unitTest("isInstalled - returns false when only binary exists (no version file)"
   const tempDir = Deno.makeTempDirSync();
   try {
     const { platform } = detectCftPlatform();
+    const binName = chromeHeadlessShellBinaryName();
+    // CfT layout: chrome-headless-shell-{platform}/binary
+    // Playwright arm64 layout: chrome-linux/binary (found via walkSync fallback)
     const subdir = join(tempDir, `chrome-headless-shell-${platform}`);
     Deno.mkdirSync(subdir);
-    const binaryName = isWindows ? "chrome-headless-shell.exe" : "chrome-headless-shell";
-    Deno.writeTextFileSync(join(subdir, binaryName), "fake");
+    const target = isWindows ? `${binName}.exe` : binName;
+    Deno.writeTextFileSync(join(subdir, target), "fake");
     assertEquals(isInstalled(tempDir), false);
   } finally {
     safeRemoveSync(tempDir, { recursive: true });
@@ -108,10 +111,11 @@ unitTest("isInstalled - returns true when version file and binary exist", async 
   try {
     noteInstalledVersion(tempDir, "145.0.0.0");
     const { platform } = detectCftPlatform();
+    const binName = chromeHeadlessShellBinaryName();
     const subdir = join(tempDir, `chrome-headless-shell-${platform}`);
     Deno.mkdirSync(subdir);
-    const binaryName = isWindows ? "chrome-headless-shell.exe" : "chrome-headless-shell";
-    Deno.writeTextFileSync(join(subdir, binaryName), "fake");
+    const target = isWindows ? `${binName}.exe` : binName;
+    Deno.writeTextFileSync(join(subdir, target), "fake");
 
     assertEquals(isInstalled(tempDir), true);
   } finally {
@@ -129,7 +133,12 @@ unitTest("latestRelease - returns valid RemotePackageInfo", async () => {
     `version format wrong: ${release.version}`,
   );
   assert(release.url.startsWith("https://"), `URL should be https: ${release.url}`);
-  assert(release.url.includes(release.version), "URL should contain version");
+  // CfT URLs contain the version; Playwright CDN URLs contain a revision number instead
+  if (!isPlaywrightCdnPlatform()) {
+    assert(release.url.includes(release.version), "CfT URL should contain version");
+  } else {
+    assert(release.url.includes("cdn.playwright.dev"), "arm64 URL should use Playwright CDN");
+  }
   assert(release.assets.length > 0, "should have at least one asset");
   assertEquals(release.assets[0].name, "chrome-headless-shell");
 }, { ignore: runningInCI() });
@@ -163,7 +172,7 @@ unitTest("preparePackage - downloads and extracts chrome-headless-shell", async 
   try {
     assert(pkg.version, "version should be non-empty");
     assert(pkg.filePath, "filePath should be non-empty");
-    const binary = findCftExecutable(pkg.filePath, "chrome-headless-shell");
+    const binary = findCftExecutable(pkg.filePath, chromeHeadlessShellBinaryName());
     assert(binary !== undefined, "binary should exist in extracted dir");
   } finally {
     safeRemoveSync(pkg.filePath, { recursive: true });


### PR DESCRIPTION
> [!IMPORTANT]
> Partial backport from #14334

## Summary

- Add arm64 Linux support for `quarto install chrome-headless-shell` using Playwright CDN as download source (Chrome for Testing has no arm64 Linux builds)
- Add deprecation warning on `quarto install chromium` and `quarto update chromium` directing users to `chrome-headless-shell`
- Add `quarto check install` warning when legacy Chromium is detected in the installed tools list
- Add CI workflow (`test-install.yml`) testing tool installation on arm64 Linux and macOS, and chromium deprecation warnings across all platforms

## arm64 Linux via Playwright CDN

On arm64 Linux, `chrome-headless-shell` install uses Microsoft's Playwright CDN as the download source (same approach as [Remotion](https://github.com/remotion-dev/remotion)). Version metadata comes from Playwright's [`browsers.json`](https://github.com/microsoft/playwright/blob/main/packages/playwright-core/browsers.json). The arm64 binary is named `headless_shell` (vs CfT's `chrome-headless-shell`); `chromeHeadlessShellBinaryName()` abstracts this difference.

## Deprecation warnings

- `quarto install chromium` shows deprecation before proceeding (including on WSL, where the install is also blocked)
- `quarto update chromium` shows deprecation before proceeding
- `quarto check install` shows migration guidance when legacy Chromium is in the installed tools list, regardless of whether system Chrome is also available

## Backport scope

Only the arm64 support and deprecation warnings from #14334. Excluded from this backport to keep the diff minimal on a stable branch:
- Function/type renames (cosmetic)
- Full deprecation redirect (`chromium` → `chrome-headless-shell` transparent install)
- Binder script changes

## CI workflow: `test-install.yml`

New workflow testing `quarto install` on platforms not covered by smoke tests:
- **`test-install` job:** arm64 Linux + macOS — installs tinytex and chrome-headless-shell, runs `quarto check install`
- **`test-chromium-deprecation` job:** all 4 OS/arch — verifies deprecation warnings on install and update, verifies `quarto check` outdated warning when chromium is installed
- Path-filtered to `src/tools/**` with weekly schedule for upstream CDN/API breakage detection
- Added to `paths-ignore` in `test-smokes-parallel.yml` and `test-ff-matrix.yml`

Prerequisite: #14336 (merged) added the workflow file to `main` so triggers work.

## Test plan

- [x] Existing chrome-for-testing unit tests pass
- [x] Existing chrome-headless-shell unit tests pass
- [x] New unit tests for Playwright CDN helpers
- [x] New unit test for `chromeHeadlessShellBinaryName`
- [x] Unit tests handle arm64 binary layout differences
- [x] CI `test-install` job passes on arm64 Linux and macOS
- [x] CI `test-chromium-deprecation` job passes on all 4 platforms
- [x] Full smoke test suite passes

Fixes #11877
Fixes #9710