### PR TITLE
Fix printCallRDiagnostics masking the original callR error

### DIFF
--- a/src/execute/rmd.ts
+++ b/src/execute/rmd.ts
@@ -500,50 +500,63 @@ function withinActiveRenv() {
   }
 }
 
-async function printCallRDiagnostics() {
-  const rBin = await checkRBinary();
-  if (rBin === undefined) {
-    info("");
-    info(rInstallationMessage());
-    info("");
-  } else {
-    const caps = await knitrCapabilities(rBin);
-    if (caps === undefined) {
-      info(
-        `Problem with running R found at ${rBin} to check environment configurations.`,
-      );
-      info("Please check your installation of R.");
+export async function printCallRDiagnostics(
+  checkRBinaryImpl: () => Promise<string | undefined> = checkRBinary,
+) {
+  // This re-enters R discovery to explain a callR failure. A throw here
+  // (e.g. from checkRBinaryImpl/rBinaryPath) must never replace the
+  // original callR error the caller is already reporting.
+  try {
+    const rBin = await checkRBinaryImpl();
+    if (rBin === undefined) {
+      info("");
+      info(rInstallationMessage());
       info("");
     } else {
-      if (
-        !caps?.packages.rmarkdown || !caps?.packages.knitr ||
-        !caps?.packages.knitrVersOk || !caps?.packages.rmarkdownVersOk
-      ) {
-        info("R installation:");
-        info(knitrCapabilitiesMessage(caps, "  "));
-        if (!!!caps?.packages.knitr || !caps?.packages.knitrVersOk) {
-          info("");
-          info(
-            knitrInstallationMessage(
-              "",
-              "knitr",
-              !!caps.packages.knitr && !caps.packages.knitrVersOk,
-            ),
-          );
-        }
-        if (!!!caps?.packages.rmarkdown || !caps?.packages.rmarkdownVersOk) {
-          info("");
-          info(
-            knitrInstallationMessage(
-              "",
-              "rmarkdown",
-              !!caps?.packages.rmarkdown && !caps?.packages.rmarkdownVersOk,
-            ),
-          );
-        }
+      const caps = await knitrCapabilities(rBin);
+      if (caps === undefined) {
+        info(
+          `Problem with running R found at ${rBin} to check environment configurations.`,
+        );
+        info("Please check your installation of R.");
         info("");
+      } else {
+        if (
+          !caps?.packages.rmarkdown || !caps?.packages.knitr ||
+          !caps?.packages.knitrVersOk || !caps?.packages.rmarkdownVersOk
+        ) {
+          info("R installation:");
+          info(knitrCapabilitiesMessage(caps, "  "));
+          if (!!!caps?.packages.knitr || !caps?.packages.knitrVersOk) {
+            info("");
+            info(
+              knitrInstallationMessage(
+                "",
+                "knitr",
+                !!caps.packages.knitr && !caps.packages.knitrVersOk,
+              ),
+            );
+          }
+          if (!!!caps?.packages.rmarkdown || !caps?.packages.rmarkdownVersOk) {
+            info("");
+            info(
+              knitrInstallationMessage(
+                "",
+                "rmarkdown",
+                !!caps?.packages.rmarkdown && !caps?.packages.rmarkdownVersOk,
+              ),
+            );
+          }
+          info("");
+        }
       }
     }
+  } catch (e) {
+    warning(
+      `Unable to gather R diagnostics: ${
+        e instanceof Error ? e.message : String(e)
+      }`,
+    );
   }
 }
 

--- a/tests/unit/print-call-r-diagnostics.test.ts
+++ b/tests/unit/print-call-r-diagnostics.test.ts
@@ -1,0 +1,31 @@
+/*
+ * print-call-r-diagnostics.test.ts
+ *
+ * Tests that a failure while gathering R diagnostics (e.g. checkRBinary
+ * throwing) never masks the original callR error.
+ * See https://github.com/quarto-dev/quarto-cli/issues/14775
+ *
+ * Copyright (C) 2026 Posit Software, PBC
+ */
+
+import { unitTest } from "../test.ts";
+import { assert } from "testing/asserts";
+import { printCallRDiagnostics } from "../../src/execute/rmd.ts";
+
+unitTest(
+  "printCallRDiagnostics - swallows a throw from R discovery",
+  async () => {
+    let threw = false;
+    try {
+      await printCallRDiagnostics(() => {
+        throw new Error("boom from checkRBinary");
+      });
+    } catch {
+      threw = true;
+    }
+    assert(
+      !threw,
+      "printCallRDiagnostics should not propagate a failure from R discovery",
+    );
+  },
+);


### PR DESCRIPTION
When callR fails, printCallRDiagnostics re-enters R discovery (checkRBinary -> rBinaryPath) to explain why. A throw during that re-entry propagates and replaces the original callR error, so the user only sees a failure from the diagnostics code instead of the real cause.

This is the second concern raised on #14775, alongside the malformed `QUARTO_R` crash fixed in #14790: `rBinaryPath` no longer throws for that specific case, but `printCallRDiagnostics` itself was never hardened against a throw anywhere in the discovery chain it re-enters.

Wraps `printCallRDiagnostics`'s body in try/catch and logs a warning on diagnostics failure instead of throwing over the original error.

Related to #14775