### PR TITLE
Remove invalid `role="menu"` from the navbar collapse toggler

### DIFF
--- a/news/changelog-1.11.md
+++ b/news/changelog-1.11.md
@@ -1,10 +1,8 @@
 All changes included in 1.11:
 
-## Projects
+## Accessibility
 
-### `website`
-
-- ([#14615](https://github.com/quarto-dev/quarto-cli/issues/14615)): Fix invalid `role="menu"` on the navbar's collapse toggle button, flagged by axe-core (`aria-allowed-role`) and WAVE (`aria_menu_broken`) when the navbar collapses to the hamburger at narrow viewports.
+- ([#14615](https://github.com/quarto-dev/quarto-cli/issues/14615)): Fix invalid `role="menu"` on the website navbar's collapse toggle button, flagged by axe-core (`aria-allowed-role`) and WAVE (`aria_menu_broken`) when the navbar collapses to the hamburger at narrow viewports.
 
 ## Engines
 

--- a/news/changelog-1.11.md
+++ b/news/changelog-1.11.md
@@ -1,5 +1,11 @@
 All changes included in 1.11:
 
+## Projects
+
+### `website`
+
+- ([#14615](https://github.com/quarto-dev/quarto-cli/issues/14615)): Fix invalid `role="menu"` on the navbar's collapse toggle button, flagged by axe-core (`aria-allowed-role`) and WAVE (`aria_menu_broken`) when the navbar collapses to the hamburger at narrow viewports.
+
 ## Engines
 
 ### `knitr`

--- a/src/resources/projects/website/templates/navtoggle.ejs
+++ b/src/resources/projects/website/templates/navtoggle.ejs
@@ -1,5 +1,5 @@
 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse"
-  aria-controls="navbarCollapse" role="menu" aria-expanded="false" aria-label="<%- language['toggle-navigation'] %>"
+  aria-controls="navbarCollapse" aria-expanded="false" aria-label="<%- language['toggle-navigation'] %>"
   onclick="if (window.quartoToggleHeadroom) { window.quartoToggleHeadroom(); }">
   <span class="navbar-toggler-icon"></span>
 </button>

--- a/tests/docs/smoke-all/website/navbar-toggler-role/.gitignore
+++ b/tests/docs/smoke-all/website/navbar-toggler-role/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/tests/docs/smoke-all/website/navbar-toggler-role/.gitignore
+++ b/tests/docs/smoke-all/website/navbar-toggler-role/.gitignore
@@ -1,2 +1,3 @@
 /.quarto/
+/_site/
 **/*.quarto_ipynb

--- a/tests/docs/smoke-all/website/navbar-toggler-role/_quarto.yml
+++ b/tests/docs/smoke-all/website/navbar-toggler-role/_quarto.yml
@@ -1,0 +1,11 @@
+project:
+  type: website
+
+website:
+  title: "navbar-toggler-role"
+  navbar:
+    right:
+      - text: Home
+        href: index.qmd
+      - text: About
+        href: index.qmd

--- a/tests/docs/smoke-all/website/navbar-toggler-role/index.qmd
+++ b/tests/docs/smoke-all/website/navbar-toggler-role/index.qmd
@@ -1,0 +1,15 @@
+---
+title: "Home"
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        -
+          - 'button.navbar-toggler[aria-expanded][aria-controls][aria-label]'
+        -
+          - 'button.navbar-toggler[role]'
+---
+
+The navbar's collapse toggle button must keep its native button semantics:
+no `role` override (`role="menu"` is invalid on a button — #14615), with
+`aria-expanded`, `aria-controls`, and `aria-label` intact.


### PR DESCRIPTION

## Description

Fixes #14615.

The website navbar's hamburger toggle rendered as a `<button>` with `role="menu"`. That role is not valid on a button. axe-core reports it as `aria-allowed-role`. WAVE reports the same markup as an Error (`aria_menu_broken`), mapped to WCAG 2.2 SC 2.1.1 and 4.1.2, because a `menu` must contain at least one `menuitem` child. The toggle only appears when the navbar collapses at narrow viewports, so the violation only shows in mobile-width scans.

**Why the role was there.** #9553 (May 2024) added roles because Lighthouse reported that `role="button"` did not support `aria-expanded`. That was true under ARIA 1.1, which the axe-core of that time used. ARIA 1.2 permits `aria-expanded` on the `button` role, so the override is no longer needed. A second commit in #9553 already replaced `role="menu"` on the dropdown toggles with `role="link"`. The hamburger toggler was the one instance left.

**The fix.** Remove the `role` attribute. The button keeps `aria-controls`, `aria-expanded`, and its "Toggle navigation" label. This matches the markup in Bootstrap's own navbar documentation, which carries no `role`. A repo-wide search found no other `role="menu"`, and no CSS, JS, or test keys off it.

**Verification.** With the two-file repro from the issue at a 600 px viewport: 1 axe-core violation (`aria-allowed-role` on `.navbar-toggler`) before the fix, 0 after, with best-practice rules on. After the fix, a click still flips `aria-expanded` to `true` and opens the collapse.

**New test.** A website smoke-all test (`tests/docs/smoke-all/website/navbar-toggler-role/`) asserts that the rendered toggler carries `aria-expanded`, `aria-controls`, and `aria-label` but no `role` attribute. The fix is a static template change, so no browser test is needed. The test fails against the old markup (verified by temporarily restoring `role="menu"`).

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes
- [x] updated the appropriate changelog in the PR
- [x] ensured the present test suite passes
- [x] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR — not applicable: this PR changes internal navbar markup only, and no documented option or behavior changes

<details>
<summary>AI-assisted PR</summary>

- **AI tool used**: Claude Code
- **Codebase grounding**: local clone (git history of the template, repo-wide search, rendered repro)
- **Human review**: I have reviewed, tested, and verified the AI-generated content before submitting.

Note: autonomous AI agents submitting PRs without human oversight are not permitted — see the [Code of Conduct](CODE_OF_CONDUCT.md).

</details>
