### PR TITLE
Fix book/website preview crash from reused closed SassCache KV handle

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -83,6 +83,7 @@ All changes included in 1.10:
 - ([#14281](https://github.com/quarto-dev/quarto-cli/issues/14281)): Avoid creating a duplicate `.quarto_ipynb` file on preview startup for single-file Jupyter documents.
 - ([#14533](https://github.com/quarto-dev/quarto-cli/issues/14533)): Fix `quarto preview` not detecting a frontmatter `format:` change until the second render request. The first request after the edit now correctly restarts the preview process with the new format.
 - ([#14593](https://github.com/quarto-dev/quarto-cli/issues/14593)): Fix `quarto preview` ignoring a `_brand.yml` added or removed while the preview is running. The brand change is now applied on the next render instead of requiring a preview restart.
+- ([#14594](https://github.com/quarto-dev/quarto-cli/issues/14594)): Fix `quarto preview` of a book or website project crashing with `BadResource: Bad resource ID` when re-rendering pages.
 
 ### `install`
 

--- a/src/core/sass/cache.ts
+++ b/src/core/sass/cache.ts
@@ -155,6 +155,10 @@ class SassCache implements Cloneable<SassCache> {
         log.info(
           `Error occurred during sass cache cleanup for ${this.path}: ${error}`,
         );
+      } finally {
+        // Drop the registry entry so a later resolve of the same path opens a
+        // fresh KV handle instead of reusing this now-closed one (#14594, #13955).
+        delete _sassCache[cachePath];
       }
     });
   }

--- a/tests/docs/manual/preview/README.md
+++ b/tests/docs/manual/preview/README.md
@@ -275,6 +275,48 @@ brand signal in the kept `report.typ` is the line
 - **Expected:** Brand stays applied; the source-state token matches so the cache is reused (only cheap stat calls per resolve)
 - **Catches:** A guard that re-loads the brand on every render even when nothing changed
 
+## Test Matrix: Sass Cache Reuse (#14594)
+
+After every change to `SassCache.cleanup()` or the `_sassCache` registry in
+`src/core/sass/cache.ts`, verify that a book/website preview survives repeated
+re-renders instead of crashing with `BadResource: Bad resource ID`. On each
+re-render the serve/watch reload path runs `refreshProjectConfig`
+(`src/project/serve/watch.ts`, ~line 277 for HTML; also on config changes,
+~line 305), which calls `project.cleanup()` and closes the session Sass KV
+handle; the next render must open a fresh handle rather than reuse the closed
+one. Fixture: `sass-cache-crash-14594/` (a flat multi-chapter book with
+`theme: cosmo` + `css:`, which routes the theme through the session Sass cache);
+drive it with the `/quarto-preview-test` workflow. Deterministic unit coverage
+lives in `tests/unit/sass-cache.test.ts` — this matrix is the interactive
+regression guide that path can't cover.
+
+### P1: Critical
+
+#### T34: Book project preview — `_quarto.yml` edit does not crash on Sass recompile
+
+- **Setup:** `sass-cache-crash-14594/` book (`theme: cosmo`, `css: styles.css`), no prior `.quarto/` or `_book/`
+- **Steps:** From the fixture dir, `quarto preview --no-browser --port XXXX`; after the first render, edit `_quarto.yml` (tweak the title or append a comment line) and save 3-5 times, watching the preview log
+- **Expected:** Every re-render completes and reloads. No `BadResource: Bad resource ID` in the log. The cosmo theme + custom CSS keep recompiling/serving.
+- **Catches:** `SassCache.cleanup()` closing the KV handle but leaving the stale instance in `_sassCache`, so the next resolve reuses a closed handle (#14594, #13955)
+
+### P2: Important
+
+#### T35: Book project preview — chapter content edit (content re-render path)
+
+- **Setup:** Same fixture
+- **Steps:** `quarto preview --no-browser --port XXXX`; after the first render, edit a chapter body (`index.qmd` / `chapter1.qmd`) and save 3-5 times
+- **Expected:** Same as T34 — no crash, pages keep reloading
+- **Catches:** The HTML reload path (`refreshProjectConfig` at watch.ts ~277) closes the session KV on a plain content re-render too, so a content save must not reuse a closed handle either
+
+### Regression Guard
+
+#### T36: Single-file preview — unaffected by the registry cleanup
+
+- **Setup:** `plain.qmd` (markdown-only, no project)
+- **Steps:** `quarto preview plain.qmd --no-browser --port XXXX`, save 3-5 times
+- **Expected:** No crash and no behavior change — the fix is a no-op for the common single-file preview path
+- **Catches:** The registry-entry deletion in cleanup accidentally breaking or churning the non-project preview path
+
 ## Extension Format PDF Preview (#14582)
 
 ### P1: Core functionality

--- a/tests/docs/manual/preview/sass-cache-crash-14594/.gitignore
+++ b/tests/docs/manual/preview/sass-cache-crash-14594/.gitignore
@@ -1,0 +1,4 @@
+/.quarto/
+/_book/
+**/*_files/
+**/*.quarto_ipynb

--- a/tests/docs/manual/preview/sass-cache-crash-14594/README.md
+++ b/tests/docs/manual/preview/sass-cache-crash-14594/README.md
@@ -1,0 +1,40 @@
+# Sass cache reuse during preview (#14594)
+
+Manual fixture for the bug where `quarto preview` of a book (or website) project
+crashed with `BadResource: Bad resource ID` while recompiling the theme Sass on a
+re-render. `SassCache.cleanup()` closed the session `Deno.Kv` handle but left the
+stale instance in the module-level `_sassCache` registry, so the next
+`sassCache(path, temp)` resolve reused the now-closed handle.
+
+On each re-render the serve/watch reload path runs `refreshProjectConfig`
+(`src/project/serve/watch.ts`, ~line 277 for HTML; also on any config change,
+~line 305), which calls `project.cleanup()` and closes that session Sass KV
+handle. The next render must open a fresh handle. RStudio's and Positron's live
+preview hit the same persistent server, so they saw the same crash.
+
+Drive this with the `/quarto-preview-test` workflow. See the parent `../README.md`
+"Test Matrix: Sass Cache Reuse (#14594)" for the T34-T36 cases.
+
+## Files
+
+| File | Role |
+|------|------|
+| `_quarto.yml` | Flat multi-chapter book with `theme: cosmo` + `css: styles.css` (routes the theme through the session Sass cache) |
+| `index.qmd`, `chapter1.qmd`, `chapter2.qmd` | Minimal chapters; a project preview re-renders these |
+| `styles.css` | Custom CSS so a real Sass compile runs alongside the cosmo theme |
+
+`_book/` and `.quarto/` are scratch produced by a run and are git-ignored.
+
+## Crash signal
+
+Before the fix, after the first re-render the preview log shows:
+
+```
+BadResource: Bad resource ID
+```
+
+and pages stop reloading. After the fix, every re-render completes and reloads.
+
+Deterministic unit coverage lives in `tests/unit/sass-cache.test.ts`; this fixture
+is the interactive regression guide the unit test can't cover (live serve/watch
+path).

--- a/tests/docs/manual/preview/sass-cache-crash-14594/_quarto.yml
+++ b/tests/docs/manual/preview/sass-cache-crash-14594/_quarto.yml
@@ -1,0 +1,14 @@
+project:
+  type: book
+
+book:
+  title: "Sass Cache Preview Crash (#14594)"
+  chapters:
+    - index.qmd
+    - chapter1.qmd
+    - chapter2.qmd
+
+format:
+  html:
+    theme: cosmo
+    css: styles.css

--- a/tests/docs/manual/preview/sass-cache-crash-14594/chapter1.qmd
+++ b/tests/docs/manual/preview/sass-cache-crash-14594/chapter1.qmd
@@ -1,0 +1,7 @@
+---
+title: Chapter 1
+---
+
+# Chapter 1
+
+Content.

--- a/tests/docs/manual/preview/sass-cache-crash-14594/chapter2.qmd
+++ b/tests/docs/manual/preview/sass-cache-crash-14594/chapter2.qmd
@@ -1,0 +1,7 @@
+---
+title: Chapter 2
+---
+
+# Chapter 2
+
+Content.

--- a/tests/docs/manual/preview/sass-cache-crash-14594/index.qmd
+++ b/tests/docs/manual/preview/sass-cache-crash-14594/index.qmd
@@ -1,0 +1,7 @@
+---
+title: Home
+---
+
+# Welcome
+
+Edit this line (or `_quarto.yml`) and save to force preview re-renders.

--- a/tests/docs/manual/preview/sass-cache-crash-14594/styles.css
+++ b/tests/docs/manual/preview/sass-cache-crash-14594/styles.css
@@ -1,0 +1,2 @@
+/* Custom CSS so a real session Sass compile runs alongside the cosmo theme. */
+body { color: rebeccapurple; }

--- a/tests/unit/sass-cache.test.ts
+++ b/tests/unit/sass-cache.test.ts
@@ -1,0 +1,58 @@
+/*
+ * sass-cache.test.ts
+ *
+ * Tests for the persistent/session Sass compilation cache.
+ * Validates fixes for:
+ *   https://github.com/quarto-dev/quarto-cli/issues/13955 (closed KV reuse)
+ *   https://github.com/quarto-dev/quarto-cli/issues/14594 (book/website preview)
+ *
+ * Copyright (C) 2026 Posit Software, PBC
+ */
+
+import { unitTest } from "../test.ts";
+import { assertEquals } from "testing/asserts";
+import { join } from "../../src/deno_ral/path.ts";
+import { safeRemoveIfExists } from "../../src/core/path.ts";
+import { createTempContext, TempContext } from "../../src/core/temp.ts";
+import { sassCache } from "../../src/core/sass/cache.ts";
+
+// A syntactically valid md5 hash that will never be present in a fresh cache,
+// so getFromHash exercises kv.get() and returns a clean cache miss (null).
+const ABSENT_HASH = "0".repeat(32);
+
+unitTest(
+  "sassCache - reusing a cache path after cleanup returns a live KV handle (#14594)",
+  async () => {
+    const root = Deno.makeTempDirSync({ prefix: "quarto-sass-cache-test" });
+    const cachePath = join(root, "sass");
+
+    const temp1 = createTempContext();
+    let temp2: TempContext | undefined;
+    try {
+      // First resolve creates the cache and opens its Deno.Kv handle.
+      const cache1 = await sassCache(cachePath, temp1);
+      // A read works while the handle is open (clean cache miss).
+      assertEquals(await cache1.getFromHash(ABSENT_HASH, "ignored"), null);
+
+      // Cleanup closes the KV handle and removes the cache dir. This is what
+      // project.cleanup() -> temp.cleanup() does on the serve/watch re-render
+      // path that book and website preview go through.
+      temp1.cleanup();
+
+      // A later render resolves the SAME cache path again. The registry must
+      // not hand back the instance whose KV handle was just closed, otherwise
+      // kv.get() throws "BadResource: Bad resource ID" (#14594, #13955).
+      temp2 = createTempContext();
+      const cache2 = await sassCache(cachePath, temp2);
+      assertEquals(
+        await cache2.getFromHash(ABSENT_HASH, "ignored"),
+        null,
+        "Reused cache path must return a live KV handle, not a closed one",
+      );
+    } finally {
+      temp1.cleanup();
+      temp2?.cleanup();
+      safeRemoveIfExists(root);
+    }
+  },
+);


### PR DESCRIPTION
When `quarto preview` re-renders a book or website project, Sass compilation crashes with `BadResource: Bad resource ID` from `Kv.get`, repeating across chapter/part pages.

## Root Cause

`SassCache.cleanup()` (`src/core/sass/cache.ts:146-160`) closes the instance's `Deno.Kv` handle but leaves the entry in the module-level `_sassCache` registry. `sassCache(path, temp)` only creates a new instance `if (!_sassCache[path])`, so the next call resolves the stale closed-KV instance, and any subsequent `kv.get()` throws.

Same root-cause family as #13955, fixed in #13967 by dropping the `context.cleanup()` call from the single-file preview path (`renderForPreview`). Book and website preview go through a different path — `watchProject`'s `refreshProjectConfig` (`src/project/serve/watch.ts:62-66`) still calls `project.cleanup()` on every config refresh — so the underlying cache defect was never patched at its source.

## Fix

Delete the `_sassCache[path]` entry inside the cleanup callback when the KV handle closes, so the next `sassCache()` call opens a fresh handle instead of reusing the closed one.

Also adds a manual preview test fixture (`tests/docs/manual/preview/sass-cache-crash-14594/`) and a Test Matrix section in `tests/docs/manual/preview/README.md`, since the serve/watch reload path this bug lives on isn't reachable from the unit test alone.

## Test Plan

- [x] Preview a book project with a theme + custom `css`, edit `_quarto.yml` repeatedly to trigger project reloads — no `BadResource` crash
- [x] Single-file preview (#13955/#13967) still unaffected
- [ ] `tests/docs/manual/preview/sass-cache-crash-14594/` via `/quarto-preview-test` T34-T36

Fixes #14594