### PR TITLE
Defend against incorrect QUARTO_R

### DIFF
--- a/news/changelog-1.11.md
+++ b/news/changelog-1.11.md
@@ -8,4 +8,4 @@ All changes included in 1.11:
 
 ## Other fixes and improvements
 
-- Fix a crash when the `QUARTO_R` environment variable is set to a malformed path. Quarto now warns and falls back to other R lookup strategies instead of aborting the render.
+- [#14735](https://github.com/quarto-dev/quarto-cli/issues/14735) Fix a crash when the `QUARTO_R` environment variable is set to a malformed path. Quarto now warns and falls back to other R lookup strategies instead of aborting the render. ([posit-dev/positron#15614](https://github.com/posit-dev/positron/discussions/15614))

--- a/news/changelog-1.11.md
+++ b/news/changelog-1.11.md
@@ -5,3 +5,7 @@ All changes included in 1.11:
 ### `knitr`
 
 - ([#14735](https://github.com/quarto-dev/quarto-cli/issues/14735)): Fix `cache-globals` rejecting arrays and booleans, so it now accepts the same forms as `cache-vars` and as knitr itself. Previously only a single string validated, which rejected both `cache-globals: [var_1, var_2]` and the documented `cache-globals: false`.
+
+## Other fixes and improvements
+
+- Fix a crash when the `QUARTO_R` environment variable is set to a malformed path. Quarto now warns and falls back to other R lookup strategies instead of aborting the render.

--- a/src/core/resources.ts
+++ b/src/core/resources.ts
@@ -102,7 +102,9 @@ export async function rBinaryPath(
   const quartoR = Deno.env.get("QUARTO_R");
   debug(`Looking for '${binary}' in QUARTO_R: ${quartoR}`);
   if (quartoR) {
-    if (existsSync(quartoR)) {
+    // Use safeExistsSync: a malformed QUARTO_R (e.g. invalid path syntax)
+    // makes the raw existsSync throw instead of returning false.
+    if (safeExistsSync(quartoR)) {
       const rBinDir = Deno.statSync(quartoR).isDirectory
         ? quartoR
         : dirname(quartoR);


### PR DESCRIPTION
In the Positron discussion https://github.com/posit-dev/positron/discussions/15614, a user was unable to use Quarto due to a malformed `QUARTO_R` path; the exception that fires if `QUARTO_R` is malformed is never caught so it crashes Quarto.

This extremely minor change prevents a bad `QUARTO_R` from crashing Quarto so that a fallback R can be used.