### PR TITLE
Add verify-l10n-pr skill for localization PR review

### DIFF
--- a/.claude/skills/verify-l10n-pr/SKILL.md
+++ b/.claude/skills/verify-l10n-pr/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: verify-l10n-pr
+description: Use when reviewing a PR that adds or modifies a `_language-<code>.yml` localization file in `src/resources/language/`. Runs structural checks that need no translation tool, plus an optional MT spot-check when a translation MCP is connected.
+---
+
+# Verify a Localization PR
+
+Most quarto-cli maintainers cannot read most of the 30+ languages `src/resources/language/*.yml` covers. This skill separates what's checkable without any language knowledge (structural correctness) from what benefits from a machine-translation second opinion (semantic plausibility) — and treats the second part as optional, since not every reviewer has a translation tool connected.
+
+## Step 1 — Structural checks (always run, no tool dependency)
+
+```bash
+uv run .claude/skills/verify-l10n-pr/scripts/structural_check.py \
+  src/resources/language/_language.yml \
+  src/resources/language/_language-<code>.yml
+```
+
+Catches: missing/extra keys vs. the base English file, `{0}`/`{1}`-style placeholder mismatches, empty values where the base has content, raw trailing whitespace on the line (what `git diff --check` flags), and a heuristic check for quarto's accessibility rule that `navigation-*-label` values must not contain the language's word for "navigation" (screen readers already announce the landmark role — see the rule comment around `src/resources/language/_language.yml:87-96`). That last check is language-agnostic: it compares each label value's words against the same file's `toggle-navigation` value, which is expected to contain the word. A shared stem is a likely violation worth a look, not a certain one — always confirm before commenting on the PR.
+
+On Windows, run via PowerShell or Git Bash with `PYTHONIOENCODING=utf-8` set — `uv run` scripts printing non-Latin script (Cyrillic, Arabic, CJK, etc.) hit `UnicodeEncodeError` on Windows' default console codepage otherwise.
+
+## Step 2 — MT spot-check (optional, only if a translation MCP is connected)
+
+Check whether `mcp__lara-translate__translate` (or an equivalent translation MCP) is available in this session. If not, **say so plainly in the review and stop here** — the structural checks above still stand on their own; don't attempt MT verification with tools known to be unreliable for this (see `references/why-not-libretranslate.md`).
+
+If Lara (or similar) is available, read `references/mt-spot-check.md` before running it — it covers the `context` parameter, how to read the results, and a real false-positive this technique produces (`navigation-*-label` again) that you must not miss.
+
+## Step 3 — Writing up findings
+
+If this produces PR review comments, use the `gh-issue-style` skill for voice before drafting. Don't reference this skill, its scripts, or any MCP/tool name in the public comment — describe findings by what they are (a missing placeholder, a possible accessibility-rule conflict), not how you found them.

--- a/.claude/skills/verify-l10n-pr/references/mt-spot-check.md
+++ b/.claude/skills/verify-l10n-pr/references/mt-spot-check.md
@@ -1,0 +1,31 @@
+# MT Spot-Check with a Context-Aware Translation Tool
+
+Only relevant if a translation MCP (e.g. `mcp__lara-translate__translate`) is connected. If none is, skip this file — don't try to substitute a plain/free MT API here (see `why-not-libretranslate.md` for why that specifically fails on this content).
+
+## Running it
+
+Batch the changed strings both directions in one call each — `source→target` (back-translation, checked against the base English meaning) and `target→source` (forward, checked against the contributor's actual value). Always set the `context` parameter to describe the domain, e.g.:
+
+> "Short UI labels from a documentation/publishing software's interface (button labels, navigation landmarks, tooltips, accessibility labels)"
+
+Without `context`, short/single-word strings ("Note", "Draft", "Page") lose enough surrounding meaning that even a good MT engine can drift. With it, single-word UI labels translate sensibly.
+
+## Reading the results
+
+Most differences between MT output and the contributor's value are **not errors** — they're normal translator-to-translator variation:
+
+- Register (formal vs. informal imperative, e.g. "open" vs. "please open")
+- Loanword vs. native-vocabulary synonym for the same concept (e.g. an international loanword for "copy" vs. a native verb meaning "transfer")
+- Paraphrase that preserves the same meaning with different word order or an added/dropped connective word
+
+Only flag something when the MT output and the contributor's value diverge in **meaning**, not just phrasing — and even then, treat it as "worth a second look," not "wrong." Neither you nor the MT tool is a native speaker.
+
+## The false positive you will hit: `navigation-*-label` keys
+
+Quarto's accessibility convention (`src/resources/language/_language.yml:87-96`) requires the five `navigation-*-label` values (site/section/toolbar/page/breadcrumbs landmark labels) to **avoid** the word for "navigation" in that language — screen readers already announce the landmark role, so repeating it is redundant. A plain MT engine doesn't know this rule. Translating "Breadcrumbs" forward without context will often produce something like "navigation path," because that's a perfectly reasonable generic translation — and it will look like a mismatch against a contributor who correctly wrote something like "page path" instead to follow the project's rule.
+
+**Do not flag a `navigation-*-label` mismatch as a translation error without first checking whether the contributor's value avoids the word for "navigation" and the MT suggestion doesn't.** If that's the pattern, the contributor is right and the MT suggestion is the one to discard. The structural check's navigation-landmark heuristic (Step 1) is the more reliable signal for this specific rule — use the MT spot-check to corroborate general meaning, not to police this particular convention.
+
+## Terminology ambiguity vs. genuine error
+
+Sometimes a back-translation reveals that a word the contributor used is genuinely ambiguous in the target language (has two plausible glosses in English, one of which sounds wrong). That's worth a note, but check whether the *forward* translation (context→target) independently landed on the same word — if both directions converge on it, it's likely the standard term in that language for this context, not a mistake, and the back-translation's alternate gloss is just MT picking the less-likely sense of an ambiguous word.

--- a/.claude/skills/verify-l10n-pr/references/why-not-libretranslate.md
+++ b/.claude/skills/verify-l10n-pr/references/why-not-libretranslate.md
@@ -1,0 +1,7 @@
+# Why Free Self-Hosted MT (LibreTranslate/Argos) Doesn't Work Here
+
+Tested against quarto-cli PR #14878 (Azerbaijani localization). Self-hosted LibreTranslate (`uvx libretranslate --load-only en,az`, no Docker needed — the Docker image crashed silently and repeatedly for unrelated reasons) mode-collapsed on short, context-free strings: unrelated single Azerbaijani words all translated to the identical wrong output. Confirmed it wasn't a usage bug by bypassing LibreTranslate's HTTP layer entirely and calling the underlying Argos Translate library directly — same collapse.
+
+Root cause is structural, not a configuration mistake: Argos's models are trained mostly on full-sentence parallel corpora and have no way to disambiguate a bare single word with no surrounding context, and low-resource language pairs (fewer than a widely-spoken pair like French or Spanish) make it worse. Longer, sentence-length strings translated reasonably; most quarto UI-label keys are exactly the short, context-free shape this fails on.
+
+If no context-aware/LLM-assisted translation MCP is available in a session, don't fall back to a plain free MT API expecting it to work on this content — it demonstrably doesn't, for this specific and common shape of string. Structural checks (Step 1 in `SKILL.md`) still catch real issues without needing any translation quality tool at all; rely on those and skip the MT step rather than trust a plain MT engine's short-string output.

--- a/.claude/skills/verify-l10n-pr/scripts/structural_check.py
+++ b/.claude/skills/verify-l10n-pr/scripts/structural_check.py
@@ -1,0 +1,146 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "ruamel.yaml",
+# ]
+# ///
+"""Structural checks for a quarto-cli `_language-<code>.yml` localization file
+against the base `src/resources/language/_language.yml`. No translation
+quality judgment — that needs a human or an MT spot-check (see SKILL.md)."""
+
+import re
+import sys
+
+from ruamel.yaml import YAML
+
+PLACEHOLDER_RE = re.compile(r"\{\d+\}")
+WORD_RE = re.compile(r"[^\W\d_]+", re.UNICODE)
+
+
+def load(path):
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    with open(path, encoding="utf-8") as f:
+        return yaml.load(f)
+
+
+def check_key_parity(base, target):
+    base_keys, target_keys = set(base), set(target)
+    missing = sorted(base_keys - target_keys)
+    extra = sorted(target_keys - base_keys)
+    if missing:
+        print(f"MISSING KEYS ({len(missing)}): {missing}")
+    if extra:
+        print(f"EXTRA KEYS ({len(extra)}): {extra}")
+    if not missing and not extra:
+        print(f"Key parity OK ({len(base_keys)} keys)")
+
+
+def check_placeholders(base, target):
+    problems = []
+    for key, base_val in base.items():
+        target_val = target.get(key)
+        if not isinstance(base_val, str) or not isinstance(target_val, str):
+            continue
+        base_ph = sorted(set(PLACEHOLDER_RE.findall(base_val)))
+        target_ph = sorted(set(PLACEHOLDER_RE.findall(target_val)))
+        if base_ph != target_ph:
+            problems.append((key, base_ph, target_ph))
+    if problems:
+        print(f"PLACEHOLDER MISMATCHES ({len(problems)}):")
+        for key, base_ph, target_ph in problems:
+            print(f"  {key}: base={base_ph} target={target_ph}")
+    else:
+        print("Placeholder consistency OK")
+
+
+def check_whitespace_and_empty(base, target):
+    problems = []
+    for key, val in target.items():
+        if not isinstance(val, str):
+            continue
+        if val != val.strip():
+            problems.append((key, "leading/trailing whitespace in value"))
+        base_val = base.get(key)
+        if val.strip() == "" and isinstance(base_val, str) and base_val.strip() != "":
+            problems.append((key, "empty value but base has content"))
+    if problems:
+        print(f"WHITESPACE/EMPTY ISSUES ({len(problems)}):")
+        for key, issue in problems:
+            print(f"  {key}: {issue}")
+    else:
+        print("Whitespace/empty check OK")
+
+
+def check_raw_line_trailing_whitespace(path):
+    """Catches whitespace outside the quoted value (e.g. `key: "val" ` with a
+    trailing space after the closing quote) that git diff --check would flag
+    but a parsed-value check misses."""
+    problems = []
+    with open(path, encoding="utf-8") as f:
+        for lineno, line in enumerate(f, start=1):
+            stripped = line.rstrip("\n")
+            if stripped != stripped.rstrip():
+                problems.append(lineno)
+    if problems:
+        print(f"RAW LINE TRAILING WHITESPACE ({len(problems)}): lines {problems}")
+    else:
+        print("Raw line trailing-whitespace check OK")
+
+
+def check_navigation_landmark_rule(target):
+    """Language-agnostic heuristic for quarto's accessibility rule: values for
+    navigation-*-label keys must not contain the language's word for
+    "navigation" (screen readers already announce the landmark role). We don't
+    know each language's word for "navigation", so instead compare each label
+    value's words against the words in *this same file's* `toggle-navigation`
+    value, which is expected to contain that word. A shared word/stem is a
+    likely rule violation worth a human look, not a certain one."""
+    reference = target.get("toggle-navigation")
+    if not isinstance(reference, str):
+        print("Navigation-landmark check skipped: no `toggle-navigation` key found")
+        return
+    reference_words = {w.lower() for w in WORD_RE.findall(reference) if len(w) >= 5}
+    label_keys = [k for k in target if re.match(r"^navigation-.*-label$", k)]
+    flagged = []
+    for key in label_keys:
+        val = target.get(key)
+        if not isinstance(val, str):
+            continue
+        val_words = {w.lower() for w in WORD_RE.findall(val) if len(w) >= 5}
+        shared = {
+            w
+            for w in val_words
+            for r in reference_words
+            if w in r or r in w
+        }
+        if shared:
+            flagged.append((key, val, shared))
+    if flagged:
+        print(f"NAVIGATION-LANDMARK RULE — POSSIBLE VIOLATIONS ({len(flagged)}):")
+        for key, val, shared in flagged:
+            print(f"  {key} = {val!r} shares {shared} with toggle-navigation = {reference!r}")
+        print("  (heuristic, not certain — confirm against the accessibility rule comment in _language.yml)")
+    else:
+        print(f"Navigation-landmark check OK ({len(label_keys)} label keys checked)")
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: structural_check.py <base _language.yml> <target _language-XX.yml>")
+        sys.exit(1)
+    base = load(sys.argv[1])
+    target = load(sys.argv[2])
+    check_key_parity(base, target)
+    print()
+    check_placeholders(base, target)
+    print()
+    check_whitespace_and_empty(base, target)
+    print()
+    check_raw_line_trailing_whitespace(sys.argv[2])
+    print()
+    check_navigation_landmark_rule(target)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Most maintainers can't read most of the 30+ languages under `src/resources/language/`, so reviewing a localization PR usually comes down to trusting the diff. Free machine-translation tools don't reliably fill that gap either: a self-hosted LibreTranslate instance mode-collapses on short, context-free strings — the exact shape of most UI-label keys in these files — confirmed by bypassing its HTTP layer entirely and calling the underlying Argos Translate model directly, which produced the same collapse. A context-aware translation service handles the same short strings correctly, but not every reviewer has one connected.

This adds a Claude Code skill that splits the review into what's checkable without any language knowledge and what benefits from an optional second opinion:

- Structural checks always run, no translation tool needed: key parity against the base `_language.yml`, `{0}`-style placeholder consistency, empty values where the base has content, raw trailing whitespace, and a language-agnostic heuristic for the accessibility rule that `navigation-*-label` values must not contain the word for "navigation" (it compares each label against that file's own `toggle-navigation` value for a shared stem, rather than hardcoding every language's word).
- An MT spot-check step only runs if a translation MCP is connected, and is explicitly skipped otherwise rather than falling back to a free MT API known to be unreliable here.

## Test Plan

- [x] Ran the structural check script against the real `_language.yml`/`_language-az.yml` pair from #14878 — correctly caught the genuine trailing-whitespace issue on `toggle-reader-mode`, correctly did not flag the intentionally-empty `search-text-placeholder`, correctly found no accessibility-landmark violations