### PR TITLE
Fail early when renv packages are not synchronized after restore in CI

### DIFF
--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -175,6 +175,13 @@ jobs:
           cat("::group::Restoring R packages from renv.lock\n")
           renv::restore()
           cat("::endgroup::\n")
+          cat("::group::Verifying R packages are synchronized after restore\n")
+          status <- renv::status()
+          if (!isTRUE(status$synchronized)) {
+            cat("::error::R packages are not synchronized after restore - some packages may have failed to install\n")
+            quit(status = 1)
+          }
+          cat("::endgroup::\n")
           cat("::group::Installing dev versions of knitr and rmarkdown\n")
           # Install dev versions for our testing
           # Use r-universe to avoid github api calls


### PR DESCRIPTION
When `renv::restore()` encounters network errors (e.g. the package manager returning HTTP errors for binary packages), it can complete without failing even though some packages were not properly installed. Downstream test steps then fail with cryptic errors like `object 'select' not found whilst loading namespace 'dplyr'`.

## Fix

Add `renv::status()` after the restore call and exit with status 1 if `$synchronized` is not `TRUE`. This surfaces the installation failure at the right point rather than letting the workflow continue with a broken R library.