### PR TITLE
Fix/citation bibtex copy button scaffold

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -6,6 +6,7 @@ All changes included in 1.10:
 - ([#14281](https://github.com/quarto-dev/quarto-cli/issues/14281)): Fix transient `.quarto_ipynb` files accumulating during `quarto preview` with Jupyter engine.
 - ([#14298](https://github.com/quarto-dev/quarto-cli/issues/14298)): Fix `quarto preview` browse URL including output filename (e.g., `hello.html`) for single-file documents, breaking Posit Workbench proxied server access.
 - ([rstudio/rstudio#17333](https://github.com/rstudio/rstudio/issues/17333)): Fix `quarto inspect` on standalone files emitting project metadata that breaks RStudio's publishing wizard.
+- ([#13669](https://github.com/quarto-dev/quarto-cli/issues/13669)): Fix BibTeX copy button in citation appendix not visible due to missing `div.code-copy-outer-scaffold` wrapper, a regression from 1.8. (author: @AJBogo9)
 
 ## Formats
 

--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -7,6 +7,7 @@ All changes included in 1.10:
 - ([#14298](https://github.com/quarto-dev/quarto-cli/issues/14298)): Fix `quarto preview` browse URL including output filename (e.g., `hello.html`) for single-file documents, breaking Posit Workbench proxied server access.
 - ([#14489](https://github.com/quarto-dev/quarto-cli/issues/14489)): Restore `--output-dir` support for `quarto preview` of single files when no `_quarto.yml` is present (e.g. R-package workspaces). Regression introduced in v1.9.18.
 - ([rstudio/rstudio#17333](https://github.com/rstudio/rstudio/issues/17333)): Fix `quarto inspect` on standalone files emitting project metadata that breaks RStudio's publishing wizard.
+- ([#13669](https://github.com/quarto-dev/quarto-cli/issues/13669)): Fix BibTeX copy button in citation appendix not visible due to missing `div.code-copy-outer-scaffold` wrapper, a regression from 1.8. (author: @AJBogo9)
 
 ## Accessibility
 

--- a/src/format/html/format-html-appendix.ts
+++ b/src/format/html/format-html-appendix.ts
@@ -304,10 +304,14 @@ export async function processDocumentAppendix(
 
             const bibTexDiv = createCodeBlock(doc, cite.bibtex, "bibtex");
             bibTexDiv.classList.add(kQuartoCiteBibtexClass);
-            contentsDiv.appendChild(bibTexDiv);
+            
+            const outerScaffold = doc.createElement("div");
+            outerScaffold.classList.add("code-copy-outer-scaffold");
+            outerScaffold.appendChild(bibTexDiv);
+            contentsDiv.appendChild(outerScaffold);
 
             const copyButton = createCodeCopyButton(doc, format);
-            bibTexDiv.appendChild(copyButton);
+            outerScaffold.appendChild(copyButton);
           }
 
           if (cite?.html) {


### PR DESCRIPTION
## Description

In 1.8 the CSS copy-button hover selector was changed to require a `div.code-copy-outer-scaffold` parent. Regular code blocks were updated but the citation appendix template was not. The consequence was that the copy button became invisible on BibTeX citation entries. This fix wraps the BibTeX `<pre>` block in the scaffold div to match.

Closes #13669

## Checklist

I have (if applicable):

- [x] filed a [contributor agreement](https://github.com/quarto-dev/quarto-cli/blob/main/CONTRIBUTING.md).
- [x] referenced the GitHub issue this PR closes
- [x] updated the appropriate changelog in the PR
- [x] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR
