### PR TITLE
[backport] typst gather which await v1.10

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -1,5 +1,13 @@
 All changes included in 1.10:
 
+# v1.11 backports
+
+## In this release
+
+- ([#14731](https://github.com/quarto-dev/quarto-cli/pull/14731)): Fix `QUARTO_VENDOR_BINARIES=false` builds silently succeeding with missing binaries. The `configure` step's "is it on PATH?" check for `typst-gather`, `typst`, `pandoc` and `esbuild` compared an unawaited `Promise` against `undefined`, so the guard never fired. A build with `typst-gather` neither vendored nor on PATH reported success and produced a Quarto tree without it, surfacing only at render time as `typst-gather analyze failed; staging all packages as fallback`. The missing-binary error message now also names the path that was checked and the `QUARTO_TYPST_GATHER` environment variable.
+
+# v1.10 changes
+
 ## Regression fixes
 
 - ([#13583](https://github.com/quarto-dev/quarto-cli/issues/13583)): Fix "Show All Code" and "Hide All Code" in the `code-tools` menu doing nothing when `code-copy` is enabled. (author: @mcanouil)

--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -2,6 +2,7 @@
 
 ## In this release
 
+- ([#14731](https://github.com/quarto-dev/quarto-cli/pull/14731)): Fix `QUARTO_VENDOR_BINARIES=false` builds silently succeeding with missing binaries. The `configure` step's "is it on PATH?" check for `typst-gather`, `typst`, `pandoc` and `esbuild` compared an unawaited `Promise` against `undefined`, so the guard never fired. A build with `typst-gather` neither vendored nor on PATH reported success and produced a Quarto tree without it, surfacing only at render time as `typst-gather analyze failed; staging all packages as fallback`. The missing-binary error message now also names the path that was checked and the `QUARTO_TYPST_GATHER` environment variable.
 - ([#14741](https://github.com/quarto-dev/quarto-cli/issues/14741)): Don't wrap the `longtable` environment of a cross-referenceable table in a `{ ... }` group. Pandoc emits that group to scope its `\def\LTcaptype{none}`, which Quarto removes when adding its own `\caption`; keeping the now-pointless group broke packages that move the environment out of the text flow, such as `endfloat` with `\DeclareDelayedFloatFlavor*{longtable}{table}`.
 - ([#14857](https://github.com/quarto-dev/quarto-cli/issues/14857)): Fix `quarto install chrome-headless-shell` (and `quarto install chromium`) failing with a 404 on Linux arm64 due to a stale Playwright CDN URL.
 
@@ -10,14 +11,6 @@
 # v1.10 changes
 
 All changes included in 1.10:
-
-# v1.11 backports
-
-## In this release
-
-- ([#14731](https://github.com/quarto-dev/quarto-cli/pull/14731)): Fix `QUARTO_VENDOR_BINARIES=false` builds silently succeeding with missing binaries. The `configure` step's "is it on PATH?" check for `typst-gather`, `typst`, `pandoc` and `esbuild` compared an unawaited `Promise` against `undefined`, so the guard never fired. A build with `typst-gather` neither vendored nor on PATH reported success and produced a Quarto tree without it, surfacing only at render time as `typst-gather analyze failed; staging all packages as fallback`. The missing-binary error message now also names the path that was checked and the `QUARTO_TYPST_GATHER` environment variable.
-
-# v1.10 changes
 
 ## Regression fixes
 

--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -11,6 +11,14 @@
 
 All changes included in 1.10:
 
+# v1.11 backports
+
+## In this release
+
+- ([#14731](https://github.com/quarto-dev/quarto-cli/pull/14731)): Fix `QUARTO_VENDOR_BINARIES=false` builds silently succeeding with missing binaries. The `configure` step's "is it on PATH?" check for `typst-gather`, `typst`, `pandoc` and `esbuild` compared an unawaited `Promise` against `undefined`, so the guard never fired. A build with `typst-gather` neither vendored nor on PATH reported success and produced a Quarto tree without it, surfacing only at render time as `typst-gather analyze failed; staging all packages as fallback`. The missing-binary error message now also names the path that was checked and the `QUARTO_TYPST_GATHER` environment variable.
+
+# v1.10 changes
+
 ## Regression fixes
 
 - ([#13583](https://github.com/quarto-dev/quarto-cli/issues/13583)): Fix "Show All Code" and "Hide All Code" in the `code-tools` menu doing nothing when `code-copy` is enabled. (author: @mcanouil)

--- a/package/src/common/dependencies/esbuild.ts
+++ b/package/src/common/dependencies/esbuild.ts
@@ -56,7 +56,7 @@ export function esBuild(version: string): Dependency {
           }
         } else {
           // verify that the binary is on PATH, but otherwise don't do anything
-          if (which(file) === undefined) {
+          if ((await which(file)) === undefined) {
             throw new Error(
               `${file} is not on PATH. Please install it and add it to PATH.`,
             );

--- a/package/src/common/dependencies/pandoc.ts
+++ b/package/src/common/dependencies/pandoc.ts
@@ -70,7 +70,7 @@ export function pandoc(version: string): Dependency {
           }
         } else {
           // verify that the binary is on PATH, but otherwise don't do anything
-          if (which(pandocBinary) === undefined) {
+          if ((await which(pandocBinary)) === undefined) {
             throw new Error(
               `${pandocBinary} is not on PATH. Please install it and add it to PATH.`,
             );

--- a/package/src/common/dependencies/typst-gather.ts
+++ b/package/src/common/dependencies/typst-gather.ts
@@ -28,7 +28,7 @@ export function typstGather(version: string): Dependency {
           Deno.renameSync(extractedPath, join(targetDir, file));
         } else {
           // verify that the binary is on PATH, but otherwise don't do anything
-          if (which(file) === undefined) {
+          if ((await which(file)) === undefined) {
             throw new Error(
               `${file} is not on PATH. Please install it and add it to PATH.`,
             );

--- a/package/src/common/dependencies/typst.ts
+++ b/package/src/common/dependencies/typst.ts
@@ -45,7 +45,7 @@ export function typst(version: string ): Dependency {
           }
         } else {
           // verify that the binary is on PATH, but otherwise don't do anything
-          if (which(file) === undefined) {
+          if ((await which(file)) === undefined) {
             throw new Error(
               `${file} is not on PATH. Please install it and add it to PATH.`,
             );

--- a/src/command/dev-call/typst-gather/cmd.ts
+++ b/src/command/dev-call/typst-gather/cmd.ts
@@ -40,10 +40,17 @@ export const typstGatherCommand = new Command()
     const typstGatherBinary = Deno.env.get("QUARTO_TYPST_GATHER") ||
       architectureToolsPath(binaryName);
     if (!existsSync(typstGatherBinary)) {
-      error(
-        `typst-gather binary not found.\n` +
-          "Run ./configure.sh to build and install it.",
-      );
+      error(`typst-gather binary not found at ${typstGatherBinary}.`);
+      if (Deno.env.get("QUARTO_TYPST_GATHER")) {
+        error(
+          "QUARTO_TYPST_GATHER is set but does not point to an existing file.",
+        );
+      } else {
+        error(
+          "Run ./configure.sh to download it, or set QUARTO_TYPST_GATHER to " +
+            "the path of a typst-gather binary.",
+        );
+      }
       Deno.exit(1);
     }
 

--- a/src/core/typst-gather.ts
+++ b/src/core/typst-gather.ts
@@ -37,8 +37,12 @@ export function typstGatherBinaryPath(): string {
 
   if (!existsSync(binary)) {
     throw new Error(
-      `typst-gather binary not found.\n` +
-        `Run ./configure.sh to build and install it.`,
+      `typst-gather binary not found at ${binary}.\n` +
+        (Deno.env.get("QUARTO_TYPST_GATHER")
+          ? `QUARTO_TYPST_GATHER is set but does not point to an existing file.`
+          : `Reinstall Quarto to restore the bundled binary, or set ` +
+            `QUARTO_TYPST_GATHER to the path of a typst-gather binary.\n` +
+            `In a Quarto source checkout, run ./configure.sh to download it.`),
     );
   }
 


### PR DESCRIPTION
> [!NOTE]
> THis PR is a backport to v1.10
 
## Description

Backport of #14731 to `v1.10`.

`v1.10` carries all four instances of the bug identically: the non-vendored
branch of each dependency's `configure` callback in
`package/src/common/dependencies/` checks `if (which(file) === undefined)`, but
`which` is `async` (`src/core/path.ts`), so this compares a `Promise` to
`undefined` — always false, guard never fires.

With `QUARTO_VENDOR_BINARIES=false` (what conda-forge uses, so binary deps come
from conda packages rather than downloaded release assets), `configureDependency`
skips the download but still calls `configure()`. This guard is the only thing
meant to catch a missing binary, so the build reports success and produces a
Quarto tree without it. Confirmed against a real green CI build of **quarto
1.10.18 on conda-forge** — which is why this matters on the stable branch rather
than only on `main`. The failure surfaces only at runtime: every Typst render
prints `typst-gather analyze failed; staging all packages as fallback: ...`, and
`quarto call typst-gather` dies with a misleading error.

Also refreshes the stale "binary not found" message in `typstGatherBinaryPath()`
and the `dev-call typst-gather` command, which told users to
`Run ./configure.sh to build and install it.` — `configure.sh` no longer *builds*
typst-gather (the cargo step and `package/typst-gather/` were removed in 1.10;
it is a downloaded release binary), and neither message mentioned
`QUARTO_TYPST_GATHER`, which both code paths already honour.

## Backport notes

Prepared per `dev-docs/checklist-backport-a-pr.md`:

- The code commit cherry-picks onto `v1.10` with **zero conflicts** in all six
  source files. The only conflict was `news/changelog-1.11.md`, which does not
  exist on this branch and was dropped, as the checklist prescribes.
- The changelog entry is a **separate commit**, filed under
  `# v1.11 backports > ## In this release` in `news/changelog-1.10.md` per
  `.claude/rules/changelog.md`.
- This is the **first backport of the v1.11 cycle onto `v1.10`**, so that commit
  also introduces the dual top-level structure (`# v1.11 backports` /
  `# v1.10 changes`) that the file did not have yet. The pre-existing `v1.10`
  content is unchanged, just moved under the `# v1.10 changes` heading.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes
- [x] updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- [ ] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR

The checklist step of manually running the test-suite GHA workflow on `v1.10`
has **not** been done and is worth doing before merge — nothing in this change
has been built or test-run. Note also that `package/src` is not covered by any
test suite and no CI workflow runs `deno check` over it, which is how
`Promise<string | undefined> === undefined` (TS error 2367) shipped in the first
place.

<details>
<summary>AI-assisted PR</summary>

- **AI tool used**: Claude Code
- **Codebase grounding**: local clone — `src/core/path.ts` (confirmed `which` is
  async), the four `configure` callbacks in
  `package/src/common/dependencies/`, verified against the real `v1.10` branch
  that all four instances and the stale error message are present there;
  `dev-docs/checklist-backport-a-pr.md` and `.claude/rules/changelog.md` for the
  backport and changelog-placement conventions.
- **Human review**: I have reviewed, tested, and verified the AI-generated
  content before submitting.

</details>
