### PR TITLE
Fix inline code in dashboard card titles being moved out of position

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -44,6 +44,10 @@ All changes included in 1.10:
 - ([#14354](https://github.com/quarto-dev/quarto-cli/pull/14354)): Fix trailing whitespace after author name on title slide when ORCID is not set. (author: @jnkatz)
 - ([#14585](https://github.com/quarto-dev/quarto-cli/issues/14585)): Fix empty blockquote (`> `) crashing render for revealjs format.
 
+### `dashboard`
+
+- ([#14646](https://github.com/quarto-dev/quarto-cli/issues/14646)): Fix inline code formatting in a dashboard card title being extracted from its original position and appended elsewhere in the header instead of staying inline, the same issue previously fixed for math, emphasis and bold in [#10340](https://github.com/quarto-dev/quarto-cli/issues/10340).
+
 ## Projects
 
 ### Manuscripts

--- a/src/format/dashboard/format-dashboard-card.ts
+++ b/src/format/dashboard/format-dashboard-card.ts
@@ -159,6 +159,7 @@ export function processCards(doc: Document, dashboardMeta: DashboardMeta) {
       const isText = (node: Node) => node.nodeType === Node.TEXT_NODE;
       const isEmphasis = (node: Node) => node.nodeName === "EM";
       const isBold = (node: Node) => node.nodeName === "STRONG";
+      const isCode = (node: Node) => node.nodeName === "CODE";
       const isMath = (node: Node) =>
         node.nodeName === "SPAN" &&
         (node as Element).classList.contains("math") &&
@@ -169,6 +170,7 @@ export function processCards(doc: Document, dashboardMeta: DashboardMeta) {
           (isText(headerChildNode) ||
             isEmphasis(headerChildNode) ||
             isBold(headerChildNode) ||
+            isCode(headerChildNode) ||
             isMath(headerChildNode)) &&
           headerChildNode.textContent.trim() !== ""
         ) {

--- a/tests/docs/smoke-all/2026/07/03/issue-14646.qmd
+++ b/tests/docs/smoke-all/2026/07/03/issue-14646.qmd
@@ -1,0 +1,51 @@
+---
+title: "Card titles with inline code (issue #14646)"
+format: dashboard
+_quarto:
+  tests:
+    dashboard:
+      ensureHtmlElements:
+        -
+          - ".test-attr-code .card-title code"
+          - ".cell .card-title code"
+          - ".test-combined .card-title code"
+        -
+          - ".test-attr-code .card-header > code"
+          - ".cell .card-header > code"
+          - ".test-combined .card-header > code"
+          - ".test-combined .card-header > span.math.inline"
+          - ".test-combined .card-header > em"
+          - ".test-combined .card-header > strong"
+---
+
+Regression test for #14646. Inline verbatim code (backtick) formatting in
+dashboard card titles was extracted from its original position and appended
+after the rest of the title text, instead of staying inline where it was
+written — the same bug previously fixed for math, emphasis and bold in
+#10340. The card `title` attribute and the executable cell `title` option
+both build the card header through the same code path, so both forms are
+covered here. Each card carries its own scoping class (or relies on the
+executable cell's implicit `.cell` class) so a failure in one card cannot
+be masked by another card's passing assertion.
+
+## card title attribute
+
+::: {.card .test-attr-code title="Inline `code` between words"}
+
+:::
+
+## executable cell title option
+
+```{python}
+#| title: "Inline `code` between words"
+1 + 1
+```
+
+## combined formatting
+
+Code alongside math, emphasis and bold in the same title exercises the
+same loose-text extraction loop that #10340 covers without code.
+
+::: {.card .test-combined title="`code`, $math$, *em*, and **bold** together"}
+
+:::


### PR DESCRIPTION
Inline verbatim code (backtick-formatted text) in a dashboard card title gets extracted from its original position and appended after the rest of the title, instead of staying inline where it was written.

## Root Cause

The card-header loose-text extraction in `src/format/dashboard/format-dashboard-card.ts` only recognized text nodes, `<em>`, `<strong>` and inline math `<span>` as title content to pull into the `.card-title` wrapper. This logic was added in #10800 to fix #10340 for math, emphasis and bold, but never covered `<code>` nodes, so backtick-formatted text stayed behind in the header while everything else was extracted around it.

## Fix

Add a `<code>` predicate alongside the existing text/em/strong/math checks. The regression test covers both the `.card` div `title` attribute and the executable cell `#| title:` option, plus a combined-formatting case (code, math, emphasis and bold together in one title) mirroring the existing #10340 coverage.

Fixes #14646