### PR TITLE
fix(pdf/latex): wrap Note content in Blocks list for reference-location margin (#13588)

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -9,6 +9,10 @@ All changes included in 1.10:
 
 ## Formats
 
+### `pdf`
+
+- ([#13588](https://github.com/quarto-dev/quarto-cli/issues/13588)): Fix Lua error when rendering PDF with `reference-location: margin` and a footnote alongside a figure with `fig-cap`. (author: @mcanouil)
+
 ### `typst`
 
 - ([#14261](https://github.com/quarto-dev/quarto-cli/issues/14261)): Fix theorem/example block titles containing inline code producing invalid Typst markup when syntax highlighting is applied.

--- a/src/resources/filters/quarto-post/latex.lua
+++ b/src/resources/filters/quarto-post/latex.lua
@@ -478,7 +478,7 @@ function render_latex()
     Note = function(n)
       if marginReferences() then
         -- This is to support multiple paragraphs in footnotes in margin as sidenotes CTAN has some issue (quarto-dev/quarto-cli#7534)
-        n.content = pandoc.Para(pandoc.utils.blocks_to_inlines(n.content, {pandoc.RawInline('latex', '\n\\endgraf\n')}))
+        n.content = pandoc.Blocks({pandoc.Para(pandoc.utils.blocks_to_inlines(n.content, {pandoc.RawInline('latex', '\n\\endgraf\n')}))})
         return n
       end
     end

--- a/tests/docs/smoke-all/2026/04/30/13588.qmd
+++ b/tests/docs/smoke-all/2026/04/30/13588.qmd
@@ -1,0 +1,22 @@
+---
+title: footnote and fig-cap with reference-location margin in PDF (#13588)
+format: pdf
+reference-location: margin
+_quarto:
+  tests:
+    pdf: null
+    latex:
+      ensureFileRegexMatches:
+        - ['This is a footnote']
+        - []
+---
+
+A footnote[^1] and a figure.
+
+[^1]: This is a footnote.
+
+```{r}
+#| fig-cap: Some figure
+
+plot(1:10, 1:10)
+```


### PR DESCRIPTION
`n.content` on a `Note` element must be a `Blocks` list, but the handler introduced for #7534 was assigning a bare `pandoc.Para(...)` (a single `Block`), causing `scopedwalk.lua` to crash with `attempt to get length of a Block value` whenever a footnote appeared alongside a figure with `fig-cap` in a PDF document using `reference-location: margin`.

Wrapping the `Para` in `pandoc.Blocks({...})` restores the correct type and preserves the `\endgraf` behaviour needed for multi-paragraph sidenotes.

Closes #13588  