### PR TITLE
Fix configure warning showing binary path instead of directory for PATH

### DIFF
--- a/package/src/common/configure.ts
+++ b/package/src/common/configure.ts
@@ -126,9 +126,7 @@ export async function configure(
           info(`> Didn't create symlink at ${symlinkPath}`);
           if (i === symlinksFiltered.length - 1) {
             warning(
-              `\n> Please ensure that ${
-                join(config.directoryInfo.bin, "quarto")
-              } is in your path.`,
+              `\n> Please ensure that ${config.directoryInfo.bin} is in your path.`,
             );
           }
         }
@@ -136,9 +134,7 @@ export async function configure(
     } else {
       // Just warn the user and create a symlink in our last resort
       warning(
-        `\n> Please ensure that ${
-          join(config.directoryInfo.bin, "quarto")
-        } is in your path.`,
+        `\n> Please ensure that ${config.directoryInfo.bin} is in your path.`,
       );
     }
   }


### PR DESCRIPTION
Closes #14426

When the `configure` script cannot create a `quarto` symlink in a
user-writable bin path, it falls back to printing:

```
> Please ensure that <path> is in your path.
```

The interpolated path was `join(config.directoryInfo.bin, "quarto")` — i.e.
the binary itself (`.../package/dist/bin/quarto`). Since `PATH` expects a
directory, the suggested path was always wrong: copy-pasting it into
`PATH` would never work.

Use `config.directoryInfo.bin` directly so the warning prints the
directory the developer actually needs to add to `PATH`.

Reported by @wlatendresse.