### PR TITLE
[backport] Fix Firefox font-size precision failures in revealjs tests (#14854)

### DIFF
--- a/tests/integration/playwright/src/utils.ts
+++ b/tests/integration/playwright/src/utils.ts
@@ -206,13 +206,22 @@ export async function getCSSProperty(loc: Locator, variable: string, asNumber = 
   }
 }
 
+// Different browser engines resolve compounding relative-unit (em/rem)
+// font-size cascades with slightly different subpixel rounding, so an
+// exact/decimal-precision comparison is too strict across Chromium/Firefox/WebKit.
+// Use a small fixed absolute tolerance instead — mirrors Playwright's own
+// pattern for cross-engine CSS/DIP rounding drift.
+export function expectCloseTo(actual: number, expected: number, tolerance: number = 0.1) {
+  expect(Math.abs(actual - expected)).toBeLessThanOrEqual(tolerance);
+}
+
 export async function checkCSSproperty(loc1: Locator, loc2: Locator, property: string, asNumber: false | true, checkType: 'identical' | 'similar', factor: number = 1) {
   let loc1Property = await getCSSProperty(loc1, property, asNumber);
   let loc2Property = await getCSSProperty(loc2, property, asNumber);
   if (checkType === 'identical') {
     await expect(loc2).toHaveCSS(property, loc1Property as string);
   } else {
-    await expect(loc1Property).toBeCloseTo(loc2Property as number * factor);
+    expectCloseTo(loc1Property as number, loc2Property as number * factor);
   }
 }
 

--- a/tests/integration/playwright/tests/revealjs-themes.spec.ts
+++ b/tests/integration/playwright/tests/revealjs-themes.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Locator } from '@playwright/test';
-import { asRGB, checkColor, checkColorIdentical, checkFontSizeSimilar, getCSSProperty, RGBColor } from '../src/utils';
+import { asRGB, checkColor, checkColorIdentical, checkFontSizeSimilar, expectCloseTo, getCSSProperty, RGBColor } from '../src/utils';
 
 async function getRevealMainFontSize(page: any): Promise<number> {
   return await getCSSProperty(page.locator('body'), "--r-main-font-size", true) as number;
@@ -25,9 +25,9 @@ test('Code font size in callouts and smaller slide is scaled down', async ({ pag
   const codeBlockFontSizeDefault = await getCSSProperty(page.locator('#highlighted-cell pre'), "font-size", true) as number;
   const codeInlineFontSizeDefault = await getCSSProperty(page.locator('#no-callout-inline').getByText('testthat::test_that()'), "font-size", true) as number;
   // Font size in callout for inline code should be scaled smaller than default inline code
-  expect(await getCSSProperty(page.locator('#callouts').getByText('testthat::test_that()'), "font-size", true)).toBeCloseTo(codeInlineFontSizeDefault * scaleFactor);
+  expectCloseTo(await getCSSProperty(page.locator('#callouts').getByText('testthat::test_that()'), "font-size", true) as number, codeInlineFontSizeDefault * scaleFactor);
   // Font size for code block in callout should be scaled smaller that default code block
-  expect(await getCSSProperty(page.locator('#callouts .callout pre code'), 'font-size', true)).toBeCloseTo(codeBlockFontSizeDefault * scaleFactor);
+  expectCloseTo(await getCSSProperty(page.locator('#callouts .callout pre code'), 'font-size', true) as number, codeBlockFontSizeDefault * scaleFactor);
   // Font size in callout for inline code should be samely size as text than by default
   const codeInlineFontSize = await getRevealCodeInlineFontSize(page);
   await checkFontSizeSimilar( 
@@ -48,9 +48,9 @@ test('Code font size in smaller slide is scaled down', async ({ page }) => {
   const codeBlockFontSizeDefault = await getCSSProperty(page.locator('#highlighted-cell pre'), "font-size", true) as number;
   const codeInlineFontSizeDefault = await getCSSProperty(page.locator('#no-callout-inline').getByText('testthat::test_that()'), "font-size", true) as number;
   // Font size in callout for inline code should be scaled smaller than default inline code
-  expect(await getCSSProperty(page.locator('#smaller-slide p').filter({ hasText: 'Some inline code' }).getByRole('code'), "font-size", true)).toBeCloseTo(codeInlineFontSizeDefault * scaleFactor);
+  expectCloseTo(await getCSSProperty(page.locator('#smaller-slide p').filter({ hasText: 'Some inline code' }).getByRole('code'), "font-size", true) as number, codeInlineFontSizeDefault * scaleFactor);
   // Font size for code block in callout should be scaled smaller that default code block
-  expect(await getCSSProperty(page.locator('#smaller-slide pre').getByRole('code'), 'font-size', true)).toBeCloseTo(codeBlockFontSizeDefault * scaleFactor);
+  expectCloseTo(await getCSSProperty(page.locator('#smaller-slide pre').getByRole('code'), 'font-size', true) as number, codeBlockFontSizeDefault * scaleFactor);
   // Font size in callout for inline code should be samely size as text than by default
   const codeInlineFontSize = await getRevealCodeInlineFontSize(page);
   await checkFontSizeSimilar( 


### PR DESCRIPTION
Backport of #14854 to v1.10.

Test-only change, no user-facing impact: `revealjs-themes.spec.ts` was failing deterministically on Firefox in scheduled CI due to subpixel rounding drift (~0.006px) past the `toBeCloseTo` decimal-precision threshold. Replaces it with a fixed absolute pixel tolerance, matching Playwright's own approach for cross-engine CSS rounding drift.