### PR TITLE
Hide deprecated chromium from tool listings when not installed

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -120,6 +120,16 @@ jobs:
             exit 1
           fi
 
+      - name: Verify quarto list tools does not show chromium
+        shell: bash
+        run: |
+          output=$(quarto list tools 2>&1)
+          echo "$output"
+          if echo "$output" | grep -iq "chromium"; then
+            echo "::error::Deprecated chromium should not appear in 'quarto list tools' when not installed"
+            exit 1
+          fi
+
       - name: Update chromium (should redirect) and capture result
         id: update-chromium
         shell: bash

--- a/src/tools/tools-console.ts
+++ b/src/tools/tools-console.ts
@@ -12,6 +12,7 @@ import {
   installableTool,
   installableTools,
   installTool,
+  isDeprecatedTool,
   toolSummary,
   uninstallTool,
   updateTool,
@@ -94,6 +95,7 @@ export async function loadTools(): Promise<ToolInfo[]> {
     for (const key of installableTools()) {
       const tool = installableTool(key);
       const installed = await tool.installed();
+      if (!installed && isDeprecatedTool(key)) continue;
       const version = await tool.installedVersion();
       const latest = await tool.latestRelease();
       toolInfos.push({ key, tool, version, installed, latest });

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -37,6 +37,13 @@ const kInstallableTools: { [key: string]: InstallableTool } = {
   verapdf: verapdfInstallable,
 };
 
+// Tools deprecated in v1.10, to be removed from the registry in v1.11
+const kDeprecatedTools = new Set(["chromium"]);
+
+export function isDeprecatedTool(key: string): boolean {
+  return kDeprecatedTools.has(key);
+}
+
 export async function allTools(): Promise<{
   installed: InstallableTool[];
   notInstalled: InstallableTool[];
@@ -50,7 +57,7 @@ export async function allTools(): Promise<{
     const isInstalled = await tool.installed();
     if (isInstalled) {
       installed.push(tool);
-    } else {
+    } else if (!isDeprecatedTool(name)) {
       notInstalled.push(tool);
     }
   }


### PR DESCRIPTION
Follow-up to #14334.

`quarto list tools` and `quarto check install` still show chromium as "Not installed" for users who never had it. Since `quarto install chromium` now redirects to chrome-headless-shell, there is no reason to list it.

## Fix

Add `isDeprecatedTool()` helper used by both `loadTools()` (for `quarto list tools`) and `allTools()` (for `quarto check install`) to skip deprecated tools when not installed. Users who have chromium installed still see it with the deprecation hint. The helper and chromium registry entry get removed in v1.11.

Also adds a CI step in test-install.yml to verify chromium does not appear in `quarto list tools` after the redirect install.