### PR TITLE
Add characterization test for criClient's Chrome launch flags

### DIFF
--- a/tests/unit/chrome-launch-flags.test.ts
+++ b/tests/unit/chrome-launch-flags.test.ts
@@ -1,0 +1,162 @@
+/*
+ * chrome-launch-flags.test.ts
+ *
+ * Copyright (C) 2026 Posit Software, PBC
+ */
+
+import { assert, assertEquals, assertRejects } from "testing/asserts";
+import { stub } from "testing/mock";
+import { criClient } from "../../src/core/cri/cri.ts";
+import { findOpenPort } from "../../src/core/port.ts";
+import { unitTest } from "../test.ts";
+
+function fakeChildProcess(): Deno.ChildProcess {
+  return {
+    pid: 1,
+    status: Promise.resolve({ success: true, code: 0, signal: null }),
+    stdin: new WritableStream<Uint8Array>(),
+    stdout: new ReadableStream<Uint8Array>(),
+    stderr: new ReadableStream<Uint8Array>(),
+    kill: () => {},
+    ref: () => {},
+    unref: () => {},
+    output: () =>
+      Promise.resolve({
+        success: true,
+        code: 0,
+        signal: null,
+        stdout: new Uint8Array(),
+        stderr: new Uint8Array(),
+      }),
+  } as unknown as Deno.ChildProcess;
+}
+
+interface CapturedCommand {
+  app: string;
+  options: Deno.CommandOptions;
+}
+
+// Replaces the global Deno.Command constructor so criClient's real
+// argument-construction logic runs, but no OS process is ever spawned.
+// This patches the Deno namespace itself, so it intercepts the call no
+// matter which module in criClient's call graph performs it - load-bearing
+// for staying green across the shared-launcher refactor this test exists
+// to pin behaviour against.
+function stubDenoCommand(): { captured: CapturedCommand[]; restore: () => void } {
+  const captured: CapturedCommand[] = [];
+  // A plain `function`, not a `class`: std/testing/mock's stub() wraps the
+  // replacement in its own constructor function and invokes the underlying
+  // implementation via .apply(), which throws on an ES6 class ("Class
+  // constructor cannot be invoked without 'new'").
+  function FakeCommand(
+    this: { spawn: () => Deno.ChildProcess },
+    app: string,
+    options: Deno.CommandOptions,
+  ): void {
+    captured.push({ app, options });
+    this.spawn = () => fakeChildProcess();
+  }
+  const cmdStub = stub(
+    Deno,
+    "Command",
+    // deno-lint-ignore no-explicit-any
+    FakeCommand as unknown as (this: typeof Deno, ...args: unknown[]) => any,
+  );
+  return { captured, restore: () => cmdStub.restore() };
+}
+
+// criClient's readiness wait is a real fetch() against the port, so a real
+// server has to be listening. Bound-but-non-200 (rather than nothing
+// listening at all) matters for the rejection case: fetch() against a
+// closed localhost port on Windows takes over 2s to fail with
+// connection-refused, and criClient's retry loop counts a fixed 50ms per
+// attempt regardless of how long each fetch() actually took, so a closed
+// port would turn the nominal 3s readiness timeout into minutes of real
+// wall-clock time.
+async function withFakeChromeDevtoolsServer<T>(
+  port: number,
+  readyStatus: number,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const server = Deno.serve(
+    { port, onListen: () => {} },
+    (req: Request) => {
+      const url = new URL(req.url);
+      if (url.pathname === "/json/list") {
+        return new Response("[]", { status: readyStatus });
+      }
+      return new Response("", { status: 404 });
+    },
+  );
+  try {
+    return await fn();
+  } finally {
+    await server.shutdown();
+  }
+}
+
+unitTest(
+  "chrome-launch-flags - headless mode and required flags",
+  async () => {
+    const port = findOpenPort();
+    const { captured, restore } = stubDenoCommand();
+    // Read-only: never set/delete Deno.env in this suite. Test files share
+    // Deno.env under the default parallel runner, and save/restore doesn't
+    // help (see llm-docs/testing-patterns.md, "Environment Variable Testing
+    // Pitfalls") - a concurrent test elsewhere in the suite could observe a
+    // mutated value while this test is in flight. So this mirrors criClient's
+    // own default-substitution logic against whatever value is actually
+    // ambient, rather than forcing a specific one.
+    const ambientHeadlessMode = Deno.env.get("QUARTO_CHROMIUM_HEADLESS_MODE") ??
+      "none";
+    const expectedHeadlessFlag = ambientHeadlessMode === "none"
+      ? "--headless"
+      : `--headless=${ambientHeadlessMode}`;
+    try {
+      await withFakeChromeDevtoolsServer(
+        port,
+        200,
+        () => criClient("fake-chrome", port),
+      );
+    } finally {
+      restore();
+    }
+
+    assertEquals(captured.length, 1);
+    const { app, options } = captured[0];
+    assertEquals(app, "fake-chrome");
+    assertEquals(options.stdout, "piped");
+    assertEquals(options.stderr, "piped");
+
+    const argv = options.args as string[];
+    assert(
+      argv.includes(expectedHeadlessFlag),
+      `expected ${expectedHeadlessFlag} in ${JSON.stringify(argv)}`,
+    );
+    assert(argv.includes("--no-sandbox"));
+    assert(argv.includes("--disable-gpu"));
+    assert(argv.includes("--renderer-process-limit=1"));
+    assert(argv.includes(`--remote-debugging-port=${port}`));
+    assert(
+      !argv.some((a) => a.startsWith("--user-data-dir")),
+      `expected no --user-data-dir in ${JSON.stringify(argv)}`,
+    );
+  },
+);
+
+unitTest(
+  "chrome-launch-flags - Chrome that never becomes ready rejects instead of resolving",
+  async () => {
+    const port = findOpenPort();
+    const { restore } = stubDenoCommand();
+    try {
+      await withFakeChromeDevtoolsServer(
+        port,
+        404,
+        () => assertRejects(() => criClient("fake-chrome", port)),
+      );
+    } finally {
+      restore();
+    }
+  },
+);

--- a/tests/unit/chrome-launch-flags.test.ts
+++ b/tests/unit/chrome-launch-flags.test.ts
@@ -65,20 +65,22 @@ async function writeFakeChromeExecutable(
 // actually exited. Waiting on this (rather than a fixed delay after the
 // /shutdown request) avoids removing the temp dir while the still-running
 // process holds its script file open, which fails with "file in use" on
-// Windows.
+// Windows. Returns whether the port actually closed, so a stuck process
+// can be reported instead of failing silently.
 async function waitForPortClosed(
   port: number,
   timeoutMs = 2000,
-): Promise<void> {
+): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {
       await fetch(`http://localhost:${port}/json/list`);
     } catch {
-      return;
+      return true;
     }
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
+  return false;
 }
 
 unitTest(
@@ -125,8 +127,16 @@ unitTest(
       );
     } finally {
       await fetch(`http://localhost:${port}/shutdown`).catch(() => {});
-      await waitForPortClosed(port);
-      await Deno.remove(dir, { recursive: true }).catch(() => {});
+      const closed = await waitForPortClosed(port);
+      if (!closed) {
+        console.error(
+          `chrome-launch-flags: fake Chrome on port ${port} did not shut down; leaving ${dir} in place`,
+        );
+      } else {
+        await Deno.remove(dir, { recursive: true }).catch((e) => {
+          console.error(`chrome-launch-flags: failed to remove ${dir}: ${e}`);
+        });
+      }
     }
   },
 );

--- a/tests/unit/chrome-launch-flags.test.ts
+++ b/tests/unit/chrome-launch-flags.test.ts
@@ -88,6 +88,7 @@ unitTest(
   async () => {
     const port = findOpenPort();
     const dir = await Deno.makeTempDir({ prefix: "chrome-launch-flags-" });
+    let primaryError: unknown;
     try {
       const argvOutPath = join(dir, "argv.json");
       const fakeChrome = await writeFakeChromeExecutable(
@@ -125,18 +126,43 @@ unitTest(
         !argv.some((a) => a.startsWith("--user-data-dir")),
         `expected no --user-data-dir in ${JSON.stringify(argv)}`,
       );
-    } finally {
-      await fetch(`http://localhost:${port}/shutdown`).catch(() => {});
-      const closed = await waitForPortClosed(port);
-      if (!closed) {
-        console.error(
-          `chrome-launch-flags: fake Chrome on port ${port} did not shut down; leaving ${dir} in place`,
-        );
-      } else {
-        await Deno.remove(dir, { recursive: true }).catch((e) => {
-          console.error(`chrome-launch-flags: failed to remove ${dir}: ${e}`);
-        });
-      }
+    } catch (e) {
+      primaryError = e;
+    }
+
+    // Cleanup runs unconditionally, but a failure here must not silently
+    // hide a genuine assertion failure above (or vice versa) -- combine
+    // both into an AggregateError rather than letting one overwrite the
+    // other, which is what a second throw from a finally block would do.
+    const cleanupErrors: unknown[] = [];
+    await fetch(`http://localhost:${port}/shutdown`).catch(() => {});
+    const closed = await waitForPortClosed(port);
+    if (!closed) {
+      cleanupErrors.push(
+        new Error(
+          `fake Chrome on port ${port} did not shut down; left ${dir} in place`,
+        ),
+      );
+    } else {
+      await Deno.remove(dir, { recursive: true }).catch((e) => {
+        cleanupErrors.push(new Error(`failed to remove ${dir}: ${e}`));
+      });
+    }
+
+    if (primaryError !== undefined && cleanupErrors.length > 0) {
+      throw new AggregateError(
+        [primaryError, ...cleanupErrors],
+        "chrome-launch-flags test failed and cleanup also failed",
+      );
+    }
+    if (primaryError !== undefined) {
+      throw primaryError;
+    }
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError(
+        cleanupErrors,
+        "chrome-launch-flags cleanup failed",
+      );
     }
   },
 );

--- a/tests/unit/chrome-launch-flags.test.ts
+++ b/tests/unit/chrome-launch-flags.test.ts
@@ -14,8 +14,9 @@ import { unitTest } from "../test.ts";
 // Windows, a shebang script on Unix) that re-invokes the currently running
 // deno binary to run a small script. That script records its own argv --
 // exactly what criClient passed as Chrome's command line -- to a JSON file,
-// then serves /json/list so criClient's readiness check resolves. It
-// self-exits shortly after so no process lingers past the test.
+// then serves /json/list so criClient's readiness check resolves. A
+// /shutdown route lets the test terminate it deterministically instead of
+// guessing at a lifetime.
 async function writeFakeChromeExecutable(
   dir: string,
   argvOutPath: string,
@@ -33,10 +34,12 @@ async function writeFakeChromeExecutable(
       "  const url = new URL(req.url);",
       '  if (url.pathname === "/json/list") {',
       '    return new Response("[]", { status: 200 });',
+      '  } else if (url.pathname === "/shutdown") {',
+      "    setTimeout(() => Deno.exit(0), 50);",
+      '    return new Response("", { status: 200 });',
       "  }",
       '  return new Response("", { status: 404 });',
       "});",
-      "setTimeout(() => Deno.exit(0), 2000);",
     ].join("\n"),
   );
 
@@ -63,34 +66,46 @@ unitTest(
   async () => {
     const port = findOpenPort();
     const dir = await Deno.makeTempDir({ prefix: "chrome-launch-flags-" });
-    const argvOutPath = join(dir, "argv.json");
-    const fakeChrome = await writeFakeChromeExecutable(dir, argvOutPath, port);
+    try {
+      const argvOutPath = join(dir, "argv.json");
+      const fakeChrome = await writeFakeChromeExecutable(
+        dir,
+        argvOutPath,
+        port,
+      );
 
-    // Read-only: never set/delete Deno.env in this suite. Test files share
-    // Deno.env under the default parallel runner, and save/restore doesn't
-    // help (see llm-docs/testing-patterns.md, "Environment Variable Testing
-    // Pitfalls"). Mirror criClient's own default-substitution logic against
-    // whatever value is actually ambient, rather than forcing a specific one.
-    const ambientHeadlessMode =
-      Deno.env.get("QUARTO_CHROMIUM_HEADLESS_MODE") ?? "none";
-    const expectedHeadlessFlag = ambientHeadlessMode === "none"
-      ? "--headless"
-      : `--headless=${ambientHeadlessMode}`;
+      // Read-only: never set/delete Deno.env in this suite. Test files
+      // share Deno.env under the default parallel runner, and save/restore
+      // doesn't help (see llm-docs/testing-patterns.md, "Environment
+      // Variable Testing Pitfalls"). Mirror criClient's own
+      // default-substitution logic against whatever value is actually
+      // ambient, rather than forcing a specific one.
+      const ambientHeadlessMode =
+        Deno.env.get("QUARTO_CHROMIUM_HEADLESS_MODE") ?? "none";
+      const expectedHeadlessFlag = ambientHeadlessMode === "none"
+        ? "--headless"
+        : `--headless=${ambientHeadlessMode}`;
 
-    await criClient(fakeChrome, port);
+      await criClient(fakeChrome, port);
+      await fetch(`http://localhost:${port}/shutdown`);
 
-    const argv = JSON.parse(await Deno.readTextFile(argvOutPath)) as string[];
-    assert(
-      argv.includes(expectedHeadlessFlag),
-      `expected ${expectedHeadlessFlag} in ${JSON.stringify(argv)}`,
-    );
-    assert(argv.includes("--no-sandbox"));
-    assert(argv.includes("--disable-gpu"));
-    assert(argv.includes("--renderer-process-limit=1"));
-    assert(argv.includes(`--remote-debugging-port=${port}`));
-    assert(
-      !argv.some((a) => a.startsWith("--user-data-dir")),
-      `expected no --user-data-dir in ${JSON.stringify(argv)}`,
-    );
+      const argv = JSON.parse(
+        await Deno.readTextFile(argvOutPath),
+      ) as string[];
+      assert(
+        argv.includes(expectedHeadlessFlag),
+        `expected ${expectedHeadlessFlag} in ${JSON.stringify(argv)}`,
+      );
+      assert(argv.includes("--no-sandbox"));
+      assert(argv.includes("--disable-gpu"));
+      assert(argv.includes("--renderer-process-limit=1"));
+      assert(argv.includes(`--remote-debugging-port=${port}`));
+      assert(
+        !argv.some((a) => a.startsWith("--user-data-dir")),
+        `expected no --user-data-dir in ${JSON.stringify(argv)}`,
+      );
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
   },
 );

--- a/tests/unit/chrome-launch-flags.test.ts
+++ b/tests/unit/chrome-launch-flags.test.ts
@@ -61,6 +61,26 @@ async function writeFakeChromeExecutable(
   return shPath;
 }
 
+// Polls until the fake Chrome's port stops answering, i.e. the process has
+// actually exited. Waiting on this (rather than a fixed delay after the
+// /shutdown request) avoids removing the temp dir while the still-running
+// process holds its script file open, which fails with "file in use" on
+// Windows.
+async function waitForPortClosed(
+  port: number,
+  timeoutMs = 2000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(`http://localhost:${port}/json/list`);
+    } catch {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
 unitTest(
   "chrome-launch-flags - headless mode and required flags",
   async () => {
@@ -87,7 +107,6 @@ unitTest(
         : `--headless=${ambientHeadlessMode}`;
 
       await criClient(fakeChrome, port);
-      await fetch(`http://localhost:${port}/shutdown`);
 
       const argv = JSON.parse(
         await Deno.readTextFile(argvOutPath),
@@ -105,7 +124,9 @@ unitTest(
         `expected no --user-data-dir in ${JSON.stringify(argv)}`,
       );
     } finally {
-      await Deno.remove(dir, { recursive: true });
+      await fetch(`http://localhost:${port}/shutdown`).catch(() => {});
+      await waitForPortClosed(port);
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
     }
   },
 );

--- a/tests/unit/chrome-launch-flags.test.ts
+++ b/tests/unit/chrome-launch-flags.test.ts
@@ -4,131 +4,82 @@
  * Copyright (C) 2026 Posit Software, PBC
  */
 
-import { assert, assertEquals, assertRejects } from "testing/asserts";
-import { stub } from "testing/mock";
+import { assert } from "testing/asserts";
+import { join } from "path";
 import { criClient } from "../../src/core/cri/cri.ts";
 import { findOpenPort } from "../../src/core/port.ts";
 import { unitTest } from "../test.ts";
 
-function fakeChildProcess(): Deno.ChildProcess {
-  return {
-    pid: 1,
-    status: Promise.resolve({ success: true, code: 0, signal: null }),
-    stdin: new WritableStream<Uint8Array>(),
-    stdout: new ReadableStream<Uint8Array>(),
-    stderr: new ReadableStream<Uint8Array>(),
-    kill: () => {},
-    ref: () => {},
-    unref: () => {},
-    output: () =>
-      Promise.resolve({
-        success: true,
-        code: 0,
-        signal: null,
-        stdout: new Uint8Array(),
-        stderr: new Uint8Array(),
-      }),
-  } as unknown as Deno.ChildProcess;
-}
-
-interface CapturedCommand {
-  app: string;
-  options: Deno.CommandOptions;
-}
-
-// Replaces the global Deno.Command constructor so criClient's real
-// argument-construction logic runs, but no OS process is ever spawned.
-// This patches the Deno namespace itself, so it intercepts the call no
-// matter which module in criClient's call graph performs it - load-bearing
-// for staying green across the shared-launcher refactor this test exists
-// to pin behaviour against.
-function stubDenoCommand(): { captured: CapturedCommand[]; restore: () => void } {
-  const captured: CapturedCommand[] = [];
-  // A plain `function`, not a `class`: std/testing/mock's stub() wraps the
-  // replacement in its own constructor function and invokes the underlying
-  // implementation via .apply(), which throws on an ES6 class ("Class
-  // constructor cannot be invoked without 'new'").
-  function FakeCommand(
-    this: { spawn: () => Deno.ChildProcess },
-    app: string,
-    options: Deno.CommandOptions,
-  ): void {
-    captured.push({ app, options });
-    this.spawn = () => fakeChildProcess();
-  }
-  const cmdStub = stub(
-    Deno,
-    "Command",
-    // deno-lint-ignore no-explicit-any
-    FakeCommand as unknown as (this: typeof Deno, ...args: unknown[]) => any,
-  );
-  return { captured, restore: () => cmdStub.restore() };
-}
-
-// criClient's readiness wait is a real fetch() against the port, so a real
-// server has to be listening. Bound-but-non-200 (rather than nothing
-// listening at all) matters for the rejection case: fetch() against a
-// closed localhost port on Windows takes over 2s to fail with
-// connection-refused, and criClient's retry loop counts a fixed 50ms per
-// attempt regardless of how long each fetch() actually took, so a closed
-// port would turn the nominal 3s readiness timeout into minutes of real
-// wall-clock time.
-async function withFakeChromeDevtoolsServer<T>(
+// Generates a fake Chrome executable: a platform-native wrapper (.cmd on
+// Windows, a shebang script on Unix) that re-invokes the currently running
+// deno binary to run a small script. That script records its own argv --
+// exactly what criClient passed as Chrome's command line -- to a JSON file,
+// then serves /json/list so criClient's readiness check resolves. It
+// self-exits shortly after so no process lingers past the test.
+async function writeFakeChromeExecutable(
+  dir: string,
+  argvOutPath: string,
   port: number,
-  readyStatus: number,
-  fn: () => Promise<T>,
-): Promise<T> {
-  const server = Deno.serve(
-    { port, onListen: () => {} },
-    (req: Request) => {
-      const url = new URL(req.url);
-      if (url.pathname === "/json/list") {
-        return new Response("[]", { status: readyStatus });
-      }
-      return new Response("", { status: 404 });
-    },
+): Promise<string> {
+  const scriptPath = join(dir, "fake-chrome.js");
+  await Deno.writeTextFile(
+    scriptPath,
+    [
+      "const args = Deno.args;",
+      `await Deno.writeTextFile(${
+        JSON.stringify(argvOutPath)
+      }, JSON.stringify(args));`,
+      `Deno.serve({ port: ${port}, onListen: () => {} }, (req) => {`,
+      "  const url = new URL(req.url);",
+      '  if (url.pathname === "/json/list") {',
+      '    return new Response("[]", { status: 200 });',
+      "  }",
+      '  return new Response("", { status: 404 });',
+      "});",
+      "setTimeout(() => Deno.exit(0), 2000);",
+    ].join("\n"),
   );
-  try {
-    return await fn();
-  } finally {
-    await server.shutdown();
+
+  const deno = Deno.execPath();
+  if (Deno.build.os === "windows") {
+    const cmdPath = join(dir, "fake-chrome.cmd");
+    await Deno.writeTextFile(
+      cmdPath,
+      `@echo off\r\n"${deno}" run --allow-net --allow-write="${argvOutPath}" "${scriptPath}" %*\r\n`,
+    );
+    return cmdPath;
   }
+  const shPath = join(dir, "fake-chrome.sh");
+  await Deno.writeTextFile(
+    shPath,
+    `#!/bin/sh\n"${deno}" run --allow-net --allow-write="${argvOutPath}" "${scriptPath}" "$@"\n`,
+  );
+  await Deno.chmod(shPath, 0o755);
+  return shPath;
 }
 
 unitTest(
   "chrome-launch-flags - headless mode and required flags",
   async () => {
     const port = findOpenPort();
-    const { captured, restore } = stubDenoCommand();
+    const dir = await Deno.makeTempDir({ prefix: "chrome-launch-flags-" });
+    const argvOutPath = join(dir, "argv.json");
+    const fakeChrome = await writeFakeChromeExecutable(dir, argvOutPath, port);
+
     // Read-only: never set/delete Deno.env in this suite. Test files share
     // Deno.env under the default parallel runner, and save/restore doesn't
     // help (see llm-docs/testing-patterns.md, "Environment Variable Testing
-    // Pitfalls") - a concurrent test elsewhere in the suite could observe a
-    // mutated value while this test is in flight. So this mirrors criClient's
-    // own default-substitution logic against whatever value is actually
-    // ambient, rather than forcing a specific one.
-    const ambientHeadlessMode = Deno.env.get("QUARTO_CHROMIUM_HEADLESS_MODE") ??
-      "none";
+    // Pitfalls"). Mirror criClient's own default-substitution logic against
+    // whatever value is actually ambient, rather than forcing a specific one.
+    const ambientHeadlessMode =
+      Deno.env.get("QUARTO_CHROMIUM_HEADLESS_MODE") ?? "none";
     const expectedHeadlessFlag = ambientHeadlessMode === "none"
       ? "--headless"
       : `--headless=${ambientHeadlessMode}`;
-    try {
-      await withFakeChromeDevtoolsServer(
-        port,
-        200,
-        () => criClient("fake-chrome", port),
-      );
-    } finally {
-      restore();
-    }
 
-    assertEquals(captured.length, 1);
-    const { app, options } = captured[0];
-    assertEquals(app, "fake-chrome");
-    assertEquals(options.stdout, "piped");
-    assertEquals(options.stderr, "piped");
+    await criClient(fakeChrome, port);
 
-    const argv = options.args as string[];
+    const argv = JSON.parse(await Deno.readTextFile(argvOutPath)) as string[];
     assert(
       argv.includes(expectedHeadlessFlag),
       `expected ${expectedHeadlessFlag} in ${JSON.stringify(argv)}`,
@@ -141,22 +92,5 @@ unitTest(
       !argv.some((a) => a.startsWith("--user-data-dir")),
       `expected no --user-data-dir in ${JSON.stringify(argv)}`,
     );
-  },
-);
-
-unitTest(
-  "chrome-launch-flags - Chrome that never becomes ready rejects instead of resolving",
-  async () => {
-    const port = findOpenPort();
-    const { restore } = stubDenoCommand();
-    try {
-      await withFakeChromeDevtoolsServer(
-        port,
-        404,
-        () => assertRejects(() => criClient("fake-chrome", port)),
-      );
-    } finally {
-      restore();
-    }
   },
 );


### PR DESCRIPTION
PR #14835 moves criClient's Chrome argument-building into a shared launcher. This pins criClient's current command-line flags first, so that refactor can be verified as behavior-preserving rather than trusted by inspection.

The test spawns a generated fake Chrome executable instead of mocking `Deno.Command`, so it observes the same argv contract any real Chrome launch depends on, independent of which module ends up building it -- surviving the refactor without needing to change.