### PR TITLE
Fix CI step swallowing quarto list tools errors

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -123,8 +123,15 @@ jobs:
       - name: Verify quarto list tools does not show chromium
         shell: bash
         run: |
+          set +e
           output=$(quarto list tools 2>&1)
+          exit_code=$?
+          set -e
           echo "$output"
+          if [ "$exit_code" -ne 0 ]; then
+            echo "::error::'quarto list tools' exited with code $exit_code (see output above)"
+            exit 1
+          fi
           if echo "$output" | grep -iq "chromium"; then
             echo "::error::Deprecated chromium should not appear in 'quarto list tools' when not installed"
             exit 1


### PR DESCRIPTION
The "Verify quarto list tools does not show chromium" step in
test-install.yml runs under `bash -e` (errexit). If `quarto list tools`
exits non-zero — e.g. a transient network failure in one of the
`latestRelease()` calls — the script dies at the command substitution
before `echo "$output"` runs, leaving zero diagnostics in the CI log.

This is what happened in https://github.com/quarto-dev/quarto-cli/actions/runs/24194985703/job/70622305236
(macOS-only, same code passed on the PR run minutes earlier).

## Fix

Use `set +e` around the command and check the exit code separately —
matching the pattern already used by the install and update steps in
the same workflow.

## Test plan

- The workflow change is self-contained (CI only)
- If `quarto list tools` crashes again, the log will now show the actual
  error output before failing