### PR TITLE
fix(pdf): auto-install fonts missing from font fallbacks

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -25,6 +25,7 @@ All changes included in 1.10:
 ### `pdf`
 
 - ([#13588](https://github.com/quarto-dev/quarto-cli/issues/13588)): Fix Lua error when rendering PDF with `reference-location: margin` and a footnote alongside a figure with `fig-cap`. (author: @mcanouil)
+- ([#14553](https://github.com/quarto-dev/quarto-cli/issues/14553), [#14558](https://github.com/quarto-dev/quarto-cli/issues/14558)): Fix PDF render failing instead of auto-installing a missing font referenced by `monofontfallback` (and other `mainfont`/`sansfont`/`monofont` fallbacks).
 
 ### `typst`
 

--- a/src/command/render/latexmk/parse-error.ts
+++ b/src/command/render/latexmk/parse-error.ts
@@ -265,6 +265,14 @@ const formatFontFilter = (match: string, _text: string) => {
   return /[.]/.test(base) ? base : fontSearchTerm(base);
 };
 
+// luaotfload appends ';-fallback' internally to each fallback-chain entry
+// (registered via monofontfallback / luaotfload.add_fallback) to prevent
+// recursive fallback resolution. Strip it before building the search term.
+// https://github.com/quarto-dev/quarto-cli/issues/14558
+const luaotfloadFontFilter = (match: string, text: string) => {
+  return formatFontFilter(match.replace(/;-fallback$/, ""), text);
+};
+
 const estoPdfFilter = (_match: string, _text: string) => {
   return "epstopdf";
 };
@@ -290,6 +298,13 @@ const packageMatchers = [
   {
     regex: /.*\(fontspec\)\s+The font "([^"]+)" cannot be.*/g,
     filter: formatFontFilter,
+  },
+  {
+    // luaotfload fallback-chain font (monofontfallback) missing. fontspec does
+    // not fire its own error in this path, so this is the only signal.
+    // https://github.com/quarto-dev/quarto-cli/issues/14558
+    regex: /.*luaotfload.*reason: Font "([^"]+)" not found.*/g,
+    filter: luaotfloadFontFilter,
   },
   {
     regex: /.*Package widetext error: Install the ([^ ]+) package.*/g,

--- a/tests/unit/latexmk/parse-error.test.ts
+++ b/tests/unit/latexmk/parse-error.test.ts
@@ -35,6 +35,9 @@ unitTest("Detect missing files with `findMissingFontsAndPackages`", async () => 
   assertFound('! Font \\JY3/mc/m/n/10=file:HaranoAjiMincho-Regular.otf:-kern;jfm=ujis at 9.24713pt not loadable: metric data not found or bad.', "HaranoAjiMincho-Regular.otf");
   assertFound('! The font "Noto Emoji" cannot be found.', fontSearchTerm("Noto Emoji"));
   assertFound('! Package fontspec Error: The font "DejaVu Sans" cannot be found.', fontSearchTerm("DejaVu Sans"));
+  // luaotfload fallback-chain font (monofontfallback) - https://github.com/quarto-dev/quarto-cli/issues/14558
+  // luaotfload appends ;-fallback internally; it must be stripped before building the search term
+  assertFound('luaotfload | db : Reload initiated (formats: otf,ttf,ttc); reason: Font "DejaVu Sans Mono;-fallback" not found.', fontSearchTerm("DejaVu Sans Mono"));
   assertFound("! LaTeX Error: File `framed.sty' not found.", "framed.sty");
   assertFound("! LaTeX Error: File 'framed.sty' not found.", "framed.sty");
   assertFound("/usr/local/bin/mktexpk: line 123: mf: command not found", "mf");


### PR DESCRIPTION
When a font listed in `monofontfallback` (or any `mainfont`/`sansfont`/`monofont` fallback) is not installed, the PDF render fails and Quarto makes no attempt to auto-install the missing font.

## Root Cause

luaotfload reports the missing fallback font as:

```
luaotfload | db : Reload initiated (formats: otf,ttf,ttc); reason: Font "DejaVu Sans Mono;-fallback" not found.
```

The `packageMatchers` in `src/command/render/latexmk/parse-error.ts` had no pattern for this format. The primary `monofont` case only works because fontspec *also* raises `! Package fontspec Error: The font "X" cannot be found`, which is matched. The fallback path registers fonts via `luaotfload.add_fallback()`; when that fails, fontspec stays silent, so the unrecognized luaotfload message is the only signal.

luaotfload also appends `;-fallback` internally to each fallback-chain entry. Left in place, the extracted name corrupts the `tlmgr` search-term regex.

## Fix

Add a matcher for the luaotfload format and strip the `;-fallback` suffix before building the search term. `DejaVu Sans Mono` then resolves to the `dejavu` CTAN package and auto-installs.

## Test Plan

- [x] Unit test in `tests/unit/latexmk/parse-error.test.ts` extracts the font name (suffix stripped) from the luaotfload log line
- [x] Existing parse-error font cases still pass

## Manual verification

Rendered a document with `pdf-engine: lualatex`, `monofont: Latin Modern Mono`, `monofontfallback: [DejaVu Sans Mono]` (uninstalled) and a glyph absent from the primary font, using a dev build with this change. The new matcher now fires where nothing did before:

```
finding package for DejaVu\s*Sans\s*Mono(-(Bold|Italic|Regular).*)?[.](tfm|afm|mf|otf|ttf)
> 1 package to install
> installing dejavu (1 of 1)
```

`tlmgr` then installs the `dejavu` package — the detection and auto-install path works as intended.

Note: completing the PDF still requires a fix outside this change. After the font is installed, luaotfload's fallback resolver looks up the literal suffixed name `DejaVu Sans Mono;-fallback`, fails, and aborts in `luaotfload-fallback.lua` even with the font present and its name database rebuilt. This is reproducible with bare `lualatex` and no Quarto involved, so it is tracked separately and does not affect the scope of this fix (recognizing the error format so auto-install is attempted).

Closes #14558
