### PR TITLE
[backport] fix(preview): restore --output-dir for single-file preview without _quarto.yml

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -34,6 +34,7 @@ All changes included in 1.9:
 - ([#13633](https://github.com/quarto-dev/quarto-cli/issues/13633)): Fix detection and auto-installation of babel language packages from newer error format that doesn't explicitly mention `.ldf` filename.
 - ([#13694](https://github.com/quarto-dev/quarto-cli/issues/13694)): Fix `notebook-view.url` being ignored - external notebook links now properly use specified URLs instead of local preview files.
 - ([#13732](https://github.com/quarto-dev/quarto-cli/issues/13732)): Fix automatic font package installation for fonts with spaces in their names (e.g., "Noto Emoji", "DejaVu Sans"). Font file search patterns now match both with and without spaces.
+- ([#14489](https://github.com/quarto-dev/quarto-cli/issues/14489)): Restore `--output-dir` support for `quarto preview` of single files when no `_quarto.yml` is present (e.g. R-package workspaces). Regression introduced in v1.9.18.
 
 ## Dependencies
 

--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -4,6 +4,7 @@
 
 - ([#14304](https://github.com/quarto-dev/quarto-cli/issues/14304)): Fix `quarto install tinytex` silently ignoring extraction failures. When archive extraction fails (e.g., `.tar.xz` on a system without `xz-utils`), the installer now reports a clear error instead of proceeding and failing with a confusing `NotFound` message.
 - ([#14367](https://github.com/quarto-dev/quarto-cli/issues/14367)): Fix Dart Sass invocation failing on enterprise Windows systems where Group Policy blocks `.bat` execution from `%TEMP%`. When the `safeWindowsExec` temp wrapper is blocked, Quarto now falls back to calling `sass.bat` directly.
+- ([#14489](https://github.com/quarto-dev/quarto-cli/issues/14489)): Restore `--output-dir` support for `quarto preview` of single files when no `_quarto.yml` is present (e.g. R-package workspaces). Regression introduced in v1.9.18.
 
 ## In previous releases
 
@@ -34,7 +35,6 @@ All changes included in 1.9:
 - ([#13633](https://github.com/quarto-dev/quarto-cli/issues/13633)): Fix detection and auto-installation of babel language packages from newer error format that doesn't explicitly mention `.ldf` filename.
 - ([#13694](https://github.com/quarto-dev/quarto-cli/issues/13694)): Fix `notebook-view.url` being ignored - external notebook links now properly use specified URLs instead of local preview files.
 - ([#13732](https://github.com/quarto-dev/quarto-cli/issues/13732)): Fix automatic font package installation for fonts with spaces in their names (e.g., "Noto Emoji", "DejaVu Sans"). Font file search patterns now match both with and without spaces.
-- ([#14489](https://github.com/quarto-dev/quarto-cli/issues/14489)): Restore `--output-dir` support for `quarto preview` of single files when no `_quarto.yml` is present (e.g. R-package workspaces). Regression introduced in v1.9.18.
 
 ## Dependencies
 

--- a/src/command/render/render-shared.ts
+++ b/src/command/render/render-shared.ts
@@ -49,10 +49,15 @@ export async function render(
   // determine target context/files
   let context = pContext || (await projectContext(path, nbContext, options));
 
-  // Create a synthetic project when --output-dir is used without a project file
-  // This creates a temporary .quarto directory to manage the render, which must
-  // be fully cleaned up afterward to avoid leaving debris (see #9745)
-  if (!context && options.flags?.outputDir) {
+  // Create a synthetic project when --output-dir is used without a real project.
+  // Triggers in two situations:
+  //   1. No context yet (render path: no _quarto.yml found above)
+  //   2. pContext is a single-file context (preview pre-creates one in
+  //      preview.ts before calling render(), which would otherwise bypass
+  //      synthetic-project creation — regression behind #14489)
+  // The synthetic project provides a temporary .quarto directory so output-dir
+  // handling works the same as for real projects (see #9745, #13625).
+  if (options.flags?.outputDir && (!context || context.isSingleFile)) {
     context = await projectContextForDirectory(path, nbContext, options);
 
     // forceClean signals this is a synthetic project that needs full cleanup

--- a/tests/unit/render-shared-output-dir.test.ts
+++ b/tests/unit/render-shared-output-dir.test.ts
@@ -1,0 +1,75 @@
+/*
+ * render-shared-output-dir.test.ts
+ *
+ * Regression test for posit-dev/positron#13370 / quarto-dev/quarto-cli#14489.
+ *
+ * When `quarto preview file.qmd --output-dir <dir>` runs in a directory
+ * without _quarto.yml, preview pre-creates a singleFileProjectContext and
+ * passes it to render() as pContext. The synthetic-project trigger in
+ * render-shared.ts only fired when pContext was null, so the path fell
+ * through to validateDocumentRenderFlags() and threw.
+ *
+ * This test mimics that exact pattern and asserts no throw + output
+ * landed in --output-dir.
+ *
+ * Copyright (C) 2026 Posit Software, PBC
+ */
+
+import { unitTest } from "../test.ts";
+import { assert } from "testing/asserts";
+import { join } from "../../src/deno_ral/path.ts";
+import { existsSync } from "../../src/deno_ral/fs.ts";
+import { render } from "../../src/command/render/render-shared.ts";
+import { singleFileProjectContext } from "../../src/project/types/single-file/single-file.ts";
+import { notebookContext } from "../../src/render/notebook/notebook-context.ts";
+import { renderServices } from "../../src/command/render/render-services.ts";
+import { initYamlIntelligenceResourcesFromFilesystem } from "../../src/core/schema/utils.ts";
+
+unitTest(
+  "render() with --output-dir succeeds when caller pre-passes a single-file context (#14489)",
+  async () => {
+    await initYamlIntelligenceResourcesFromFilesystem();
+
+    const tempBase = Deno.makeTempDirSync({ prefix: "quarto_test_outdir_" });
+    const inputDir = join(tempBase, "src");
+    const outputDir = join(tempBase, "out");
+    Deno.mkdirSync(inputDir);
+    Deno.mkdirSync(outputDir);
+
+    const inputFile = join(inputDir, "test.qmd");
+    Deno.writeTextFileSync(
+      inputFile,
+      "---\ntitle: Test\nformat: html\n---\n\nHello world.\n",
+    );
+
+    const nbCtx = notebookContext();
+    const services = renderServices(nbCtx);
+
+    const renderOptions = {
+      services,
+      flags: { outputDir },
+      pandocArgs: [],
+    };
+
+    // Mimic preview's pattern: pre-create singleFileProjectContext, pass as pContext.
+    const project = await singleFileProjectContext(inputFile, nbCtx, renderOptions);
+
+    try {
+      // Before the fix this throws "The --output-dir flag can only be used
+      // when rendering projects."
+      await render(inputFile, renderOptions, project);
+
+      assert(
+        existsSync(join(outputDir, "test.html")),
+        `Expected output HTML at ${join(outputDir, "test.html")} after render with --output-dir`,
+      );
+    } finally {
+      services.cleanup?.();
+      try {
+        Deno.removeSync(tempBase, { recursive: true });
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  },
+);


### PR DESCRIPTION
> [!IMPORTANT]
> Backport from #14491

Restores `quarto preview file.qmd --output-dir <dir>` for single files in directories without `_quarto.yml` (e.g. R-package workspaces). Regressed in v1.9.18 when preview started pre-creating a single-file `ProjectContext`, which bypassed the synthetic-project trigger in `render-shared.ts` and surfaced the project-only-flag check.

Extends the trigger to also fire when the pre-passed context is a single-file context. Adds a unit test that exercises the exact preview pattern.

Fixes #14489