### PR TITLE
Surface pandoc failures as real ERROR log records

### DIFF
--- a/src/command/render/pandoc.ts
+++ b/src/command/render/pandoc.ts
@@ -12,7 +12,7 @@ import {
   resolve,
 } from "../../deno_ral/path.ts";
 
-import { info, warning } from "../../deno_ral/log.ts";
+import { error, info, warning } from "../../deno_ral/log.ts";
 
 import { ensureDir, existsSync, expandGlobSync } from "../../deno_ral/fs.ts";
 
@@ -25,6 +25,7 @@ import * as ld from "../../core/lodash.ts";
 import { Document } from "../../core/deno-dom.ts";
 
 import { execProcess } from "../../core/process.ts";
+import { ErrorEx } from "../../core/lib/error.ts";
 import { dirAndStem, normalizePath } from "../../core/path.ts";
 import { mergeConfigs } from "../../core/config.ts";
 import { isExternalPath } from "../../core/url.ts";
@@ -319,7 +320,7 @@ function captureRenderCommand(
 export async function runPandoc(
   options: PandocOptions,
   sysFilters: string[],
-): Promise<RunPandocResult | null> {
+): Promise<RunPandocResult> {
   const beforePandocHooks: (() => unknown)[] = [];
   const afterPandocHooks: (() => unknown)[] = [];
   const setupPandocHooks = (
@@ -1435,7 +1436,16 @@ export async function runPandoc(
       clearCodePageCache();
     }
 
-    return null;
+    const stderr = result.stderr?.trim();
+    if (stderr) {
+      error(stderr);
+    }
+    throw new ErrorEx(
+      "Error",
+      `Pandoc conversion failed (exit code ${result.code})`,
+      false,
+      false,
+    );
   }
 }
 

--- a/src/command/render/render.ts
+++ b/src/command/render/render.ts
@@ -205,9 +205,6 @@ export async function renderPandoc(
 
   // run pandoc conversion (exit on failure)
   const pandocResult = await runPandoc(pandocOptions, executeResult.filters);
-  if (!pandocResult) {
-    return Promise.reject();
-  }
 
   return {
     complete: async (renderedFormats: RenderedFormat[], cleanup?: boolean) => {

--- a/tests/smoke/logging/log-level-and-formats.test.ts
+++ b/tests/smoke/logging/log-level-and-formats.test.ts
@@ -34,6 +34,7 @@ function testLogDirectly(options: {
   logFile?: string,
   fileToRender?: string,
   quiet?: boolean,
+  env?: Record<string, string>,
   expectedOutputs?: {
     // To test log output for document with errors
     shouldSucceed?: boolean
@@ -90,7 +91,8 @@ function testLogDirectly(options: {
           cmd: quartoDevCmd(),
           args: args,
           stdout: "piped",
-          stderr: "piped"
+          stderr: "piped",
+          env: options.env,
         });
         
         // Get stdout/stderr with fallback to empty string
@@ -219,7 +221,7 @@ testLogDirectly({
   format: "plain",
   fileToRender: testDocWithError,
   expectedOutputs: {
-    shouldContain: ["WARN:", "ERROR:"],
+    shouldContain: ["ERROR:"],
     shouldNotContain: [debugHintText, infoHintText(testDocWithError)],
     shouldSucceed: false
   }
@@ -233,6 +235,18 @@ testLogDirectly({
   expectedOutputs: {
     shouldContain: ["ERROR:"],
     shouldNotContain: [debugHintText, infoHintText(testDocWithError), "WARN:"],
+    shouldSucceed: false
+  }
+});
+
+testLogDirectly({
+  testName: "Plain format - ERROR level should report a real error without QUARTO_DEBUG",
+  level: "error",
+  format: "plain",
+  fileToRender: testDocWithError,
+  env: { QUARTO_DEBUG: "false" },
+  expectedOutputs: {
+    shouldContain: ["ERROR:", "error-filter.lua"],
     shouldSucceed: false
   }
 });
@@ -268,7 +282,7 @@ testLogDirectly({
   fileToRender: testDocWithError,
   expectedOutputs: {
     shouldSucceed: false,
-    shouldContainLevel: ["WARN", "ERROR"],
+    shouldContainLevel: ["ERROR"],
     shouldNotContainLevel: ["INFO", "DEBUG"],
   }
 });
@@ -331,7 +345,7 @@ testLogDirectly({
   fileToRender: testDocWithError,
   expectedOutputs: {
     shouldSucceed: false,
-    shouldContainLevel: ["DEBUG", "INFO", "WARN", "ERROR"]
+    shouldContainLevel: ["DEBUG", "INFO", "ERROR"]
   }
 });
 
@@ -354,7 +368,7 @@ testLogDirectly({
   format: "plain",
   fileToRender: testDocWithError,
   expectedOutputs: {
-    shouldContain: ["WARN:", "ERROR:"],
+    shouldContain: ["ERROR:"],
     shouldNotContain: [debugHintText, infoHintText(testDocWithError)],
     shouldSucceed: false
   }


### PR DESCRIPTION
When pandoc exits non-zero during render, a released (non-debug) quarto binary produces a completely silent exit code 1, with zero bytes on stdout or stderr at any log level. Dev builds mask this because `quarto.cmd` forces `QUARTO_DEBUG=true`, which accidentally surfaces the failure as a raw stack trace instead of the real pandoc/filter error text.

## Root Cause

When `runPandoc` in `src/command/render/pandoc.ts` hits the failure branch, it discards the captured stderr and returns `null`. `render.ts` reacts with a bare `Promise.reject()` carrying no reason, which `render-files.ts` wraps into an `Error` with an empty message. `logError()` only substitutes a stack trace for an empty message when `QUARTO_DEBUG` is set, so nothing gets printed in a normal binary run.

## Fix

Mirror the existing precedent in `output-typst.ts`: on pandoc failure, log the trimmed stderr via `error()` and throw an `ErrorEx` carrying a real message instead of returning `null`. `render.ts`'s bare reject is removed since it existed for exactly this one case.

This also means pandoc failures no longer produce the WARN record that four tests depended on, itself a symptom of the same bug (`warn()` fired only because the rejection wasn't a real `Error`). Those test expectations were updated to assert the real ERROR record instead.

Accepted tradeoff: at the default `info` log level, pandoc's stderr is now printed twice, once streamed live and once as the ERROR record. This matches typst's existing double-print behavior. Under `--quiet`, console output stays fully silent on failure as before; the ERROR record is still visible via `--log`.