### PR TITLE
[backport] Fix chrome-headless-shell install on Linux arm64

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -3,6 +3,7 @@
 ## In this release
 
 - ([#14741](https://github.com/quarto-dev/quarto-cli/issues/14741)): Don't wrap the `longtable` environment of a cross-referenceable table in a `{ ... }` group. Pandoc emits that group to scope its `\def\LTcaptype{none}`, which Quarto removes when adding its own `\caption`; keeping the now-pointless group broke packages that move the environment out of the text flow, such as `endfloat` with `\DeclareDelayedFloatFlavor*{longtable}{table}`.
+- ([#14857](https://github.com/quarto-dev/quarto-cli/issues/14857)): Fix `quarto install chrome-headless-shell` (and `quarto install chromium`) failing with a 404 on Linux arm64 due to a stale Playwright CDN URL.
 
 ## In previous releases
 

--- a/src/tools/impl/chrome-for-testing.ts
+++ b/src/tools/impl/chrome-for-testing.ts
@@ -130,19 +130,18 @@ export async function fetchLatestCftRelease(): Promise<CftStableRelease> {
 
 /** Parsed entry from Playwright's browsers.json for chromium-headless-shell. */
 export interface PlaywrightBrowserEntry {
-  revision: string;
   browserVersion: string;
 }
 
 // Source: https://github.com/microsoft/playwright/blob/main/packages/playwright-core/browsers.json
-// This file lists the browser revisions Playwright pins per release, including
+// This file lists the browser versions Playwright pins per release, including
 // chromium-headless-shell builds for linux arm64 that CfT does not provide.
 const kPlaywrightBrowsersJsonUrl =
   "https://raw.githubusercontent.com/microsoft/playwright/main/packages/playwright-core/browsers.json";
 
 /**
  * Fetch Playwright's browsers.json and extract the chromium-headless-shell entry.
- * Used as the version/revision source for arm64 Linux where CfT has no builds.
+ * Used as the version source for arm64 Linux where CfT has no builds.
  */
 export async function fetchPlaywrightBrowsersJson(): Promise<PlaywrightBrowserEntry> {
   let response: Response;
@@ -179,24 +178,26 @@ export async function fetchPlaywrightBrowsersJson(): Promise<PlaywrightBrowserEn
 
   // deno-lint-ignore no-explicit-any
   const entry = browsers.find((b: any) => b.name === "chromium-headless-shell");
-  if (!entry || !entry.revision || !entry.browserVersion) {
+  if (!entry || !entry.browserVersion) {
     throw new Error(
-      "Playwright browsers.json has no 'chromium-headless-shell' entry with revision and browserVersion",
+      "Playwright browsers.json has no 'chromium-headless-shell' entry with browserVersion",
     );
   }
 
   return {
-    revision: entry.revision,
     browserVersion: entry.browserVersion,
   };
 }
 
 /**
  * Construct the Playwright CDN download URL for chrome-headless-shell on linux arm64.
- * Uses the primary CDN mirror (cdn.playwright.dev).
+ * Uses the primary CDN mirror (cdn.playwright.dev). Matches Playwright's own
+ * registry (packages/playwright-core/src/server/registry/index.ts, cftUrl),
+ * which keys builds by browserVersion under the "cft" path, not the legacy
+ * revision-keyed "chromium" path.
  */
-export function playwrightCdnDownloadUrl(revision: string): string {
-  return `https://cdn.playwright.dev/builds/chromium/${revision}/chromium-headless-shell-linux-arm64.zip`;
+export function playwrightCdnDownloadUrl(browserVersion: string): string {
+  return `https://cdn.playwright.dev/builds/cft/${browserVersion}/linux-arm64/chrome-headless-shell-linux-arm64.zip`;
 }
 
 /**

--- a/src/tools/impl/chrome-headless-shell-paths.ts
+++ b/src/tools/impl/chrome-headless-shell-paths.ts
@@ -11,10 +11,7 @@
 import { join } from "../../deno_ral/path.ts";
 import { existsSync } from "../../deno_ral/fs.ts";
 import { quartoDataDir } from "../../core/appdirs.ts";
-import {
-  findChromeExecutable,
-  isPlaywrightCdnPlatform,
-} from "./chrome-for-testing.ts";
+import { findChromeExecutable } from "./chrome-for-testing.ts";
 
 const kVersionFileName = "version";
 
@@ -24,16 +21,13 @@ export function chromeHeadlessShellInstallDir(): string {
 }
 
 /**
- * The executable name for chrome-headless-shell on the current platform.
- * CfT builds use "chrome-headless-shell", Playwright arm64 builds use "headless_shell".
- * Returns the CfT name if platform detection fails (unsupported platform).
+ * The executable name for chrome-headless-shell.
+ * The Playwright CDN arm64 mirror redirects to the same chrome-for-testing-public
+ * bucket used for every other platform, so it shares the "chrome-headless-shell"
+ * binary name too.
  */
 export function chromeHeadlessShellBinaryName(): string {
-  try {
-    return isPlaywrightCdnPlatform() ? "headless_shell" : "chrome-headless-shell";
-  } catch {
-    return "chrome-headless-shell";
-  }
+  return "chrome-headless-shell";
 }
 
 /**

--- a/src/tools/impl/chrome-headless-shell-paths.ts
+++ b/src/tools/impl/chrome-headless-shell-paths.ts
@@ -11,9 +11,34 @@
 import { join } from "../../deno_ral/path.ts";
 import { existsSync } from "../../deno_ral/fs.ts";
 import { quartoDataDir } from "../../core/appdirs.ts";
-import { findChromeExecutable } from "./chrome-for-testing.ts";
+import {
+  findChromeExecutable,
+  isPlaywrightCdnPlatform,
+} from "./chrome-for-testing.ts";
 
 const kVersionFileName = "version";
+
+/**
+ * Binary name used by the Playwright-hosted arm64 archives that predate
+ * Playwright's move to the browserVersion-keyed builds/cft/ CDN path. Those
+ * archives shipped Playwright's own package layout — chrome-linux/headless_shell
+ * — instead of the CfT layout every platform (arm64 included) gets today.
+ * Installs made in that window are still on disk and must stay detectable.
+ */
+const kLegacyPlaywrightBinaryName = "headless_shell";
+
+/**
+ * Whether the legacy Playwright arm64 layout is worth probing for on this host.
+ * isPlaywrightCdnPlatform() throws on unsupported os/arch combinations, in which
+ * case no Quarto-installed arm64 binary can exist here anyway.
+ */
+function hostMayHaveLegacyPlaywrightLayout(): boolean {
+  try {
+    return isPlaywrightCdnPlatform();
+  } catch {
+    return false;
+  }
+}
 
 /** Return the chrome-headless-shell install directory under quartoDataDir. */
 export function chromeHeadlessShellInstallDir(): string {
@@ -31,6 +56,28 @@ export function chromeHeadlessShellBinaryName(): string {
 }
 
 /**
+ * Locate the chrome-headless-shell binary inside an install directory.
+ * Prefers the current CfT layout; on arm64 Linux also accepts the legacy
+ * Playwright layout left behind by pre-CDN-migration installs.
+ *
+ * allowLegacyPlaywrightLayout defaults to host detection and exists as an
+ * explicit parameter so the arm64 branch is reachable from tests on any host.
+ */
+export function findChromeHeadlessShellExecutable(
+  dir: string,
+  allowLegacyPlaywrightLayout: boolean = hostMayHaveLegacyPlaywrightLayout(),
+): string | undefined {
+  const found = findChromeExecutable(dir, chromeHeadlessShellBinaryName());
+  if (found !== undefined) {
+    return found;
+  }
+  if (allowLegacyPlaywrightLayout) {
+    return findChromeExecutable(dir, kLegacyPlaywrightBinaryName);
+  }
+  return undefined;
+}
+
+/**
  * Find the chrome-headless-shell executable in the install directory.
  * Returns the absolute path if installed, undefined otherwise.
  */
@@ -39,7 +86,7 @@ export function chromeHeadlessShellExecutablePath(): string | undefined {
   if (!existsSync(dir)) {
     return undefined;
   }
-  return findChromeExecutable(dir, chromeHeadlessShellBinaryName());
+  return findChromeHeadlessShellExecutable(dir);
 }
 
 /** Record the installed version as a plain text file. */
@@ -58,7 +105,11 @@ export function readInstalledVersion(dir: string): string | undefined {
 }
 
 /** Check if chrome-headless-shell is installed in the given directory. */
-export function isInstalled(dir: string): boolean {
+export function isInstalled(
+  dir: string,
+  allowLegacyPlaywrightLayout?: boolean,
+): boolean {
   return existsSync(join(dir, kVersionFileName)) &&
-    findChromeExecutable(dir, chromeHeadlessShellBinaryName()) !== undefined;
+    findChromeHeadlessShellExecutable(dir, allowLegacyPlaywrightLayout) !==
+      undefined;
 }

--- a/src/tools/impl/chrome-headless-shell.ts
+++ b/src/tools/impl/chrome-headless-shell.ts
@@ -58,7 +58,7 @@ async function latestRelease(): Promise<RemotePackageInfo> {
   if (isPlaywrightCdnPlatform(platformInfo)) {
     // arm64 Linux: use Playwright CDN
     const entry = await fetchPlaywrightBrowsersJson();
-    const url = playwrightCdnDownloadUrl(entry.revision);
+    const url = playwrightCdnDownloadUrl(entry.browserVersion);
     return {
       url,
       version: entry.browserVersion,

--- a/tests/unit/tools/chrome-for-testing.test.ts
+++ b/tests/unit/tools/chrome-for-testing.test.ts
@@ -130,25 +130,6 @@ unitTest("findChromeExecutable - finds binary in nested structure", async () => 
   }
 });
 
-// Step 3b: findChromeExecutable() — Playwright arm64 layout
-// Skip on Windows: arm64 layout is Linux-only, no .exe extension.
-unitTest("findChromeExecutable - finds binary in Playwright arm64 layout", async () => {
-  if (isWindows) return; // arm64 layout is Linux-only
-  const tempDir = Deno.makeTempDirSync();
-  try {
-    // Playwright arm64 extracts to chrome-linux/headless_shell
-    const subdir = join(tempDir, "chrome-linux");
-    Deno.mkdirSync(subdir);
-    Deno.writeTextFileSync(join(subdir, "headless_shell"), "fake binary");
-
-    const found = findChromeExecutable(tempDir, "headless_shell");
-    assert(found !== undefined, "should find headless_shell in chrome-linux/");
-    assert(found!.endsWith("headless_shell"), `should end with headless_shell, got: ${found}`);
-  } finally {
-    safeRemoveSync(tempDir, { recursive: true });
-  }
-});
-
 // Playwright CDN tests
 // Skipped on CI: makes external HTTP calls to GitHub/Playwright CDN.
 // Same pattern as CfT API tests above — run locally to catch API contract changes.

--- a/tests/unit/tools/chrome-for-testing.test.ts
+++ b/tests/unit/tools/chrome-for-testing.test.ts
@@ -154,11 +154,6 @@ unitTest("findChromeExecutable - finds binary in Playwright arm64 layout", async
 // Same pattern as CfT API tests above — run locally to catch API contract changes.
 unitTest("fetchPlaywrightBrowsersJson - returns chromium-headless-shell entry", async () => {
   const entry = await fetchPlaywrightBrowsersJson();
-  assert(entry.revision, "revision should be non-empty");
-  assert(
-    /^\d+$/.test(entry.revision),
-    `revision should be numeric, got: ${entry.revision}`,
-  );
   assert(entry.browserVersion, "browserVersion should be non-empty");
   assert(
     /^\d+\.\d+\.\d+\.\d+$/.test(entry.browserVersion),
@@ -167,17 +162,17 @@ unitTest("fetchPlaywrightBrowsersJson - returns chromium-headless-shell entry", 
 }, { ignore: runningInCI() });
 
 unitTest("playwrightCdnDownloadUrl - constructs correct arm64 URL", async () => {
-  const url = playwrightCdnDownloadUrl("1219");
+  const url = playwrightCdnDownloadUrl("121.0.6167.85");
   assert(
     url.startsWith("https://cdn.playwright.dev/"),
     `URL should start with cdn.playwright.dev, got: ${url}`,
   );
   assert(
-    url.includes("/builds/chromium/1219/"),
-    `URL should contain revision path, got: ${url}`,
+    url.includes("/builds/cft/121.0.6167.85/linux-arm64/"),
+    `URL should contain browserVersion path, got: ${url}`,
   );
   assert(
-    url.endsWith("chromium-headless-shell-linux-arm64.zip"),
+    url.endsWith("chrome-headless-shell-linux-arm64.zip"),
     `URL should end with arm64 zip name, got: ${url}`,
   );
 });

--- a/tests/unit/tools/chrome-headless-shell.test.ts
+++ b/tests/unit/tools/chrome-headless-shell.test.ts
@@ -139,10 +139,9 @@ unitTest("latestRelease - returns valid RemotePackageInfo", async () => {
     `version format wrong: ${release.version}`,
   );
   assert(release.url.startsWith("https://"), `URL should be https: ${release.url}`);
-  // CfT URLs contain the version; Playwright CDN URLs contain a revision number instead
-  if (!isPlaywrightCdnPlatform()) {
-    assert(release.url.includes(release.version), "CfT URL should contain version");
-  } else {
+  // Both CfT and Playwright CDN URLs contain the browserVersion
+  assert(release.url.includes(release.version), "URL should contain version");
+  if (isPlaywrightCdnPlatform()) {
     assert(release.url.includes("cdn.playwright.dev"), "arm64 URL should use Playwright CDN");
   }
   assert(release.assets.length > 0, "should have at least one asset");
@@ -155,14 +154,14 @@ unitTest("latestRelease - returns valid RemotePackageInfo", async () => {
 
 unitTest("Playwright CDN - browsers.json and URL construction", async () => {
   const entry = await fetchPlaywrightBrowsersJson();
-  const url = playwrightCdnDownloadUrl(entry.revision);
+  const url = playwrightCdnDownloadUrl(entry.browserVersion);
   assert(
     /^\d+\.\d+\.\d+\.\d+$/.test(entry.browserVersion),
     `browserVersion format wrong: ${entry.browserVersion}`,
   );
   assert(
-    url.includes(entry.revision),
-    `URL should contain revision ${entry.revision}`,
+    url.includes(entry.browserVersion),
+    `URL should contain browserVersion ${entry.browserVersion}`,
   );
   assert(
     url.includes("linux-arm64"),

--- a/tests/unit/tools/chrome-headless-shell.test.ts
+++ b/tests/unit/tools/chrome-headless-shell.test.ts
@@ -24,6 +24,7 @@ import {
   chromeHeadlessShellBinaryName,
   chromeHeadlessShellInstallDir,
   chromeHeadlessShellExecutablePath,
+  findChromeHeadlessShellExecutable,
   isInstalled,
   noteInstalledVersion,
   readInstalledVersion,
@@ -124,6 +125,107 @@ unitTest("isInstalled - returns true when version file and binary exist", async 
     Deno.writeTextFileSync(join(subdir, target), "fake");
 
     assertEquals(isInstalled(tempDir), true);
+  } finally {
+    safeRemoveSync(tempDir, { recursive: true });
+  }
+});
+
+// -- Step 3b: legacy Playwright arm64 layout (backward compatibility) --
+//
+// Linux arm64 installs made before Playwright's CDN moved to the
+// browserVersion-keyed builds/cft/ path (roughly 2026-04 through 2026-08-31)
+// extracted Playwright's own package layout: chrome-linux/headless_shell.
+// Current installs use the CfT layout chrome-headless-shell-linux-arm64/
+// chrome-headless-shell. Detection has to keep recognising the old layout,
+// otherwise a machine with a perfectly good binary on disk falls through to
+// system-Chrome detection and every Chrome-backed render dies with
+// "Chrome not found".
+//
+// allowLegacyPlaywrightLayout is passed explicitly in these tests because the
+// default is derived from isPlaywrightCdnPlatform(), which auto-detects the
+// *host* platform — so the arm64 branch is otherwise unreachable here.
+
+// Legacy fixture: chrome-linux/headless_shell. findChromeExecutable appends
+// ".exe" whenever the host is Windows, so the fixture matches that to exercise
+// the same code path off-Linux.
+function writeLegacyPlaywrightFixture(dir: string): string {
+  const legacyDir = join(dir, "chrome-linux");
+  Deno.mkdirSync(legacyDir, { recursive: true });
+  const target = isWindows ? "headless_shell.exe" : "headless_shell";
+  const path = join(legacyDir, target);
+  Deno.writeTextFileSync(path, "fake");
+  return path;
+}
+
+// Current CfT fixture: chrome-headless-shell-{platform}/chrome-headless-shell.
+function writeCftFixture(dir: string): string {
+  const { platform } = detectChromePlatform();
+  const binName = chromeHeadlessShellBinaryName();
+  const subdir = join(dir, `chrome-headless-shell-${platform}`);
+  Deno.mkdirSync(subdir, { recursive: true });
+  const target = isWindows ? `${binName}.exe` : binName;
+  const path = join(subdir, target);
+  Deno.writeTextFileSync(path, "fake");
+  return path;
+}
+
+unitTest("findChromeHeadlessShellExecutable - finds legacy Playwright arm64 layout", async () => {
+  const tempDir = Deno.makeTempDirSync();
+  try {
+    const legacyPath = writeLegacyPlaywrightFixture(tempDir);
+
+    // Sanity check: the current binary name genuinely cannot see the legacy
+    // file, since findChromeExecutable matches on exact basename.
+    assertEquals(
+      findChromeExecutable(tempDir, chromeHeadlessShellBinaryName()),
+      undefined,
+      "sanity check: current binary name must not match headless_shell",
+    );
+
+    const found = findChromeHeadlessShellExecutable(tempDir, true);
+    assertEquals(found, legacyPath);
+  } finally {
+    safeRemoveSync(tempDir, { recursive: true });
+  }
+});
+
+unitTest("findChromeHeadlessShellExecutable - ignores legacy layout when legacy lookup is off", async () => {
+  const tempDir = Deno.makeTempDirSync();
+  try {
+    writeLegacyPlaywrightFixture(tempDir);
+    assertEquals(findChromeHeadlessShellExecutable(tempDir, false), undefined);
+  } finally {
+    safeRemoveSync(tempDir, { recursive: true });
+  }
+});
+
+unitTest("findChromeHeadlessShellExecutable - prefers current CfT layout over legacy", async () => {
+  const tempDir = Deno.makeTempDirSync();
+  try {
+    const cftPath = writeCftFixture(tempDir);
+    writeLegacyPlaywrightFixture(tempDir);
+    assertEquals(findChromeHeadlessShellExecutable(tempDir, true), cftPath);
+  } finally {
+    safeRemoveSync(tempDir, { recursive: true });
+  }
+});
+
+unitTest("isInstalled - returns true for legacy Playwright arm64 layout", async () => {
+  const tempDir = Deno.makeTempDirSync();
+  try {
+    noteInstalledVersion(tempDir, "140.0.7259.2");
+    writeLegacyPlaywrightFixture(tempDir);
+    assertEquals(isInstalled(tempDir, true), true);
+  } finally {
+    safeRemoveSync(tempDir, { recursive: true });
+  }
+});
+
+unitTest("isInstalled - returns false for legacy layout with no version file", async () => {
+  const tempDir = Deno.makeTempDirSync();
+  try {
+    writeLegacyPlaywrightFixture(tempDir);
+    assertEquals(isInstalled(tempDir, true), false);
   } finally {
     safeRemoveSync(tempDir, { recursive: true });
   }

--- a/tests/unit/tools/chrome-headless-shell.test.ts
+++ b/tests/unit/tools/chrome-headless-shell.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { unitTest } from "../../test.ts";
+import { withTempDir } from "../../utils.ts";
 import { assert, assertEquals } from "testing/asserts";
 import { join } from "../../../src/deno_ral/path.ts";
 import { existsSync, safeRemoveSync } from "../../../src/deno_ral/fs.ts";
@@ -169,67 +170,62 @@ function writeCftFixture(dir: string): string {
   return path;
 }
 
-unitTest("findChromeHeadlessShellExecutable - finds legacy Playwright arm64 layout", async () => {
-  const tempDir = Deno.makeTempDirSync();
-  try {
-    const legacyPath = writeLegacyPlaywrightFixture(tempDir);
+unitTest(
+  "findChromeHeadlessShellExecutable - finds legacy Playwright arm64 layout",
+  () =>
+    withTempDir((tempDir) => {
+      const legacyPath = writeLegacyPlaywrightFixture(tempDir);
 
-    // Sanity check: the current binary name genuinely cannot see the legacy
-    // file, since findChromeExecutable matches on exact basename.
-    assertEquals(
-      findChromeExecutable(tempDir, chromeHeadlessShellBinaryName()),
-      undefined,
-      "sanity check: current binary name must not match headless_shell",
-    );
+      // Sanity check: the current binary name genuinely cannot see the legacy
+      // file, since findChromeExecutable matches on exact basename.
+      assertEquals(
+        findChromeExecutable(tempDir, chromeHeadlessShellBinaryName()),
+        undefined,
+        "sanity check: current binary name must not match headless_shell",
+      );
 
-    const found = findChromeHeadlessShellExecutable(tempDir, true);
-    assertEquals(found, legacyPath);
-  } finally {
-    safeRemoveSync(tempDir, { recursive: true });
-  }
-});
+      const found = findChromeHeadlessShellExecutable(tempDir, true);
+      assertEquals(found, legacyPath);
+    }),
+);
 
-unitTest("findChromeHeadlessShellExecutable - ignores legacy layout when legacy lookup is off", async () => {
-  const tempDir = Deno.makeTempDirSync();
-  try {
-    writeLegacyPlaywrightFixture(tempDir);
-    assertEquals(findChromeHeadlessShellExecutable(tempDir, false), undefined);
-  } finally {
-    safeRemoveSync(tempDir, { recursive: true });
-  }
-});
+unitTest(
+  "findChromeHeadlessShellExecutable - ignores legacy layout when legacy lookup is off",
+  () =>
+    withTempDir((tempDir) => {
+      writeLegacyPlaywrightFixture(tempDir);
+      assertEquals(findChromeHeadlessShellExecutable(tempDir, false), undefined);
+    }),
+);
 
-unitTest("findChromeHeadlessShellExecutable - prefers current CfT layout over legacy", async () => {
-  const tempDir = Deno.makeTempDirSync();
-  try {
-    const cftPath = writeCftFixture(tempDir);
-    writeLegacyPlaywrightFixture(tempDir);
-    assertEquals(findChromeHeadlessShellExecutable(tempDir, true), cftPath);
-  } finally {
-    safeRemoveSync(tempDir, { recursive: true });
-  }
-});
+unitTest(
+  "findChromeHeadlessShellExecutable - prefers current CfT layout over legacy",
+  () =>
+    withTempDir((tempDir) => {
+      const cftPath = writeCftFixture(tempDir);
+      writeLegacyPlaywrightFixture(tempDir);
+      assertEquals(findChromeHeadlessShellExecutable(tempDir, true), cftPath);
+    }),
+);
 
-unitTest("isInstalled - returns true for legacy Playwright arm64 layout", async () => {
-  const tempDir = Deno.makeTempDirSync();
-  try {
-    noteInstalledVersion(tempDir, "140.0.7259.2");
-    writeLegacyPlaywrightFixture(tempDir);
-    assertEquals(isInstalled(tempDir, true), true);
-  } finally {
-    safeRemoveSync(tempDir, { recursive: true });
-  }
-});
+unitTest(
+  "isInstalled - returns true for legacy Playwright arm64 layout",
+  () =>
+    withTempDir((tempDir) => {
+      noteInstalledVersion(tempDir, "140.0.7259.2");
+      writeLegacyPlaywrightFixture(tempDir);
+      assertEquals(isInstalled(tempDir, true), true);
+    }),
+);
 
-unitTest("isInstalled - returns false for legacy layout with no version file", async () => {
-  const tempDir = Deno.makeTempDirSync();
-  try {
-    writeLegacyPlaywrightFixture(tempDir);
-    assertEquals(isInstalled(tempDir, true), false);
-  } finally {
-    safeRemoveSync(tempDir, { recursive: true });
-  }
-});
+unitTest(
+  "isInstalled - returns false for legacy layout with no version file",
+  () =>
+    withTempDir((tempDir) => {
+      writeLegacyPlaywrightFixture(tempDir);
+      assertEquals(isInstalled(tempDir, true), false);
+    }),
+);
 
 // -- Step 4: latestRelease() (external HTTP call, skip on CI) --
 

--- a/tests/unit/tools/chrome-headless-shell.test.ts
+++ b/tests/unit/tools/chrome-headless-shell.test.ts
@@ -13,6 +13,7 @@ import { runningInCI } from "../../../src/core/ci-info.ts";
 import { InstallContext } from "../../../src/tools/types.ts";
 import {
   detectChromePlatform,
+  downloadAndExtractChrome,
   fetchPlaywrightBrowsersJson,
   findChromeExecutable,
   isPlaywrightCdnPlatform,
@@ -100,8 +101,7 @@ unitTest("isInstalled - returns false when only binary exists (no version file)"
   try {
     const { platform } = detectChromePlatform();
     const binName = chromeHeadlessShellBinaryName();
-    // CfT layout: chrome-headless-shell-{platform}/binary
-    // Playwright arm64 layout: chrome-linux/binary (found via walkSync fallback)
+    // CfT layout (all platforms, including Playwright CDN arm64): chrome-headless-shell-{platform}/binary
     const subdir = join(tempDir, `chrome-headless-shell-${platform}`);
     Deno.mkdirSync(subdir);
     const target = isWindows ? `${binName}.exe` : binName;
@@ -167,6 +167,39 @@ unitTest("Playwright CDN - browsers.json and URL construction", async () => {
     url.includes("linux-arm64"),
     "URL should be for linux-arm64",
   );
+}, { ignore: runningInCI() });
+
+// The Playwright CDN arm64 archive redirects to the same chrome-for-testing-public
+// bucket used for every other platform, so it shares that layout: a
+// chrome-headless-shell-linux-arm64/chrome-headless-shell binary, not Playwright's
+// older chrome-linux/headless_shell layout. This downloads the real archive to
+// guard against CfT (or Playwright's mirror of it) changing that layout again.
+// Checked with existsSync against the literal extracted path rather than
+// findChromeExecutable(), which appends ".exe" whenever the *host* is Windows —
+// irrelevant here since the archive itself is always a Linux arm64 build,
+// regardless of what platform runs this test.
+unitTest("Playwright CDN arm64 archive uses chrome-headless-shell binary name, not headless_shell", async () => {
+  const entry = await fetchPlaywrightBrowsersJson();
+  const url = playwrightCdnDownloadUrl(entry.browserVersion);
+  const tempDir = Deno.makeTempDirSync();
+  try {
+    await downloadAndExtractChrome(
+      "Chrome Headless Shell (arm64)",
+      url,
+      tempDir,
+      createMockContext(tempDir),
+    );
+    assert(
+      existsSync(join(tempDir, "chrome-headless-shell-linux-arm64", "chrome-headless-shell")),
+      "arm64 archive should contain chrome-headless-shell-linux-arm64/chrome-headless-shell",
+    );
+    assert(
+      !existsSync(join(tempDir, "chrome-linux", "headless_shell")),
+      "arm64 archive should not use Playwright's old chrome-linux/headless_shell layout",
+    );
+  } finally {
+    safeRemoveSync(tempDir, { recursive: true });
+  }
 }, { ignore: runningInCI() });
 
 // -- Step 5: preparePackage() (downloads ~50MB, skip on CI) --


### PR DESCRIPTION
> [!IMPORTANT]
> Backport from #14860

Cherry-pick fix for `quarto install chrome-headless-shell` (and `quarto install chromium`) failing on Linux arm64: a stale Playwright CDN URL, the archive layout change that came with it, and a compatibility fallback for installs made before the CDN migration.

Fixes #14857
