### PR TITLE
Fail fast when npm is missing during configure

### DIFF
--- a/package/src/common/configure.ts
+++ b/package/src/common/configure.ts
@@ -25,15 +25,12 @@ import { isWindows } from "../../../src/deno_ral/platform.ts";
 export async function configure(
   config: Configuration,
 ) {
-  // npm is only required for building quarto-preview.js (used by `quarto preview`
-  // for HTML/revealjs live-reload). Warn upfront so the user knows before the
-  // long dependency downloads; the JS build is skipped below if npm is missing.
-  const hasNpm = (await which("npm")) !== undefined;
-  if (!hasNpm) {
-    warning(
-      "npm not found on PATH. The 'quarto preview' live-reload feature " +
-        "will not be available. Install Node.js (which provides npm) and " +
-        "re-run configure to enable it.",
+  // npm is required later for building quarto-preview.js (used by `quarto
+  // preview` live-reload). Check upfront to fail fast before downloading
+  // hundreds of MB of dependencies when npm is missing.
+  if ((await which("npm")) === undefined) {
+    throw new Error(
+      "npm not found on PATH. Please install Node.js (which provides npm) before running configure.",
     );
   }
 
@@ -46,16 +43,12 @@ export async function configure(
     await configureDependency(dependency, targetDir, config);
   }
 
-  if (hasNpm) {
-    info("Building quarto-preview.js...");
-    const result = buildQuartoPreviewJs(config.directoryInfo.src);
-    if (!result.success) {
-      throw new Error();
-    }
-    info("Build completed.");
-  } else {
-    info("Skipping quarto-preview.js build (npm not found).");
+  info("Building quarto-preview.js...");
+  const result = buildQuartoPreviewJs(config.directoryInfo.src);
+  if (!result.success) {
+    throw new Error();
   }
+  info("Build completed.");
 
   // Move the quarto script into place
   info("Placing Quarto script");

--- a/package/src/common/configure.ts
+++ b/package/src/common/configure.ts
@@ -18,13 +18,25 @@ import {
   configureDependency,
   kDependencies,
 } from "./dependencies/dependencies.ts";
-import { suggestUserBinPaths } from "../../../src/core/path.ts";
+import { suggestUserBinPaths, which } from "../../../src/core/path.ts";
 import { buildQuartoPreviewJs } from "./previewjs.ts";
 import { isWindows } from "../../../src/deno_ral/platform.ts";
 
 export async function configure(
   config: Configuration,
 ) {
+  // npm is only required for building quarto-preview.js (used by `quarto preview`
+  // for HTML/revealjs live-reload). Warn upfront so the user knows before the
+  // long dependency downloads; the JS build is skipped below if npm is missing.
+  const hasNpm = (await which("npm")) !== undefined;
+  if (!hasNpm) {
+    warning(
+      "npm not found on PATH. The 'quarto preview' live-reload feature " +
+        "will not be available. Install Node.js (which provides npm) and " +
+        "re-run configure to enable it.",
+    );
+  }
+
   // Download dependencies
   for (const dependency of kDependencies) {
     const targetDir = join(
@@ -34,12 +46,16 @@ export async function configure(
     await configureDependency(dependency, targetDir, config);
   }
 
-  info("Building quarto-preview.js...");
-  const result = buildQuartoPreviewJs(config.directoryInfo.src);
-  if (!result.success) {
-    throw new Error();
+  if (hasNpm) {
+    info("Building quarto-preview.js...");
+    const result = buildQuartoPreviewJs(config.directoryInfo.src);
+    if (!result.success) {
+      throw new Error();
+    }
+    info("Build completed.");
+  } else {
+    info("Skipping quarto-preview.js build (npm not found).");
   }
-  info("Build completed.");
 
   // Move the quarto script into place
   info("Placing Quarto script");


### PR DESCRIPTION
On systems without `npm`, `./configure.sh` downloads ~300MB of dependencies (Deno, Pandoc, Dart Sass, esbuild, Typst) before finally failing with a cryptic `NotFound: Failed to spawn 'npm': entity not found` from the `buildQuartoPreviewJs()` step.

## Root Cause

`configure()` in `package/src/common/configure.ts` runs the dependency download loop before calling `buildQuartoPreviewJs()`, which is the only step in configure that requires `npm`. The `npm` executable is used to build `src/resources/preview/quarto-preview.js` — the webui that powers the `quarto preview` live-reload feature.

## Fix

Check `npm` presence upfront using the existing `which()` helper from `src/core/path.ts`. If missing, throw a clear error before any downloads:

> npm not found on PATH. Please install Node.js (which provides npm) before running configure.

This fails fast and avoids wasting download time on a build that cannot complete. A silent skip was considered but rejected — a Quarto build without `quarto-preview.js` would later fail at runtime when `quarto preview` tries to read the missing file, producing another confusing error.

Fixes #14420