### PR TITLE
Fix dead toc_title auto-fallback in typst outline template

### DIFF
--- a/src/resources/formats/typst/pandoc/quarto/typst-template.typ
+++ b/src/resources/formats/typst/pandoc/quarto/typst-template.typ
@@ -128,7 +128,7 @@
     }
     block(above: 0em, below: 2em)[
     #outline(
-      title: toc_title,
+      title: title,
       depth: toc_depth,
       indent: toc_indent
     );

--- a/tests/docs/smoke-all/typst/toc/strip-toc-title.lua
+++ b/tests/docs/smoke-all/typst/toc/strip-toc-title.lua
@@ -1,5 +1,5 @@
--- Removes the toc-title metadata that Quarto fills in before Pandoc runs,
--- so the Typst template receives its own `toc_title: none` default.
+-- Removes the toc-title metadata that Quarto adds before Pandoc runs,
+-- causing article() to use its `toc_title: none` default.
 function Meta(meta)
   meta["toc-title"] = nil
   return meta

--- a/tests/docs/smoke-all/typst/toc/strip-toc-title.lua
+++ b/tests/docs/smoke-all/typst/toc/strip-toc-title.lua
@@ -1,0 +1,6 @@
+-- Removes the toc-title metadata that Quarto fills in before Pandoc runs,
+-- so the Typst template receives its own `toc_title: none` default.
+function Meta(meta)
+  meta["toc-title"] = nil
+  return meta
+end

--- a/tests/docs/smoke-all/typst/toc/toc-title-auto-fallback.qmd
+++ b/tests/docs/smoke-all/typst/toc/toc-title-auto-fallback.qmd
@@ -24,7 +24,7 @@ _quarto:
 ---
 
 Quarto fills `toc-title` with a localized default before Pandoc runs, so the
-Typst `article()` function normally always receives a `toc_title` argument.
-A user Lua `Meta` filter that removes the key is the one path that reaches the
-function's own `toc_title: none` default, which is where `outline(title: auto)`
-has to take over so the table of contents still gets a heading.
+Typst `article()` function normally receives a `toc_title` argument. This test
+uses a Lua `Meta` filter to remove the key and reach the function's own
+`toc_title: none` default. In that case, `outline(title: auto)` provides the
+table of contents heading.

--- a/tests/docs/smoke-all/typst/toc/toc-title-auto-fallback.qmd
+++ b/tests/docs/smoke-all/typst/toc/toc-title-auto-fallback.qmd
@@ -1,0 +1,30 @@
+---
+title: "TOC title auto fallback"
+lang: en
+toc: true
+format:
+  typst:
+    keep-typ: true
+    filters:
+      - strip-toc-title.lua
+_quarto:
+  tests:
+    typst:
+      ensureTypstFileRegexMatches:
+        - # Patterns that MUST be found
+          # The outline is emitted, so the `if toc` branch of article() ran
+          - '#outline\('
+        - # Patterns that must NOT be found
+          # No toc_title argument in the article() call: the filter removed the
+          # metadata, so article() falls back to its own `toc_title: none` default
+          - 'toc_title: \['
+      ensurePdfRegexMatches:
+        - # Typst's `auto` outline title for lang: en
+          - 'Contents'
+---
+
+Quarto fills `toc-title` with a localized default before Pandoc runs, so the
+Typst `article()` function normally always receives a `toc_title` argument.
+A user Lua `Meta` filter that removes the key is the one path that reaches the
+function's own `toc_title: none` default, which is where `outline(title: auto)`
+has to take over so the table of contents still gets a heading.


### PR DESCRIPTION
The typst toc block computes a fallback title (auto when toc_title is none) but passes toc_title directly to outline() instead of the computed local, so the fallback never applies.

Found while investigating #14786. Quarto always fills toc-title metadata before pandoc runs for a normal render, so this had no visible effect. A user Lua Meta filter that removes toc-title does reach the none case, which is the exact path #14786 is investigating.

Added a regression test that removes toc-title via a filter and asserts on the compiled PDF text, since asserting on the generated .typ source would just re-check the line the fix changed rather than the outline's actual rendered title.

Related to #14786