### PR TITLE
fix(docker): add unzip installation to "quarto" Docker image

### DIFF
--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -49,6 +49,10 @@ runs:
       run: |
         cat << 'EOF' >> Dockerfile
         FROM ubuntu:22.04
+        ENV DEBIAN_FRONTEND=noninteractive
+        RUN apt-get update \
+          && apt-get install -y --no-install-recommends unzip \
+          && rm -rf /var/lib/apt/lists/*
         COPY ["${{ inputs.source }}", "quarto-linux-amd64.deb"]
         RUN dpkg -i quarto-linux-amd64.deb && rm quarto-linux-amd64.deb
         EOF


### PR DESCRIPTION
Add unzip installation to the Dockerfile to handle dependencies more effectively. Set the `DEBIAN_FRONTEND` to noninteractive to streamline the build process.

Most tools that you can install with `quarto install` require unzip.
The most common I believe is `quarto install chrome-headless-shell` which currently leads to:

```txt
Installing chrome-headless-shell
[✓] Downloading Chrome Headless Shell
ERROR: Error executing 'unzip': Failed to spawn 'unzip': entity not found

Stack trace:
    at execProcess (file:///opt/quarto/bin/quarto.js:7918:11)
    at unzip (file:///opt/quarto/bin/quarto.js:67214:14)
    at downloadAndExtractChrome (file:///opt/quarto/bin/quarto.js:67391:11)
    at eventLoopTick (ext:core/01_core.js:179:7)
    at async Object.preparePackage3 [as preparePackage] (file:///opt/quarto/bin/quarto.js:160811:5)
    at async installTool (file:///opt/quarto/bin/quarto.js:161246:27)
    at async _Command.actionHandler (file:///opt/quarto/bin/quarto.js:165171:11)
    at async _Command.execute (file:///opt/quarto/bin/quarto.js:102027:7)
    at async _Command.parseCommand (file:///opt/quarto/bin/quarto.js:101904:14)
    at async quarto4 (file:///opt/quarto/bin/quarto.js:187717:5)
    at async file:///opt/quarto/bin/quarto.js:187746:5
    at async file:///opt/quarto/bin/quarto.js:187600:14
    at async mainRunner (file:///opt/quarto/bin/quarto.js:187602:5)
    at async file:///opt/quarto/bin/quarto.js:187739:3
```

"quarto-full" has unzip so no issues.