### PR TITLE
[backport] Fix Dart Sass failing in enterprise Windows with Group Policy restrictions

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -3,6 +3,7 @@
 ## In this release
 
 - ([#14304](https://github.com/quarto-dev/quarto-cli/issues/14304)): Fix `quarto install tinytex` silently ignoring extraction failures. When archive extraction fails (e.g., `.tar.xz` on a system without `xz-utils`), the installer now reports a clear error instead of proceeding and failing with a confusing `NotFound` message.
+- ([#14367](https://github.com/quarto-dev/quarto-cli/issues/14367)): Fix Dart Sass invocation failing on enterprise Windows systems where Group Policy blocks `.bat` execution from `%TEMP%`. When the `safeWindowsExec` temp wrapper is blocked, Quarto now falls back to calling `sass.bat` directly.
 
 ## In previous releases
 

--- a/src/core/dart-sass.ts
+++ b/src/core/dart-sass.ts
@@ -125,7 +125,22 @@ export async function dartCommand(
         });
       },
     );
-    return processResult(result);
+    if (result.success) {
+      return processResult(result);
+    }
+
+    // safeWindowsExec failed — fall back to direct execution (v1.8 behavior).
+    // Enterprise environments may block .bat execution from %TEMP% via
+    // Group Policy / AppLocker, causing the temp wrapper to fail.
+    // See https://github.com/quarto-dev/quarto-cli/issues/14367
+    debug("[DART] safeWindowsExec failed, falling back to direct execution");
+    const directResult = await execProcess({
+      cmd: sass,
+      args,
+      stdout: "piped",
+      stderr: "piped",
+    });
+    return processResult(directResult);
   }
 
   // Non-Windows: direct execution


### PR DESCRIPTION
> [!IMPORTANT]
> v1.9-specific fix for #14367. The full fix (bypassing `sass.bat` entirely) is in v1.10 via #14273.

In v1.9, #14002 routed `sass.bat` through a `safeWindowsExec` temp `.bat` wrapper to handle path quoting with spaces. On enterprise Windows systems where Group Policy / AppLocker blocks `.bat` execution from `%TEMP%`, this breaks dart-sass invocation — a regression from v1.8 where `sass.bat` was called directly from the trusted install directory.

When `safeWindowsExec` fails, Quarto now falls back to direct `sass.bat` execution (v1.8 behavior), restoring functionality in locked-down environments.

Fixes #14367