### PR TITLE
Use _quarto.modules registry instead of redundant module requires in filters

### DIFF
--- a/src/resources/filters/common/citations.lua
+++ b/src/resources/filters/common/citations.lua
@@ -6,8 +6,6 @@
 -- restructured into the standard has
 -- format
 
-local constants = require("modules/constants")
-
 local function processTypedId(el) 
   if pandoc.utils.type(el) == "Inlines" then
     return { value = el }
@@ -36,23 +34,23 @@ end
 
 function processCitationMeta(meta)
   if meta then
-    local citationMeta = meta[constants.kCitation]
+    local citationMeta = meta[_quarto.modules.constants.kCitation]
     if citationMeta and type(citationMeta) == "object" then
-      local containerIds = citationMeta[constants.kContainerId]
+      local containerIds = citationMeta[_quarto.modules.constants.kContainerId]
       if containerIds ~= nil then
-        meta[constants.kCitation][constants.kContainerId] = normalizeTypedId(containerIds)
+        meta[_quarto.modules.constants.kCitation][_quarto.modules.constants.kContainerId] = normalizeTypedId(containerIds)
       end
 
-      local articleIds = citationMeta[constants.kArticleId]
+      local articleIds = citationMeta[_quarto.modules.constants.kArticleId]
       if articleIds ~= nil then
-        meta[constants.kCitation][constants.kArticleId] = normalizeTypedId(articleIds)
+        meta[_quarto.modules.constants.kCitation][_quarto.modules.constants.kArticleId] = normalizeTypedId(articleIds)
       end
 
-      if citationMeta[constants.kPage] and citationMeta[constants.kPageFirst] == nil and citationMeta[constants.kPageLast] == nil then
-        local pagerange = split(pandoc.utils.stringify(citationMeta[constants.kPage]), '-')
-        meta[constants.kCitation][constants.kPageFirst] = pandoc.Inlines(pagerange[1])
+      if citationMeta[_quarto.modules.constants.kPage] and citationMeta[_quarto.modules.constants.kPageFirst] == nil and citationMeta[_quarto.modules.constants.kPageLast] == nil then
+        local pagerange = split(pandoc.utils.stringify(citationMeta[_quarto.modules.constants.kPage]), '-')
+        meta[_quarto.modules.constants.kCitation][_quarto.modules.constants.kPageFirst] = pandoc.Inlines(pagerange[1])
         if pagerange[2] then
-          meta[constants.kCitation][constants.kPageLast] = pandoc.Inlines(pagerange[2])
+          meta[_quarto.modules.constants.kCitation][_quarto.modules.constants.kPageLast] = pandoc.Inlines(pagerange[2])
         end
       end
     end

--- a/src/resources/filters/common/tables.lua
+++ b/src/resources/filters/common/tables.lua
@@ -1,8 +1,6 @@
 -- tables.lua
 -- Copyright (C) 2021-2022 Posit Software, PBC
 
-local patterns = require("modules/patterns")
-
 function anonymousTblId()
   return "tbl-anonymous-" .. tostring(math.random(10000000))
 end
@@ -106,7 +104,7 @@ end
 
 function hasGtHtmlTable(raw)
   if _quarto.format.isRawHtml(raw) and _quarto.format.isHtmlOutput() then
-    return raw.text:match(patterns.html_gt_table)
+    return raw.text:match(_quarto.modules.patterns.html_gt_table)
   else
     return false
   end
@@ -114,7 +112,7 @@ end
 
 function hasPagedHtmlTable(raw)
   if _quarto.format.isRawHtml(raw) and _quarto.format.isHtmlOutput() then
-    return raw.text:match(patterns.html_paged_table)
+    return raw.text:match(_quarto.modules.patterns.html_paged_table)
   else
     return false
   end
@@ -122,7 +120,7 @@ end
 
 function hasRawHtmlTable(raw)
   if _quarto.format.isRawHtml(raw) and _quarto.format.isHtmlOutput() then
-    return raw.text:match(patterns.html_table)
+    return raw.text:match(_quarto.modules.patterns.html_table)
   else
     return false
   end

--- a/src/resources/filters/crossref/tables.lua
+++ b/src/resources/filters/crossref/tables.lua
@@ -5,8 +5,6 @@
 -- wrapped in a div so they can carry parent information and so that
 -- we can create a hyperef target for latex)
 
-local patterns = require("modules/patterns")
-
 function preprocessRawTableBlock(rawEl, parentId)
   
   local function divWrap(el, label, caption)
@@ -21,7 +19,7 @@ function preprocessRawTableBlock(rawEl, parentId)
   end
   
   if _quarto.format.isRawHtml(rawEl) and _quarto.format.isHtmlOutput() then
-    local captionPattern = patterns.html_table_caption
+    local captionPattern = _quarto.modules.patterns.html_table_caption
     local _, caption, _ = string.match(rawEl.text, captionPattern) 
     if caption then
       -- extract id if there is one
@@ -165,7 +163,7 @@ function processRawTable(divEl)
       local label = divEl.attr.identifier
       -- html table
       if _quarto.format.isRawHtml(rawEl) then
-        local captionPattern = patterns.html_table_caption
+        local captionPattern = _quarto.modules.patterns.html_table_caption
         local _, caption, _ = string.match(rawEl.text, captionPattern)
         if caption then
           

--- a/src/resources/filters/customnodes/content-hidden.lua
+++ b/src/resources/filters/customnodes/content-hidden.lua
@@ -2,20 +2,18 @@
 -- Copyright (C) 2022 Posit Software, PBC
 
 
-local constants = require("modules/constants")
-
 local kConditions = pandoc.List({
-  constants.kWhenMeta, constants.kUnlessMeta, 
-  constants.kWhenFormat, constants.kUnlessFormat, 
-  constants.kWhenProfile, constants.kUnlessProfile
+  _quarto.modules.constants.kWhenMeta, _quarto.modules.constants.kUnlessMeta, 
+  _quarto.modules.constants.kWhenFormat, _quarto.modules.constants.kUnlessFormat, 
+  _quarto.modules.constants.kWhenProfile, _quarto.modules.constants.kUnlessProfile
 })
 
 function is_visible(node)
   local profiles = pandoc.List(param("quarto_profile", {}))
   local match = propertiesMatch(node.condition, profiles)
-  if node.behavior == constants.kContentVisible then
+  if node.behavior == _quarto.modules.constants.kContentVisible then
     return match
-  elseif node.behavior == constants.kContentHidden then
+  elseif node.behavior == _quarto.modules.constants.kContentHidden then
     return not match
   else
     -- luacov: disable
@@ -26,14 +24,14 @@ function is_visible(node)
 end
 
 _quarto.ast.add_handler({
-  class_name = { constants.kContentVisible, constants.kContentHidden },
+  class_name = { _quarto.modules.constants.kContentVisible, _quarto.modules.constants.kContentHidden },
   
   ast_name = "ConditionalBlock",
 
   kind = "Block",
 
   parse = function(div)
-    local behavior = div.classes:find(constants.kContentVisible) or div.classes:find(constants.kContentHidden)
+    local behavior = div.classes:find(_quarto.modules.constants.kContentVisible) or div.classes:find(_quarto.modules.constants.kContentHidden)
     local condition = pandoc.List({})
     local remaining_attributes = pandoc.List({})
     for i, v in ipairs(div.attributes) do
@@ -44,7 +42,7 @@ _quarto.ast.add_handler({
       end
     end
     div.attributes = remaining_attributes
-    div.classes = div.classes:filter(function(k) return k ~= constants.kContentVisible and k ~= constants.kContentHidden end)
+    div.classes = div.classes:filter(function(k) return k ~= _quarto.modules.constants.kContentVisible and k ~= _quarto.modules.constants.kContentHidden end)
 
     return quarto.ConditionalBlock({
       node = div,
@@ -144,10 +142,10 @@ end
 function handleHiddenVisible(profiles)
   return function(el)
     local visible
-    if el.attr.classes:find(constants.kContentVisible) then
+    if el.attr.classes:find(_quarto.modules.constants.kContentVisible) then
       visible = propertiesMatch(el.attributes, profiles)
       clearHiddenVisibleAttributes(el)
-    elseif el.attr.classes:find(constants.kContentHidden) then
+    elseif el.attr.classes:find(_quarto.modules.constants.kContentHidden) then
       visible = not propertiesMatch(el.attributes, profiles)
       clearHiddenVisibleAttributes(el)
     else
@@ -191,12 +189,12 @@ function propertiesMatch(properties, profiles)
     end
   end
   local tests = {
-    { constants.kWhenMeta, check_meta, false },
-    { constants.kUnlessMeta, check_meta, true },
-    { constants.kWhenFormat, quarto.format.is_format, false },
-    { constants.kUnlessFormat, quarto.format.is_format, true },
-    { constants.kWhenProfile, check_profile, false },
-    { constants.kUnlessProfile, check_profile, true }
+    { _quarto.modules.constants.kWhenMeta, check_meta, false },
+    { _quarto.modules.constants.kUnlessMeta, check_meta, true },
+    { _quarto.modules.constants.kWhenFormat, quarto.format.is_format, false },
+    { _quarto.modules.constants.kUnlessFormat, quarto.format.is_format, true },
+    { _quarto.modules.constants.kWhenProfile, check_profile, false },
+    { _quarto.modules.constants.kUnlessProfile, check_profile, true }
   }
   local match = true
   for _, test in ipairs(tests) do
@@ -211,10 +209,10 @@ function propertiesMatch(properties, profiles)
 end
 
 function clearHiddenVisibleAttributes(el)
-  el.attributes[constants.kUnlessFormat] = nil
-  el.attributes[constants.kWhenFormat] = nil
-  el.attributes[constants.kUnlessProfile] = nil
-  el.attributes[constants.kWhenProfile] = nil
-  el.attr.classes = removeClass(el.attr.classes, constants.kContentVisible)
-  el.attr.classes = removeClass(el.attr.classes, constants.kContentHidden)
+  el.attributes[_quarto.modules.constants.kUnlessFormat] = nil
+  el.attributes[_quarto.modules.constants.kWhenFormat] = nil
+  el.attributes[_quarto.modules.constants.kUnlessProfile] = nil
+  el.attributes[_quarto.modules.constants.kWhenProfile] = nil
+  el.attr.classes = removeClass(el.attr.classes, _quarto.modules.constants.kContentVisible)
+  el.attr.classes = removeClass(el.attr.classes, _quarto.modules.constants.kContentHidden)
 end

--- a/src/resources/filters/customnodes/floatreftarget.lua
+++ b/src/resources/filters/customnodes/floatreftarget.lua
@@ -2,7 +2,6 @@
 -- Copyright (C) 2023 Posit Software, PBC
 
 local drop_class = require("modules/filters").drop_class
-local patterns = require("modules/patterns")
 
 -- Track whether we've injected the Typst show rule for listing alignment
 local injected_listing_align_rule = false
@@ -565,7 +564,7 @@ end, function(float)
   -- and recreating it below.
   -- See #7937
   if _quarto.format.isRawLatex(float.content) then
-    local _b, _e, _beginenv, inner_content, _endenv = float.content.text:find(patterns.latex_table_star)
+    local _b, _e, _beginenv, inner_content, _endenv = float.content.text:find(_quarto.modules.patterns.latex_table_star)
     if _b ~= nil then 
       figEnv = "table*"
       float.content.text = inner_content

--- a/src/resources/filters/layout/figures.lua
+++ b/src/resources/filters/layout/figures.lua
@@ -1,18 +1,16 @@
 -- figures.lua
 -- Copyright (C) 2020-2022 Posit Software, PBC
 
-local constants = require("modules/constants")
-
 function preventExtendedFigure(el)
-  el.attr.attributes[constants.kFigExtended] = "false"
+  el.attr.attributes[_quarto.modules.constants.kFigExtended] = "false"
 end
 
 function forceExtendedFigure(el) 
-  el.attr.attributes[constants.kFigExtended] = "true"
+  el.attr.attributes[_quarto.modules.constants.kFigExtended] = "true"
 end
 
 function shouldHandleExtended(el)
-  return el.attr.attributes[constants.kFigExtended] ~= "false"
+  return el.attr.attributes[_quarto.modules.constants.kFigExtended] ~= "false"
 end
 
 -- By default, images without captions should be
@@ -38,7 +36,7 @@ function shouldHandleExtendedImage(el)
   end
 
   -- handle extended if it was explicitly enabled
-  if el.attr.attributes[constants.kFigExtended] == "true" then
+  if el.attr.attributes[_quarto.modules.constants.kFigExtended] == "true" then
     return true
   end
 

--- a/src/resources/filters/layout/lightbox.lua
+++ b/src/resources/filters/layout/lightbox.lua
@@ -1,9 +1,6 @@
 -- lightbox.lua
 -- Copyright (C) 2020-2022 Posit Software, PBC
 
-local lightbox_module = require("modules/lightbox")
-
-
 -- attributes to forward from the image to the newly created link
 local kDescription = "description"
 local kForwardedAttr = {
@@ -178,7 +175,7 @@ function lightbox()
 
       Meta = function(meta)
         -- Set auto lightbox mode, if need be
-        auto = lightbox_module.automatic(meta) == true
+        auto = _quarto.modules.lightbox.automatic(meta) == true
         imgCount = 0
       end,
       -- Find images that are already within links

--- a/src/resources/filters/layout/manuscript.lua
+++ b/src/resources/filters/layout/manuscript.lua
@@ -1,7 +1,6 @@
 -- manuscript.lua
 -- Copyright (C) 2021-2022 Posit Software, PBC
 
-local constants = require("modules/constants")
 local kUnrollMarkdownCells = "unroll-markdown-cells"
 
 function manuscriptUnroll() 
@@ -28,10 +27,10 @@ function manuscript()
   if _quarto.format.isWordProcessorOutput() or _quarto.format.isLatexOutput() then
 
     local language = param("language", nil);
-    local notebookPrefix = language[constants.kLangSourcePrefix]
+    local notebookPrefix = language[_quarto.modules.constants.kLangSourcePrefix]
     
-    local manuscriptBaseUrl = param(constants.kManuscriptUrl)
-    local notebookLinks = param(constants.kNotebookLinks)
+    local manuscriptBaseUrl = param(_quarto.modules.constants.kManuscriptUrl)
+    local notebookLinks = param(_quarto.modules.constants.kNotebookLinks)
 
     return {
       traverse = 'topdown',
@@ -51,8 +50,8 @@ function manuscript()
         end
 
         -- Read notebook parameters from the cell, if present
-        local nbAbsPath = divEl.attributes[constants.kNotebook]
-        local nbTitle = divEl.attributes[constants.kNotebookTitle]
+        local nbAbsPath = divEl.attributes[_quarto.modules.constants.kNotebook]
+        local nbTitle = divEl.attributes[_quarto.modules.constants.kNotebookTitle]
 
         -- If this is a notebook embed cell, 'lift' the contents of any child divs
         -- up (unroll their contents), this will help us avoid
@@ -115,7 +114,7 @@ function manuscript()
           end
 
           -- The Id
-          local cellId = divEl.attributes[constants.kNotebookCellId];
+          local cellId = divEl.attributes[_quarto.modules.constants.kNotebookCellId];
           if cellId ~= nil then
             cellId = '#' .. cellId
           else

--- a/src/resources/filters/layout/pandoc3_figure.lua
+++ b/src/resources/filters/layout/pandoc3_figure.lua
@@ -5,8 +5,6 @@
 -- never cross-referenceable but they need to be rendered as 
 -- if they were.
 
-local scope_utils = require("modules/scope")
-
 function render_pandoc3_figure()
   local function html_handle_linked_image(figure)
     local div = pandoc.Div({})
@@ -151,7 +149,7 @@ function render_pandoc3_figure()
         image.attributes['quarto-caption-env'] = 'subcaption'
       end
       image.classes:extend(figure.classes)
-      if scope_utils.lookup_class(scope, "column-margin") then
+      if _quarto.modules.scope.lookup_class(scope, "column-margin") then
         image.classes:insert("column-margin")
       end
       return latexImageFigure(image)

--- a/src/resources/filters/normalize/flags.lua
+++ b/src/resources/filters/normalize/flags.lua
@@ -5,16 +5,12 @@
 -- so that we can skip as many filters as possible
 -- when we don't need them
 
-local patterns = require("modules/patterns")
-local constants = require("modules/constants")
-local lightbox_module = require("modules/lightbox")
-
 flags = {}
 
 function compute_flags()
-  local table_pattern = patterns.html_table
-  local table_tag_pattern = patterns.html_table_tag_name
-  local gt_table_pattern = patterns.html_gt_table
+  local table_pattern = _quarto.modules.patterns.html_table
+  local table_tag_pattern = _quarto.modules.patterns.html_table_tag_name
+  local gt_table_pattern = _quarto.modules.patterns.html_gt_table
   local function find_shortcode_in_attributes(el)
     for k, v in pairs(el.attributes) do
       if type(v) == "string" and v:find("%{%{%<") then
@@ -79,7 +75,7 @@ function compute_flags()
         flags.has_theorem_refs = true
       end
 
-      local has_lightbox = lightbox_module.el_has_lightbox(node)
+      local has_lightbox = _quarto.modules.lightbox.el_has_lightbox(node)
       if has_lightbox then
         flags.has_lightbox = true
       end
@@ -161,7 +157,7 @@ function compute_flags()
         flags.has_shortcodes = true
       end
 
-      local has_lightbox = lightbox_module.el_has_lightbox(node)
+      local has_lightbox = _quarto.modules.lightbox.el_has_lightbox(node)
       if has_lightbox then
         flags.has_lightbox = true
       end
@@ -193,7 +189,7 @@ function compute_flags()
     end,
   }, {
     Meta = function(el)
-      local lightbox_auto = lightbox_module.automatic(el)
+      local lightbox_auto = _quarto.modules.lightbox.automatic(el)
       if lightbox_auto then
         flags.has_lightbox = true
       elseif lightbox_auto == false then

--- a/src/resources/filters/quarto-init/includes.lua
+++ b/src/resources/filters/quarto-init/includes.lua
@@ -1,25 +1,23 @@
 -- includes.lua
 -- Copyright (C) 2020-2022 Posit Software, PBC
 
-local constants = require("modules/constants")
-
 function read_includes(meta)
   -- return {
   --   Meta = function(meta)
       -- ensure all includes are meta lists
-      ensureIncludes(meta, constants.kHeaderIncludes)
-      ensureIncludes(meta, constants.kIncludeBefore)
-      ensureIncludes(meta, constants.kIncludeAfter)
+      ensureIncludes(meta, _quarto.modules.constants.kHeaderIncludes)
+      ensureIncludes(meta, _quarto.modules.constants.kIncludeBefore)
+      ensureIncludes(meta, _quarto.modules.constants.kIncludeAfter)
           
       -- read file includes
-      readIncludeFiles(meta, constants.kIncludeInHeader, constants.kHeaderIncludes)
-      readIncludeFiles(meta, constants.kIncludeBeforeBody, constants.kIncludeBefore)
-      readIncludeFiles(meta, constants.kIncludeAfterBody, constants.kIncludeAfter)
+      readIncludeFiles(meta, _quarto.modules.constants.kIncludeInHeader, _quarto.modules.constants.kHeaderIncludes)
+      readIncludeFiles(meta, _quarto.modules.constants.kIncludeBeforeBody, _quarto.modules.constants.kIncludeBefore)
+      readIncludeFiles(meta, _quarto.modules.constants.kIncludeAfterBody, _quarto.modules.constants.kIncludeAfter)
 
       -- read text based includes
-      readIncludeStrings(meta, constants.kHeaderIncludes)
-      readIncludeStrings(meta, constants.kIncludeBefore)
-      readIncludeStrings(meta, constants.kIncludeAfter)
+      readIncludeStrings(meta, _quarto.modules.constants.kHeaderIncludes)
+      readIncludeStrings(meta, _quarto.modules.constants.kIncludeBefore)
+      readIncludeStrings(meta, _quarto.modules.constants.kIncludeAfter)
      
       return meta
   --   end

--- a/src/resources/filters/quarto-init/includes.lua
+++ b/src/resources/filters/quarto-init/includes.lua
@@ -1,23 +1,25 @@
 -- includes.lua
 -- Copyright (C) 2020-2022 Posit Software, PBC
 
+local constants = require("modules/constants")
+
 function read_includes(meta)
   -- return {
   --   Meta = function(meta)
       -- ensure all includes are meta lists
-      ensureIncludes(meta, _quarto.modules.constants.kHeaderIncludes)
-      ensureIncludes(meta, _quarto.modules.constants.kIncludeBefore)
-      ensureIncludes(meta, _quarto.modules.constants.kIncludeAfter)
-          
+      ensureIncludes(meta, constants.kHeaderIncludes)
+      ensureIncludes(meta, constants.kIncludeBefore)
+      ensureIncludes(meta, constants.kIncludeAfter)
+
       -- read file includes
-      readIncludeFiles(meta, _quarto.modules.constants.kIncludeInHeader, _quarto.modules.constants.kHeaderIncludes)
-      readIncludeFiles(meta, _quarto.modules.constants.kIncludeBeforeBody, _quarto.modules.constants.kIncludeBefore)
-      readIncludeFiles(meta, _quarto.modules.constants.kIncludeAfterBody, _quarto.modules.constants.kIncludeAfter)
+      readIncludeFiles(meta, constants.kIncludeInHeader, constants.kHeaderIncludes)
+      readIncludeFiles(meta, constants.kIncludeBeforeBody, constants.kIncludeBefore)
+      readIncludeFiles(meta, constants.kIncludeAfterBody, constants.kIncludeAfter)
 
       -- read text based includes
-      readIncludeStrings(meta, _quarto.modules.constants.kHeaderIncludes)
-      readIncludeStrings(meta, _quarto.modules.constants.kIncludeBefore)
-      readIncludeStrings(meta, _quarto.modules.constants.kIncludeAfter)
+      readIncludeStrings(meta, constants.kHeaderIncludes)
+      readIncludeStrings(meta, constants.kIncludeBefore)
+      readIncludeStrings(meta, constants.kIncludeAfter)
      
       return meta
   --   end

--- a/src/resources/filters/quarto-post/cites.lua
+++ b/src/resources/filters/quarto-post/cites.lua
@@ -2,12 +2,10 @@
 -- Copyright (C) 2020-2022 Posit Software, PBC
 
 local discoveredCites = pandoc.List()
-local constants = require("modules/constants")
-
 function indexCites()   
   return {
     Div = function(el) 
-      local refsIndentifier = param(constants.kRefsIndentifier)
+      local refsIndentifier = param(_quarto.modules.constants.kRefsIndentifier)
       if el.attr.identifier == 'refs' and refsIndentifier then 
         tappend(el.content, {pandoc.Plain(refsIndentifier)})
         return el;

--- a/src/resources/filters/quarto-post/code.lua
+++ b/src/resources/filters/quarto-post/code.lua
@@ -1,7 +1,5 @@
 -- code.lua
 -- Copyright (C) 2020-2022 Posit Software, PBC
-local constants = require("modules/constants")
-
 local function toLines(s)
   if s:sub(-1)~="\n" then s=s.."\n" end
   return s:gmatch("(.-)\n")
@@ -12,7 +10,7 @@ function removeCodeOptions()
     CodeBlock = function(codeEl)
       local lang = codeEl.attr.classes[1] 
   
-      local commentChars = constants.kLangCommentChars[lang]
+      local commentChars = _quarto.modules.constants.kLangCommentChars[lang]
       if commentChars then
         local pattern = '^' .. patternEscape(commentChars[1]) .. "|%s*%S+%s*:.+" 
         if #commentChars == 2 then

--- a/src/resources/filters/quarto-post/email.lua
+++ b/src/resources/filters/quarto-post/email.lua
@@ -16,7 +16,6 @@ Extension for generating email components needed for Posit Connect
 6. Produces a local `index.html` file that contains the HTML email for previewing purposes
    (this can be disabled by setting `email-preview: false` in the YAML header)
 --]]
-local constants = require("modules/constants")
 local connectversion = require("modules/connectversion")
 
 -- Get the file extension of any file residing on disk
@@ -432,7 +431,7 @@ function process_document(doc)
     end
   else
     -- Fall back to version sniffing if no explicit override
-    if connectversion.is_connect_version_at_least(constants.kConnectEmailMetadataChangeVersion) then
+    if connectversion.is_connect_version_at_least(_quarto.modules.constants.kConnectEmailMetadataChangeVersion) then
       connect_supports_v2 = true
     end
   end
@@ -486,7 +485,7 @@ function process_document(doc)
 
   -- If Connect doesn't support v2 format, only keep first email and warn
   if not use_v2_email_format and not has_top_level_metadata then
-    quarto.log.warning("Detected Connect version < " .. constants.kConnectEmailMetadataChangeVersion .. " which doesn't support multiple emails. Only the first email will be sent. Upgrade Connect to " .. constants.kConnectEmailMetadataChangeVersion .. "+ for multi-email support.")
+    quarto.log.warning("Detected Connect version < " .. _quarto.modules.constants.kConnectEmailMetadataChangeVersion .. " which doesn't support multiple emails. Only the first email will be sent. Upgrade Connect to " .. _quarto.modules.constants.kConnectEmailMetadataChangeVersion .. "+ for multi-email support.")
     emails = { emails[1] }
     email_count = 1
   end

--- a/src/resources/filters/quarto-post/typst-css-property-processing.lua
+++ b/src/resources/filters/quarto-post/typst-css-property-processing.lua
@@ -1,5 +1,3 @@
-local constants = require("modules/constants")
-
 function format_typst_float(x)
   local f = string.format('%.2f', x)
   -- trim zeros after decimal point
@@ -8,7 +6,7 @@ end
 
 function render_typst_css_property_processing()
   if not _quarto.format.isTypstOutput() or
-    param(constants.kCssPropertyProcessing, 'translate') ~= 'translate' then
+    param(_quarto.modules.constants.kCssPropertyProcessing, 'translate') ~= 'translate' then
     return {}
   end
 

--- a/src/resources/filters/quarto-post/typst.lua
+++ b/src/resources/filters/quarto-post/typst.lua
@@ -6,8 +6,7 @@
 -- FIXME Ideally this would go directly on init.lua, but
 -- the module path set up doesn't appear to be working there.
 
-local typst = require("modules/typst")
-_quarto.format.typst = typst
+_quarto.format.typst = _quarto.modules.typst
 
 -- Helper to format marginalia shift parameter
 -- auto/true/false are unquoted, "avoid"/"ignore" are quoted strings

--- a/src/resources/filters/quarto-pre/code-annotation.lua
+++ b/src/resources/filters/quarto-pre/code-annotation.lua
@@ -1,13 +1,10 @@
 -- code.lua
 -- Copyright (C) 2020-2022 Posit Software, PBC
 
-local constants = require("modules/constants")
-
-
 local hasAnnotations = false
 
 function isAnnotationCell(el) 
-  return el and is_regular_node(el, "Div") and el.attr.classes:includes(constants.kCellAnnotationClass)
+  return el and is_regular_node(el, "Div") and el.attr.classes:includes(_quarto.modules.constants.kCellAnnotationClass)
 end
 -- annotations appear at the end of the line and are of the form
 -- # <1> 
@@ -20,7 +17,7 @@ end
 -- can be used to resolve annotation numbers and strip them from source 
 -- code
 local function annoteProvider(lang) 
-  local commentChars = constants.kLangCommentChars[lang] or constants.kDefaultCodeAnnotationComment
+  local commentChars = _quarto.modules.constants.kLangCommentChars[lang] or _quarto.modules.constants.kDefaultCodeAnnotationComment
   if commentChars ~= nil then
 
     local startComment = patternEscape(commentChars[1])
@@ -233,7 +230,7 @@ function processLaTeXAnnotation(line, annoteNumber, annotationProvider)
   -- we specially handle LaTeX output in coordination with the post processor
   -- which will replace any of these tokens as appropriate.   
   local hasHighlighting = param('text-highlighting', false)
-  if param(constants.kCodeAnnotationsParam) == constants.kCodeAnnotationStyleNone then
+  if param(_quarto.modules.constants.kCodeAnnotationsParam) == _quarto.modules.constants.kCodeAnnotationStyleNone then
     local replaced = annotationProvider.stripAnnotation(line, annoteNumber) 
     return replaced
   else
@@ -252,7 +249,7 @@ function processLaTeXAnnotation(line, annoteNumber, annotationProvider)
 end
 
 function processAsciidocAnnotation(line, annoteNumber, annotationProvider)
-  if param(constants.kCodeAnnotationsParam) == constants.kCodeAnnotationStyleNone then
+  if param(_quarto.modules.constants.kCodeAnnotationsParam) == _quarto.modules.constants.kCodeAnnotationStyleNone then
     local replaced = annotationProvider.replaceAnnotation(line, annoteNumber, '') 
     return replaced
   else
@@ -271,7 +268,7 @@ end
 function code_meta()
   return {
     Meta = function(meta)
-      if _quarto.format.isLatexOutput() and hasAnnotations and param(constants.kCodeAnnotationsParam) ~= constants.kCodeAnnotationStyleNone then
+      if _quarto.format.isLatexOutput() and hasAnnotations and param(_quarto.modules.constants.kCodeAnnotationsParam) ~= _quarto.modules.constants.kCodeAnnotationStyleNone then
         -- ensure we have tikx for making the circles
         quarto.doc.use_latex_package("tikz");
         quarto.doc.include_text('in-header', [[
@@ -294,10 +291,10 @@ function code_annotations()
   local idCounter = 1
 
   -- the user request code annotations value
-  local codeAnnotations = param(constants.kCodeAnnotationsParam)
+  local codeAnnotations = param(_quarto.modules.constants.kCodeAnnotationsParam)
 
-  local requireNonIncremental = PANDOC_WRITER_OPTIONS[constants.kIncremental] and (
-    codeAnnotations == constants.kCodeAnnotationStyleSelect or codeAnnotations == constants.kCodeAnnotationStyleHover
+  local requireNonIncremental = PANDOC_WRITER_OPTIONS[_quarto.modules.constants.kIncremental] and (
+    codeAnnotations == _quarto.modules.constants.kCodeAnnotationStyleSelect or codeAnnotations == _quarto.modules.constants.kCodeAnnotationStyleHover
   )
 
   -- walk the blocks and look for annotated code
@@ -371,8 +368,8 @@ function code_annotations()
             pendingCellId = identifier
             
             -- decorate the cell and return it
-            if codeAnnotations ~= constants.kCodeAnnotationStyleNone then
-              resolvedCodeBlock.attr.classes:insert(constants.kDataCodeAnnonationClz);
+            if codeAnnotations ~= _quarto.modules.constants.kCodeAnnotationStyleNone then
+              resolvedCodeBlock.attr.classes:insert(_quarto.modules.constants.kDataCodeAnnonationClz);
             end
             return resolvedCodeBlock
           else
@@ -401,7 +398,7 @@ function code_annotations()
                   local codeCell = processCodeCell(el, cellId)
                   if codeCell then
                     processedAnnotation = true
-                    if codeAnnotations ~= constants.kCodeAnnotationStyleNone then
+                    if codeAnnotations ~= _quarto.modules.constants.kCodeAnnotationStyleNone then
                       codeCell.attr.identifier = cellId;
                     end
                   end
@@ -431,7 +428,7 @@ function code_annotations()
                 local cellId = resolveCellId(codeblock.attr.identifier)
                 local codeCell = processCodeCell(codeblock, cellId)
                 if codeCell then
-                  if codeAnnotations ~= constants.kCodeAnnotationStyleNone then
+                  if codeAnnotations ~= _quarto.modules.constants.kCodeAnnotationStyleNone then
                     codeCell.attr.identifier = cellId;
                   end
                   block.content[1].content[1] = codeCell
@@ -457,7 +454,7 @@ function code_annotations()
               local cellId = resolveCellId(block.attr.identifier)
               local codeCell = processCodeCell(block, cellId)
               if codeCell then
-                if codeAnnotations ~= constants.kCodeAnnotationStyleNone then
+                if codeAnnotations ~= _quarto.modules.constants.kCodeAnnotationStyleNone then
                   codeCell.attr.identifier = cellId;
                 end
                 outputBlock(codeCell)
@@ -489,9 +486,9 @@ function code_annotations()
                   term = "<" .. tostring(annotationNumber) .. ">"
                 else
                   if lineNumMeta.count == 1 then
-                    term = language[constants.kCodeLine] .. " " .. lineNumMeta.text;
+                    term = language[_quarto.modules.constants.kCodeLine] .. " " .. lineNumMeta.text;
                   else
-                    term = language[constants.kCodeLines] .. " " .. lineNumMeta.text;
+                    term = language[_quarto.modules.constants.kCodeLines] .. " " .. lineNumMeta.text;
                   end
                 end
 
@@ -506,9 +503,9 @@ function code_annotations()
                   -- use an attribute list since it then guarantees that the
                   -- order of the attributes is consistent from run to run
                   local attribs = pandoc.AttributeList {
-                    {constants.kDataCodeCellTarget, pendingCellId},
-                    {constants.kDataCodeCellLines, lineNumMeta.lineNumbers},
-                    {constants.kDataCodeCellAnnotation, annotationToken}
+                    {_quarto.modules.constants.kDataCodeCellTarget, pendingCellId},
+                    {_quarto.modules.constants.kDataCodeCellLines, lineNumMeta.lineNumbers},
+                    {_quarto.modules.constants.kDataCodeCellAnnotation, annotationToken}
                   }
                   definition = pandoc.Span(definitionContent, pandoc.Attr(attribs))
                 else 
@@ -541,10 +538,10 @@ function code_annotations()
             end
 
             -- if there is a pending code cell, then insert into that and add it
-            if codeAnnotations ~= constants.kCodeAnnotationStyleNone then
+            if codeAnnotations ~= _quarto.modules.constants.kCodeAnnotationStyleNone then
               if pendingCodeCell ~= nil then
                 -- wrap the definition list in a cell
-                local dlDiv = pandoc.Div({dl}, pandoc.Attr("", {constants.kCellAnnotationClass, requireNonIncremental and constants.kNonIncremental or nil }))
+                local dlDiv = pandoc.Div({dl}, pandoc.Attr("", {_quarto.modules.constants.kCellAnnotationClass, requireNonIncremental and _quarto.modules.constants.kNonIncremental or nil }))
                 if is_custom_node(pendingCodeCell) then
                   local custom = _quarto.ast.resolve_custom_data(pendingCodeCell) or pandoc.Div({}) -- won't happen but the Lua analyzer doesn't know it
                   custom.content:insert(2, dlDiv)
@@ -555,7 +552,7 @@ function code_annotations()
               else
                 if requireNonIncremental then
                   -- wrap in Non Incremental Div to prevent automatique 
-                  outputBlockClearPending(pandoc.Div({dl}, pandoc.Attr("", {constants.kNonIncremental})))
+                  outputBlockClearPending(pandoc.Div({dl}, pandoc.Attr("", {_quarto.modules.constants.kNonIncremental})))
                 else 
                   outputBlockClearPending(dl)
                 end
@@ -579,7 +576,7 @@ function code_annotations()
   -- return code_filter
   return {
     Pandoc = function(doc)
-      local codeAnnotations = param(constants.kCodeAnnotationsParam)
+      local codeAnnotations = param(_quarto.modules.constants.kCodeAnnotationsParam)
 
       -- if code annotations is false, then don't even walk it
       if codeAnnotations == false then

--- a/src/resources/filters/quarto-pre/engine-escape.lua
+++ b/src/resources/filters/quarto-pre/engine-escape.lua
@@ -1,8 +1,6 @@
 -- engine-escape.lua
 -- Copyright (C) 2021-2022 Posit Software, PBC
 
-local patterns = require("modules/patterns")
-
 function engine_escape()
   -- Line-by-line replacement for the pattern (\n?[^`\n]+`+){({+([^<}]+)}+)}
   -- which suffers from O(n^2) backtracking on long lines without backticks.
@@ -10,7 +8,7 @@ function engine_escape()
   --
   -- The original pattern cannot cross newlines (due to [^`\n]+), so processing
   -- per-line is semantically equivalent and avoids catastrophic backtracking.
-  local line_pattern = "([^`\n]+`+)" .. patterns.engine_escape
+  local line_pattern = "([^`\n]+`+)" .. _quarto.modules.patterns.engine_escape
   local function unescape_inline_engine_codes(text)
     if not text:find("{{", 1, true) then
       return text
@@ -41,7 +39,7 @@ function engine_escape()
 
       -- handle code block with 'escaped' language engine
       if #el.attr.classes == 1 or #el.attr.classes == 2 and el.attr.classes[2] == 'code-annotation-code' then
-        local engine, lang = el.attr.classes[1]:match(patterns.engine_escape)
+        local engine, lang = el.attr.classes[1]:match(_quarto.modules.patterns.engine_escape)
         if engine then
           el.text = "```" .. engine .. "\n" .. el.text .. "\n" .. "```"
           el.attr.classes[1] = "markdown"
@@ -50,7 +48,7 @@ function engine_escape()
       end
 
       -- handle escaped engines within a code block
-      el.text = el.text:gsub("```" .. patterns.engine_escape, function(engine, lang)
+      el.text = el.text:gsub("```" .. _quarto.modules.patterns.engine_escape, function(engine, lang)
         if #el.attr.classes == 0 or not isHighlightClass(el.attr.classes[1]) then
           el.attr.classes:insert(1, "markdown")
         end
@@ -64,13 +62,13 @@ function engine_escape()
 
     Code = function(el)
       -- don't accidentally process escaped shortcodes
-      if el.text:match("^" .. patterns.shortcode) then
+      if el.text:match("^" .. _quarto.modules.patterns.shortcode) then
         return el
       end
       -- handle `{{python}} code`
-      el.text = el.text:gsub("^" .. patterns.engine_escape, "%1")
+      el.text = el.text:gsub("^" .. _quarto.modules.patterns.engine_escape, "%1")
       -- handles `` `{{python}} code` ``
-      el.text = el.text:gsub("^(`+)" .. patterns.engine_escape, "%1%2")
+      el.text = el.text:gsub("^(`+)" .. _quarto.modules.patterns.engine_escape, "%1%2")
       return el
     end
   }

--- a/src/resources/filters/quarto-pre/input-traits.lua
+++ b/src/resources/filters/quarto-pre/input-traits.lua
@@ -1,8 +1,6 @@
 -- input-traits.lua
 -- Copyright (C) 2020-2022 Posit Software, PBC
 
-local constants = require("modules/constants")
-
 function addInputTrait(key, value)
   quarto_global_state.results.inputTraits[key] = value
 end
@@ -11,7 +9,7 @@ function input_traits()
   return {
     Div = function(el) 
       if el.attr.identifier == 'refs' then
-        addInputTrait(constants.kPositionedRefs, true) 
+        addInputTrait(_quarto.modules.constants.kPositionedRefs, true) 
       end
     end
   }

--- a/src/resources/filters/quarto-pre/line-numbers.lua
+++ b/src/resources/filters/quarto-pre/line-numbers.lua
@@ -1,20 +1,18 @@
 -- line-numbers.lua
 -- Copyright (C) 2020-2022 Posit Software, PBC
 
-local constants = require("modules/constants")
-
 function line_numbers()
   return {
     CodeBlock = function(el)
       if #el.attr.classes > 0 then
         local lineNumbers = lineNumbersAttribute(el)
-        el.attr.attributes[constants.kCodeLineNumbers] = nil
+        el.attr.attributes[_quarto.modules.constants.kCodeLineNumbers] = nil
         if lineNumbers ~= false then
           -- use the pandoc line numbering class
           el.attr.classes:insert("number-lines")
           -- remove for all formats except reveal and docusaurus
           if type(lineNumbers) == "string" and (_quarto.format.isRevealJsOutput() or _quarto.format.isDocusaurusOutput()) then
-            el.attr.attributes[constants.kCodeLineNumbers] = lineNumbers
+            el.attr.attributes[_quarto.modules.constants.kCodeLineNumbers] = lineNumbers
           end
         end
         return el
@@ -24,8 +22,8 @@ function line_numbers()
 end
 
 function lineNumbersAttribute(el)
-  local default = param(constants.kCodeLineNumbers, false)
-  local lineNumbers = attribute(el, constants.kCodeLineNumbers, default)
+  local default = param(_quarto.modules.constants.kCodeLineNumbers, false)
+  local lineNumbers = attribute(el, _quarto.modules.constants.kCodeLineNumbers, default)
   -- format that do accept string for this attributes. "1" and "0" should not be parsed as TRUE / FALSE
   local acceptStrings = _quarto.format.isRevealJsOutput() or _quarto.format.isDocusaurusOutput()
   if lineNumbers == true or lineNumbers == "true" or (lineNumbers == "1" and not acceptStrings) then

--- a/src/resources/filters/quarto-pre/parsefiguredivs.lua
+++ b/src/resources/filters/quarto-pre/parsefiguredivs.lua
@@ -1,8 +1,6 @@
 -- parsefiguredivs.lua
 -- Copyright (C) 2023 Posit Software, PBC
 
-local patterns = require("modules/patterns")
-
 local attributes_to_not_merge = pandoc.List({
   "width", "height"
 })
@@ -88,14 +86,14 @@ local function kable_raw_latex_fixups(content, identifier)
       if not _quarto.format.isRawLatex(raw) then
         return nil
       end
-      if raw.text:match(patterns.latex_long_table) == nil then
+      if raw.text:match(_quarto.modules.patterns.latex_long_table) == nil then
         return nil
       end
-      local b, e, match1, label_identifier = raw.text:find(patterns.latex_label)
+      local b, e, match1, label_identifier = raw.text:find(_quarto.modules.patterns.latex_label)
       if b ~= nil then
         raw.text = raw.text:sub(1, b - 1) .. raw.text:sub(e + 1)
       end
-      local b, e, match2, caption_content = raw.text:find(patterns.latex_caption)
+      local b, e, match2, caption_content = raw.text:find(_quarto.modules.patterns.latex_caption)
       if b ~= nil then
         raw.text = raw.text:sub(1, b - 1) .. raw.text:sub(e + 1)
       end
@@ -738,31 +736,31 @@ function parse_floatreftargets()
       -- first we check if all of the expected bits are present
 
       -- check for {#...} or \label{...}
-      if rawText:find(patterns.latex_label) == nil and 
-         rawText:find(patterns.attr_identifier) == nil then
+      if rawText:find(_quarto.modules.patterns.latex_label) == nil and 
+         rawText:find(_quarto.modules.patterns.attr_identifier) == nil then
         return nil
       end
 
       -- check for \caption{...}
-      if rawText:find(patterns.latex_caption) == nil then
+      if rawText:find(_quarto.modules.patterns.latex_caption) == nil then
         return nil
       end
 
       -- check for tabular or longtable
-      if rawText:find(patterns.latex_long_table) == nil and
-         rawText:find(patterns.latex_tabular) == nil then
+      if rawText:find(_quarto.modules.patterns.latex_long_table) == nil and
+         rawText:find(_quarto.modules.patterns.latex_tabular) == nil then
         return nil
       end
       
       -- if we're here, then we're going to parse this as a FloatRefTarget
       -- and we need to remove the label and caption from the raw block
       local identifier = ""
-      local b, e, _ , label_identifier = rawText:find(patterns.latex_label)
+      local b, e, _ , label_identifier = rawText:find(_quarto.modules.patterns.latex_label)
       if b ~= nil then
         rawText = rawText:sub(1, b - 1) .. rawText:sub(e + 1)
         identifier = label_identifier
       else
-        local b, e, _ , attr_identifier = rawText:find(patterns.attr_identifier)
+        local b, e, _ , attr_identifier = rawText:find(_quarto.modules.patterns.attr_identifier)
         if b ~= nil then
           rawText = rawText:sub(1, b - 1) .. rawText:sub(e + 1)
           identifier = attr_identifier
@@ -782,7 +780,7 @@ function parse_floatreftargets()
       end
 
       local caption
-      local b, e, _, caption_content = rawText:find(patterns.latex_caption)
+      local b, e, _, caption_content = rawText:find(_quarto.modules.patterns.latex_caption)
       if b ~= nil then
         rawText = rawText:sub(1, b - 1) .. rawText:sub(e + 1)
         caption = pandoc.RawBlock("latex", caption_content)

--- a/src/resources/filters/quarto-pre/project-paths.lua
+++ b/src/resources/filters/quarto-pre/project-paths.lua
@@ -1,8 +1,6 @@
 -- project_paths.lua
 -- Copyright (C) 2020-2022 Posit Software, PBC
 
-local constants = require("modules/constants")
-
 local function resolveProjectPath(path)
   local offset = _quarto.projectOffset()
   if offset and path and startsWith(path, '/') then
@@ -19,8 +17,8 @@ end
 function project_paths()
   return {
     Image = function(el)
-      if el.attr.attributes[constants.kProjectResolverIgnore] then
-        el.attr.attributes[constants.kProjectResolverIgnore] = ''
+      if el.attr.attributes[_quarto.modules.constants.kProjectResolverIgnore] then
+        el.attr.attributes[_quarto.modules.constants.kProjectResolverIgnore] = ''
         return el
       end
 
@@ -50,8 +48,8 @@ function project_paths()
     end,
 
     Link = function(el)
-      if el.attr.attributes[constants.kProjectResolverIgnore] then
-        el.attr.attributes[constants.kProjectResolverIgnore] = ''
+      if el.attr.attributes[_quarto.modules.constants.kProjectResolverIgnore] then
+        el.attr.attributes[_quarto.modules.constants.kProjectResolverIgnore] = ''
         return el
       end
 

--- a/src/resources/filters/quarto-pre/table-captions.lua
+++ b/src/resources/filters/quarto-pre/table-captions.lua
@@ -1,8 +1,6 @@
 -- table-captions.lua
 -- Copyright (C) 2020-2022 Posit Software, PBC
 
-local patterns = require("modules/patterns")
-
 function table_captions()
   local kTblCap = "tbl-cap"
   local kTblSubCap = "tbl-subcap"
@@ -153,8 +151,8 @@ function applyTableCaptions(el, tblCaptions, tblLabels)
         -- (2) Append the tblLabels[idx] to whatever caption is there
         if hasRawHtmlTable(raw) then
           -- html table patterns
-          local tablePattern = patterns.html_table
-          local captionPattern = patterns.html_table_caption
+          local tablePattern = _quarto.modules.patterns.html_table
+          local captionPattern = _quarto.modules.patterns.html_table_caption
           -- insert caption if there is none
           local beginCaption, caption = raw.text:match(captionPattern)
           if not beginCaption then

--- a/src/resources/filters/quarto-pre/table-rawhtml.lua
+++ b/src/resources/filters/quarto-pre/table-rawhtml.lua
@@ -5,8 +5,6 @@
 -- back together here so they can be processed by our raw table
 -- caption handling
 
-local patterns = require("modules/patterns")
-
 function table_merge_raw_html()
   if not _quarto.format.isHtmlOutput() then
     return {}
@@ -18,7 +16,7 @@ function table_merge_raw_html()
       local next_element_idx = 1
       for _, el in ipairs(blocks) do
         if _quarto.format.isRawHtml(el) and
-           el.text:find(patterns.html_table_tag_name) then
+           el.text:find(_quarto.modules.patterns.html_table_tag_name) then
           pending_raw:insert(el.text)
         else
           if next(pending_raw) then


### PR DESCRIPTION
When packaging the Lua filter bundle, Pandoc's Lua interpreter enforces a 200 top-level-local-variable limit (`MAXVARS`) across all inlined filter files. `main` is already at that ceiling with zero headroom, which surfaced while evaluating room to bump the bundled Pandoc to 3.10.

`modules/import_all.lua` already centralizes most `modules/*` requires into a single `_quarto.modules` registry table, at no additional local-slot cost no matter how many modules get registered. But ~24 inlined filter files still redundantly re-required the same modules (`constants`, `patterns`, `lightbox`, `scope`, `typst`) as fresh top-level locals instead of referencing the existing registry - each costing one slot in the shared budget.

This replaces those redundant `local X = require("modules/Y")` aliases with direct `_quarto.modules.Y` access at every call site. Pure access-path change to an already-loaded singleton table - no logic or API change.

26 alias declarations removed across 24 files. Packaged bundle `main.lua` top-level local count drops from ~200 to 173.

Verified manually: packaged `quarto check` passes with no "too many local variables" error, packaged renders of lightbox (HTML) and typst (PDF) fixtures succeed, and smoke-all chunks covering the edited filters (2022, 2023/01) pass locally.

Follow up on #14664 where we hit the limit