### PR TITLE
Gate Playwright CI setup on bucket content

### DIFF
--- a/.github/workflows/test-smokes.yml
+++ b/.github/workflows/test-smokes.yml
@@ -85,8 +85,16 @@ jobs:
         with:
           node-version: 22
 
+      # Playwright setup is only needed when this job can actually run the
+      # playwright suite: a bucket containing playwright-tests.test.ts, or a
+      # full run (empty buckets, which includes integration/). Windows never
+      # needs it: the suite is ignored on Windows CI (playwright-tests.test.ts,
+      # `ignore: gha.isGitHubActions() && isWindows`).
       - name: Cache multiplex server node_modules
-        if: ${{ runner.os != 'Windows' || github.event_name == 'schedule' }}
+        if: >-
+          runner.os != 'Windows'
+          && (format('{0}', inputs.buckets) == ''
+              || contains(inputs.buckets, 'playwright-tests.test.ts'))
         uses: actions/cache@v5
         with:
           path: tests/integration/playwright/multiplex-server/node_modules
@@ -95,13 +103,19 @@ jobs:
             ${{ runner.os }}-multiplex-server-
 
       - name: Install node dependencies
-        if: ${{ runner.os != 'Windows' || github.event_name == 'schedule' }}
+        if: >-
+          runner.os != 'Windows'
+          && (format('{0}', inputs.buckets) == ''
+              || contains(inputs.buckets, 'playwright-tests.test.ts'))
         run: npm install --loglevel=error --no-audit
         working-directory: ./tests/integration/playwright
         shell: bash
 
       - name: Get Playwright version
-        if: ${{ runner.os != 'Windows' || github.event_name == 'schedule' }}
+        if: >-
+          runner.os != 'Windows'
+          && (format('{0}', inputs.buckets) == ''
+              || contains(inputs.buckets, 'playwright-tests.test.ts'))
         run: |
           VERSION=$(node -p "require('@playwright/test/package.json').version")
           echo "PLAYWRIGHT_VERSION=$VERSION" >> "$GITHUB_ENV"
@@ -109,7 +123,10 @@ jobs:
         shell: bash
 
       - name: Cache Playwright browsers
-        if: ${{ runner.os != 'Windows' || github.event_name == 'schedule' }}
+        if: >-
+          runner.os != 'Windows'
+          && (format('{0}', inputs.buckets) == ''
+              || contains(inputs.buckets, 'playwright-tests.test.ts'))
         uses: actions/cache@v5
         with:
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
@@ -118,13 +135,19 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright system dependencies
-        if: ${{ runner.os != 'Windows' || github.event_name == 'schedule' }}
+        if: >-
+          runner.os != 'Windows'
+          && (format('{0}', inputs.buckets) == ''
+              || contains(inputs.buckets, 'playwright-tests.test.ts'))
         timeout-minutes: 15
         run: npx playwright install-deps
         working-directory: ./tests/integration/playwright
 
       - name: Install Playwright Browsers
-        if: ${{ runner.os != 'Windows' || github.event_name == 'schedule' }}
+        if: >-
+          runner.os != 'Windows'
+          && (format('{0}', inputs.buckets) == ''
+              || contains(inputs.buckets, 'playwright-tests.test.ts'))
         timeout-minutes: 15
         run: npx playwright install
         working-directory: ./tests/integration/playwright


### PR DESCRIPTION
Six Playwright setup steps in `test-smokes.yml` (node dependency install, browser cache/install, system deps) run on every Linux job regardless of whether the job's test bucket actually contains a Playwright test.

Under `test-smokes-parallel.yml` — which runs on every push/PR to main and splits the suite into ~20 bucket jobs — that means ~19 jobs pay 2–3 minutes of browser and system-dependency installation they never use, and carry its failure surface for no benefit. Run 30081294158 saw a job die in `npx playwright install-deps` on a transient apt failure, in a bucket that had no Playwright test to run.

The workflow already has the right precedent: the "Install rsvg-convert" step gates on `format('{0}', inputs.buckets) == '' || contains(inputs.buckets, ...)`. The six Playwright steps now use the same idiom — they run only for a full serial run (empty buckets, which includes `integration/`) or a bucket containing `integration/playwright-tests.test.ts`, the only test file whose path matches "playwright".

The `schedule` escape is dropped rather than carried forward: the suite is ignored on Windows CI (`ignore: gha.isGitHubActions() && isWindows` in `playwright-tests.test.ts`), so `npx playwright test` never runs on Windows in any mode — browser setup there was pure waste, scheduled or not.

## Self-trial

This PR's own "Parallel Smokes Tests" run exercises the gate directly. In the run's jobs, a bucket without a Playwright test shows the six setup steps skipped, while the bucket containing `integration/playwright-tests.test.ts` still installs browsers and passes. The only path not covered by PR CI is the Windows-`schedule` tightening — there is no scheduled event on a PR — which rests on the Windows `ignore` gate cited above.

No changelog entry: CI-only change with no user-facing effect.
