### PR TITLE
Fix hidden call subcommands rejecting forwarded --log options

### DIFF
--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -83,7 +83,11 @@ export function appendLogOptions(cmd: Command<any>): Command<any> {
   // to the outer command
   //
   // Fixes https://github.com/quarto-dev/quarto-cli/issues/8438
-  const subCommands = cmd.getCommands();
+  //
+  // Include hidden subcommands (e.g. `quarto call axe`, which is `.hidden()`
+  // while experimental): `.hidden()` only affects `--help` visibility, not
+  // whether the subcommand should accept forwarded log options.
+  const subCommands = cmd.getCommands(true);
   if (subCommands.length > 0) {
     subCommands.forEach((command) => {
       addLogOptions(command);

--- a/tests/unit/core/append-log-options.test.ts
+++ b/tests/unit/core/append-log-options.test.ts
@@ -1,0 +1,45 @@
+/*
+ * append-log-options.test.ts
+ *
+ * appendLogOptions (src/core/log.ts) forwards --log/--log-level/--log-format/
+ * --quiet to a command's direct subcommands. `.hidden()` only controls
+ * whether a subcommand is advertised in `--help` output (e.g. `quarto call
+ * axe`, an experimental subcommand) — it must not also exclude the
+ * subcommand from receiving forwarded log options.
+ *
+ * Copyright (C) 2026 Posit Software, PBC
+ */
+
+import { unitTest } from "../../test.ts";
+import { assert } from "testing/asserts";
+import { Command } from "cliffy/command/mod.ts";
+import { appendLogOptions } from "../../../src/core/log.ts";
+
+unitTest(
+  "appendLogOptions forwards log options to hidden subcommands",
+  // deno-lint-ignore require-await
+  async () => {
+    const visible = new Command().name("visible");
+    const hidden = new Command().name("hidden").hidden();
+    const parent = new Command()
+      .name("parent")
+      .command("visible", visible)
+      .command("hidden", hidden);
+
+    appendLogOptions(parent);
+
+    const forwarded = parent.getCommands(true).find(
+      (cmd) => cmd.getName() === "hidden",
+    );
+    assert(
+      forwarded,
+      "hidden subcommand should still be reachable via getCommands(true)",
+    );
+    for (const name of ["log", "log-level", "log-format", "quiet"]) {
+      assert(
+        forwarded!.hasOption(name),
+        `hidden subcommand is missing forwarded --${name} option`,
+      );
+    }
+  },
+);


### PR DESCRIPTION
`quarto call axe` (currently `.hidden()` while experimental) rejects `--log`/`--log-level`/`--log-format`/`--quiet` as unknown options when run via a built binary, so axe-core never runs and no findings.json is produced.

## Root Cause

`appendLogOptions` in `src/core/log.ts` forwards log options to a command's direct subcommands via `cmd.getCommands()`. Cliffy's `getCommands()` filters out subcommands registered with `.hidden()` unless called as `getCommands(true)`. `axeCommand` in `src/command/call/axe/cmd.ts` is `.hidden()` intentionally, to keep it out of `quarto call --help`'s listing, but that also silently excluded it from receiving forwarded log options.

This only surfaces when log options are passed as real CLI flags — dev-mode tests capture logs in-process through the test harness's own logger and never pass `--log`, while a built-binary subprocess has no other way to hand back logs.

## Fix

Change `cmd.getCommands()` to `cmd.getCommands(true)` in `appendLogOptions`. `.hidden()` now only affects `--help` visibility, not log-option forwarding. This also fixes the same latent gap for other hidden subcommands (e.g. `dev-call`'s `build-artifacts`, `validate-yaml`).

## Test Plan

- [x] Added unit test on `appendLogOptions` with a synthetic hidden subcommand, confirmed RED before the fix
- [x] `quarto call axe --help` now lists `--log`/`--log-level`/`--log-format`/`--quiet`
- [x] `quarto call axe <dir> --log x.json --log-format json-stream --log-level info` runs the full pipeline and produces `findings.json`
- [x] All axe smoke/unit tests pass (axe-brand, axe-darkly, axe-findings, axe-matrix, axe-exit-codes, axe-transport-failclosed, axe-config, axe-artifacts)
- [x] `quarto call --help` still hides `axe` as intended (visibility unaffected)