### PR TITLE
[backport] Bump julia-actions/cache to v3

### DIFF
--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -223,7 +223,7 @@ jobs:
           version: "1.11.7"
 
       - name: Load Julia packages from cache
-        uses: julia-actions/cache@v2
+        uses: julia-actions/cache@v3
         with:
           cache-name: julia-cache;workflow=${{ github.workflow }};job=${{ github.job }};julia=${{ steps.setup-julia.outputs.julia-version }}
 


### PR DESCRIPTION
> [!IMPORTANT]
> Backport from #14410

Reduces per-run Julia cache accumulation on v1.9 so patch runs don't keep contributing to the shared 10 GB cache cap. Only the `julia-actions/cache@v3` bump is backported — the `cleanup-caches.yml` fix targets fork-PR edge cases that rarely apply to v1.9.