### PR TITLE
fix(llms): preserve heading section in llms-hidden conditional content

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -43,6 +43,7 @@ All changes included in 1.10:
 ### Websites
 
 - ([#13565](https://github.com/quarto-dev/quarto-cli/issues/13565), [#14353](https://github.com/quarto-dev/quarto-cli/issues/14353)): Fix sidebar logo not appearing on secondary sidebars in multi-sidebar website layouts.
+- ([#14562](https://github.com/quarto-dev/quarto-cli/issues/14562)): Fix a heading inside `content-hidden when-format="llms-txt"` (visible in HTML) losing its `<section>` wrapper and `id` in a website with `llms-txt` enabled, which broke its table-of-contents link, anchors, and cross-references.
 - ([#14563](https://github.com/quarto-dev/quarto-cli/issues/14563)): Fix a fatal error when a shortcode is used inside conditional content (e.g. `content-visible when-format="llms-txt"`) in a website with `llms-txt` enabled.
 
 ## Commands

--- a/src/project/types/website/website-llms.ts
+++ b/src/project/types/website/website-llms.ts
@@ -108,11 +108,22 @@ function cleanupConditionalContent(doc: Document): void {
     (el as Element).remove();
   }
 
-  // Unwrap llms-hidden markers (keep content, remove wrapper div)
+  // Unwrap llms-hidden markers (keep content, remove wrapper div).
+  //
+  // When the marked block leads with a heading, Pandoc's --section-divs fuses
+  // the marker class onto the <section> it generates for that heading (e.g.
+  // <section id="..." class="level2 llms-hidden-content">). Unwrapping that
+  // section would strip the <section> and its id, breaking the TOC, anchors,
+  // and cross-references. So keep the section and only drop the marker class;
+  // genuine wrapper divs are still unwrapped. See issue #14562.
   for (const el of doc.querySelectorAll(".llms-hidden-content")) {
-    const parent = (el as Element).parentElement;
+    const element = el as Element;
+    if (element.tagName === "SECTION") {
+      element.classList.remove("llms-hidden-content");
+      continue;
+    }
+    const parent = element.parentElement;
     if (parent) {
-      const element = el as Element;
       while (element.firstChild) {
         parent.insertBefore(element.firstChild as Node, element as Node);
       }

--- a/tests/docs/smoke-all/website/llms-txt/conditional-headings-no-section-divs.qmd
+++ b/tests/docs/smoke-all/website/llms-txt/conditional-headings-no-section-divs.qmd
@@ -1,0 +1,43 @@
+---
+title: "Conditional Headings (no section-divs)"
+# Companion regression test for https://github.com/quarto-dev/quarto-cli/issues/14562
+# Even with `section-divs: false` (normal headings render as bare <h2 id>), the
+# conditional block's leading heading still acquires a <section> wrapper that the
+# `llms-hidden-content` marker class fuses onto. The llms HTML finalizer must keep
+# that heading's id intact for HTML, while still excluding the content from the
+# .llms.md output.
+format:
+  html:
+    section-divs: false
+_quarto:
+  tests:
+    html:
+      ensureLlmsMdExists: true
+      ensureHtmlElements:
+        -
+          # The html-only heading keeps its id (TOC link target survives)
+          - '#html-only-heading'
+        -
+          # No internal marker classes leak into the HTML output
+          - '.llms-hidden-content'
+          - '.llms-conditional-content'
+      ensureLlmsMdRegexMatches:
+        -
+          # Normal content is present in the .llms.md output
+          - 'NODIVSNORMALTEXT'
+        -
+          # html-only content is excluded from the .llms.md output
+          - 'NODIVSHTMLONLYTEXT'
+---
+
+## Normal Section
+
+NODIVSNORMALTEXT
+
+::: {.content-hidden when-format="llms-txt"}
+
+## HTML Only Heading
+
+NODIVSHTMLONLYTEXT
+
+:::

--- a/tests/docs/smoke-all/website/llms-txt/conditional-headings.qmd
+++ b/tests/docs/smoke-all/website/llms-txt/conditional-headings.qmd
@@ -1,0 +1,40 @@
+---
+title: "Conditional Headings"
+# Regression test for https://github.com/quarto-dev/quarto-cli/issues/14562
+# A heading that leads a `content-hidden when-format="llms-txt"` block is visible
+# in HTML. Pandoc's --section-divs fuses the `llms-hidden-content` marker class
+# onto the <section> it creates for that heading. The llms HTML finalizer must
+# keep that <section> (and its id) intact for HTML while still excluding the
+# content from the .llms.md output.
+_quarto:
+  tests:
+    html:
+      ensureLlmsMdExists: true
+      ensureHtmlElements:
+        -
+          # HTML keeps the section + id for the html-only heading
+          - 'section#html-only-heading.level2'
+        -
+          # No internal marker classes leak into the HTML output
+          - '.llms-hidden-content'
+          - '.llms-conditional-content'
+      ensureLlmsMdRegexMatches:
+        -
+          # Normal content is present in the .llms.md output
+          - 'NORMALSECTIONTEXT'
+        -
+          # html-only content is excluded from the .llms.md output
+          - 'HTMLONLYHEADINGCONTENT'
+---
+
+## Normal Section
+
+NORMALSECTIONTEXT
+
+::: {.content-hidden when-format="llms-txt"}
+
+## HTML Only Heading
+
+HTMLONLYHEADINGCONTENT
+
+:::

--- a/tests/docs/smoke-all/website/llms-txt/conditional-headings.qmd
+++ b/tests/docs/smoke-all/website/llms-txt/conditional-headings.qmd
@@ -18,10 +18,14 @@ _quarto:
           # No internal marker classes leak into the HTML output
           - '.llms-hidden-content'
           - '.llms-conditional-content'
+          # llms-only content is removed entirely from the HTML output
+          - 'section#llms-only-heading'
       ensureLlmsMdRegexMatches:
         -
           # Normal content is present in the .llms.md output
           - 'NORMALSECTIONTEXT'
+          # llms-only content is present in the .llms.md output
+          - 'LLMSONLYHEADINGCONTENT'
         -
           # html-only content is excluded from the .llms.md output
           - 'HTMLONLYHEADINGCONTENT'
@@ -36,5 +40,13 @@ NORMALSECTIONTEXT
 ## HTML Only Heading
 
 HTMLONLYHEADINGCONTENT
+
+:::
+
+::: {.content-visible when-format="llms-txt"}
+
+## LLMS Only Heading
+
+LLMSONLYHEADINGCONTENT
 
 :::


### PR DESCRIPTION
When a heading is the first element inside `::: {.content-hidden when-format="llms-txt"}` in a website with `llms-txt: true`, the heading renders in HTML as a bare `<h2>` with no `<section id="...">` wrapper. The auto-generated TOC link points at an `id` that no longer exists, so clicking it does not scroll, and the heading's anchor and cross-references break too.

## Root Cause

The llms conditional-content filter marks "visible in HTML, hidden from llms" blocks by wrapping them in `<div class="llms-hidden-content">`. When that block leads with a heading, Pandoc's `--section-divs` does not keep the heading nested in the div — it fuses the marker class onto the `<section>` it generates for the heading:

```html
<section id="conditional-section" class="level2 llms-hidden-content">
```

`cleanupConditionalContent` in `src/project/types/website/website-llms.ts` then unwraps every `.llms-hidden-content` element. Since the class now rides on the `<section>`, unwrapping strips the section and its `id`, leaving the bare `<h2>`. Only the leading-heading shape is affected; with text before the heading or multiple headings, Pandoc keeps the wrapper div separate, so the unwrap is harmless.

## Fix

When the marked element is a `<section>` (the marker fused onto it), keep the section and drop only the `llms-hidden-content` class; genuine wrapper divs are still unwrapped. Content stays excluded from the `.llms.md` output, which is generated before cleanup runs.

## Test Plan

- [x] Render an `llms-txt` website with a heading inside `content-hidden when-format="llms-txt"` — heading keeps its `<section id>` and the TOC link scrolls
- [x] `.llms.md` still excludes the HTML-only content
- [x] `content-visible when-format="llms-txt"` (llms-only) content stays absent from HTML, present in `.llms.md`
- [x] `section-divs: false` documents still render the heading with its `id`

Fixes #14562
