### PR TITLE
Fix configure scripts destroying restored Deno CI cache

### DIFF
--- a/configure.cmd
+++ b/configure.cmd
@@ -15,27 +15,31 @@ if NOT DEFINED QUARTO_VENDOR_BINARIES (
 
 if "%QUARTO_VENDOR_BINARIES%" == "true" (
 
-  REM Windows-specific: Check if deno.exe is running before deleting package/dist
-  REM Extracted to package/scripts/windows/check-deno-in-use.cmd for maintainability
-  call package\scripts\windows\check-deno-in-use.cmd "!QUARTO_DIST_PATH!"
-  if "!ERRORLEVEL!"=="1" exit /B 1
+  REM CI sets QUARTO_SKIP_DENO_CACHE_WIPE=1 so the restored deno_cache survives
+  REM (matches the gate used by package\scripts\vendoring\vendor.cmd).
+  IF NOT "!QUARTO_SKIP_DENO_CACHE_WIPE!"=="1" (
+    REM Windows-specific: Check if deno.exe is running before deleting package/dist
+    REM Extracted to package/scripts/windows/check-deno-in-use.cmd for maintainability
+    call package\scripts\windows\check-deno-in-use.cmd "!QUARTO_DIST_PATH!"
+    if "!ERRORLEVEL!"=="1" exit /B 1
 
-  echo Removing package/dist/ directory...
-  RMDIR /S /Q "!QUARTO_DIST_PATH!" 2>NUL
+    echo Removing package/dist/ directory...
+    RMDIR /S /Q "!QUARTO_DIST_PATH!" 2>NUL
 
-  REM Fallback: Verify deletion succeeded (defense in depth)
-  if exist "!QUARTO_DIST_PATH!" (
-    echo.
-    echo ============================================================
-    echo Error: Could not delete package/dist/ directory
-    echo This may be due to permissions, antivirus, or another process holding files
-    echo ============================================================
-    echo.
-    echo Try closing applications and run configure.cmd again
-    exit /B 1
+    REM Fallback: Verify deletion succeeded (defense in depth)
+    if exist "!QUARTO_DIST_PATH!" (
+      echo.
+      echo ============================================================
+      echo Error: Could not delete package/dist/ directory
+      echo This may be due to permissions, antivirus, or another process holding files
+      echo ============================================================
+      echo.
+      echo Try closing applications and run configure.cmd again
+      exit /B 1
+    )
   )
 
-  MKDIR !QUARTO_BIN_PATH!\tools
+  IF NOT EXIST "!QUARTO_BIN_PATH!\tools" MKDIR !QUARTO_BIN_PATH!\tools
   PUSHD !QUARTO_BIN_PATH!\tools
 
   ECHO Bootstrapping Deno...

--- a/configure.sh
+++ b/configure.sh
@@ -37,7 +37,11 @@ if [[ "${QUARTO_VENDOR_BINARIES}" = "true" ]]; then
     # Ensure directory is there for Deno
     echo "Bootstrapping Deno..."
 
-    rm -rf "$QUARTO_DIST_PATH"
+    # CI sets QUARTO_SKIP_DENO_CACHE_WIPE=1 so the restored deno_cache survives
+    # (matches the gate used by package/scripts/vendoring/vendor.sh).
+    if [ "${QUARTO_SKIP_DENO_CACHE_WIPE}" != "1" ]; then
+      rm -rf "$QUARTO_DIST_PATH"
+    fi
 
     ## Binary Directory
     mkdir -p "$QUARTO_BIN_PATH/tools"


### PR DESCRIPTION
The CI Deno dev cache (added by #14408) restored `package/dist/bin/deno_cache` before configure ran, but every `Revendoring quarto dependencies` phase still showed hundreds of `Download` lines on cache hit.

## Root Cause

`configure.sh` and `configure.cmd` unconditionally wiped `package/dist` while bootstrapping Deno, destroying the just-restored cache before `vendor.sh` reached it. The vendor scripts already honor `QUARTO_SKIP_DENO_CACHE_WIPE=1` to preserve the cache, but the configure-time wipe was missed.

Evidence in a recent main run:
https://github.com/quarto-dev/quarto-cli/actions/runs/24893863352/job/72893237475

Cache restores at `14:11:22.6755Z`, then `rm -rf package/dist` fires at `14:11:22.7048Z`, followed by 743 `Download` lines during `Revendoring quarto dependencies`.

## Fix

Apply the same `QUARTO_SKIP_DENO_CACHE_WIPE` gate to `configure.sh` and `configure.cmd`. CI sets the variable in `.github/workflows/actions/quarto-dev/action.yml` so the restored cache survives; local devs (env var unset) keep the original wipe behavior.