### PR TITLE
[backport] Fix tinytex install silently ignoring extraction failures

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -2,6 +2,8 @@
 
 ## In this release
 
+- ([#14304](https://github.com/quarto-dev/quarto-cli/issues/14304)): Fix `quarto install tinytex` silently ignoring extraction failures. When archive extraction fails (e.g., `.tar.xz` on a system without `xz-utils`), the installer now reports a clear error instead of proceeding and failing with a confusing `NotFound` message.
+
 ## In previous releases
 
 - ([#14267](https://github.com/quarto-dev/quarto-cli/issues/14267)): Fix Windows paths with accented characters (e.g., `C:\Users\Sébastien\`) breaking dart-sass compilation.

--- a/package/src/linux/installer.ts
+++ b/package/src/linux/installer.ts
@@ -92,11 +92,15 @@ async function createNfpmConfig(
   // Format-specific configuration
   if (format === 'deb') {
     config.overrides.deb = {
-      recommends: ["unzip"],
+      recommends: ["unzip", "xz-utils"],
     };
     // Add Debian-specific metadata
     config.section = "user/text";
     config.priority = "optional";
+  } else if (format === 'rpm') {
+    config.overrides.rpm = {
+      recommends: ["xz"],
+    };
   }
   return config;
 }

--- a/src/tools/impl/tinytex.ts
+++ b/src/tools/impl/tinytex.ts
@@ -192,8 +192,8 @@ async function install(
         async () => {
           const result = await unzip(pkgInfo.filePath);
           if (!result.success) {
-            const hint = pkgInfo.filePath.endsWith(".tar.xz")
-              ? "\nOn Linux, you may need to install xz-utils (e.g., apt install xz-utils)."
+            const hint = pkgInfo.filePath.endsWith(".tar.xz") && isLinux
+              ? "\nYou may need to install xz-utils (e.g., apt install xz-utils)."
               : "";
             throw new Error(
               `Failed to extract ${basename(pkgInfo.filePath)}.${hint}\n${result.stderr}`,

--- a/src/tools/impl/tinytex.ts
+++ b/src/tools/impl/tinytex.ts
@@ -190,7 +190,15 @@ async function install(
       await context.withSpinner(
         { message: `Unzipping ${basename(pkgInfo.filePath)}` },
         async () => {
-          await unzip(pkgInfo.filePath);
+          const result = await unzip(pkgInfo.filePath);
+          if (!result.success) {
+            const hint = pkgInfo.filePath.endsWith(".tar.xz")
+              ? "\nOn Linux, you may need to install xz-utils (e.g., apt install xz-utils)."
+              : "";
+            throw new Error(
+              `Failed to extract ${basename(pkgInfo.filePath)}.${hint}\n${result.stderr}`,
+            );
+          }
         },
       );
 

--- a/tests/unit/tools/tinytex.test.ts
+++ b/tests/unit/tools/tinytex.test.ts
@@ -5,10 +5,14 @@
  */
 
 import { unitTest } from "../../test.ts";
-import { assert, assertEquals } from "testing/asserts";
-import { tinyTexPkgName } from "../../../src/tools/impl/tinytex.ts";
+import { assert, assertEquals, assertRejects } from "testing/asserts";
+import {
+  tinyTexInstallable,
+  tinyTexPkgName,
+} from "../../../src/tools/impl/tinytex.ts";
 import { getLatestRelease } from "../../../src/tools/github.ts";
-import { GitHubRelease } from "../../../src/tools/types.ts";
+import { GitHubRelease, InstallContext, PackageInfo } from "../../../src/tools/types.ts";
+import { join } from "../../../src/deno_ral/path.ts";
 
 // ---- Pure logic tests for tinyTexPkgName ----
 
@@ -156,5 +160,83 @@ unitTest(
       arch: "x86_64",
     });
     assertAssetExists(candidates, assetNames, "Windows");
+  },
+);
+
+// ---- Extraction failure tests ----
+
+function createMockContext(workingDir: string): InstallContext {
+  return {
+    workingDir,
+    info: (_msg: string) => {},
+    withSpinner: async (_options, op) => {
+      await op();
+    },
+    error: (_msg: string) => {},
+    confirm: async (_msg: string) => true,
+    download: async (_name: string, _url: string, _target: string) => {},
+    props: {},
+    flags: {},
+  };
+}
+
+unitTest(
+  "install - throws on extraction failure for corrupt archive",
+  async () => {
+    const workingDir = Deno.makeTempDirSync({ prefix: "quarto-tinytex-test" });
+    try {
+      // Create a corrupt .tar.xz file that tar cannot extract
+      const badArchive = join(
+        workingDir,
+        "TinyTeX-linux-x86_64-v2026.04.tar.xz",
+      );
+      Deno.writeTextFileSync(badArchive, "this is not a valid archive");
+
+      const pkgInfo: PackageInfo = {
+        filePath: badArchive,
+        version: "v2026.04",
+      };
+      const context = createMockContext(workingDir);
+
+      await assertRejects(
+        () => tinyTexInstallable.install(pkgInfo, context),
+        Error,
+        "Failed to extract",
+      );
+    } finally {
+      Deno.removeSync(workingDir, { recursive: true });
+    }
+  },
+);
+
+unitTest(
+  "install - extraction failure for .tar.xz includes xz-utils hint",
+  async () => {
+    const workingDir = Deno.makeTempDirSync({ prefix: "quarto-tinytex-test" });
+    try {
+      const badArchive = join(
+        workingDir,
+        "TinyTeX-linux-x86_64-v2026.04.tar.xz",
+      );
+      Deno.writeTextFileSync(badArchive, "this is not a valid archive");
+
+      const pkgInfo: PackageInfo = {
+        filePath: badArchive,
+        version: "v2026.04",
+      };
+      const context = createMockContext(workingDir);
+
+      try {
+        await tinyTexInstallable.install(pkgInfo, context);
+        throw new Error("Expected install to throw");
+      } catch (e) {
+        assert(
+          e instanceof Error && e.message.includes("xz-utils"),
+          `Error message should mention xz-utils, got: ${e}`,
+        );
+      }
+    } finally {
+      Deno.removeSync(workingDir, { recursive: true });
+    }
   },
 );

--- a/tests/unit/tools/tinytex.test.ts
+++ b/tests/unit/tools/tinytex.test.ts
@@ -231,15 +231,19 @@ unitTest(
         await tinyTexInstallable.install(pkgInfo, context);
         throw new Error("Expected install to throw");
       } catch (e) {
+        assert(
+          e instanceof Error && e.message.includes("Failed to extract"),
+          `Error should indicate extraction failure, got: ${e}`,
+        );
         if (isLinux) {
           assert(
-            e instanceof Error && e.message.includes("xz-utils"),
-            `On Linux, error should mention xz-utils, got: ${e}`,
+            e.message.includes("xz-utils"),
+            `On Linux, error should mention xz-utils, got: ${e.message}`,
           );
         } else {
           assert(
-            e instanceof Error && !e.message.includes("xz-utils"),
-            `On non-Linux, error should not mention xz-utils, got: ${e}`,
+            !e.message.includes("xz-utils"),
+            `On non-Linux, error should not mention xz-utils, got: ${e.message}`,
           );
         }
       }

--- a/tests/unit/tools/tinytex.test.ts
+++ b/tests/unit/tools/tinytex.test.ts
@@ -13,6 +13,7 @@ import {
 import { getLatestRelease } from "../../../src/tools/github.ts";
 import { GitHubRelease, InstallContext, PackageInfo } from "../../../src/tools/types.ts";
 import { join } from "../../../src/deno_ral/path.ts";
+import { isLinux } from "../../../src/deno_ral/platform.ts";
 
 // ---- Pure logic tests for tinyTexPkgName ----
 
@@ -210,7 +211,7 @@ unitTest(
 );
 
 unitTest(
-  "install - extraction failure for .tar.xz includes xz-utils hint",
+  "install - extraction failure for .tar.xz includes xz-utils hint only on Linux",
   async () => {
     const workingDir = Deno.makeTempDirSync({ prefix: "quarto-tinytex-test" });
     try {
@@ -230,10 +231,17 @@ unitTest(
         await tinyTexInstallable.install(pkgInfo, context);
         throw new Error("Expected install to throw");
       } catch (e) {
-        assert(
-          e instanceof Error && e.message.includes("xz-utils"),
-          `Error message should mention xz-utils, got: ${e}`,
-        );
+        if (isLinux) {
+          assert(
+            e instanceof Error && e.message.includes("xz-utils"),
+            `On Linux, error should mention xz-utils, got: ${e}`,
+          );
+        } else {
+          assert(
+            e instanceof Error && !e.message.includes("xz-utils"),
+            `On non-Linux, error should not mention xz-utils, got: ${e}`,
+          );
+        }
       }
     } finally {
       Deno.removeSync(workingDir, { recursive: true });


### PR DESCRIPTION
> [!IMPORTANT]
> Backport from #14357

Fix `quarto install tinytex` silently ignoring extraction failures. Check the `unzip()` return value, provide a clear error message with xz-utils hint for `.tar.xz` archives, and add `xz-utils`/`xz` to `.deb`/`.rpm` Recommends.

Fixes #14304