### PR TITLE
docs: add missing issue/PR reference to build-ts-extension changelog entry

### DIFF
--- a/news/changelog-1.9.md
+++ b/news/changelog-1.9.md
@@ -178,7 +178,7 @@ All changes included in 1.9:
 
 ### `call build-ts-extension`
 
-- (): New `quarto call build-ts-extension` command builds a TypeScript extension, such as an engine extension, and places the artifacts in the `_extensions` directory. See the [engine extension pre-release documentation](https://prerelease.quarto.org/docs/extensions/engine.html) for details.
+- ([#13718](https://github.com/quarto-dev/quarto-cli/pull/13718)): New `quarto call build-ts-extension` command builds a TypeScript extension, such as an engine extension, and places the artifacts in the `_extensions` directory. See the [engine extension pre-release documentation](https://prerelease.quarto.org/docs/extensions/engine.html) for details.
 
 ### `install`
 


### PR DESCRIPTION
## Description

The `call build-ts-extension` entry in `news/changelog-1.9.md` had no issue/PR reference, so it renders with an empty `- ():` prefix once the changelog is published (#14730). Every sibling entry carries a `([#NNNN](url))` reference.

The `quarto call build-ts-extension` command was added in #13718 ("feature: engine extension", commit `92bbe865`), so this fills in `([#13718](https://github.com/quarto-dev/quarto-cli/pull/13718))` on that entry, matching the surrounding style.

Closes #14730.

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes
- [x] updated the appropriate changelog in the PR (this change *is* the changelog fix)
- [ ] ensured the present test suite passes (n/a - changelog text only)
- [ ] added new tests (n/a)
- [ ] created a separate documentation PR in Quarto's website repo (n/a - changelog only)

<details>
<summary>AI-assisted PR</summary>

- **AI tool used**: Claude Code
- **Codebase grounding**: local verification via the GitHub API - confirmed `build-ts-extension` was introduced by commit `92bbe865`, which landed in PR #13718, and matched the reference format against the sibling entries in this same changelog.
- **Human review**: I reviewed and verified the change (the #13718 reference and the single-line diff) against the source before submitting, and I am accountable for it.

</details>
