### PR TITLE
Cache Playwright browsers and bound install timeout in CI

### DIFF
--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -58,6 +58,8 @@ jobs:
           - os: windows-latest
             time-test: true
     runs-on: ${{ matrix.os }}
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/ms-playwright-browsers
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
@@ -98,8 +100,26 @@ jobs:
         working-directory: ./tests/integration/playwright
         shell: bash
 
+      - name: Get Playwright version
+        if: ${{ runner.os != 'Windows' || github.event_name == 'schedule' }}
+        run: |
+          VERSION=$(node -p "require('@playwright/test/package.json').version")
+          echo "PLAYWRIGHT_VERSION=$VERSION" >> "$GITHUB_ENV"
+        working-directory: ./tests/integration/playwright
+        shell: bash
+
+      - name: Cache Playwright browsers
+        if: ${{ runner.os != 'Windows' || github.event_name == 'schedule' }}
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install Playwright Browsers
         if: ${{ runner.os != 'Windows' || github.event_name == 'schedule' }}
+        timeout-minutes: 10
         run: npx playwright install --with-deps
         working-directory: ./tests/integration/playwright
 


### PR DESCRIPTION
Recent CI runs showed the "Install Playwright Browsers" step hanging for 2+ hours on a subset of ubuntu-latest runners while sibling runners in the same workflow run finished the same step in ~40s. Since the step has no timeout, a stuck runner burns until GitHub's 6h job cap and blocks the smoke-test matrix.

## Changes

- Set `PLAYWRIGHT_BROWSERS_PATH` at job level to pin the browsers install location to a single path under `github.workspace` that resolves identically on Linux, Windows, and macOS. Install and test steps inherit the env, so they agree on the location.
- Cache that path via `actions/cache@v5`, keyed on the resolved Playwright version (read from the installed `@playwright/test` `package.json` via `node -p`, not from the lockfile — current lockfile is stale).
- Add `timeout-minutes: 10` on the install step so a hung runner fails fast.
- Keep `npx playwright install --with-deps` as-is per upstream Playwright guidance (microsoft/playwright#20603).

## Verification

- First run on this PR: cache-miss path — install completes in ~1 min as today.
- Second run (empty commit): cache-hit path — install drops to ~30s, browser download skipped.

## Non-goals

- apt dep caching: upstream doesn't recommend it and the observed failure looks infra-transient rather than apt-slow.
- Retry logic: deferred; revisit if cache + timeout alone is insufficient.
- Fixing the stale `tests/integration/playwright/package-lock.json` (1.47.0 pinned while `package.json` specifies `^1.59.1`). Tangential cleanup.