### PR TITLE
fix(llms): expand shortcodes inside llms-keyed conditional content

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -43,6 +43,7 @@ All changes included in 1.10:
 ### Websites
 
 - ([#13565](https://github.com/quarto-dev/quarto-cli/issues/13565), [#14353](https://github.com/quarto-dev/quarto-cli/issues/14353)): Fix sidebar logo not appearing on secondary sidebars in multi-sidebar website layouts.
+- ([#14563](https://github.com/quarto-dev/quarto-cli/issues/14563)): Fix a fatal error when a shortcode is used inside conditional content (e.g. `content-visible when-format="llms-txt"`) in a website with `llms-txt` enabled.
 
 ## Commands
 

--- a/src/resources/filters/quarto-pre/llms-conditional-content.lua
+++ b/src/resources/filters/quarto-pre/llms-conditional-content.lua
@@ -44,10 +44,20 @@ function llms_resolve_conditional_content()
       local html_visible = is_visible(tbl)  -- from content-hidden.lua
       if llms_visible == html_visible then return nil end  -- no intervention needed
 
-      local div = tbl.original_node:clone()
+      local div
       if llms_visible then
+        -- Case A: shown only for llms. The live slot was cleared at parse time
+        -- (content-hidden.lua, issue #4867), so the parse-time snapshot is the
+        -- only surviving copy and its shortcodes were never expanded (the main
+        -- shortcode pass never saw this hidden content). Expand them now on the
+        -- resurrected subtree.
+        div = tbl.original_node:clone()
+        div = process_shortcodes(div)
         div.classes:insert("llms-conditional-content")
       else
+        -- Case B: shown in HTML, hidden for llms. The live slot already holds
+        -- fully-processed content; use it instead of the stale snapshot.
+        div = tbl.node:clone()
         div.classes:insert("llms-hidden-content")
       end
       return div

--- a/tests/docs/smoke-all/website/llms-txt/_quarto.yml
+++ b/tests/docs/smoke-all/website/llms-txt/_quarto.yml
@@ -1,6 +1,6 @@
 project:
   type: website
-  output-dir: .
+  output-dir: _site
 
 website:
   title: "llms-txt Test Site"

--- a/tests/docs/smoke-all/website/llms-txt/conditional-shortcodes.qmd
+++ b/tests/docs/smoke-all/website/llms-txt/conditional-shortcodes.qmd
@@ -1,0 +1,45 @@
+---
+title: "Conditional Shortcodes"
+sc-a-when: "AWHENEXPANDED"
+sc-a-unless: "AUNLESSEXPANDED"
+sc-b-when: "BWHENEXPANDED"
+sc-b-unless: "BUNLESSEXPANDED"
+_quarto:
+  tests:
+    html:
+      ensureLlmsMdExists: true
+      ensureFileRegexMatches:
+        # MUST match in HTML: Case B content present, shortcode expanded
+        - ["BWHENEXPANDED", "BUNLESSEXPANDED"]
+        # MUST NOT match in HTML: Case A content absent; no raw shortcode keys; no marker classes
+        - ["AWHENEXPANDED", "AUNLESSEXPANDED", "sc-a-when", "sc-a-unless", "sc-b-when", "sc-b-unless", "llms-conditional-content", "llms-hidden-content"]
+      ensureLlmsMdRegexMatches:
+        # MUST match in .llms.md: Case A content present, shortcode expanded
+        - ["AWHENEXPANDED", "AUNLESSEXPANDED"]
+        # MUST NOT match in .llms.md: Case B content absent; no raw shortcode keys
+        - ["BWHENEXPANDED", "BUNLESSEXPANDED", "sc-a-when", "sc-a-unless", "sc-b-when", "sc-b-unless"]
+---
+
+## Case A1 — content-visible when-format llms-txt (llms-only)
+
+::: {.content-visible when-format="llms-txt"}
+Case A1 shortcode: {{< meta sc-a-when >}}
+:::
+
+## Case A2 — content-hidden unless-format llms-txt (llms-only)
+
+::: {.content-hidden unless-format="llms-txt"}
+Case A2 shortcode: {{< meta sc-a-unless >}}
+:::
+
+## Case B1 — content-visible unless-format llms-txt (html-only)
+
+::: {.content-visible unless-format="llms-txt"}
+Case B1 shortcode: {{< meta sc-b-unless >}}
+:::
+
+## Case B2 — content-hidden when-format llms-txt (html-only)
+
+::: {.content-hidden when-format="llms-txt"}
+Case B2 shortcode: {{< meta sc-b-when >}}
+:::

--- a/tests/docs/smoke-all/website/llms-txt/conditional-shortcodes.qmd
+++ b/tests/docs/smoke-all/website/llms-txt/conditional-shortcodes.qmd
@@ -12,10 +12,10 @@ _quarto:
         # MUST match in HTML: Case B content present, shortcode expanded
         - ["BWHENEXPANDED", "BUNLESSEXPANDED"]
         # MUST NOT match in HTML: Case A content absent; no raw shortcode keys; no marker classes
-        - ["AWHENEXPANDED", "AUNLESSEXPANDED", "sc-a-when", "sc-a-unless", "sc-b-when", "sc-b-unless", "llms-conditional-content", "llms-hidden-content"]
+        - ["AWHENEXPANDED", "AUNLESSEXPANDED", "sc-a-when", "sc-a-unless", "sc-b-when", "sc-b-unless", "llms-conditional-content", "llms-hidden-content", "Lorem ipsum"]
       ensureLlmsMdRegexMatches:
         # MUST match in .llms.md: Case A content present, shortcode expanded
-        - ["AWHENEXPANDED", "AUNLESSEXPANDED"]
+        - ["AWHENEXPANDED", "AUNLESSEXPANDED", "Lorem ipsum"]
         # MUST NOT match in .llms.md: Case B content absent; no raw shortcode keys
         - ["BWHENEXPANDED", "BUNLESSEXPANDED", "sc-a-when", "sc-a-unless", "sc-b-when", "sc-b-unless"]
 ---
@@ -42,4 +42,10 @@ Case B1 shortcode: {{< meta sc-b-unless >}}
 
 ::: {.content-hidden when-format="llms-txt"}
 Case B2 shortcode: {{< meta sc-b-when >}}
+:::
+
+## Case A3 — content-visible when-format llms-txt with lipsum shortcode
+
+::: {.content-visible when-format="llms-txt"}
+{{< lipsum 1 >}}
 :::


### PR DESCRIPTION
When a shortcode appears inside a `content-visible when-format="llms-txt"` block (or any `content-hidden`/`unless-format` variant) in a website with `llms-txt: true`, rendering aborts with a fatal internal error.

## Root Cause

`content-hidden.lua` snapshots `original_node` at parse time (before shortcode expansion) and clears the live `node.content` for html-hidden blocks — an intentional invariant from #4867. The `llms-conditional-content.lua` handler always resurrected `original_node:clone()` regardless of direction, re-injecting unexpanded `Shortcode` nodes. Those reached the post-phase render placeholder, which calls `internal_error()`.

## Fix

The handler now selects the content source per direction. For llms-only blocks (html-hidden), the live slot was cleared, so `original_node` is the only surviving copy; `process_shortcodes()` is called on the resurrected clone to expand shortcodes the main pass never saw. For html-only blocks (llms-hidden), the live slot already holds fully-processed content; `tbl.node:clone()` is used instead of the stale snapshot.

Fixes #14563