### PR TITLE
Update floatreftarget.lua

### DIFF
--- a/src/resources/filters/customnodes/floatreftarget.lua
+++ b/src/resources/filters/customnodes/floatreftarget.lua
@@ -15,7 +15,10 @@ local function split_longtable_start(content_str)
   -- we do this by counting the number of open braces
   
   -- we need to do this through utf8 because lua strings are not unicode-aware
-  local codepoints = table.pack(utf8.codepoint(content_str, 1, #content_str))
+  local codepoints = {}
+  for _, c in utf8.codes(content_str) do
+    table.insert(codepoints, c)
+  end
   local function find_codepoint(start_idx, ...)
     if start_idx > #codepoints then
       return nil

--- a/src/resources/filters/customnodes/floatreftarget.lua
+++ b/src/resources/filters/customnodes/floatreftarget.lua
@@ -16,8 +16,10 @@ local function split_longtable_start(content_str)
   
   -- we need to do this through utf8 because lua strings are not unicode-aware
   local codepoints = {}
+  local n = 0
   for _, c in utf8.codes(content_str) do
-    table.insert(codepoints, c)
+    n = n + 1
+    codepoints[n] = c
   end
   local function find_codepoint(start_idx, ...)
     if start_idx > #codepoints then


### PR DESCRIPTION
## Description

Working around using ut8.codepoint in split_longtable_start since that was causing a stack overflow with rather large tables.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog in the PR
- [x] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR

<!-- If an AI assistant helped prepare this PR, uncomment and complete this section:

<details>
<summary>AI-assisted PR</summary>

- **AI tool used**: None

Note: autonomous AI agents submitting PRs without human oversight are not permitted — see the [Code of Conduct](CODE_OF_CONDUCT.md).

</details>

