### PR TITLE
Add `recursive` option to anchor listing `contents` globs to the listing directory

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -32,6 +32,7 @@ All changes included in 1.10:
 ### Websites
 
 - ([#13565](https://github.com/quarto-dev/quarto-cli/issues/13565), [#14353](https://github.com/quarto-dev/quarto-cli/issues/14353)): Fix sidebar logo not appearing on secondary sidebars in multi-sidebar website layouts.
+- ([#14512](https://github.com/quarto-dev/quarto-cli/issues/14512)): Add `recursive: false` option to `listing` to anchor `contents` globs to the listing's own directory. Prevents a listing's `contents: posts/*.qmd` from also matching files in sibling subdirectories such as `ko/posts/*.qmd`, which is the common breakage in multi-section / bilingual websites.
 
 ## Commands
 

--- a/src/project/types/website/listing/website-listing-read.ts
+++ b/src/project/types/website/listing/website-listing-read.ts
@@ -20,6 +20,7 @@ import { existsSync } from "../../../../deno_ral/fs.ts";
 import { Format, Metadata } from "../../../../config/types.ts";
 import {
   filterPaths,
+  GlobOptions,
   pathWithForwardSlashes,
   resolvePathGlobs,
   safeExistsSync,
@@ -68,6 +69,7 @@ import {
   kListing,
   kMaxDescLength,
   kPageSize,
+  kRecursive,
   kSortAsc,
   kSortDesc,
   kSortUi,
@@ -720,6 +722,14 @@ async function readContents(
   );
 
   const filterListingFiles = (globOrPaths: string[]) => {
+    // Default: smart globs (current behavior, recursive across the project).
+    // Opt out with `recursive: false` on the listing to anchor `contents`
+    // globs to the listing's own directory.
+    const recursive = listing[kRecursive] !== false;
+    const globOptions: GlobOptions | undefined = recursive
+      ? undefined
+      : { mode: "auto", explicitSubfolderSearch: true };
+
     const hasDefaultGlob = globOrPaths.some((glob) => {
       return glob === kDefaultContentsGlobToken;
     });
@@ -758,6 +768,7 @@ async function readContents(
         dirname(source),
         inputsWithoutSource,
         finalGlobs,
+        globOptions,
       );
 
       // If a glob points to a file that exists, go ahead and just include
@@ -776,6 +787,7 @@ async function readContents(
         dirname(source),
         finalGlobs,
         ["_*", ".*", "**/_*", "**/.*", source],
+        globOptions,
       );
     }
   };

--- a/src/project/types/website/listing/website-listing-shared.ts
+++ b/src/project/types/website/listing/website-listing-shared.ts
@@ -93,6 +93,7 @@ export const kTableHover = "table-hover";
 // Items to include
 export const kInclude = "include";
 export const kExclude = "exclude";
+export const kRecursive = "recursive";
 
 // Fields
 export const kFieldTitle = "title";

--- a/src/resources/schema/definitions.yml
+++ b/src/resources/schema/definitions.yml
@@ -1530,6 +1530,21 @@
             - string
             - ref: website-listing-contents-object
         description: "The files or path globs of Quarto documents or YAML files that should be included in the listing."
+      recursive:
+        boolean:
+          default: true
+          description:
+            short: "Match `contents` globs recursively across the project."
+            long: |
+              When `true` (the default), non-anchored globs in `contents`
+              (e.g. `posts/*.qmd`) are expanded with an implicit globstar
+              prefix and may match nested directories anywhere under the
+              project root.
+
+              Set to `false` to anchor `contents` globs to the listing's own
+              directory. Useful for multi-section or bilingual sites where two
+              listings each own a sibling `posts/` subdirectory and should not
+              pull each other's files.
       sort:
         anyOf:
           - boolean


### PR DESCRIPTION
## Summary

Adds a new `recursive: false` option to listing configuration that anchors `contents` globs to the listing's own directory, preventing them from matching files in sibling subdirectories elsewhere in the project.

Closes #14512. Related: #13677 (different symptom in the same `listing` path-handling area).

## Motivation

Today, Quarto's listing applies "smart glob" semantics that silently prepends `**/` to any non-`/`-anchored entry in `contents`. This is intentional and helpful for nested post folders, but it has a surprising side effect in multi-section / bilingual projects:

```
project/
├── index.qmd              # listing: contents: "posts/*.qmd"
├── posts/foo.qmd
└── ko/
    ├── index.qmd          # listing: contents: "posts/*.qmd"
    └── posts/foo.qmd
```

The English listing matches **both** `posts/foo.qmd` and `ko/posts/foo.qmd` because `posts/*.qmd` is silently rewritten to `**/posts/*.qmd`. Debug log:

```
[listing] Contents: posts/*.qmd
[listing] matches 2 files:
[listing] Reading file .../project/posts/foo.qmd
[listing] Reading file .../project/ko/posts/foo.qmd     ← unexpected
```

`GlobOptions.explicitSubfolderSearch` in `src/core/path.ts` already controls exactly this — per its inline comment, *"set this to true to never prepend `**/` to globs to create nested directory searching"*. It's just never wired through from the YAML.

## Behavior

Default behavior is preserved (smart globs continue to match recursively):

```yaml
listing:
  contents: "posts/*.qmd"   # default: matches **/posts/*.qmd across project
```

Opt out with the new flag:

```yaml
listing:
  contents: "posts/*.qmd"
  recursive: false          # anchored to dirname(listing.qmd)
```

## Changes

Four source files, +29/−0:

- `src/project/types/website/listing/website-listing-shared.ts` — add `kRecursive` constant.
- `src/project/types/website/listing/website-listing-read.ts` — in `filterListingFiles`, read `listing[kRecursive]` and pass `{ mode: "auto", explicitSubfolderSearch: true }` to `filterPaths` / `resolvePathGlobs` when `false`. (`recursive !== false`, so omitting the field or leaving the default keeps current behavior.)
- `src/resources/schema/definitions.yml` — add `recursive` field to the `website-listing` schema with user-facing docs.
- `news/changelog-1.10.md` — entry under Projects → Websites.

I did regenerate the schema artifacts locally with `quarto dev-call build-artifacts` to confirm the description text doesn't break code generation (an earlier draft used `` `**/` `` literally, which terminated the block comment in `schema-types.ts` and broke `validate-bundle`). The regenerated artifact diffs also included drift from earlier source changes that hadn't been re-emitted yet (e.g. the "Supports markdown formatting" descriptions from #14503), so per the maintainer convention (`20cb9d252` etc.) I'm **leaving artifact regeneration out of this PR** and letting it ride along with the next periodic `artifacts` commit.

## Test plan

- [x] Manual: minimal bilingual repro (`posts/foo.qmd` + `ko/posts/foo.qmd`) — listing with `recursive: false` excludes the sibling. Verified locally that `listings.json` matches the listing's directory only.
- [x] Default behavior unchanged for projects without the new field (omitted → `recursive !== false` is true → no `GlobOptions` passed → existing code path).
- [x] `quarto dev-call build-artifacts` produces a `deno fmt --check`-clean `schema-types.ts` with the new field, confirming the schema description does not break the type generator.
- [ ] Docs PR to `quarto-dev/quarto-web` to follow after this is merged.

Open to maintainer suggestions on the field name (`recursive` vs `anchored` vs `match-subfolders` vs …) — happy to rename.