### PR TITLE
fix(html): prepend floating color-scheme toggle

### DIFF
--- a/src/resources/formats/html/templates/quarto-html-after-body.ejs
+++ b/src/resources/formats/html/templates/quarto-html-after-body.ejs
@@ -55,7 +55,7 @@
       }
       container.classList.add('quarto-color-scheme-toggle-container');
       container.appendChild(toggle);
-      window.document.body.appendChild(container);
+      window.document.body.prepend(container);
     }
     setColorSchemeToggle(hasAlternateSentinel())
 
@@ -716,4 +716,3 @@
   
   </script>
   <% } %>
-  

--- a/tests/integration/playwright/tests/html-color-scheme-toggle.spec.ts
+++ b/tests/integration/playwright/tests/html-color-scheme-toggle.spec.ts
@@ -20,6 +20,9 @@ test("fallback color-scheme toggle sits in a header landmark", async ({
     "body > header.quarto-color-scheme-toggle-container",
   );
   await expect(container).toHaveCount(1);
+  await expect(page.locator("body > :first-child")).toHaveClass(
+    /quarto-color-scheme-toggle-container/,
+  );
   await expect(
     container.locator("button.quarto-color-scheme-toggle"),
   ).toHaveCount(1);
@@ -75,7 +78,9 @@ test("fallback color-scheme toggle sees a banner that is not a child of body", a
     page.locator("body > div > header#title-block-header"),
   ).toHaveCount(1);
   await expect(
-    page.locator('body > div.quarto-color-scheme-toggle-container[role="region"]'),
+    page.locator(
+      'body > div.quarto-color-scheme-toggle-container[role="region"]',
+    ),
   ).toHaveCount(1);
   await expect(page.getByRole("banner")).toHaveCount(1);
 });


### PR DESCRIPTION
## Description

Place the floating color-scheme toggle container first in the body so its DOM order matches its visual position. Add a Playwright assertion that protects the insertion order.

Closes #14838

## Testing

- `npx playwright test tests/html-color-scheme-toggle.spec.ts --list` (9 tests discovered)
- `npx prettier --check src/resources/formats/html/templates/quarto-html-after-body.ejs tests/integration/playwright/tests/html-color-scheme-toggle.spec.ts`
- Source contract check and `git diff --check`

Full browser execution was not run because the generated fixture sites and browser dependencies are not available in this checkout.

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes
- [ ] updated the appropriate changelog in the PR
- [ ] ensured the present test suite passes
- [x] added new tests
- [ ] created a separate documentation PR in Quarto's website repo and linked it to this PR

<details>
<summary>AI-assisted PR</summary>

- **AI tool used**: OpenAI Codex
- **Codebase grounding**: Local clone of `quarto-dev/quarto-cli`
- **Human review**: John Finnerty reviewed the prepared change summary and authorized submission. Verification performed by Codex is listed above.

</details>