### PR TITLE
Fix Julia cache flood in CI workflows

### DIFF
--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -1,6 +1,10 @@
 name: Cleanup github runner caches on closed pull requests
 on:
-  pull_request:
+  # pull_request_target is required so fork PRs can delete their own caches on close.
+  # pull_request from a fork ships a read-only GITHUB_TOKEN regardless of the
+  # permissions: block, causing gh cache delete to fail with HTTP 403.
+  # Safe here: no PR code is checked out, the workflow only calls gh cache list/delete.
+  pull_request_target:
     types:
       - closed
 

--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -223,7 +223,7 @@ jobs:
           version: "1.12.5"
 
       - name: Load Julia packages from cache
-        uses: julia-actions/cache@v2
+        uses: julia-actions/cache@v3
         with:
           cache-name: julia-cache;workflow=${{ github.workflow }};job=${{ github.job }};julia=${{ steps.setup-julia.outputs.julia-version }}
 


### PR DESCRIPTION
The repository hit its 10 GB GH Actions cache cap (9.81 GB actual), with 9.42 GB dominated by `julia-actions/cache` entries. 37 julia caches on `refs/heads/main` alone accounted for 7.78 GB, evicting useful caches for other CI workflows (R `renv`, `deno_std`).

## Root cause: per-run accumulation on main

`julia-actions/cache@v2` is a composite action whose post-save and `delete-old-caches` steps do not run reliably. Each cache key contains `run_id` and `run_attempt`, so every CI run creates a new ~250 MB entry and older entries are never deleted. 37 entries were observed on `main` across only 4 days.

`v3` is a JavaScript rewrite with a proper post hook. Combined with the `actions: write` permission already granted in `test-smokes.yml`, the action now keeps only the newest entry per `(workflow, os)` tuple. `v3` also uses Node.js 24 directly, dropping the transitive Node 20 dependency from `v2`'s bundled `actions/cache` — partially reduces the remaining scope in #14201 but does not close it.

## Root cause: fork PR cleanup silently failed

`cleanup-caches.yml` triggered on `pull_request: closed`, but `pull_request` events from forks ship a read-only `GITHUB_TOKEN` regardless of the `permissions:` block. Verified on merged PR #14374: all 8 `gh cache delete` calls returned `HTTP 403: Resource not accessible by integration`, leaving 1.98 GB orphaned. `set +e` swallowed the failures so the run reported success.

`pull_request_target` runs in the base-branch context with full write permissions. Safe here: the workflow does not check out PR code — it only calls `gh cache list/delete` using the PR number from the event payload. The fix only applies to PR closes after this merges, since `pull_request_target` reads its workflow from the base branch.

A one-off manual cleanup of pre-existing stale caches (32 entries, ~7.7 GB) has already been run; this PR prevents recurrence.

Refs #14201