### PR TITLE
Fix bare CALL sites in configure.cmd that silently fail on Windows

### DIFF
--- a/configure.cmd
+++ b/configure.cmd
@@ -7,7 +7,7 @@ REM    using ! ! instead of % %. However, this only allows one level of expansio
 REM    try to create a variable that derives from a derived variable. It will be empty.
 
 call package\src\store_win_configuration.bat
-call win_configuration.bat
+call .\win_configuration.bat
 
 if NOT DEFINED QUARTO_VENDOR_BINARIES (
   set "QUARTO_VENDOR_BINARIES=true"
@@ -89,7 +89,7 @@ IF NOT DEFINED QUARTO_DENO_DIR (
 
 PUSHD !QUARTO_PACKAGE_PATH!\src
 ECHO Configuring Quarto from !cd!
-CALL quarto-bld.cmd configure --log-level info
+CALL .\quarto-bld.cmd configure --log-level info
 echo Configuration done
 
 POPD


### PR DESCRIPTION
When running configure.cmd on Windows, `call win_configuration.bat` and `CALL quarto-bld.cmd configure` both fail with "not recognized as an internal or external command", but neither failure is checked, so the script prints its usual success message and exits 0 without ever generating `package/dist/bin/quarto.cmd`.

## Root Cause

cmd.exe resolves a bare .bat/.cmd name (no path separator) through PATH search rather than the current directory. Every other CALL in configure.cmd targets a path with a separator (a relative subdir, a %~dp0-prefixed path, or a full path variable), which cmd.exe always resolves against the current directory - these two were the only bare ones.

## Fix

Prefix both call sites with .\ so they resolve as explicit relative paths instead of going through PATH search.

## Test Plan

- [x] Ran configure.cmd on a fresh unconfigured worktree; before the fix it errors with "not recognized" and package/dist/bin/quarto.cmd is never created
- [x] After the fix, the same fresh worktree run completes and produces package/dist/bin/quarto.cmd, with `quarto --version` printing correctly