### PR TITLE
Fix ipynb rendering an empty title header when no title is set

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -49,6 +49,10 @@ All changes included in 1.10:
 
 - ([#14646](https://github.com/quarto-dev/quarto-cli/issues/14646)): Fix inline code formatting in a dashboard card title being extracted from its original position and appended elsewhere in the header instead of staying inline, the same issue previously fixed for math, emphasis and bold in [#10340](https://github.com/quarto-dev/quarto-cli/issues/10340).
 
+### `ipynb`
+
+- ([#14693](https://github.com/quarto-dev/quarto-cli/issues/14693)): Fix an empty level-1 heading (`# `) being emitted in the first markdown cell when rendering a document with no `title` to `ipynb`.
+
 ## Projects
 
 ### Manuscripts

--- a/src/resources/formats/ipynb/templates/title-block.md
+++ b/src/resources/formats/ipynb/templates/title-block.md
@@ -1,6 +1,6 @@
 $-- Be very careful about whitespace in this document - line breaks are very meaningful
 $-- and it is very easy to break the layout with poorly considered line breaks
-# $title$
+$if(title)$# $title$$endif$
 
 $if(subtitle)$$subtitle$$endif$
 

--- a/tests/docs/doc-layout/title-block-no-title.qmd
+++ b/tests/docs/doc-layout/title-block-no-title.qmd
@@ -1,0 +1,1 @@
+hello world

--- a/tests/docs/smoke-all/2024/01/19/8356.ipynb.snapshot
+++ b/tests/docs/smoke-all/2024/01/19/8356.ipynb.snapshot
@@ -4,8 +4,6 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "# \n",
-        "\n",
         "## hello\n",
         "\n",
         "<table>\n",

--- a/tests/smoke/render/render-title-block.test.ts
+++ b/tests/smoke/render/render-title-block.test.ts
@@ -90,3 +90,13 @@ testRender(orcidIpynbAffilInput, "ipynb", true, [
     matches: [/ORCID\s+profile\s+for\s+Norah\s+Jones/],
   }),
 ]);
+
+// ipynb: no title metadata should not produce an empty "# " header (#14693).
+const noTitleInput = docs("doc-layout/title-block-no-title.qmd");
+const noTitleIpynbOutput = outputForInput(noTitleInput, "ipynb");
+testRender(noTitleInput, "ipynb", true, [
+  ensureIpynbCellMatches(noTitleIpynbOutput.outputPath, {
+    cellType: "markdown",
+    noMatches: [/^#\s*$/m],
+  }),
+]);


### PR DESCRIPTION
Rendering a document with no `title` metadata to `ipynb` emits an empty level-1 heading (`# `) as the first line of the notebook's first markdown cell.

`title-block.md` unconditionally emits `# $title$` regardless of whether a title is set. Every other title template (html, pdf/beamer, typst, asciidoc) already guards this with `$if(title)$`; ipynb was missing it since the template was added in 2022.

Fixes #14693