### PR TITLE
Fix Firefox font-size precision failures in revealjs tests

### DIFF
--- a/tests/integration/playwright/src/utils.ts
+++ b/tests/integration/playwright/src/utils.ts
@@ -206,13 +206,22 @@ export async function getCSSProperty(loc: Locator, variable: string, asNumber = 
   }
 }
 
+// Different browser engines resolve compounding relative-unit (em/rem)
+// font-size cascades with slightly different subpixel rounding, so an
+// exact/decimal-precision comparison is too strict across Chromium/Firefox/WebKit.
+// Use a small fixed absolute tolerance instead — mirrors Playwright's own
+// pattern for cross-engine CSS/DIP rounding drift.
+export function expectCloseTo(actual: number, expected: number, tolerance: number = 0.1) {
+  expect(Math.abs(actual - expected)).toBeLessThanOrEqual(tolerance);
+}
+
 export async function checkCSSproperty(loc1: Locator, loc2: Locator, property: string, asNumber: false | true, checkType: 'identical' | 'similar', factor: number = 1) {
   let loc1Property = await getCSSProperty(loc1, property, asNumber);
   let loc2Property = await getCSSProperty(loc2, property, asNumber);
   if (checkType === 'identical') {
     await expect(loc2).toHaveCSS(property, loc1Property as string);
   } else {
-    await expect(loc1Property).toBeCloseTo(loc2Property as number * factor);
+    expectCloseTo(loc1Property as number, loc2Property as number * factor);
   }
 }
 

--- a/tests/integration/playwright/tests/revealjs-themes.spec.ts
+++ b/tests/integration/playwright/tests/revealjs-themes.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Locator } from '@playwright/test';
-import { asRGB, checkColor, checkColorIdentical, checkFontSizeSimilar, getCSSProperty, RGBColor } from '../src/utils';
+import { asRGB, checkColor, checkColorIdentical, checkFontSizeSimilar, expectCloseTo, getCSSProperty, RGBColor } from '../src/utils';
 
 async function getRevealMainFontSize(page: any): Promise<number> {
   return await getCSSProperty(page.locator('body'), "--r-main-font-size", true) as number;
@@ -25,9 +25,9 @@ test('Code font size in callouts and smaller slide is scaled down', async ({ pag
   const codeBlockFontSizeDefault = await getCSSProperty(page.locator('#highlighted-cell pre'), "font-size", true) as number;
   const codeInlineFontSizeDefault = await getCSSProperty(page.locator('#no-callout-inline').getByText('testthat::test_that()'), "font-size", true) as number;
   // Font size in callout for inline code should be scaled smaller than default inline code
-  expect(await getCSSProperty(page.locator('#callouts').getByText('testthat::test_that()'), "font-size", true)).toBeCloseTo(codeInlineFontSizeDefault * scaleFactor);
+  expectCloseTo(await getCSSProperty(page.locator('#callouts').getByText('testthat::test_that()'), "font-size", true) as number, codeInlineFontSizeDefault * scaleFactor);
   // Font size for code block in callout should be scaled smaller that default code block
-  expect(await getCSSProperty(page.locator('#callouts .callout pre code'), 'font-size', true)).toBeCloseTo(codeBlockFontSizeDefault * scaleFactor);
+  expectCloseTo(await getCSSProperty(page.locator('#callouts .callout pre code'), 'font-size', true) as number, codeBlockFontSizeDefault * scaleFactor);
   // Font size in callout for inline code should be samely size as text than by default
   const codeInlineFontSize = await getRevealCodeInlineFontSize(page);
   await checkFontSizeSimilar( 
@@ -48,9 +48,9 @@ test('Code font size in smaller slide is scaled down', async ({ page }) => {
   const codeBlockFontSizeDefault = await getCSSProperty(page.locator('#highlighted-cell pre'), "font-size", true) as number;
   const codeInlineFontSizeDefault = await getCSSProperty(page.locator('#no-callout-inline').getByText('testthat::test_that()'), "font-size", true) as number;
   // Font size in callout for inline code should be scaled smaller than default inline code
-  expect(await getCSSProperty(page.locator('#smaller-slide p').filter({ hasText: 'Some inline code' }).getByRole('code'), "font-size", true)).toBeCloseTo(codeInlineFontSizeDefault * scaleFactor);
+  expectCloseTo(await getCSSProperty(page.locator('#smaller-slide p').filter({ hasText: 'Some inline code' }).getByRole('code'), "font-size", true) as number, codeInlineFontSizeDefault * scaleFactor);
   // Font size for code block in callout should be scaled smaller that default code block
-  expect(await getCSSProperty(page.locator('#smaller-slide pre').getByRole('code'), 'font-size', true)).toBeCloseTo(codeBlockFontSizeDefault * scaleFactor);
+  expectCloseTo(await getCSSProperty(page.locator('#smaller-slide pre').getByRole('code'), 'font-size', true) as number, codeBlockFontSizeDefault * scaleFactor);
   // Font size in callout for inline code should be samely size as text than by default
   const codeInlineFontSize = await getRevealCodeInlineFontSize(page);
   await checkFontSizeSimilar( 


### PR DESCRIPTION
A scheduled CI run (https://github.com/quarto-dev/quarto-cli/actions/runs/34079745762) shows `revealjs-themes.spec.ts` failing on Firefox only, deterministically across all retries, with a ~0.006px difference on scaled code font-size.

## Root Cause

`getCSSProperty` in `tests/integration/playwright/src/utils.ts:197` reads `window.getComputedStyle(...)` directly, Playwright applies no rounding. The test computes its expected value with a single JS float multiply (`codeBlockFontSizeDefault * scaleFactor`), but the actual value comes from a real multi-level CSS cascade (`.reveal.smaller .slides section { font-size: 0.7em }` compounding with the `--r-block-code-font-size` em-based custom property). Each browser engine resolves that cascade with its own subpixel rounding, so Firefox lands ~0.006px off the JS approximation, past the default `toBeCloseTo` threshold (`numDigits=2`, 0.005 absolute).

Playwright's own test suite hits the same class of bug for CSS-to-DIP rounding drift across engines, and solves it with a fixed absolute pixel tolerance rather than `toBeCloseTo`'s decimal-digit precision.

## Fix

Add an `expectCloseTo` helper (0.1px absolute tolerance) in `utils.ts` and route all font-size comparisons in `revealjs-themes.spec.ts` and `checkCSSproperty` through it, replacing the decimal-precision `toBeCloseTo` calls.

Verified locally across chromium/firefox/webkit, and confirmed the tolerance still catches a real regression: manually widening the expected value by 1px made the assertion fail as expected.