### PR TITLE
Log smoke-all cleanup only on actual file removal

### DIFF
--- a/tests/smoke/smoke-all.test.ts
+++ b/tests/smoke/smoke-all.test.ts
@@ -158,7 +158,10 @@ interface QuartoInlineTestSpec {
   verifyFns: Verify[];
 }
 
-// Functions to cleanup leftover testing
+// Functions to cleanup leftover testing.
+// postRenderCleanupFiles is a module-global list swept by EVERY render
+// teardown, so a registered entry only logs/removes at the teardowns where the
+// file actually exists (its owning document), not on every subsequent teardown.
 const postRenderCleanupFiles: string[] = [];
 function registerPostRenderCleanupFile(file: string): void {
   postRenderCleanupFiles.push(file);
@@ -168,8 +171,8 @@ const postRenderCleanup = () => {
     return;
   }
   for (const file of postRenderCleanupFiles) {
-    console.log(`Cleaning up ${file} in ${Deno.cwd()}`);
     if (safeExistsSync(file)) {
+      console.log(`Cleaning up ${file} in ${Deno.cwd()}`);
       // recursive so a registered entry can be a directory (e.g. an embedded
       // notebook's `*_files` support dir), not just a single file
       safeRemoveSync(file, { recursive: true });


### PR DESCRIPTION
The smoke-all test harness registers cleanup files in a module-global list that every render teardown sweeps. The `Cleaning up ...` log line sat outside the existence check, so every teardown printed a line for each registered file whether or not it existed in that teardown's scope. With ~10 registered files across ~1600 teardowns, a full serial run emitted ~16k such lines, almost all describing removals that never happened.

Moving the log inside the `safeExistsSync` branch prints it only when a file is actually removed. Same files removed as before; only log frequency changes.