### PR TITLE
Fix .quarto_ipynb files not cleaned up after render

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -52,3 +52,4 @@ All changes included in 1.10:
 - ([#6651](https://github.com/quarto-dev/quarto-cli/issues/6651)): Fix dart-sass compilation failing in enterprise environments where `.bat` files are blocked by group policy.
 - ([#14255](https://github.com/quarto-dev/quarto-cli/issues/14255)): Fix shortcodes inside inline and display math expressions not being resolved.
 - ([#14342](https://github.com/quarto-dev/quarto-cli/issues/14342)): Work around TOCTOU race in Deno's `expandGlobSync` that can cause unexpected exceptions to be raised while traversing directories during project initialization.
+- ([#14359](https://github.com/quarto-dev/quarto-cli/issues/14359)): Fix intermediate `.quarto_ipynb` file not being deleted after rendering a `.qmd` with Jupyter engine, causing numbered variants (`_1`, `_2`, ...) to accumulate on disk across renders.

--- a/src/command/render/output-typst.ts
+++ b/src/command/render/output-typst.ts
@@ -62,7 +62,7 @@ export interface NeededPackage {
 
 // Collect all package source directories (built-in + extensions)
 async function collectPackageSources(
-  input: string,
+  inputDir: string,
   projectDir: string,
 ): Promise<string[]> {
   const sources: string[] = [];
@@ -74,7 +74,7 @@ async function collectPackageSources(
   }
 
   // 2. Extension packages
-  const extensionDirs = inputExtensionDirs(input, projectDir);
+  const extensionDirs = inputExtensionDirs(inputDir, projectDir);
   const subtreePath = builtinSubtreeExtensions();
   for (const extDir of extensionDirs) {
     const extensions = extDir === subtreePath
@@ -173,7 +173,7 @@ export function stageAllPackages(sources: string[], cacheDir: string): void {
 // Stage typst packages to .quarto/typst-packages/
 // First stages built-in packages, then extension packages (which can override)
 async function stageTypstPackages(
-  input: string,
+  inputDir: string,
   typstInput: string,
   projectDir?: string,
 ): Promise<string | undefined> {
@@ -181,7 +181,7 @@ async function stageTypstPackages(
     return undefined;
   }
 
-  const packageSources = await collectPackageSources(input, projectDir);
+  const packageSources = await collectPackageSources(inputDir, projectDir);
   if (packageSources.length === 0) {
     return undefined;
   }
@@ -249,7 +249,7 @@ export function typstPdfOutputRecipe(
 
       // Stage extension typst packages
       const packagePath = await stageTypstPackages(
-        input,
+        inputDir,
         typstInput,
         project.dir,
       );

--- a/src/execute/jupyter/jupyter.ts
+++ b/src/execute/jupyter/jupyter.ts
@@ -7,7 +7,7 @@
 import { basename, dirname, join, relative } from "../../deno_ral/path.ts";
 import { satisfies } from "semver/mod.ts";
 
-import { existsSync } from "../../deno_ral/fs.ts";
+import { existsSync, safeRemoveSync } from "../../deno_ral/fs.ts";
 
 import { error, info } from "../../deno_ral/log.ts";
 
@@ -870,6 +870,8 @@ function cleanupNotebook(
     if (cached.target && cached.target.data) {
       (cached.target.data as JupyterTargetData).transient = false;
     }
+  } else if (data.transient) {
+    safeRemoveSync(target.input);
   }
 }
 

--- a/src/execute/jupyter/jupyter.ts
+++ b/src/execute/jupyter/jupyter.ts
@@ -863,16 +863,26 @@ function cleanupNotebook(
   format: Format,
   project: EngineProjectContext,
 ) {
-  // Make notebook non-transient when keep-ipynb is set
   const data = target.data as JupyterTargetData;
-  const cached = project.fileInformationCache.get(target.source);
-  if (cached && data.transient && format.execute[kKeepIpynb]) {
-    if (cached.target && cached.target.data) {
+
+  // Nothing to do for non-transient notebooks (user-authored .ipynb files)
+  if (!data.transient) {
+    return;
+  }
+
+  // User wants to keep the notebook — do not delete.
+  // Also mark the cache entry (if any) as non-transient so later cache
+  // cleanup doesn't remove it.
+  if (format.execute[kKeepIpynb]) {
+    const cached = project.fileInformationCache.get(target.source);
+    if (cached && cached.target && cached.target.data) {
       (cached.target.data as JupyterTargetData).transient = false;
     }
-  } else if (data.transient) {
-    safeRemoveSync(target.input);
+    return;
   }
+
+  // Otherwise the transient notebook is no longer needed; delete it.
+  safeRemoveSync(target.input);
 }
 
 interface JupyterTargetData {

--- a/tests/docs/manual/preview/14359-positron-kill-quarto-ipynb.md
+++ b/tests/docs/manual/preview/14359-positron-kill-quarto-ipynb.md
@@ -1,0 +1,42 @@
+# Manual Test: .quarto_ipynb cleanup on ungraceful termination (#14359)
+
+## Purpose
+
+Verify that `.quarto_ipynb` files are cleaned up after render even when preview
+is killed ungracefully (e.g., Positron terminal bin icon). This tests the fix
+that restores immediate deletion in `cleanupNotebook()`.
+
+**Why manual?** Ungraceful termination bypasses normal cleanup handlers.
+The fix ensures deletion happens right after execution, before any signal
+could interrupt the process.
+
+## Automated coverage
+
+The smoke-all test `tests/docs/smoke-all/2025/05/21/keep_ipynb_single-file/14359.qmd`
+verifies the core behavior (file deleted after render). This manual test
+covers the interactive preview scenario.
+
+## Steps
+
+1. Open Positron (or VS Code with Quarto extension)
+2. Open `tests/docs/manual/preview/14281-quarto-ipynb-accumulation.qmd`
+3. Start Quarto Preview (terminal or Quarto extension)
+4. Wait for first render to complete
+5. Check directory: `ls *.quarto_ipynb*` — should be zero files (file was deleted after render)
+6. Edit and save the file to trigger a re-render
+7. After re-render completes, check again — still zero `.quarto_ipynb` files
+8. Kill preview ungracefully (Positron terminal bin icon / close terminal)
+9. Check directory — still zero `.quarto_ipynb` files
+
+## Expected
+
+- Zero `.quarto_ipynb` files at all times (the file is deleted immediately
+  after each execution, not deferred to cleanup handlers)
+- Ungraceful termination does not leave stale files because deletion already
+  happened
+
+## Related
+
+- #14281 — within-session accumulation (fixed by PR #14287)
+- #12780 — `keep-ipynb` support (PR #12793 introduced this regression)
+- posit-dev/positron#13006 — Killing Quarto Preview should exit process

--- a/tests/docs/manual/preview/14359-positron-kill-quarto-ipynb.md
+++ b/tests/docs/manual/preview/14359-positron-kill-quarto-ipynb.md
@@ -35,8 +35,16 @@ covers the interactive preview scenario.
 - Ungraceful termination does not leave stale files because deletion already
   happened
 
+## Note on Positron fix
+
+Quarto extension v1.131.0 (posit-dev/positron#13006) now sends
+`previewTerminateRequest()` when the terminal is closed, giving Quarto
+a clean shutdown. Our fix (immediate deletion after execution) and their
+fix (clean shutdown signal) are complementary — either alone prevents
+stale files, both together provide defense in depth.
+
 ## Related
 
 - #14281 — within-session accumulation (fixed by PR #14287)
 - #12780 — `keep-ipynb` support (PR #12793 introduced this regression)
-- posit-dev/positron#13006 — Killing Quarto Preview should exit process
+- posit-dev/positron#13006 — Killing Quarto Preview should exit process (fixed in extension v1.131.0)

--- a/tests/docs/smoke-all/2025/05/21/keep_ipynb_single-file/14359.qmd
+++ b/tests/docs/smoke-all/2025/05/21/keep_ipynb_single-file/14359.qmd
@@ -1,0 +1,12 @@
+---
+format: html
+_quarto:
+  tests:
+    html:
+      fileNotExists:
+        outputPath: 14359.quarto_ipynb
+---
+
+```{python}
+1 + 1
+```

--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -34,6 +34,7 @@ import {
   ensureTypstFileRegexMatches,
   ensureSnapshotMatches,
   fileExists,
+  fileNotExists,
   noErrors,
   noErrorsOrWarnings,
   ensurePptxXpath,
@@ -266,6 +267,22 @@ function resolveTestSpecs(
               } else if (path === "supportPath") {
                 verifyFns.push(
                   fileExists(join(outputFile.supportPath, file)),
+                );
+              }
+            }
+          } else if (key === "fileNotExists") {
+            for (
+              const [path, file] of Object.entries(
+                value as Record<string, string>,
+              )
+            ) {
+              if (path === "outputPath") {
+                verifyFns.push(
+                  fileNotExists(join(dirname(outputFile.outputPath), file)),
+                );
+              } else if (path === "supportPath") {
+                verifyFns.push(
+                  fileNotExists(join(outputFile.supportPath, file)),
                 );
               }
             }

--- a/tests/verify.ts
+++ b/tests/verify.ts
@@ -235,6 +235,16 @@ export const fileExists = (file: string): Verify => {
   };
 };
 
+export const fileNotExists = (file: string): Verify => {
+  return {
+    name: `File ${file} does not exist`,
+    verify: (_output: ExecuteOutput[]) => {
+      verifyNoPath(file);
+      return Promise.resolve();
+    },
+  };
+};
+
 export const pathDoNotExists = (path: string): Verify => {
   return {
     name: `path ${path} do not exists`,


### PR DESCRIPTION
When rendering a `.qmd` file with Jupyter execution, the intermediate `.quarto_ipynb` file is never deleted. Each subsequent preview creates numbered variants (`_1`, `_2`, etc.) that accumulate on disk.

## Root Cause

PR #12793 added `keep-ipynb: true` support by integrating `cleanupNotebook()` with `fileInformationCache`. As a side effect, it dropped the immediate file deletion for the default `keep-ipynb: false` case. The function only flips a `transient` flag in the cache when `keep-ipynb: true` is set, but does nothing otherwise — the file just stays on disk.

## Fix

Add an `else if (data.transient)` branch in `cleanupNotebook()` that calls `safeRemoveSync(target.input)` when `keep-ipynb` is false, restoring the original deletion behavior while preserving the cache integration for `keep-ipynb: true`.

This is safe because `execute()` already has a guard (lines 441-447) that recreates the notebook if it's missing, and `safeRemoveSync` tolerates missing files.

Also adds `fileNotExists` verification to the smoke-all test framework and a test that verifies the `.quarto_ipynb` file is cleaned up after render.

Fixes #14359