### PR TITLE
chore: disable blank issue submissions from users

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Issue guide
     url: https://quarto.org/bug-reports.html


### PR DESCRIPTION
This PR disables blank issue submissions from users.
Maintainers/owners/etc. can still open blank issues.

This is to avoid/reduce unguided AI submissions from users.