### PR TITLE
Fix dashboard showing spurious matplotlib repr text next to figures

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -89,6 +89,7 @@ All changes included in 1.10:
 
 ### Jupyter
 
+- ([#11150](https://github.com/quarto-dev/quarto-cli/issues/11150)): Fix `dashboard` format showing spurious intermediate text output (e.g. a `Text(...)` repr or a matplotlib object repr) next to a figure when a cell's top-level plotting calls echo their return values.
 - ([#13582](https://github.com/quarto-dev/quarto-cli/pull/13582)): Fix `application/pdf` and `text/latex` MIME types not being preferred over `image/svg+xml` when rendering Jupyter notebooks to PDF, which caused errors when `rsvg-convert` was not available. (author: @jkrumbiegel)
 - ([#14374](https://github.com/quarto-dev/quarto-cli/pull/14374)): Avoid a crash when a third-party Jupyter kernel (observed with Maple 2025, built on XEUS) returns `execute_reply` without the required `status` field. The failing cell is recorded as an error instead of aborting the render. (author: @ChrisJefferson)
 

--- a/src/core/jupyter/jupyter.ts
+++ b/src/core/jupyter/jupyter.ts
@@ -1774,7 +1774,8 @@ export function isDiscardableTextExecuteResult(
             // numeric coordinate (Text(0.5, ...)), unlike other libraries' Text
             const first = textPlain[0].trim();
             return /^([<(\[]).*?([>)\]])$/.test(first) ||
-              /^Text\([-\d]/.test(first);
+              /^Text\([-\d]/.test(first) ||
+              (first.startsWith("{") && first.includes("<matplotlib."));
           } else {
             // multi-line reprs that are collections of matplotlib artists, e.g.
             // the dict of Line2D returned by boxplot(). Only suppress when a

--- a/src/core/jupyter/jupyter.ts
+++ b/src/core/jupyter/jupyter.ts
@@ -1767,15 +1767,21 @@ export function isDiscardableTextExecuteResult(
       const textPlain = data?.[kTextPlain] as string[] | undefined;
       if (textPlain && textPlain.length) {
         if (haveImage) {
-          // object reprs echoed next to the figure. Bracketed wrappers
-          // (Axes, Line2D, tuples) plus matplotlib Text from
-          // title()/xlabel()/ylabel()/set_title(); and the dict of Line2D
-          // returned by boxplot()/hist(). text/plain may arrive as one
-          // multi-line string, so match against the joined text.
-          const text = textPlain.join("").trim();
-          return /^([<(\[])[\s\S]*?([>)\]])$/.test(text) ||
-            text.startsWith("Text(") ||
-            (text.startsWith("{") && text.includes("<matplotlib."));
+          if (textPlain.length === 1) {
+            // single-line object reprs echoed next to the figure: <...>/(...)/[...]
+            // wrappers (Axes, Line2D, tuples) plus matplotlib Text from
+            // title()/xlabel()/ylabel()/set_title() — whose repr leads with a
+            // numeric coordinate (Text(0.5, ...)), unlike other libraries' Text
+            const first = textPlain[0].trim();
+            return /^([<(\[]).*?([>)\]])$/.test(first) ||
+              /^Text\([-\d]/.test(first);
+          } else {
+            // multi-line reprs that are collections of matplotlib artists, e.g.
+            // the dict of Line2D returned by boxplot(). Only suppress when a
+            // matplotlib object is referenced, leaving ordinary multi-line
+            // output (lists, tuples, custom reprs) untouched
+            return textPlain.some((line) => line.includes("<matplotlib."));
+          }
         } else {
           return [
             "[<matplotlib",

--- a/src/core/jupyter/jupyter.ts
+++ b/src/core/jupyter/jupyter.ts
@@ -1757,7 +1757,7 @@ async function mdFromCodeCell(
   return md;
 }
 
-function isDiscardableTextExecuteResult(
+export function isDiscardableTextExecuteResult(
   output: JupyterOutput,
   haveImage: boolean,
 ) {
@@ -1766,8 +1766,16 @@ function isDiscardableTextExecuteResult(
     if (Object.keys(data).length === 1) {
       const textPlain = data?.[kTextPlain] as string[] | undefined;
       if (textPlain && textPlain.length) {
-        if (haveImage && textPlain.length === 1) {
-          return /^([<(\[]).*?([>)\]])$/.test(textPlain[0].trim());
+        if (haveImage) {
+          // object reprs echoed next to the figure. Bracketed wrappers
+          // (Axes, Line2D, tuples) plus matplotlib Text from
+          // title()/xlabel()/ylabel()/set_title(); and the dict of Line2D
+          // returned by boxplot()/hist(). text/plain may arrive as one
+          // multi-line string, so match against the joined text.
+          const text = textPlain.join("").trim();
+          return /^([<(\[])[\s\S]*?([>)\]])$/.test(text) ||
+            text.startsWith("Text(") ||
+            (text.startsWith("{") && text.includes("<matplotlib."));
         } else {
           return [
             "[<matplotlib",

--- a/tests/docs/smoke-all/2026/07/02/.gitignore
+++ b/tests/docs/smoke-all/2026/07/02/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/tests/docs/smoke-all/2026/07/02/11150.qmd
+++ b/tests/docs/smoke-all/2026/07/02/11150.qmd
@@ -1,0 +1,58 @@
+---
+title: "Intermediate matplotlib output shown in dashboard (#11150)"
+format:
+  html: default
+  dashboard: default
+engine: jupyter
+echo: true
+_quarto:
+  tests:
+    dashboard:
+      ensureHtmlElements:
+        - ['img']                       # the figure is still rendered
+      ensureFileRegexMatches:
+        -
+          - '<code>123</code>'          # non-last expression value preserved (shell-interactivity: all)
+          - '<code>234</code>'          # last expression value preserved
+        -
+          - 'Text\(0\.5'                # plt.title() Text repr suppressed
+          - 'whiskers'                  # plt.boxplot() dict repr suppressed
+    html:
+      ensureHtmlElements:
+        - ['img']                       # the figure is still rendered
+      ensureFileRegexMatches:
+        -
+          - '<code>234</code>'          # last expression value shown (last_expr)
+        -
+          - 'Text\(0\.5'                # plt.title() Text repr suppressed
+          - '<code>123</code>'          # non-last expression not echoed under last_expr
+---
+
+Dashboard format runs the Jupyter kernel with
+`ipynb-shell-interactivity: all`, so every top-level expression statement in a
+cell echoes its value, not just the last one. matplotlib/pandas/seaborn
+plotting calls return objects (`plt.title()` returns a `Text`, `plt.boxplot()`
+returns a dict of `Line2D`), and those object reprs leaked into the rendered
+output as spurious intermediate text next to the figure — the difference from
+HTML that #11150 reported. HTML is affected too, just less: under the default
+`last_expr` it only echoes the final expression's repr (`Text(...)`).
+
+The first cell exercises the bug: it must render the figure but must not show
+the `Text(...)` or boxplot-dict reprs, in either format. The second cell guards
+the intentional multi-output capability that `shell-interactivity: all` gives
+dashboards — both `123` and `234` must survive in the dashboard output (HTML,
+being `last_expr`, keeps only `234`).
+
+```{python}
+#| title: plot with a title
+import matplotlib.pyplot as plt
+x = [1, 2, 3, 4, 5, 10]
+plt.boxplot(x)
+plt.title("Test")
+```
+
+```{python}
+#| title: multiple values in one cell
+100 + 23
+200 + 34
+```

--- a/tests/docs/smoke-all/2026/07/02/11150.qmd
+++ b/tests/docs/smoke-all/2026/07/02/11150.qmd
@@ -9,23 +9,25 @@ _quarto:
   tests:
     dashboard:
       ensureHtmlElements:
-        - ['img']                       # the figure is still rendered
+        - ['img']                       # the matplotlib figure is still rendered
+      ensureHtmlElementCount:
+        selectors: ['table', '.plotly-graph-div']
+        counts: [1, 1]                  # table AND graph both survive in one card (shell-interactivity: all)
       ensureFileRegexMatches:
-        -
-          - '<code>123</code>'          # non-last expression value preserved (shell-interactivity: all)
-          - '<code>234</code>'          # last expression value preserved
+        - []                            # nothing required beyond the element checks
         -
           - 'Text\(0\.5'                # plt.title() Text repr suppressed
           - 'whiskers'                  # plt.boxplot() dict repr suppressed
     html:
       ensureHtmlElements:
-        - ['img']                       # the figure is still rendered
+        - ['img']                       # the matplotlib figure is still rendered
+      ensureHtmlElementCount:
+        selectors: ['table', '.plotly-graph-div']
+        counts: [0, 1]                  # last_expr keeps only the last expression (the graph); table dropped
       ensureFileRegexMatches:
-        -
-          - '<code>234</code>'          # last expression value shown (last_expr)
+        - []                            # nothing required beyond the element checks
         -
           - 'Text\(0\.5'                # plt.title() Text repr suppressed
-          - '<code>123</code>'          # non-last expression not echoed under last_expr
 ---
 
 Dashboard format runs the Jupyter kernel with
@@ -40,8 +42,10 @@ HTML that #11150 reported. HTML is affected too, just less: under the default
 The first cell exercises the bug: it must render the figure but must not show
 the `Text(...)` or boxplot-dict reprs, in either format. The second cell guards
 the intentional multi-output capability that `shell-interactivity: all` gives
-dashboards — both `123` and `234` must survive in the dashboard output (HTML,
-being `last_expr`, keeps only `234`).
+dashboards. In a dashboard one cell becomes one card, so composing a card that
+holds both a summary table and a plot requires emitting both from a single
+cell. Under `all` both survive in that one card; under HTML's `last_expr` only
+the last expression (the graph) is kept and the table is dropped.
 
 ```{python}
 #| title: plot with a title
@@ -52,7 +56,11 @@ plt.title("Test")
 ```
 
 ```{python}
-#| title: multiple values in one cell
-100 + 23
-200 + 34
+#| title: table and graph in one card
+#| echo: false
+#| layout-ncol: 2
+import plotly.express as px
+df = px.data.tips()
+df.groupby("day", observed=True)["total_bill"].mean().reset_index()
+px.box(df, x="day", y="total_bill")
 ```

--- a/tests/docs/smoke-all/2026/07/02/11150.qmd
+++ b/tests/docs/smoke-all/2026/07/02/11150.qmd
@@ -11,23 +11,14 @@ _quarto:
       ensureHtmlElements:
         - ['img']                       # the matplotlib figure is still rendered
       ensureHtmlElementCount:
-        selectors: ['table', '.plotly-graph-div']
-        counts: [1, 1]                  # table AND graph both survive in one card (shell-interactivity: all)
-      ensureFileRegexMatches:
-        - []                            # nothing required beyond the element checks
-        -
-          - 'Text\(0\.5'                # plt.title() Text repr suppressed
-          - 'whiskers'                  # plt.boxplot() dict repr suppressed
+        selectors: ['table', '.plotly-graph-div', '.cell-output-display pre']
+        counts: [1, 1, 0]               # table + graph both survive in one card (all); zero spurious text-output reprs
     html:
       ensureHtmlElements:
         - ['img']                       # the matplotlib figure is still rendered
       ensureHtmlElementCount:
-        selectors: ['table', '.plotly-graph-div']
-        counts: [0, 1]                  # last_expr keeps only the last expression (the graph); table dropped
-      ensureFileRegexMatches:
-        - []                            # nothing required beyond the element checks
-        -
-          - 'Text\(0\.5'                # plt.title() Text repr suppressed
+        selectors: ['table', '.plotly-graph-div', '.cell-output-display pre']
+        counts: [0, 1, 0]               # last_expr drops the table; one graph; zero spurious text-output reprs
 ---
 
 Dashboard format runs the Jupyter kernel with

--- a/tests/unit/jupyter/discardable-text.test.ts
+++ b/tests/unit/jupyter/discardable-text.test.ts
@@ -31,6 +31,9 @@ const boxplotDict = [
   " 'fliers': [<matplotlib.lines.Line2D at 0x17685b55010>],\n",
   " 'means': []}",
 ];
+// A single-line dict of matplotlib artists (small enough that IPython does not
+// pretty-print it across lines). Unambiguous plotting noise.
+const singleLineDict = ["{'line': <matplotlib.lines.Line2D at 0x1407>}"];
 const titleText = ["Text(0.5, 1.0, 'Test')"];
 const axesRepr = ["<Axes: title={'center': 'Test'}>"];
 const line2DRepr = ["<matplotlib.lines.Line2D at 0x14071bc7e00>"];
@@ -68,6 +71,11 @@ unitTest(
       isDiscardableTextExecuteResult(execResult(line2DRepr), true),
       true,
       "bare Line2D repr should be discarded",
+    );
+    assertEquals(
+      isDiscardableTextExecuteResult(execResult(singleLineDict), true),
+      true,
+      "single-line dict of matplotlib artists should be discarded",
     );
 
     // Gate: with no image in the cell, nothing here is discarded — a cell

--- a/tests/unit/jupyter/discardable-text.test.ts
+++ b/tests/unit/jupyter/discardable-text.test.ts
@@ -1,0 +1,128 @@
+/*
+ * discardable-text.test.ts
+ *
+ * Copyright (C) 2025 Posit Software, PBC
+ */
+
+import { unitTest } from "../../test.ts";
+import { assertEquals } from "testing/asserts";
+import { isDiscardableTextExecuteResult } from "../../../src/core/jupyter/jupyter.ts";
+import { kTextPlain } from "../../../src/core/mime.ts";
+import { JupyterOutput } from "../../../src/core/jupyter/types.ts";
+
+// An execute_result whose only mime bundle is text/plain, stored as the
+// per-line array Jupyter emits.
+const execResult = (textPlainLines: string[]): JupyterOutput => ({
+  output_type: "execute_result",
+  data: { [kTextPlain]: textPlainLines },
+});
+
+// text/plain reprs that top-level plotting expressions echo under
+// ipynb-shell-interactivity: all. The matplotlib reprs below are captured
+// verbatim from the executed 11150.quarto_ipynb (keep-ipynb: true) — Jupyter
+// emits text/plain as a per-line array, so multi-line reprs have length > 1.
+const boxplotDict = [
+  "{'whiskers': [<matplotlib.lines.Line2D at 0x17685b54980>,\n",
+  "  <matplotlib.lines.Line2D at 0x17685b54ad0>],\n",
+  " 'caps': [<matplotlib.lines.Line2D at 0x17685b54c20>,\n",
+  "  <matplotlib.lines.Line2D at 0x17685b54d70>],\n",
+  " 'boxes': [<matplotlib.lines.Line2D at 0x17685b54830>],\n",
+  " 'medians': [<matplotlib.lines.Line2D at 0x17685b54ec0>],\n",
+  " 'fliers': [<matplotlib.lines.Line2D at 0x17685b55010>],\n",
+  " 'means': []}",
+];
+const titleText = ["Text(0.5, 1.0, 'Test')"];
+const axesRepr = ["<Axes: title={'center': 'Test'}>"];
+const line2DRepr = ["<matplotlib.lines.Line2D at 0x14071bc7e00>"];
+// A DataFrame echoed alongside the figure: multi-line text/plain plus text/html
+// (also captured from 11150.quarto_ipynb). Two mime keys -> must be kept.
+const dataFrameText = [
+  "    day  total_bill\n",
+  "0   Fri   17.151579\n",
+  "1   Sat   20.441379\n",
+  "2   Sun   21.410000\n",
+  "3  Thur   17.682742",
+];
+
+unitTest(
+  "jupyter - isDiscardableTextExecuteResult drops plotting-call reprs only alongside an image",
+  // deno-lint-ignore require-await
+  async () => {
+    // Discard plotting-object noise when the cell also emitted an image.
+    // plt.title()/set_title() -> Text(...): single line, not bracket-wrapped.
+    assertEquals(
+      isDiscardableTextExecuteResult(execResult(titleText), true),
+      true,
+    );
+    // plt.boxplot() -> multi-line dict of Line2D.
+    assertEquals(
+      isDiscardableTextExecuteResult(execResult(boxplotDict), true),
+      true,
+    );
+    // seaborn/pandas Axes and bare Line2D: single-line <...>.
+    assertEquals(
+      isDiscardableTextExecuteResult(execResult(axesRepr), true),
+      true,
+    );
+    assertEquals(
+      isDiscardableTextExecuteResult(execResult(line2DRepr), true),
+      true,
+    );
+
+    // Gate: with no image in the cell, nothing here is discarded — a cell
+    // that only echoed these values (no figure) must keep them.
+    assertEquals(
+      isDiscardableTextExecuteResult(execResult(titleText), false),
+      false,
+    );
+    assertEquals(
+      isDiscardableTextExecuteResult(execResult(boxplotDict), false),
+      false,
+    );
+
+    // No over-suppression: legitimate output survives even with an image.
+    // A Name(...) repr that is not a matplotlib Text must not be swept up.
+    assertEquals(
+      isDiscardableTextExecuteResult(
+        execResult(["datetime.datetime(2020, 1, 1, 0, 0)"]),
+        true,
+      ),
+      false,
+    );
+    // An arbitrary multi-line repr with no matplotlib reference must survive.
+    assertEquals(
+      isDiscardableTextExecuteResult(
+        execResult(["MyResult(\n", "  value=42,\n", ")"]),
+        true,
+      ),
+      false,
+    );
+    // Multiple mime types (e.g. a DataFrame's text/plain + text/html) -> keep.
+    assertEquals(
+      isDiscardableTextExecuteResult(
+        {
+          output_type: "execute_result",
+          data: { [kTextPlain]: dataFrameText, "text/html": ["<table>"] },
+        },
+        true,
+      ),
+      false,
+    );
+
+    // Only execute_result is ever discardable.
+    assertEquals(
+      isDiscardableTextExecuteResult(
+        { output_type: "display_data", data: { [kTextPlain]: titleText } },
+        true,
+      ),
+      false,
+    );
+    assertEquals(
+      isDiscardableTextExecuteResult(
+        { output_type: "stream", name: "stdout", text: titleText },
+        true,
+      ),
+      false,
+    );
+  },
+);

--- a/tests/unit/jupyter/discardable-text.test.ts
+++ b/tests/unit/jupyter/discardable-text.test.ts
@@ -1,7 +1,7 @@
 /*
  * discardable-text.test.ts
  *
- * Copyright (C) 2025 Posit Software, PBC
+ * Copyright (C) 2026 Posit Software, PBC
  */
 
 import { unitTest } from "../../test.ts";
@@ -49,24 +49,25 @@ unitTest(
   // deno-lint-ignore require-await
   async () => {
     // Discard plotting-object noise when the cell also emitted an image.
-    // plt.title()/set_title() -> Text(...): single line, not bracket-wrapped.
     assertEquals(
       isDiscardableTextExecuteResult(execResult(titleText), true),
       true,
+      "plt.title()/set_title() Text repr should be discarded",
     );
-    // plt.boxplot() -> multi-line dict of Line2D.
     assertEquals(
       isDiscardableTextExecuteResult(execResult(boxplotDict), true),
       true,
+      "plt.boxplot() multi-line dict of Line2D should be discarded",
     );
-    // seaborn/pandas Axes and bare Line2D: single-line <...>.
     assertEquals(
       isDiscardableTextExecuteResult(execResult(axesRepr), true),
       true,
+      "seaborn/pandas Axes repr should be discarded",
     );
     assertEquals(
       isDiscardableTextExecuteResult(execResult(line2DRepr), true),
       true,
+      "bare Line2D repr should be discarded",
     );
 
     // Gate: with no image in the cell, nothing here is discarded — a cell
@@ -74,13 +75,15 @@ unitTest(
     assertEquals(
       isDiscardableTextExecuteResult(execResult(titleText), false),
       false,
+      "Text repr must be kept when the cell has no image",
     );
     assertEquals(
       isDiscardableTextExecuteResult(execResult(boxplotDict), false),
       false,
+      "boxplot dict must be kept when the cell has no image",
     );
 
-    // No over-suppression: legitimate output survives even with an image.
+    // No over-suppression: legitimate output survives even alongside an image.
     // A Name(...) repr that is not a matplotlib Text must not be swept up.
     assertEquals(
       isDiscardableTextExecuteResult(
@@ -88,6 +91,24 @@ unitTest(
         true,
       ),
       false,
+      "non-matplotlib single-line Name(...) repr must be kept",
+    );
+    // A non-matplotlib Text( repr (e.g. rich.text.Text -> Text('...')) has no
+    // leading coordinate, so it must be kept.
+    assertEquals(
+      isDiscardableTextExecuteResult(execResult(["Text('hello world')"]), true),
+      false,
+      "non-matplotlib Text('...') repr must be kept",
+    );
+    // A multi-line bracketed value (list/tuple) with no matplotlib reference
+    // must survive — the discard heuristic must not widen to arbitrary brackets.
+    assertEquals(
+      isDiscardableTextExecuteResult(
+        execResult(["[1, 2, 3,\n", " 4, 5, 6]"]),
+        true,
+      ),
+      false,
+      "multi-line list with no matplotlib reference must be kept",
     );
     // An arbitrary multi-line repr with no matplotlib reference must survive.
     assertEquals(
@@ -96,6 +117,7 @@ unitTest(
         true,
       ),
       false,
+      "multi-line custom repr with no matplotlib reference must be kept",
     );
     // Multiple mime types (e.g. a DataFrame's text/plain + text/html) -> keep.
     assertEquals(
@@ -107,6 +129,7 @@ unitTest(
         true,
       ),
       false,
+      "multi-mime output (DataFrame text/plain + text/html) must be kept",
     );
 
     // Only execute_result is ever discardable.
@@ -116,6 +139,7 @@ unitTest(
         true,
       ),
       false,
+      "display_data must never be discarded",
     );
     assertEquals(
       isDiscardableTextExecuteResult(
@@ -123,6 +147,7 @@ unitTest(
         true,
       ),
       false,
+      "stream output must never be discarded",
     );
   },
 );


### PR DESCRIPTION
Dashboards run the Jupyter kernel with `ipynb-shell-interactivity: all`, so every top-level expression in a cell echoes its value. matplotlib/pandas plotting calls return objects — `plt.title()` a `Text`, `plt.boxplot()` a dict of `Line2D` — whose `text/plain` repr leaked into the rendered output as spurious text beside the figure. HTML output showed a milder version under `last_expr`.

## Root Cause

The discard heuristic in `isDiscardableTextExecuteResult` (`src/core/jupyter/jupyter.ts`) only caught single-line bracket-wrapped reprs and a handful of library prefixes. It missed `Text(...)` (no leading bracket), the multi-line dict returned by `boxplot()`/`hist()`, and a single-line dict small enough for IPython to keep on one line.

Broadening the match without care risks discarding real output: a cell that emits a figure alongside a legitimate multi-line list/tuple, or a non-matplotlib value like rich's `Text('...')`, would have that output silently dropped too.

## Fix

- Discard `Text(...)` only when it leads with matplotlib's numeric coordinate signature (`Text(0.5, ...)`), not any `Text(...)` repr.
- Discard multi-line output only when it references a matplotlib object, leaving ordinary multi-line reprs untouched.
- Discard single-line `{...}` dicts the same way, covering the case where the artifact dict is short enough to stay on one line.

Guarded by unit tests on the heuristic (contract inputs captured from real executed notebooks) plus a dashboard+HTML smoke-all regression.

Fixes #11150