### PR TITLE
fix(html/axe): use literal overlay colors to avoid clobbering brand

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -9,6 +9,10 @@ All changes included in 1.10:
 
 ## Formats
 
+### `html`
+
+- ([#14468](https://github.com/quarto-dev/quarto-cli/issues/14468)): Fix `axe` enabling clobbering brand colors (e.g. `background`, `link.color`) when set via `_brand.yml` or `brand:` metadata.
+
 ### `pdf`
 
 - ([#13588](https://github.com/quarto-dev/quarto-cli/issues/13588)): Fix Lua error when rendering PDF with `reference-location: margin` and a footnote alongside a figure with `fig-cap`. (author: @mcanouil)

--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -11,7 +11,7 @@ All changes included in 1.10:
 
 ### `html`
 
-- ([#14468](https://github.com/quarto-dev/quarto-cli/issues/14468)): Fix `axe` enabling clobbering brand colors (e.g. `background`, `link.color`) when set via `_brand.yml` or `brand:` metadata.
+- ([#14468](https://github.com/quarto-dev/quarto-cli/issues/14468)): The `axe` accessibility report UI (HTML overlay, revealjs report slide, dashboard offcanvas) now uses its own theme-independent colors instead of inheriting from `brand` or theme. Keeps the report readable regardless of page styling, and stops `axe` from clobbering brand colors set via `_brand.yml`.
 
 ### `pdf`
 

--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -7,11 +7,11 @@ All changes included in 1.10:
 - ([#14298](https://github.com/quarto-dev/quarto-cli/issues/14298)): Fix `quarto preview` browse URL including output filename (e.g., `hello.html`) for single-file documents, breaking Posit Workbench proxied server access.
 - ([rstudio/rstudio#17333](https://github.com/rstudio/rstudio/issues/17333)): Fix `quarto inspect` on standalone files emitting project metadata that breaks RStudio's publishing wizard.
 
-## Formats
-
-### `html`
+## Accessibility
 
 - ([#14468](https://github.com/quarto-dev/quarto-cli/issues/14468)): The `axe` accessibility report UI (HTML overlay, revealjs report slide, dashboard offcanvas) now uses its own theme-independent colors instead of inheriting from `brand` or theme. Keeps the report readable regardless of page styling, and stops `axe` from clobbering brand colors set via `_brand.yml`.
+
+## Formats
 
 ### `pdf`
 

--- a/src/format/html/format-html-axe.ts
+++ b/src/format/html/format-html-axe.ts
@@ -64,7 +64,7 @@ body div.quarto-axe-report {
 .quarto-axe-violation-selector { padding-left: 1rem; }
 .quarto-axe-violation-target {
   padding: 0.5rem;
-  color: #0a58ca;
+  color: #0747a6;
   text-decoration: underline;
   cursor: pointer;
 }

--- a/src/format/html/format-html-axe.ts
+++ b/src/format/html/format-html-axe.ts
@@ -35,26 +35,27 @@ export function axeFormatDependencies(
 ): FormatExtras {
   if (!options) return {};
 
-  // Use reveal-theme for revealjs, bootstrap for other HTML formats.
-  // Note: For revealjs, sass-bundles compile separately from the theme
-  // (which compiles in format-reveal-theme.ts), so the !default values
-  // below are used instead of actual theme colors. This is a known
-  // limitation - see GitHub issue for architectural context.
+  // The axe report is developer chrome, not document content, so its colors
+  // are literals here rather than theme-derived (`$body-bg` etc.). This keeps
+  // the overlay readable regardless of the page's brand or theme — which
+  // matters most when the user is auditing exactly those colors.
   const isRevealjs = isRevealjsOutput(format.pandoc);
   const isDashboard = isHtmlDashboardOutput(format.identifier["base-format"]);
   const sassDependency = isRevealjs ? "reveal-theme" : "bootstrap";
 
-  // Base overlay rules shared by all formats (also serves as fallback for revealjs)
+  // Base overlay rules shared by all formats. For revealjs, the `var(--r-*)`
+  // lookups pick up the slide's actual colors at runtime; the literal
+  // fallbacks apply everywhere else.
   const baseRules = `
 body div.quarto-axe-report {
   position: fixed;
   bottom: 3rem;
   right: 3rem;
   padding: 1rem;
-  border: 1px solid var(--r-main-color, $body-color);
+  border: 1px solid var(--r-main-color, #222);
   z-index: 9999;
-  background-color: var(--r-background-color, $body-bg);
-  color: var(--r-main-color, $body-color);
+  background-color: var(--r-background-color, #fff);
+  color: var(--r-main-color, #222);
   max-height: 50vh;
   overflow-y: auto;
 }
@@ -63,7 +64,7 @@ body div.quarto-axe-report {
 .quarto-axe-violation-selector { padding-left: 1rem; }
 .quarto-axe-violation-target {
   padding: 0.5rem;
-  color: $link-color;
+  color: #2a76dd;
   text-decoration: underline;
   cursor: pointer;
 }
@@ -73,21 +74,26 @@ body div.quarto-axe-report {
   border: 2px solid red;
 }`;
 
-  // RevealJS: override overlay styles when report is embedded as a slide
+  // RevealJS: override overlay styles when report is embedded as a slide.
+  // The slide's white background is set by the JS via data-background-color;
+  // here we only need to keep text/link colors readable on white.
   const revealjsRules = isRevealjs
     ? `
 .reveal .slides section.quarto-axe-report-slide {
   text-align: left;
   font-size: 0.55em;
+  color: #222;
   h2 {
     margin-bottom: 0.5em;
     font-size: 1.8em;
+    color: #222;
   }
   div.quarto-axe-report {
     position: static;
     padding: 0;
     border: none;
     background-color: transparent;
+    color: #222;
     max-height: none;
     overflow-y: visible;
     z-index: auto;
@@ -102,15 +108,20 @@ body div.quarto-axe-report {
 }`
     : "";
 
-  // Dashboard: report inside offcanvas sidebar (not fixed overlay)
+  // Dashboard: report inside offcanvas sidebar (not fixed overlay).
+  // Override Bootstrap's themed offcanvas vars so the panel keeps axe's own
+  // colors regardless of brand/theme.
   const dashboardRules = isDashboard
     ? `
 .quarto-dashboard .offcanvas.quarto-axe-offcanvas {
+  --bs-offcanvas-bg: #fff;
+  --bs-offcanvas-color: #222;
   .quarto-axe-report {
     position: static;
     padding: 0;
     border: none;
     background-color: transparent;
+    color: #222;
     max-height: none;
     overflow-y: visible;
     z-index: auto;
@@ -148,11 +159,7 @@ body div.quarto-axe-report {
           dependency: sassDependency,
           user: [{
             uses: "",
-            defaults: `
-$body-color: #222 !default;
-$body-bg: #fff !default;
-$link-color: #2a76dd !default;
-`,
+            defaults: "",
             functions: "",
             mixins: "",
             rules: baseRules + revealjsRules + dashboardRules,

--- a/src/format/html/format-html-axe.ts
+++ b/src/format/html/format-html-axe.ts
@@ -64,7 +64,7 @@ body div.quarto-axe-report {
 .quarto-axe-violation-selector { padding-left: 1rem; }
 .quarto-axe-violation-target {
   padding: 0.5rem;
-  color: #2a76dd;
+  color: #0a58ca;
   text-decoration: underline;
   cursor: pointer;
 }

--- a/src/resources/formats/html/axe/axe-check.js
+++ b/src/resources/formats/html/axe/axe-check.js
@@ -140,6 +140,10 @@ class QuartoAxeDocumentReporter extends QuartoAxeReporter {
 
     const section = document.createElement("section");
     section.className = "slide quarto-axe-report-slide scrollable";
+    // Force a white slide background so the report stays readable regardless
+    // of the deck's brand/theme colors. Reveal applies this to the slide's
+    // generated `.slide-background` element during sync().
+    section.setAttribute("data-background-color", "#fff");
 
     const title = document.createElement("h2");
     title.textContent = "Accessibility Report";

--- a/tests/docs/smoke-all/2026/05/01/issue-14468-axe-brand.qmd
+++ b/tests/docs/smoke-all/2026/05/01/issue-14468-axe-brand.qmd
@@ -1,0 +1,23 @@
+---
+title: "Issue 14468 - axe must not clobber brand colors"
+format:
+  html:
+    axe: 
+      output: document
+brand:
+  color:
+    background: "#5e1717"
+  typography:
+    link:
+      color: "#18a918"
+_quarto:
+  tests:
+    html:
+      ensureCssRegexMatches:
+        - ['--bs-body-bg:\s*#5e1717', '--bs-link-color:\s*#18a918', 'quarto-axe-report\s*\{[^}]*background-color:\s*var\(--r-background-color,\s*#fff\)']
+        - ['--bs-body-bg:\s*#fff[\s;]']
+---
+
+## Section
+
+Some [link](http://example.org) text.

--- a/tests/docs/smoke-all/2026/05/01/issue-14468-axe-dashboard.qmd
+++ b/tests/docs/smoke-all/2026/05/01/issue-14468-axe-dashboard.qmd
@@ -1,0 +1,25 @@
+---
+title: "Issue 14468 - axe must not clobber brand colors (dashboard)"
+format:
+  dashboard:
+    axe: 
+      output: document
+brand:
+  color:
+    background: "#5e1717"
+  typography:
+    link:
+      color: "#18a918"
+_quarto:
+  tests:
+    dashboard:
+      ensureCssRegexMatches:
+        - ['--bs-body-bg:\s*#5e1717', '--bs-link-color:\s*#18a918', 'quarto-axe-offcanvas\s*\{[^}]*--bs-offcanvas-bg:\s*#fff']
+        - ['--bs-body-bg:\s*#fff[\s;]']
+---
+
+## Row
+
+Content for accessibility checking.
+
+[example](http://example.org)

--- a/tests/docs/smoke-all/2026/05/01/issue-14468-axe-no-brand.qmd
+++ b/tests/docs/smoke-all/2026/05/01/issue-14468-axe-no-brand.qmd
@@ -1,0 +1,15 @@
+---
+title: "Issue 14468 - axe defaults still work without brand"
+format:
+  html:
+    axe: true
+_quarto:
+  tests:
+    html:
+      ensureCssRegexMatches:
+        - ['--bs-body-bg:\s*#fff', '\.quarto-axe-report']
+---
+
+## Section
+
+Some [link](http://example.org) text.

--- a/tests/docs/smoke-all/2026/05/01/issue-14468-axe-revealjs.qmd
+++ b/tests/docs/smoke-all/2026/05/01/issue-14468-axe-revealjs.qmd
@@ -1,0 +1,28 @@
+---
+title: "Issue 14468 - axe sass bundle still compiles for revealjs"
+format:
+  revealjs:
+    axe: 
+      output: document
+brand:
+  color:
+    background: "#5e1717"
+    foreground: "#d6c50f"
+  typography:
+    link:
+      color: "#18a918"
+_quarto:
+  tests:
+    revealjs:
+      ensureCssRegexMatches:
+        - ['\.quarto-axe-report', 'quarto-axe-report-slide\s*\{[^}]*color:\s*#222']
+        - ['\$body-bg', '\$body-color', '\$link-color']
+---
+
+## Slide 1
+
+Content for accessibility checking. <http://example.org>.
+
+## Slide 2
+
+More content.


### PR DESCRIPTION
Closes #14468.

## Bug

Setting `axe:` on an HTML format clobbered brand-defined `background`, `foreground`, and `link.color`. The axe sass bundle declared `$body-bg`, `$body-color`, and `$link-color` defaults in its **user** SassLayer, which precede brand's user defaults during sass compilation, so axe's white/dark/blue defaults won via `!default` resolution. Affected every output mode (`true`, `console`, `document`) since the bundle is added unconditionally.

## Approach

The axe report is developer chrome, not document content — its colors should not depend on (and should not override) the page's brand or theme. The overlay's readability matters most when the page itself has poor contrast, since that's exactly what axe is reporting.

So instead of fighting over `$body-*` defaults, the overlay rules now use literal hex values scoped to axe selectors. Brand and theme colors win on the page; the overlay always looks like itself. Colors picked to pass WCAG **AAA** contrast against white (`#222` body text = 16:1, `#0747a6` links = 8.5:1) — appropriate for a debugging tool meant to surface accessibility issues.

## What changed

- **HTML overlay** (`src/format/html/format-html-axe.ts`): replaced `$body-bg` / `$body-color` / `$link-color` references in the axe rules with literal `#fff` / `#222` / `#0747a6`. Dropped the `!default` declarations entirely — they're no longer needed.
- **RevealJS report slide**: forces `data-background-color="#fff"` on the appended section (in `axe-check.js`) so reveal paints the slide white via its own `.slide-background` mechanism. Slide-scoped `color: #222` keeps text readable.
- **Dashboard report offcanvas**: overrides `--bs-offcanvas-bg` and `--bs-offcanvas-color` for `.quarto-axe-offcanvas` so the panel ignores Bootstrap/brand offcanvas theming.

## Tests

Four new smoke-all tests under `tests/docs/smoke-all/2026/05/01/`:

- `issue-14468-axe-brand.qmd` — HTML + axe + brand: brand wins on body, axe overlay keeps `#fff` fallback.
- `issue-14468-axe-revealjs.qmd` — revealjs + axe + brand: report slide rule has `color: #222`; no `\$body-*` SCSS leakage.
- `issue-14468-axe-dashboard.qmd` — dashboard + axe + brand: offcanvas has `--bs-offcanvas-bg: #fff`.
- `issue-14468-axe-no-brand.qmd` — HTML + axe, no brand: Bootstrap defaults still apply (regression guard).

All 9 existing axe tests in `tests/docs/smoke-all/accessibility/` continue to pass.