### PR TITLE
Add regression test for Beamer logooptions passthrough

### DIFF
--- a/tests/docs/smoke-all/2026/07/22/beamer-logooptions.qmd
+++ b/tests/docs/smoke-all/2026/07/22/beamer-logooptions.qmd
@@ -1,0 +1,25 @@
+---
+title: "Test"
+format:
+  beamer:
+    logo: logo.png
+    logooptions: [width=1cm]
+    # this is needed to not trigger the pdf recipe
+    output-ext: tex
+_quarto:
+  tests:
+    beamer:
+      ensureFileRegexMatches:
+        -
+          # logooptions applied to the logo's includegraphics
+          - '\\logo\{\\includegraphics\[width=1cm\]\{logo\.png\}\}'
+        -
+          # must NOT fall back to the bare, no-options form
+          - '\\logo\{\\includegraphics\{logo\.png\}\}'
+---
+
+## Quarto
+
+Guards Pandoc 3.10's `logooptions` template variable passthrough for Beamer's
+`\logo{}` command (`src/resources/formats/beamer/pandoc/title.tex`), reachable
+today via freeform YAML metadata with no dedicated schema key.


### PR DESCRIPTION
Follow-up to #14664 (Pandoc 3.10 upgrade). Pandoc 3.10 added a
`logooptions` template variable for Beamer's `\logo{}` command, mirroring
the existing `titlegraphicoptions` variable for `\titlegraphic{}`.
Quarto's customized `title.tex` already passes it through, reachable
today via freeform YAML metadata with no dedicated schema key, but had
no test coverage.

Adds a smoke-all test rendering a minimal Beamer document with `logo` and
`logooptions` set, asserting the generated `.tex` applies the option
(`\logo{\includegraphics[width=1cm]{...}}`) instead of falling back to the
bare, no-options form.