### PR TITLE
chore(julia-engine): Update subtree to 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.2.2](https://github.com/PumasAI/quarto-julia-engine/releases/tag/v0.2.2) - 2026-09-08
+
+- A failed render without an execution daemon no longer leaves the notebook's worker process running [#14](https://github.com/PumasAI/quarto-julia-engine/pull/14).
+
 ## [0.2.1](https://github.com/PumasAI/quarto-julia-engine/releases/tag/v0.2.1) - 2026-09-02
 
 - Updated to QuartoNotebookRunner 0.18.2 [#13](https://github.com/PumasAI/quarto-julia-engine/pull/13):

--- a/_extensions/julia-engine/_extension.yml
+++ b/_extensions/julia-engine/_extension.yml
@@ -1,5 +1,5 @@
 title: Quarto Julia Engine Extension
-version: 0.2.1
+version: 0.2.2
 quarto-required: ">=1.9.0"
 contributes:
   engines:

--- a/_extensions/julia-engine/julia-engine.js
+++ b/_extensions/julia-engine/julia-engine.js
@@ -1113,23 +1113,41 @@ async function executeJulia(options) {
     }
   }
   const sourceRanges = buildSourceRanges(options.target.markdown);
-  const response = await writeJuliaCommand(conn, {
-    type: "run",
-    content: {
-      file,
-      options,
-      sourceRanges
+  let response;
+  try {
+    response = await writeJuliaCommand(conn, {
+      type: "run",
+      content: {
+        file,
+        options,
+        sourceRanges
+      }
+    }, transportOptions.key, options, (update) => {
+      const n = update.nChunks.toString();
+      const i = update.chunkIndex.toString();
+      const i_padded = `${" ".repeat(n.length - i.length)}${i}`;
+      const ncols = getConsoleColumns() ?? 80;
+      const firstPart = `Running [${i_padded}/${n}] at line ${update.line}:  `;
+      const firstPartLength = firstPart.length;
+      const sigLine = firstSignificantLine(update.source, Math.max(0, ncols - firstPartLength));
+      quarto.console.info(`${firstPart}${sigLine}`);
+    });
+  } catch (e) {
+    if (options.oneShot) {
+      try {
+        await writeJuliaCommand(conn, {
+          type: "close",
+          content: {
+            file
+          }
+        }, transportOptions.key, options);
+      } catch (closeError) {
+        quarto.console.warning(`Could not close the julia worker after the failed run, it may stay open until the server exits:
+${closeError}`);
+      }
     }
-  }, transportOptions.key, options, (update) => {
-    const n = update.nChunks.toString();
-    const i = update.chunkIndex.toString();
-    const i_padded = `${" ".repeat(n.length - i.length)}${i}`;
-    const ncols = getConsoleColumns() ?? 80;
-    const firstPart = `Running [${i_padded}/${n}] at line ${update.line}:  `;
-    const firstPartLength = firstPart.length;
-    const sigLine = firstSignificantLine(update.source, Math.max(0, ncols - firstPartLength));
-    quarto.console.info(`${firstPart}${sigLine}`);
-  });
+    throw e;
+  }
   if (options.oneShot) {
     await writeJuliaCommand(conn, {
       type: "close",

--- a/news/changelog-1.11.md
+++ b/news/changelog-1.11.md
@@ -41,6 +41,7 @@ All changes included in 1.11:
 
 - ([#14834](https://github.com/quarto-dev/quarto-cli/issues/14834)): Fix `ERROR: Internal Error` when rendering documents whose payload exceeds the Julia server's socket send buffer.
 - ([PumasAI/quarto-julia-engine#8](https://github.com/PumasAI/quarto-julia-engine/pull/8)): Support `keep-ipynb`, which writes the executed notebook to `<stem>.ipynb` alongside the source file.
+- ([PumasAI/quarto-julia-engine#14](https://github.com/PumasAI/quarto-julia-engine/pull/14)): Fix the Julia worker process being left running after a failed render without an execution daemon.
 - ([PumasAI/quarto-julia-engine#13](https://github.com/PumasAI/quarto-julia-engine/pull/13)): Shell (`;`), help (`?`), and Pkg (`]`) mode cells now work when the cell has `#|` options.
 - ([PumasAI/quarto-julia-engine#11](https://github.com/PumasAI/quarto-julia-engine/pull/11)): Support `fig-format: retina`, normalized to `png` with doubled `fig-dpi` as in the `jupyter` and `knitr` engines.
 - ([PumasAI/quarto-julia-engine#7](https://github.com/PumasAI/quarto-julia-engine/pull/7)): Support `execute-dir`, shared worker processes across notebooks with matching configs (`share_worker_process: true`).

--- a/src/julia-engine.ts
+++ b/src/julia-engine.ts
@@ -729,25 +729,45 @@ async function executeJulia(
 
   const sourceRanges = buildSourceRanges(options.target.markdown);
 
-  const response = await writeJuliaCommand(
-    conn,
-    { type: "run", content: { file, options, sourceRanges } },
-    transportOptions.key,
-    options,
-    (update: ProgressUpdate) => {
-      const n = update.nChunks.toString();
-      const i = update.chunkIndex.toString();
-      const i_padded = `${" ".repeat(n.length - i.length)}${i}`;
-      const ncols = getConsoleColumns() ?? 80;
-      const firstPart = `Running [${i_padded}/${n}] at line ${update.line}:  `;
-      const firstPartLength = firstPart.length;
-      const sigLine = firstSignificantLine(
-        update.source,
-        Math.max(0, ncols - firstPartLength),
-      );
-      quarto.console.info(`${firstPart}${sigLine}`);
-    },
-  );
+  let response;
+  try {
+    response = await writeJuliaCommand(
+      conn,
+      { type: "run", content: { file, options, sourceRanges } },
+      transportOptions.key,
+      options,
+      (update: ProgressUpdate) => {
+        const n = update.nChunks.toString();
+        const i = update.chunkIndex.toString();
+        const i_padded = `${" ".repeat(n.length - i.length)}${i}`;
+        const ncols = getConsoleColumns() ?? 80;
+        const firstPart = `Running [${i_padded}/${n}] at line ${update.line}:  `;
+        const firstPartLength = firstPart.length;
+        const sigLine = firstSignificantLine(
+          update.source,
+          Math.max(0, ncols - firstPartLength),
+        );
+        quarto.console.info(`${firstPart}${sigLine}`);
+      },
+    );
+  } catch (e) {
+    if (options.oneShot) {
+      try {
+        await writeJuliaCommand(
+          conn,
+          { type: "close", content: { file } },
+          transportOptions.key,
+          options,
+        );
+      } catch (closeError) {
+        // must not mask the run error which is the actual diagnostic
+        quarto.console.warning(
+          `Could not close the julia worker after the failed run, it may stay open until the server exits:\n${closeError}`,
+        );
+      }
+    }
+    throw e;
+  }
 
   if (options.oneShot) {
     await writeJuliaCommand(

--- a/tests/docs/julia-engine/error/error.qmd
+++ b/tests/docs/julia-engine/error/error.qmd
@@ -1,0 +1,7 @@
+---
+engine: julia
+---
+
+```{julia}
+error("intentional failure")
+```

--- a/tests/smoke/julia-engine/julia.test.ts
+++ b/tests/smoke/julia-engine/julia.test.ts
@@ -198,6 +198,24 @@ Deno.test("julia engine", async (t) => {
     assertStderrIncludes(render_output, "File was force-closed during run");
   });
 
+  await t.step("failed one-shot run closes its worker", () => {
+    const render_output = new Deno.Command(
+      quartoCmd(),
+      {
+        args: ["render", "error.qmd", "--execute-daemon", "0"],
+        cwd: docs("julia-engine/error"),
+      },
+    ).outputSync();
+    assert(!render_output.success);
+
+    const status_output = new Deno.Command(
+      quartoCmd(),
+      { args: ["call", "engine", "julia", "status"], cwd: juliaTestDir },
+    ).outputSync();
+    assertSuccess(status_output);
+    assertStdoutIncludes(status_output, "workers active: 0");
+  });
+
   await t.step("log exists", () => {
     const log_output = new Deno.Command(
       quartoCmd(),


### PR DESCRIPTION
Pulls in julia-engine [v0.2.2](https://github.com/PumasAI/quarto-julia-engine/releases/tag/v0.2.2), which closes the notebook's worker process when a non-daemon render fails. Before, the worker was only closed on success, so a failing render left it running until the server exited.
