### PR TITLE
Move navbar search after nav links so tab order matches visual order

### DIFF
--- a/news/changelog-1.11.md
+++ b/news/changelog-1.11.md
@@ -1,5 +1,11 @@
 All changes included in 1.11:
 
+## Projects
+
+### Websites
+
+- ([#7058](https://github.com/quarto-dev/quarto-cli/issues/7058)): Move the navbar search control after the navigation links and tools in the DOM so keyboard and screen-reader order matches the visual order. The rendered layout is unchanged (navbar positioning is controlled by CSS `order`), but custom CSS or JS that relied on `#quarto-search` preceding the navbar links in the DOM may need updating.
+
 ## Engines
 
 ### `knitr`

--- a/src/resources/projects/website/templates/nav-before-body.ejs
+++ b/src/resources/projects/website/templates/nav-before-body.ejs
@@ -26,9 +26,6 @@ const navbarTocRight = nav['toc-location'] === "right" || nav['toc-location'] ==
       }) %>
       <% if (nav.navbar.left || nav.navbar.right) { %>  
         <% if (nav.navbar.collapse) { %>
-          <% if (nav.navbar.search) { %>
-            <% partial('navsearch.ejs',  { classes: '', language: nav.language }) %>
-          <% } %>
           <% partial('navtoggle.ejs', { language: nav.language }) %>
           <% partial('navcollapse.ejs') %>
             <% partial('navitems.ejs', { align: 'start', items: nav.navbar.left, draftMode: nav.draftMode}) %>
@@ -39,6 +36,9 @@ const navbarTocRight = nav['toc-location'] === "right" || nav['toc-location'] ==
           </div> <!-- /navcollapse -->
           <% if (!nav.navbar["tools-collapse"]) { %> 
             <% partial('navtools.ejs', { align: 'none', tools: nav.navbar.tools, darkToggle: nav.navbar.darkToggle, readerToggle: nav.navbar.readerToggle, search: false, className: navbarToolsClass, language: nav.language }) %>
+          <% } %>
+          <% if (nav.navbar.search) { %>
+            <% partial('navsearch.ejs',  { classes: '', language: nav.language }) %>
           <% } %>
         <% } else { %>
           <% partial('navitems.ejs', { align: 'start', items: nav.navbar.left, draftMode: nav.draftMode}) %>

--- a/tests/docs/smoke-all/website/navbar-search-order/.gitignore
+++ b/tests/docs/smoke-all/website/navbar-search-order/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/tests/docs/smoke-all/website/navbar-search-order/_quarto.yml
+++ b/tests/docs/smoke-all/website/navbar-search-order/_quarto.yml
@@ -1,0 +1,14 @@
+project:
+  type: website
+  output-dir: .
+
+website:
+  title: "Website"
+  search: true
+  navbar:
+    left:
+      - href: index.qmd
+        text: Home
+    tools:
+      - icon: github
+        href: https://github.com/quarto-dev/quarto-cli

--- a/tests/docs/smoke-all/website/navbar-search-order/index.qmd
+++ b/tests/docs/smoke-all/website/navbar-search-order/index.qmd
@@ -1,0 +1,20 @@
+---
+title: "Website"
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        -
+          # search comes after the collapse (nav links) and the tools
+          - '#navbarCollapse ~ #quarto-search'
+          - '.quarto-navbar-tools ~ #quarto-search'
+        -
+          # search must not precede the nav links or the toggler
+          - '#quarto-search ~ #navbarCollapse'
+          - '#quarto-search ~ .navbar-toggler'
+---
+
+Regression test for issue 7058: in the navbar, the search div must come last
+in the DOM — after the toggler, the collapsible nav links, and the tools — so
+that keyboard/screen-reader order matches the visual order (the CSS `order`
+properties place search rightmost at every breakpoint; WCAG technique C27).


### PR DESCRIPTION
## Description

Closes #7058.

In a collapsible navbar, the search control (`#quarto-search`) came second in the DOM, right after the brand. CSS flex `order` places it visually at the far right. So keyboard and screen-reader users reached Search before the navigation links: brand → **Search** → Home → About → tools. The recommended way to make focus order match visual order is to align the DOM with it ([WCAG technique C27](https://www.w3.org/WAI/WCAG22/Techniques/css/C27)).

This PR moves the `navsearch.ejs` partial to the end of the collapse branch in `nav-before-body.ejs`, after the nav links and tools. The other two branches (non-collapse, no nav items) already emit search last. Tab order becomes: brand → nav links → tools → **Search**.

**No visual change.** Every navbar child has a distinct CSS `order` at every breakpoint (`quarto-nav.scss`, `quarto-search.scss`), so DOM order never decides layout. Checks done:

- Headless-Chrome screenshots at 1400px and 500px are byte-identical to a render without this change.
- Element geometry is identical with the mobile menu collapsed and expanded, and with `tools-collapse: true`.
- The search div stays a sibling of `#navbarCollapse`, outside the collapse region, so it stays visible at small widths.

**Possible downstream effects** (noted in the changelog):

- Custom CSS or JS that expects `#quarto-search` before the nav links in the DOM (for example, sibling selectors) needs an update.
- Custom themes that set two `$navbar-*-order` variables to the same value: a tie now resolves with search later. Stock themes have no ties.

Nothing in quarto-cli depends on the old position: `quarto-search.js` finds the div with `getElementById`, and no test or stylesheet uses structural selectors on the navbar.

**Tests:** the new smoke-all test `tests/docs/smoke-all/website/navbar-search-order/` asserts `#navbarCollapse ~ #quarto-search` and `.quarto-navbar-tools ~ #quarto-search`, and rejects the reverse orderings. It fails against the old template. All `smoke/site/` and `smoke/website/` tests pass (50), plus the `website` and `website-search` smoke-all documents (21).

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes
- [x] updated the appropriate changelog in the PR
- [x] ensured the present test suite passes
- [x] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR

<details>
<summary>AI-assisted PR</summary>

- **AI tool used**: Claude Code
- **Codebase grounding**: local clone
- **Human review**: I have reviewed, tested, and verified the AI-generated content before submitting.

</details>
