### PR TITLE
Bump typst-gather to 0.2.3 to fix GLIBC 2.38 floor

### DIFF
--- a/configuration
+++ b/configuration
@@ -17,7 +17,7 @@ export PANDOC=3.8.3
 export DARTSASS=1.87.0
 export ESBUILD=0.25.10
 export TYPST=0.14.2
-export TYPST_GATHER=0.2.2
+export TYPST_GATHER=0.2.3
 export VERAPDF=1.28.2
 
 


### PR DESCRIPTION
## Summary

Bumps `typst-gather` from 0.2.2 to 0.2.3.

The 0.2.2 Linux binary was built on `ubuntu-latest` (now Ubuntu 24.04, glibc 2.39), which caused gcc to redirect `strtol` calls to `__isoc23_strtol` — a symbol introduced in glibc 2.38. The resulting binary failed to load on Ubuntu 22.04, Debian 12, and RHEL 9, including Quarto's own `ghcr.io/quarto-dev/quarto:1.10.3` image (Ubuntu 22.04, glibc 2.35), with:

```
/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
```

`typst-gather` 0.2.3 pins its release runner to `ubuntu-22.04`, dropping the floor back to glibc 2.34. See quarto-dev/typst-gather@9d9f31b.


Fixes #14445

## Test plan

- [ ] `./configure.sh` downloads the new binary cleanly
- [ ] `quarto render` of a Typst doc on `ghcr.io/quarto-dev/quarto:1.10.3` no longer logs `typst-gather analyze failed; staging all packages as fallback`
- [ ] `objdump -T` on the bundled binary shows no `GLIBC_2.38` symbols