### PR TITLE
Add `line-numbers` option for Word (docx) output

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -23,6 +23,10 @@ All changes included in 1.10:
 
 - ([#14530](https://github.com/quarto-dev/quarto-cli/pull/14530)): Add `quarto.*` Pandoc template variable namespace. `format.language` is now exposed as `$quarto.language.<key>$` in custom Pandoc templates via the defaults-file `variables:` section, with no leakage into rendered output.
 
+### `docx`
+
+- ([#14624](https://github.com/quarto-dev/quarto-cli/issues/14624)): Add `line-numbers` option to enable continuous line numbering in Word output.
+
 ### `pdf`
 
 - ([#13588](https://github.com/quarto-dev/quarto-cli/issues/13588)): Fix Lua error when rendering PDF with `reference-location: margin` and a footnote alongside a figure with `fig-cap`. (author: @mcanouil)

--- a/src/format/docx/format-docx.ts
+++ b/src/format/docx/format-docx.ts
@@ -1,15 +1,16 @@
 /*
-* format-docx.ts
-*
-* Copyright (C) 2020-2022 Posit Software, PBC
-*
-*/
+ * format-docx.ts
+ *
+ * Copyright (C) 2020-2022 Posit Software, PBC
+ */
 
 import { kFilterParams } from "../../config/constants.ts";
-import { Format } from "../../config/types.ts";
+import { Format, FormatExtras, PandocFlags } from "../../config/types.ts";
 import { mergeConfigs } from "../../core/config.ts";
 import { formatResourcePath } from "../../core/resources.ts";
 import { createWordprocessorFormat } from "../formats-shared.ts";
+import { unzip, zip } from "../../core/zip.ts";
+import { join, resolve } from "../../deno_ral/path.ts";
 
 const kIconCaution = "icon-caution";
 const kIconImportant = "icon-important";
@@ -17,12 +18,19 @@ const kIconNote = "icon-note";
 const kIconTip = "icon-tip";
 const kIconWarning = "icon-warning";
 
+const kLineNumbers = "line-numbers";
+
 export function docxFormat(): Format {
   return mergeConfigs(
     createWordprocessorFormat("MS Word", "docx"),
     {
-      formatExtras: () => {
-        return {
+      formatExtras: (
+        _input: string,
+        _markdown: string,
+        _flags: PandocFlags,
+        format: Format,
+      ): FormatExtras => {
+        const extras: FormatExtras = {
           [kFilterParams]: {
             [kIconCaution]: iconPath("caution.png"),
             [kIconImportant]: iconPath("important.png"),
@@ -31,6 +39,15 @@ export function docxFormat(): Format {
             [kIconWarning]: iconPath("warning.png"),
           },
         };
+        // `line-numbers: true` enables continuous Word line numbering. Word
+        // stores it in each section's <w:sectPr>, which pandoc writes from the
+        // reference doc after filters run, so it can only be applied by a
+        // post-processor on the finished file (see addDocxLineNumbers).
+        const lineNumbers = format.metadata[kLineNumbers];
+        if (lineNumbers === true || lineNumbers === "true") {
+          extras.postprocessors = [addDocxLineNumbers];
+        }
+        return extras;
       },
       extensions: {
         book: {
@@ -43,4 +60,36 @@ export function docxFormat(): Format {
 
 function iconPath(icon: string) {
   return formatResourcePath("docx", icon);
+}
+
+// Turn on continuous line numbering by adding <w:lnNumType> to the section
+// properties (<w:sectPr>) already present in the rendered document. Because we
+// edit the existing sections — which carry the header references and page size
+// — the running head and paper size (Letter, A4, etc.) are preserved.
+async function addDocxLineNumbers(
+  output: string,
+): Promise<{ supporting?: string[]; resources?: string[] } | void> {
+  const outputPath = resolve(output);
+  const tempDir = await Deno.makeTempDir();
+  try {
+    await unzip(outputPath, tempDir);
+    const documentXml = join(tempDir, "word", "document.xml");
+    const xml = await Deno.readTextFile(documentXml);
+    // Add line numbering to each section that lacks it (idempotent). The regex
+    // assumes sections are not nested, which holds for pandoc/Quarto output.
+    const updated = xml.replace(
+      /<w:sectPr\b[\s\S]*?<\/w:sectPr>/g,
+      (sectPr) =>
+        sectPr.includes("<w:lnNumType") ? sectPr : sectPr.replace(
+          "</w:sectPr>",
+          '<w:lnNumType w:countBy="1" w:restart="continuous"/></w:sectPr>',
+        ),
+    );
+    await Deno.writeTextFile(documentXml, updated);
+    // Repackage the edited document parts back into the .docx.
+    await Deno.remove(outputPath);
+    await zip(["."], outputPath, { cwd: tempDir });
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
 }

--- a/src/resources/schema/document-options.yml
+++ b/src/resources/schema/document-options.yml
@@ -6,6 +6,14 @@
     Use the specified file as a style reference in producing a docx, 
     pptx, or odt file.
 
+- name: line-numbers
+  tags:
+    formats: [docx]
+  schema: boolean
+  default: false
+  description: |
+    Add continuous line numbering to the margins of the document.
+
 - name: brand
   schema:
     ref: brand-path-bool-light-dark

--- a/tests/docs/smoke-all/2026/06/27/docx-line-numbers.qmd
+++ b/tests/docs/smoke-all/2026/06/27/docx-line-numbers.qmd
@@ -1,0 +1,17 @@
+---
+format:
+  docx:
+    line-numbers: true
+_quarto:
+  tests:
+    docx:
+      ensureDocxXpath:
+        -
+          - "//w:lnNumType"
+        - []
+---
+
+# Section
+
+A paragraph of text so that the rendered Word document has several lines, which
+`line-numbers: true` should number continuously in the margin.


### PR DESCRIPTION
Closes #14624.

Adds a `line-numbers: true` option for `docx` that turns on continuous line numbering.

## Approach

Word stores line numbering as `<w:lnNumType>` inside a section's `<w:sectPr>`. That section is written by pandoc from the reference doc *after* filters run, so a filter can't reach it without appending a *new* section (which drops the running head and resets the page size). Instead, this registers a `docx` output post-processor (`formatExtras().postprocessors`) that injects `<w:lnNumType w:countBy="1" w:restart="continuous"/>` into the document's existing `<w:sectPr>` elements — preserving each section's header references and page size.

## Changes

- `src/format/docx/format-docx.ts`: read `line-numbers` and register the post-processor.
- `src/resources/schema/document-options.yml`: declare the `line-numbers` docx option.
- `news/changelog-1.10.md`: changelog entry.
- `tests/docs/smoke-all/2026/06/27/docx-line-numbers.qmd`: smoke test asserting `<w:lnNumType>` is present.

## Verification

Built from source and rendered to `.docx`, then to PDF via LibreOffice:

- Line numbers appear and run continuously.
- With a header-bearing reference doc, the running head **and** page number are preserved.
- An A4 reference doc renders as true A4 (the page size is not reset to Letter).

The smoke test passes (`1 passed | 0 failed`, no errors or warnings).

Marking as **draft** pending discussion of the option name / approach in #14624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
