### PR TITLE
Add retry logic for tool downloads

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -40,11 +40,27 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          quarto install tinytex
+          for attempt in 1 2 3; do
+            if quarto install tinytex; then
+              exit 0
+            fi
+            echo "::warning::Attempt $attempt failed, retrying in 15s..."
+            sleep 15
+          done
+          echo "::error::TinyTeX install failed after 3 attempts"
+          exit 1
 
       - name: Install Chrome Headless Shell
         run: |
-          quarto install chrome-headless-shell --no-prompt
+          for attempt in 1 2 3; do
+            if quarto install chrome-headless-shell --no-prompt; then
+              exit 0
+            fi
+            echo "::warning::Attempt $attempt failed, retrying in 15s..."
+            sleep 15
+          done
+          echo "::error::Chrome Headless Shell install failed after 3 attempts"
+          exit 1
 
       - name: Verify tools with quarto check
         run: |

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -10,10 +10,12 @@ on:
       - "v1.*"
     paths:
       - "src/tools/**"
+      - "src/core/download.ts"
       - ".github/workflows/test-install.yml"
   pull_request:
     paths:
       - "src/tools/**"
+      - "src/core/download.ts"
       - ".github/workflows/test-install.yml"
   schedule:
     # Weekly Monday 9am UTC — detect upstream CDN/API breakage

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -11,11 +11,13 @@ on:
     paths:
       - "src/tools/**"
       - "src/core/download.ts"
+      - "src/core/retry.ts"
       - ".github/workflows/test-install.yml"
   pull_request:
     paths:
       - "src/tools/**"
       - "src/core/download.ts"
+      - "src/core/retry.ts"
       - ".github/workflows/test-install.yml"
   schedule:
     # Weekly Monday 9am UTC — detect upstream CDN/API breakage
@@ -46,8 +48,10 @@ jobs:
             if quarto install tinytex; then
               exit 0
             fi
-            echo "::warning::Attempt $attempt failed, retrying in 15s..."
-            sleep 15
+            if [ "$attempt" -lt 3 ]; then
+              echo "::warning::Attempt $attempt failed, retrying in 15s..."
+              sleep 15
+            fi
           done
           echo "::error::TinyTeX install failed after 3 attempts"
           exit 1
@@ -58,8 +62,10 @@ jobs:
             if quarto install chrome-headless-shell --no-prompt; then
               exit 0
             fi
-            echo "::warning::Attempt $attempt failed, retrying in 15s..."
-            sleep 15
+            if [ "$attempt" -lt 3 ]; then
+              echo "::warning::Attempt $attempt failed, retrying in 15s..."
+              sleep 15
+            fi
           done
           echo "::error::Chrome Headless Shell install failed after 3 attempts"
           exit 1

--- a/src/core/download.ts
+++ b/src/core/download.ts
@@ -6,6 +6,7 @@
 
 import { writeAll } from "io/write-all";
 import { progressBar } from "./console.ts";
+import { withRetry } from "./retry.ts";
 
 export interface DownloadError extends Error {
   statusCode: number;
@@ -17,42 +18,62 @@ export async function downloadWithProgress(
   msg: string,
   toFile: string,
 ) {
-  // Fetch the data
-  const response = await (typeof url === "string"
-    ? fetch(
-      url,
-      {
-        redirect: "follow",
-      },
-    )
-    : url);
+  await withRetry(async () => {
+    // Fetch the data
+    const response = await (typeof url === "string"
+      ? fetch(
+        url,
+        {
+          redirect: "follow",
+        },
+      )
+      : url);
 
-  // Write the data to a file
-  if (response.status === 200 && response.body) {
-    const pkgFile = await Deno.open(toFile, { create: true, write: true });
+    // Write the data to a file
+    if (response.status === 200 && response.body) {
+      const pkgFile = await Deno.open(
+        toFile,
+        { create: true, write: true, truncate: true },
+      );
 
-    const contentLength =
-      (response.headers.get("content-length") || 0) as number;
-    const contentLengthMb = contentLength / 1024 / 1024;
+      const contentLength =
+        (response.headers.get("content-length") || 0) as number;
+      const contentLengthMb = contentLength / 1024 / 1024;
 
-    const prog = progressBar(contentLengthMb, msg);
+      const prog = progressBar(contentLengthMb, msg);
 
-    let totalLength = 0;
-    for await (const chunk of response.body) {
-      await writeAll(pkgFile, chunk);
-      totalLength = totalLength + chunk.length;
-      if (contentLength > 0) {
-        prog.update(
-          totalLength / 1024 / 1024,
-          `${(totalLength / 1024 / 1024).toFixed(1)}MB`,
-        );
+      try {
+        let totalLength = 0;
+        for await (const chunk of response.body) {
+          await writeAll(pkgFile, chunk);
+          totalLength = totalLength + chunk.length;
+          if (contentLength > 0) {
+            prog.update(
+              totalLength / 1024 / 1024,
+              `${(totalLength / 1024 / 1024).toFixed(1)}MB`,
+            );
+          }
+        }
+        prog.complete();
+      } finally {
+        pkgFile.close();
       }
+    } else {
+      throw new Error(
+        `download failed (HTTP status ${response.status} - ${response.statusText})`,
+      );
     }
-    prog.complete();
-    pkgFile.close();
-  } else {
-    throw new Error(
-      `download failed (HTTP status ${response.status} - ${response.statusText})`,
-    );
-  }
+  }, {
+    attempts: 3,
+    minWait: 2000,
+    maxWait: 10000,
+    retry: (err: Error) => {
+      // Don't retry HTTP status errors (4xx, 5xx) — they're deterministic
+      if (err.message.startsWith("download failed (HTTP status")) {
+        return false;
+      }
+      // Retry network errors (connection reset, timeout, body read errors)
+      return true;
+    },
+  });
 }

--- a/src/core/retry.ts
+++ b/src/core/retry.ts
@@ -26,7 +26,7 @@ export async function withRetry<T = void>(
   let attempt = 0;
   while (true) {
     try {
-      return fn();
+      return await fn();
     } catch (err) {
       if (!(err instanceof Error)) throw err;
       if ((attempt++ >= attempts) || (retry && !retry(err))) {


### PR DESCRIPTION
Transient network failures during `quarto install` (CDN timeouts,
connection resets mid-download) cause hard failures. Seen in CI on
arm64 runners: `error reading a body from connection` during Chrome
Headless Shell download.

## Fix

Two layers of resilience:

**Internal retry (`src/core/download.ts`):** Wraps `downloadWithProgress`
in `withRetry` — 3 attempts with 2-10s jittered backoff. Only retries
network errors (connection reset, body read failures), not HTTP status
errors. Protects all `quarto install` commands for all users.

**CI retry (`.github/workflows/test-install.yml`):** Bash retry loop on
install steps as defense-in-depth. Uses `::warning::` annotations for
visibility.

Fixes https://github.com/quarto-dev/quarto-cli/actions/runs/24458183539/job/71464601541