### PR TITLE
Fix tinytex install silently ignoring extraction failures

### DIFF
--- a/.claude/rules/testing/typescript-tests.md
+++ b/.claude/rules/testing/typescript-tests.md
@@ -104,8 +104,11 @@ const markdown = asMappedString("");
 const markdownWithContent = asMappedString("# Title\nSome content");
 ```
 
-**Mock ProjectContext:**
-```typescript
-import { createMockProjectContext } from "./utils.ts";  // tests/unit/project/utils.ts
-const project = createMockProjectContext();  // Creates temp dir + FileInformationCacheMap
-```
+**Mock Contexts:**
+
+Several subsystems use context interfaces passed to functions. For unit tests, create `createMock*()` helpers with no-op stubs. Key pattern: async callbacks (like `withSpinner`) should just `await op()` so errors propagate normally. Check existing test files for helpers before writing new ones.
+
+| Context | Interface | Existing helpers |
+|---------|-----------|-----------------|
+| `ProjectContext` | `src/project/types.ts` | `tests/unit/project/utils.ts` → `createMockProjectContext()` |
+| `InstallContext` | `src/tools/types.ts` | `tests/unit/tools/chrome-headless-shell.test.ts` → `createMockContext()` |

--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -21,6 +21,7 @@ All changes included in 1.10:
 
 ### `install`
 
+- ([#14304](https://github.com/quarto-dev/quarto-cli/issues/14304)): Fix `quarto install tinytex` silently ignoring extraction failures. When archive extraction fails (e.g., `.tar.xz` on a system without `xz-utils`), the installer now reports a clear error instead of proceeding and failing with a confusing `NotFound` message.
 - ([#11877](https://github.com/quarto-dev/quarto-cli/issues/11877), [#9710](https://github.com/quarto-dev/quarto-cli/issues/9710)): Add arm64 Linux support for `quarto install chrome-headless-shell` using Playwright CDN as download source, since Chrome for Testing has no arm64 Linux builds.
 - ([#11877](https://github.com/quarto-dev/quarto-cli/issues/11877)): Deprecate `quarto install chromium` — the command now transparently redirects to `chrome-headless-shell`. Installing `chrome-headless-shell` automatically removes any legacy Chromium installation. Use `chrome-headless-shell` instead, which always installs the latest stable Chrome (the legacy `chromium` installer pins an outdated Puppeteer revision that cannot receive security updates).
 

--- a/package/src/linux/installer.ts
+++ b/package/src/linux/installer.ts
@@ -92,11 +92,15 @@ async function createNfpmConfig(
   // Format-specific configuration
   if (format === 'deb') {
     config.overrides.deb = {
-      recommends: ["unzip"],
+      recommends: ["unzip", "xz-utils"],
     };
     // Add Debian-specific metadata
     config.section = "user/text";
     config.priority = "optional";
+  } else if (format === 'rpm') {
+    config.overrides.rpm = {
+      recommends: ["xz"],
+    };
   }
   return config;
 }

--- a/src/tools/impl/tinytex.ts
+++ b/src/tools/impl/tinytex.ts
@@ -192,8 +192,8 @@ async function install(
         async () => {
           const result = await unzip(pkgInfo.filePath);
           if (!result.success) {
-            const hint = pkgInfo.filePath.endsWith(".tar.xz")
-              ? "\nOn Linux, you may need to install xz-utils (e.g., apt install xz-utils)."
+            const hint = pkgInfo.filePath.endsWith(".tar.xz") && isLinux
+              ? "\nYou may need to install xz-utils (e.g., apt install xz-utils)."
               : "";
             throw new Error(
               `Failed to extract ${basename(pkgInfo.filePath)}.${hint}\n${result.stderr}`,

--- a/src/tools/impl/tinytex.ts
+++ b/src/tools/impl/tinytex.ts
@@ -190,7 +190,15 @@ async function install(
       await context.withSpinner(
         { message: `Unzipping ${basename(pkgInfo.filePath)}` },
         async () => {
-          await unzip(pkgInfo.filePath);
+          const result = await unzip(pkgInfo.filePath);
+          if (!result.success) {
+            const hint = pkgInfo.filePath.endsWith(".tar.xz")
+              ? "\nOn Linux, you may need to install xz-utils (e.g., apt install xz-utils)."
+              : "";
+            throw new Error(
+              `Failed to extract ${basename(pkgInfo.filePath)}.${hint}\n${result.stderr}`,
+            );
+          }
         },
       );
 

--- a/tests/unit/tools/tinytex.test.ts
+++ b/tests/unit/tools/tinytex.test.ts
@@ -5,10 +5,14 @@
  */
 
 import { unitTest } from "../../test.ts";
-import { assert, assertEquals } from "testing/asserts";
-import { tinyTexPkgName } from "../../../src/tools/impl/tinytex.ts";
+import { assert, assertEquals, assertRejects } from "testing/asserts";
+import {
+  tinyTexInstallable,
+  tinyTexPkgName,
+} from "../../../src/tools/impl/tinytex.ts";
 import { getLatestRelease } from "../../../src/tools/github.ts";
-import { GitHubRelease } from "../../../src/tools/types.ts";
+import { GitHubRelease, InstallContext, PackageInfo } from "../../../src/tools/types.ts";
+import { join } from "../../../src/deno_ral/path.ts";
 
 // ---- Pure logic tests for tinyTexPkgName ----
 
@@ -156,5 +160,83 @@ unitTest(
       arch: "x86_64",
     });
     assertAssetExists(candidates, assetNames, "Windows");
+  },
+);
+
+// ---- Extraction failure tests ----
+
+function createMockContext(workingDir: string): InstallContext {
+  return {
+    workingDir,
+    info: (_msg: string) => {},
+    withSpinner: async (_options, op) => {
+      await op();
+    },
+    error: (_msg: string) => {},
+    confirm: async (_msg: string) => true,
+    download: async (_name: string, _url: string, _target: string) => {},
+    props: {},
+    flags: {},
+  };
+}
+
+unitTest(
+  "install - throws on extraction failure for corrupt archive",
+  async () => {
+    const workingDir = Deno.makeTempDirSync({ prefix: "quarto-tinytex-test" });
+    try {
+      // Create a corrupt .tar.xz file that tar cannot extract
+      const badArchive = join(
+        workingDir,
+        "TinyTeX-linux-x86_64-v2026.04.tar.xz",
+      );
+      Deno.writeTextFileSync(badArchive, "this is not a valid archive");
+
+      const pkgInfo: PackageInfo = {
+        filePath: badArchive,
+        version: "v2026.04",
+      };
+      const context = createMockContext(workingDir);
+
+      await assertRejects(
+        () => tinyTexInstallable.install(pkgInfo, context),
+        Error,
+        "Failed to extract",
+      );
+    } finally {
+      Deno.removeSync(workingDir, { recursive: true });
+    }
+  },
+);
+
+unitTest(
+  "install - extraction failure for .tar.xz includes xz-utils hint",
+  async () => {
+    const workingDir = Deno.makeTempDirSync({ prefix: "quarto-tinytex-test" });
+    try {
+      const badArchive = join(
+        workingDir,
+        "TinyTeX-linux-x86_64-v2026.04.tar.xz",
+      );
+      Deno.writeTextFileSync(badArchive, "this is not a valid archive");
+
+      const pkgInfo: PackageInfo = {
+        filePath: badArchive,
+        version: "v2026.04",
+      };
+      const context = createMockContext(workingDir);
+
+      try {
+        await tinyTexInstallable.install(pkgInfo, context);
+        throw new Error("Expected install to throw");
+      } catch (e) {
+        assert(
+          e instanceof Error && e.message.includes("xz-utils"),
+          `Error message should mention xz-utils, got: ${e}`,
+        );
+      }
+    } finally {
+      Deno.removeSync(workingDir, { recursive: true });
+    }
   },
 );

--- a/tests/unit/tools/tinytex.test.ts
+++ b/tests/unit/tools/tinytex.test.ts
@@ -231,15 +231,19 @@ unitTest(
         await tinyTexInstallable.install(pkgInfo, context);
         throw new Error("Expected install to throw");
       } catch (e) {
+        assert(
+          e instanceof Error && e.message.includes("Failed to extract"),
+          `Error should indicate extraction failure, got: ${e}`,
+        );
         if (isLinux) {
           assert(
-            e instanceof Error && e.message.includes("xz-utils"),
-            `On Linux, error should mention xz-utils, got: ${e}`,
+            e.message.includes("xz-utils"),
+            `On Linux, error should mention xz-utils, got: ${e.message}`,
           );
         } else {
           assert(
-            e instanceof Error && !e.message.includes("xz-utils"),
-            `On non-Linux, error should not mention xz-utils, got: ${e}`,
+            !e.message.includes("xz-utils"),
+            `On non-Linux, error should not mention xz-utils, got: ${e.message}`,
           );
         }
       }

--- a/tests/unit/tools/tinytex.test.ts
+++ b/tests/unit/tools/tinytex.test.ts
@@ -13,6 +13,7 @@ import {
 import { getLatestRelease } from "../../../src/tools/github.ts";
 import { GitHubRelease, InstallContext, PackageInfo } from "../../../src/tools/types.ts";
 import { join } from "../../../src/deno_ral/path.ts";
+import { isLinux } from "../../../src/deno_ral/platform.ts";
 
 // ---- Pure logic tests for tinyTexPkgName ----
 
@@ -210,7 +211,7 @@ unitTest(
 );
 
 unitTest(
-  "install - extraction failure for .tar.xz includes xz-utils hint",
+  "install - extraction failure for .tar.xz includes xz-utils hint only on Linux",
   async () => {
     const workingDir = Deno.makeTempDirSync({ prefix: "quarto-tinytex-test" });
     try {
@@ -230,10 +231,17 @@ unitTest(
         await tinyTexInstallable.install(pkgInfo, context);
         throw new Error("Expected install to throw");
       } catch (e) {
-        assert(
-          e instanceof Error && e.message.includes("xz-utils"),
-          `Error message should mention xz-utils, got: ${e}`,
-        );
+        if (isLinux) {
+          assert(
+            e instanceof Error && e.message.includes("xz-utils"),
+            `On Linux, error should mention xz-utils, got: ${e}`,
+          );
+        } else {
+          assert(
+            e instanceof Error && !e.message.includes("xz-utils"),
+            `On non-Linux, error should not mention xz-utils, got: ${e}`,
+          );
+        }
       }
     } finally {
       Deno.removeSync(workingDir, { recursive: true });


### PR DESCRIPTION
When `quarto install tinytex` downloads a `.tar.xz` archive on a system without xz-utils, `tar xf` fails but the installer shows `[✓] Unzipping` and proceeds to move files from a non-existent directory, producing a confusing `lstat`/`NotFound` error.

## Root Cause

The `unzip()` call in `tinytex.ts` discards the `ProcessResult` return value. Other callers (extension install, `quarto use template`, `quarto use brand`) all check `result.success` — the TinyTeX installer was the exception.

This became a visible problem after #14181 made `.tar.xz` the preferred format for Linux and macOS TinyTeX packages. Unlike `.tar.gz` (gzip is universal), `.tar.xz` requires xz-utils which isn't installed on minimal/container images.

## Fix

Check the `unzip()` return value and throw on failure with a clear error message. For `.tar.xz` archives, the message includes a hint to install xz-utils.

Also add `xz-utils` to `.deb` Recommends and `xz` to `.rpm` Recommends, since TinyTeX now ships `.tar.xz` as the preferred archive format.

Fixes #14304