### PR TITLE
Use the browser focus ring for sidebar section toggles

### DIFF
--- a/.claude/rules/formats/sass-theming.md
+++ b/.claude/rules/formats/sass-theming.md
@@ -6,6 +6,7 @@ paths:
   - "src/format/reveal/format-reveal-theme*"
   - "src/format/dashboard/format-dashboard-shared*"
   - "src/resources/formats/**/*.scss"
+  - "src/resources/projects/**/*.scss"
 ---
 
 # Sass Theming
@@ -22,3 +23,30 @@ background-color: var(--r-background-color, $body-bg);
 Read `llm-docs/sass-theming-architecture.md` for full compilation pipeline details.
 
 For the three-tier callout CSS architecture (Bootstrap, RevealJS, standalone HTML), see `llm-docs/callout-styling-html.md`.
+
+## Focus indicators
+
+Never author a focus ring. The browser's own ring adapts to the platform accent
+color, to the user's accessibility settings, and to forced-colors mode, where
+`box-shadow` is dropped entirely. An authored ring does none of that, and a
+second convention next to the first is visible as an inconsistency when a user
+tabs through a page.
+
+So the only focus rules Quarto writes are ones that undo a vendor rule which
+suppressed the browser ring:
+
+```scss
+// a bare .btn: Bootstrap's .btn:focus-visible sets outline: 0
+.code-tools-button:focus-visible {
+  outline: revert;
+}
+```
+
+A bare `<button>` with no `.btn` class needs no rule at all — nothing suppressed
+its ring. Bootstrap's reboot only clears the ring for `:focus:not(:focus-visible)`,
+which is the mouse-click case.
+
+When a control has no visible focus indicator, look for the suppression and
+delete or revert it, rather than adding a ring of your own. See
+`_bootstrap-rules.scss` for the one `outline: revert` rule, and quarto-cli#14774
+and quarto-cli#12118 for the two times this came up.

--- a/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
+++ b/src/resources/formats/html/bootstrap/_bootstrap-rules.scss
@@ -1061,9 +1061,21 @@ td code:not(.sourceCode) {
   padding: 0.7rem;
 }
 
-// These buttons are bare .btn elements (no btn-* variant class), so
-// Bootstrap's .btn:focus-visible leaves them with no focus indicator.
-// Restore the browser's ring; unlike box-shadow it survives forced colors.
+// Quarto's focus-indicator convention: never author a focus ring. The
+// browser's own ring adapts to the platform accent color, to the user's
+// accessibility settings, and to forced-colors mode; an authored ring
+// cannot. So the only focus rules Quarto writes are ones that undo a
+// vendor rule which suppressed that ring.
+//
+// This is the one such rule. These three buttons are bare .btn elements
+// (no btn-* variant class), so Bootstrap's .btn:focus-visible sets
+// outline: 0 and substitutes a box-shadow that only the variant classes
+// define — leaving no indicator at all. `revert` restores the browser's.
+//
+// A bare <button> with no .btn class needs no rule: nothing suppressed
+// its ring in the first place. Bootstrap's reboot only clears the ring
+// for :focus:not(:focus-visible), which is the mouse-click case.
+//
 // See https://github.com/quarto-dev/quarto-cli/issues/14774
 .quarto-btn-toggle:focus-visible,
 .quarto-search-button:focus-visible,

--- a/src/resources/projects/website/navigation/quarto-nav.scss
+++ b/src/resources/projects/website/navigation/quarto-nav.scss
@@ -409,14 +409,6 @@ $sidebar-section-bottom-margin: 0.2em;
   padding-left: 0.5rem;
 }
 
-// A bare button gets no focus ring from Bootstrap's reboot, so state one
-// explicitly rather than depend on the UA default (quarto-cli#14774).
-.sidebar-item .sidebar-item-toggle:focus-visible,
-.sidebar-item button.sidebar-item-text:focus-visible {
-  outline: 2px solid currentColor;
-  outline-offset: 2px;
-}
-
 .sidebar-item .sidebar-item-toggle .bi {
   // The dongle for opening and closing sections
   font-size: 0.7rem;

--- a/tests/docs/playwright/website/bare-btn-focus/_quarto.yml
+++ b/tests/docs/playwright/website/bare-btn-focus/_quarto.yml
@@ -15,5 +15,8 @@ website:
     contents:
       - index.qmd
       - about.qmd
+      - section: "Group"
+        contents:
+          - about.qmd
 
 format: html

--- a/tests/docs/playwright/website/bare-btn-focus/index.qmd
+++ b/tests/docs/playwright/website/bare-btn-focus/index.qmd
@@ -2,6 +2,12 @@
 title: "Home"
 ---
 
-Regression test for #14774: below 992px the secondary nav shows the
-sidebar toggle and sidebar search buttons. Both are bare Bootstrap
-`.btn` elements and must keep a visible keyboard focus indicator.
+Regression tests for Quarto's focus-indicator convention.
+
+Below 992px the secondary nav shows the sidebar toggle and sidebar search
+buttons. Both are bare Bootstrap `.btn` elements and must keep a visible
+keyboard focus indicator (#14774).
+
+At full width the sidebar shows a collapsible "Group" section. Its toggle
+is a bare `<button>` with no `.btn` class, and it takes the browser's own
+focus ring with no Quarto rule involved (#14826).

--- a/tests/integration/playwright/tests/html-focus-indicator.spec.ts
+++ b/tests/integration/playwright/tests/html-focus-indicator.spec.ts
@@ -1,13 +1,21 @@
 import { expect, Locator, Page, test } from "@playwright/test";
 import { getUrl } from "../src/utils";
 
-// Regression tests for #14774. Quarto emits three buttons that carry the
-// Bootstrap `btn` class with no `btn-*` variant class: the code tools
-// button, the sidebar toggle, and the sidebar search button. Bootstrap's
-// .btn:focus-visible removes the native focus ring (outline: 0) and
-// substitutes a box-shadow that only the variant classes define, so these
-// buttons took keyboard focus with no visible indicator. Quarto restores
-// the browser's native ring with `outline: revert`.
+// Every Quarto control must show a visible indicator on keyboard focus
+// (WCAG 2.2 SC 2.4.7). Quarto's convention is to use the browser's own
+// ring and never author one, so these tests assert only that an outline
+// is drawn — not which outline. See `.claude/rules/formats/sass-theming.md`.
+//
+// Three buttons carry the Bootstrap `btn` class with no `btn-*` variant
+// class: the code tools button, the sidebar toggle, and the sidebar search
+// button. Bootstrap's .btn:focus-visible removes the native ring
+// (outline: 0) and substitutes a box-shadow that only the variant classes
+// define, so these took keyboard focus with no indicator at all. Quarto
+// restores the browser's ring with `outline: revert` (#14774).
+//
+// The sidebar section toggles are bare `<button>` elements with no `btn`
+// class, so nothing suppresses their ring and Quarto writes no rule for
+// them (#14826).
 
 // Move focus with real Tab presses so the button matches :focus-visible —
 // the fix only applies to keyboard focus, and programmatic locator.focus()
@@ -73,4 +81,27 @@ test.describe("website secondary nav buttons", () => {
       await expect(button).not.toHaveCSS("outline-style", "none");
     });
   }
+});
+
+test.describe("website sidebar section toggle", () => {
+  // The left sidebar is display: none below the lg breakpoint (992px), so
+  // its section toggles are only focusable at full width.
+  test.use({ viewport: { width: 1400, height: 900 } });
+
+  test("shows a focus indicator on keyboard focus", async ({
+    page,
+    browserName,
+  }) => {
+    await page.goto(getUrl("website/bare-btn-focus/_site/index.html"), {
+      waitUntil: "load",
+    });
+
+    const button = page.locator(
+      "#quarto-sidebar button.sidebar-item-toggle",
+    ).first();
+    await expect(button).toBeVisible();
+    expect(await tabUntilFocused(page, browserName, button)).toBe(true);
+
+    await expect(button).not.toHaveCSS("outline-style", "none");
+  });
 });


### PR DESCRIPTION
## Description

Answers cderv's question on [#14785](https://github.com/quarto-dev/quarto-cli/pull/14785#pullrequestreview-5088170266):
two focus-indicator conventions were living next to each other in the website
sidebar. This PR settles on one — the browser's own focus ring — and deletes the
rule that departed from it.

#14826 gave the new sidebar section toggles their own ring:

```scss
.sidebar-item .sidebar-item-toggle:focus-visible,
.sidebar-item button.sidebar-item-text:focus-visible {
  outline: 2px solid currentColor;
  outline-offset: 2px;
}
```

That rule is not needed. The comment above it says a bare button gets no ring
from Bootstrap's reboot, but reboot only clears the ring for
`:focus:not(:focus-visible)` — the mouse-click case. These buttons carry no `btn`
class, so nothing suppressed their ring in the first place.

### What the browser already does

I rendered a website with a navbar, a floating sidebar, search, code tools and a
color-scheme toggle, then tabbed through it with real key presses in Chromium,
Firefox and WebKit and read the computed style of every focused element. On
`main` today:

| Control | `outline-style` | Comes from |
|---|---|---|
| `a.navbar-brand` | `auto` | browser |
| `a.quarto-navigation-tool` | `auto` | browser |
| `button.quarto-color-scheme-toggle` | `auto` | browser |
| `button.aa-DetachedSearchButton` | `auto` | browser |
| `a.sidebar-item-text.sidebar-link` | `auto` | browser |
| `button.code-copy-button` | `auto` | browser (#12118 removed a suppression) |
| `button.btn.code-tools-button` | `auto` | `outline: revert` (#14774) |
| `button.quarto-btn-toggle.btn` | `auto` | `outline: revert` (#14774) |
| `button.sidebar-item-toggle` | **`solid 2px currentColor`** | **#14826** |

Firefox and WebKit agree, with their own ring widths (`auto 1px` and `auto 3px`).
So it is one rule against everything else, and the divergent one sits between two
sidebar links that use the browser ring. Tab down the sidebar and the indicator
changes shape mid-list.

With the rule removed, the toggles compute `outline-style: auto` in all three
engines and the ring is not clipped by the sidebar, so the `outline-offset: 2px`
was not doing work either.

### Why the browser ring

- Chromium and Firefox draw a two-tone ring, so it stays visible on any
  background. An authored ring cannot do that.
- The color follows the platform accent color and the user's accessibility
  settings.
- In forced-colors mode `auto` maps to the system highlight color. I measured it
  as present on every control that uses it.
- #12118 already set the precedent. That fix
  ([`cb875f3fd`](https://github.com/quarto-dev/quarto-cli/commit/cb875f3fd8d60c9ebd00b6a4f768f4bff0a0afc6),
  "copy-code: don't hide outline on :focus") deleted
  `.code-copy-button:focus { outline: none; }` and wrote no ring in its place.

The cost is that the ring differs between browsers. It already differs for every
link on the page, so this is not a new inconsistency.

### Recording the convention

The convention is: **never author a focus ring.** The only focus rules Quarto
writes are ones that undo a vendor rule which suppressed the browser ring. There
is exactly one such rule, the `outline: revert` from #14785.

Two places say so now:

- A comment on that rule in `_bootstrap-rules.scss`, including the note that a
  bare `<button>` with no `.btn` class needs no rule.
- A "Focus indicators" section in `.claude/rules/formats/sass-theming.md`. Its
  `paths:` list gained `src/resources/projects/**/*.scss`, which it was missing —
  that glob is why the rule file did not surface when `quarto-nav.scss` was
  edited.

### Not in this PR

The audit found four older focus-ring suppressions in `quarto-search.scss`,
including [the line cscheid flagged on #12118 in April 2025](https://github.com/quarto-dev/quarto-cli/issues/12118#issuecomment-2797636922),
where the search box in an overlay navbar has no focus indicator at all. They are
the same fault as #14774 but a separate change; I will file them on their own.

Separately, Bootstrap's own indicators for `a.nav-link`, `button.navbar-toggler`
and `button.btn-close` are `box-shadow` only, so they disappear in forced-colors
mode. Bootstrap 6 moves button focus styles to `outline`
([twbs/bootstrap#42062](https://github.com/twbs/bootstrap/pull/42062)), so that
one is worth tracking rather than patching.

### Tests

`html-focus-indicator-bare-btn.spec.ts` is renamed to
`html-focus-indicator.spec.ts`, so it is the home for focus-indicator tests
rather than for one issue, and it gains a test for the sidebar section toggles.
The fixture `_quarto.yml` gains a collapsible section, and `index.qmd` explains
both cases.

The assertion is `not.toHaveCSS("outline-style", "none")`, matching the three
tests already there. It checks the requirement — a visible indicator, WCAG 2.2
SC 2.4.7 — not which indicator, so it passes under either convention and does
not need rewriting if a theme restyles the ring. That does mean the new test
passes before and after this change; it is the safety net for the deletion, not
proof of it. To make sure it can fail, I added
`.sidebar-item .sidebar-item-toggle:focus-visible { outline: none; }`, re-rendered
and re-ran: 3 of 3 fail. With that probe reverted, 12 of 12 pass in Chromium,
Firefox and WebKit.

### No changelog entry

#14826 and #14785 are both in the 1.11 cycle and both already have entries under
`## Accessibility`. This PR changes nothing that a user of 1.10 would see, so per
`.claude/rules/changelog.md` ("skip changelog entirely when the regression was
introduced by another change in the same version cycle") it needs no entry of its
own.

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes — no issue; this answers the review question on #14785
- [x] updated the appropriate changelog in the PR — not needed, see above
- [x] ensured the present test suite passes
- [x] added new tests
- [ ] created a separate documentation PR in [Quarto's website repo](https://github.com/quarto-dev/quarto-web/) and linked it to this PR — not needed, no option or documented behavior changes

<details>
<summary>AI-assisted PR</summary>

- **AI tool used**: Claude Code
- **Codebase grounding**: local clone of quarto-cli
- **Human review**: I have reviewed, tested, and verified the AI-generated content before submitting.

</details>
