### PR TITLE
Follow system theme on change when `respect-user-color-scheme: true`

### DIFF
--- a/src/resources/formats/html/templates/quarto-html-before-body.ejs
+++ b/src/resources/formats/html/templates/quarto-html-before-body.ejs
@@ -191,11 +191,12 @@
 
     <% if (respectUserColorScheme) { %>
     queryPrefersDark.addEventListener("change", e => {
-      if(window.localStorage.getItem("quarto-color-scheme") !== null)
-        return;
-      const alternate = e.matches
+      const alternate = e.matches;
+      if (window.localStorage.getItem("quarto-color-scheme") !== null) {
+        window.localStorage.removeItem("quarto-color-scheme");
+      }
       toggleColorMode(alternate);
-      localAlternateSentinel = e.matches ? 'alternate' : 'default'; // this is used alongside local storage!
+      localAlternateSentinel = alternate ? 'alternate' : 'default';
       toggleGiscusIfUsed(alternate, darkModeDefault);
     });
     <% } %>

--- a/tests/integration/playwright/tests/html-dark-mode-defaultdark.spec.ts
+++ b/tests/integration/playwright/tests/html-dark-mode-defaultdark.spec.ts
@@ -89,7 +89,7 @@ test('Project specifies dark and light brands, dynamic respect-user-color-scheme
 });
 
 
-test('Project specifies dark and light brands, do not respect-user-color-scheme after toggling', async ({ page }) => {
+test('Project specifies dark and light brands, manual override expires on system theme change', async ({ page }) => {
   await page.goto('./html/dark-brand/project-dark/simple-respect-color-scheme.html');
   const locatr = await page.locator('body').first();
   await expect(locatr).toHaveClass(`fullcontent quarto-dark`);
@@ -100,8 +100,10 @@ test('Project specifies dark and light brands, do not respect-user-color-scheme 
   await check_backgrounds(page, 'quarto-light', blue, red);
   await check_toggle(page, true);
 
+  // After the system theme changes, the manual override expires
+  // and the page follows the system again
   await page.emulateMedia({ colorScheme: 'light' });
-  await expect(locatr).toHaveClass(`fullcontent quarto-dark`);
-  await expect(locatr).toHaveCSS('background-color', red);
-  await check_toggle(page, true);
+  await expect(locatr).toHaveClass(`fullcontent quarto-light`);
+  await expect(locatr).toHaveCSS('background-color', blue);
+  await check_toggle(page, false);
 });


### PR DESCRIPTION
## Problem

When `respect-user-color-scheme: true` is set in a Quarto HTML document, the
page respects the user's OS-level light/dark preference at load time, but does
**not** follow it when the OS theme changes while the page is open. This
behaviour is described in #12426 but I believe is no longer needed, and the
expected behaviour for most users setting `respect-user-color-scheme: true`
would be for the document to follow the system theme anytime it changes.

## Root Cause

The `matchMedia('(prefers-color-scheme: dark)') change` listener in
`quarto-html-before-body.ejs` bails out early when any localStorage entry
exists:

```javascript
queryPrefersDark.addEventListener("change", e => {
  if(window.localStorage.getItem("quarto-color-scheme") !== null)
    return;                       // ← bails forever after one manual toggle
  // ... apply system theme ...
});
```

Since every manual toggle writes to `localStorage` (via `setStyleSentinel()`),
one click permanently kills system-following.

## Solution

Instead of returning early when a localStorage override is present, **clear
the override** and follow the system. The manual choice is still respected
across page loads, but it expires gracefully on the next OS theme change.

```javascript
queryPrefersDark.addEventListener("change", e => {
  const alternate = e.matches;
  if (window.localStorage.getItem("quarto-color-scheme") !== null) {
    window.localStorage.removeItem("quarto-color-scheme");   // override expires
  }
  toggleColorMode(alternate);
  localAlternateSentinel = alternate ? 'alternate' : 'default';
  toggleGiscusIfUsed(alternate, darkModeDefault);
});
```

This is the **only change**. The existing sentinel machinery
(`hasAlternateSentinel`, `getColorSchemeSentinel`, `setStyleSentinel`) works
unchanged: when localStorage is absent, it falls back to
`localAlternateSentinel` (which always reflects the current effective mode).

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Page load, system dark → light | Follows | Follows |
| User toggles once | Override sticks **forever** | Override sticks **until next OS theme change** |
| User toggles, then system changes | Page ignores system | Override expires, page follows system |
| User toggles, navigates, reloads | Choice persists | Choice persists (until next OS change) |

## Files Changed

- `src/resources/formats/html/templates/quarto-html-before-body.ejs`
  (6 lines changed in the `respectUserColorScheme` event listener)
- `tests/integration/playwright/tests/html-dark-mode-defaultdark.spec.ts`
  (updated the `'...do not respect-user-color-scheme after toggling'` test to
  reflect the new behaviour: renamed to `'...manual override expires on system
  theme change'`, assertions now expect the page to follow the system after a
  manual override expires, rather than sticking forever)

  All 14 existing tests in the dark-mode and light-mode suites continue to
  pass with these changes.

Fixes #14551
